### PR TITLE
Upgrade package.json to add node v4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Gladys is 100% written in Node.js, with the [sails.js](http://sailsjs.org/) fram
 Prerequisites
 -------------
 
-- [Node.js](http://nodejs.org) ( = v.0.10.xx, some troubles appears with node.js 0.12.x )
+- [Node.js](http://nodejs.org) ( >= v0.10 )
 - [MySQL](http://www.mysql.com/)
 - Command Line Tools
  - <img src="http://deluge-torrent.org/images/apple-logo.gif" height="17">&nbsp;**Mac OS X**: [Xcode](https://itunes.apple.com/us/app/xcode/id497799835?mt=12) (or **OS X 10.9 Mavericks**: `xcode-select --install`)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "apriori": "~1.0.4",
     "async": "~0.9.0",
     "barrels": "~1.4.0",
-    "bcrypt": "0.8.0",
+    "bcrypt": "0.8.5",
     "crypto": "~0.0.3",
     "ejs": "~0.8.4",
     "google-contacts": "~0.0.2",
@@ -31,7 +31,7 @@
     "ical": "*",
     "id3js": "~1.1.3",
     "include-all": "~0.1.3",
-    "lame": "~1.1.1",
+    "lame": "~1.2.3",
     "ncp": "^2.0.0",
     "node-dir": "~0.1.6",
     "node-schedule": "~0.1.15",
@@ -46,7 +46,7 @@
     "sails-memory": "~0.10.3",
     "sails-mysql": "~0.10.7",
     "sails-util-mvcsloader": "^0.3.0",
-    "serialport": "~1.7.1",
+    "serialport": "git://github.com/ghostoy/node-serialport.git#nan1to2",
     "speaker": "^0.2.5"
   },
   "scripts": {


### PR DESCRIPTION
Encountered one issue with serialport:
  See https://github.com/voodootikigod/node-serialport/issues/578
  A fork is currently used, waiting for node v4 official support.

Tested under following node versions:
- v0.10.40
- v0.12.7
- v3.3.1 (http://upgrade-ready.nodesource.com/summary/597b4160-6c0e-11e5-915d-a1d3ce29228e)
- v4.0.0 (http://upgrade-ready.nodesource.com/summary/f7cd4df0-6c0d-11e5-915d-a1d3ce29228e)
- v4.1.1 (http://upgrade-ready.nodesource.com/summary/9037d160-6c0d-11e5-915d-a1d3ce29228e)
- v4.1.2

Related to #39 
