### PR TITLE
🐳 Switch from node:carbon to node:8-alpine for Docker base image and add Timezone feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ RUN mkdir /src
 
 WORKDIR /src
 ADD . /src
-RUN npm install --unsafe-perm
+RUN npm install
 
-RUN npm install -g grunt-cli  --unsafe-perm
+RUN npm install -g grunt-cli
 RUN grunt buildProd
 
 # Export listening port

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:carbon
+FROM node:8-alpine
 
 # Create src folder
 RUN mkdir /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 FROM node:8-alpine
 
+# Add tzdata for timezone settings
+RUN apk add --no-cache tzdata
+
 # Create src folder
 RUN mkdir /src
 
 WORKDIR /src
 ADD . /src
-RUN npm install
+RUN npm install --unsafe-perm
 
-RUN npm install -g grunt-cli
+RUN npm install -g grunt-cli  --unsafe-perm
 RUN grunt buildProd
 
 # Export listening port


### PR DESCRIPTION
Build and Run test with success

Purpose of this modification is to reduce images size

- Size with node:carbon = 979.9 MB
- Size with node:alpine = 375.4 MB