### PR TITLE
Correction d'erreur de frappe dans rpi-install.sh

### DIFF
--- a/rpi-install.sh
+++ b/rpi-install.sh
@@ -35,7 +35,7 @@ echo "mysql-server mysql-server/root_password_again root" | debconf-set-selectio
 # Install MySQL
 sudo apt-get install -y mysql-server
 # Creating database gladys
-mysql -u root -proot -e "create database gladys"
+mysql -u root -p root -e "create database gladys"
 
 # Dependencies
 sudo apt-get install -y libasound2-dev


### PR DESCRIPTION
il manquait un espace entre le "-p" et "root" lors de la connexion à msql pour creer la database
