### PR TITLE
Erreur SQL dans la requête getDeviceType

### DIFF
--- a/api/core/devicetype/deviceType.queries.js
+++ b/api/core/devicetype/deviceType.queries.js
@@ -1,7 +1,7 @@
 
 module.exports = {
   getDeviceType: `
-    SELECT dt.id, dt.type, dt.unit, dt.min, dt.max, d.identifier, dt.device, d.service, dt.identifier as deviceTypeIdentifier
+    SELECT dt.id, dt.type, dt.unit, dt.min, dt.max, d.identifier, dt.device, d.service
     FROM device d
     JOIN devicetype dt ON (d.id = dt.device)
     WHERE dt.id = ?;


### PR DESCRIPTION
Il y avait en effet une erreur dans la requête. On utilisait un champs qui n'existe pas dans la table devicetype

Issue : https://github.com/GladysProject/Gladys/issues/99
