### PR TITLE
Nevermind - Fixed some issues with PM2 on reboot

### DIFF
--- a/api/controllers/LifeEventController.js
+++ b/api/controllers/LifeEventController.js
@@ -82,9 +82,9 @@ function getIntervalBetweenLifeEvents(userId,startEventType, stopEventType, call
   						var duration = (date1.getTime() - date2.getTime())/ (1000*60*60);
               // Round in the format :  8,2 Hours (for example) 
               duration = Math.round(duration*10)/10;
-              var month = date2.getMonth() + 1;
-              var day = date2.getDate();
-              var year = date2.getFullYear();
+              var month = date1.getMonth() + 1;
+              var day = date1.getDate();
+              var year = date1.getFullYear();
   						Interval[cpt] = {start : (year + "-" + month + "-" + day), duration : duration};
   						cpt++;
   					}

--- a/api/controllers/LifeEventController.js
+++ b/api/controllers/LifeEventController.js
@@ -103,14 +103,14 @@ module.exports = {
   
   index: function(req,res,next){
       if(typeof req.param('start') === 'undefined' || typeof req.param('end') === 'undefined') {
-        return res.json('Wrong parametre');
+        return res.json('Wrong parameter');
       }
       
       var start = parseInt(req.param('start'));
       var end = parseInt(req.param('end'));
       
       if(isNaN(start) || isNaN(end)){
-        return res.json('Must be valid number');
+        return res.json('Must be a valid number');
       }
       
       var sql = "SELECT lifeevent.id, name, BeautifulName, FaIcon,iconColor, sentence, param, datetime ";

--- a/rpi-2-install.sh
+++ b/rpi-2-install.sh
@@ -47,3 +47,4 @@ sudo npm install -g gladys --unsafe-perm
 sudo pm2 startup -u `whoami`
 sudo pm2 start /usr/local/lib/node_modules/gladys/app.js --name gladys
 sudo pm2 save
+sudo chattr +i /home/`whoami`/.pm2/dump.pm2

--- a/rpi-2-install.sh
+++ b/rpi-2-install.sh
@@ -44,6 +44,6 @@ sudo npm install -g pm2
 sudo npm install -g gladys --unsafe-perm
 
 # Starting Gladys at startup
-sudo pm2 startup
+sudo pm2 startup -u `whoami`
 sudo pm2 start /usr/local/lib/node_modules/gladys/app.js --name gladys
 sudo pm2 save


### PR DESCRIPTION
I had 2 issues with PM2 :
- The script generated by pm2 startup was using the wrong user (root instead of pi)
- The dump file containing the applications to ressurect was set to empty by PM2 when rebooting, therefore the applications where not starting automatically when rebooting manually

So I made 2 changes to rpi-2-install.sh script.

This might need to be tested on distro others than raspbian.
