### PR TITLE
Fixed some issues with PM2 on reboot

### DIFF
--- a/rpi-2-install.sh
+++ b/rpi-2-install.sh
@@ -44,6 +44,7 @@ sudo npm install -g pm2
 sudo npm install -g gladys --unsafe-perm
 
 # Starting Gladys at startup
-sudo pm2 startup
+sudo pm2 startup -u `whoami`
 sudo pm2 start /usr/local/lib/node_modules/gladys/app.js --name gladys
 sudo pm2 save
+sudo chattr +i /home/`whoami`/.pm2/dump.pm2


### PR DESCRIPTION
I had 2 issues with PM2 :

The script generated by pm2 startup was using the wrong user (root instead of pi)
The dump file containing the applications to ressurect was set to empty by PM2 when rebooting, therefore the applications where not starting automatically when rebooting manually
So I made 2 changes to rpi-2-install.sh script.

This might need to be tested on distro others than raspbian.
