### PR TITLE
Add a deviceType.getByTag function to Core

### DIFF
--- a/api/core/devicetype/deviceType.getByTag.js
+++ b/api/core/devicetype/deviceType.getByTag.js
@@ -1,8 +1,11 @@
 var queries = require('./deviceType.queries.js');
 
+/**
+ * options must have a tag attribute
+ * tag can be a simple string or an array of string to match multiple tags
+ * So {tag: 'myTag'} and {tag: ['myTag', 'anotherTag']} are both valid
+ * @param options
+ */
 module.exports = function(options){
-  const query = Array.isArray(options.tag)
-    ? queries.getDeviceTypeByTags
-    : queries.getDeviceTypeByTag;
-  return gladys.utils.sql(query, [options.tag]);
+  return gladys.utils.sql(queries.getDeviceTypeByTags, [options.tag]);
 };

--- a/api/core/devicetype/deviceType.getByTag.js
+++ b/api/core/devicetype/deviceType.getByTag.js
@@ -1,0 +1,5 @@
+var queries = require('./deviceType.queries.js');
+
+module.exports = function(options){
+    return gladys.utils.sql(queries.getDeviceTypeByTag, [options.tag]);
+};

--- a/api/core/devicetype/deviceType.getByTag.js
+++ b/api/core/devicetype/deviceType.getByTag.js
@@ -1,5 +1,8 @@
 var queries = require('./deviceType.queries.js');
 
 module.exports = function(options){
-    return gladys.utils.sql(queries.getDeviceTypeByTag, [options.tag]);
+  const query = Array.isArray(options.tag)
+    ? queries.getDeviceTypeByTags
+    : queries.getDeviceTypeByTag;
+  return gladys.utils.sql(query, [options.tag]);
 };

--- a/api/core/devicetype/deviceType.queries.js
+++ b/api/core/devicetype/deviceType.queries.js
@@ -70,14 +70,6 @@ module.exports = {
     AND (type = ? OR ? IS NULL);
   `,
 
-  getDeviceTypeByTag:
-    `
-    SELECT devicetype.* 
-    FROM devicetype 
-    JOIN device ON devicetype.device = device.id 
-    WHERE devicetype.tag = ?;
-  `,
-
   getDeviceTypeByTags:
     `
     SELECT devicetype.* 

--- a/api/core/devicetype/deviceType.queries.js
+++ b/api/core/devicetype/deviceType.queries.js
@@ -15,7 +15,7 @@ module.exports = {
     JOIN room ON d.room = room.id
     WHERE ( room.id = ? OR ? IS NULL )
   `,
-   getByRoom: `
+  getByRoom: `
    SELECT d.name, dt.id, dt.type, dt.category, dt.tag, dt.unit, dt.min, dt.max, dt.display, dt.sensor, d.identifier, dt.device, d.service,
    dt.lastValueDatetime as lastChanged, dt.lastValue
    FROM device d
@@ -51,24 +51,30 @@ module.exports = {
     JOIN devicetype dt ON (d.id = dt.device)
     LEFT JOIN room ON d.room = room.id 
     WHERE dt.id = ?;
-  `, 
+  `,
   getByType: `
     SELECT dt.*, dt.lastValueDatetime as lastChanged, room.name as roomName
     FROM device d
     JOIN devicetype dt ON (d.id = dt.device)
     LEFT JOIN room ON d.room = room.id 
     WHERE dt.type = ?;
-  `, 
+  `,
 
   getDeviceTypeByCategory:
-  `
+    `
     SELECT devicetype.* 
     FROM devicetype 
     JOIN device ON devicetype.device = device.id 
     WHERE category = ?
     AND (room = ? OR ? IS NULL)
     AND (type = ? OR ? IS NULL);
-  `
+  `,
 
-  
+  getDeviceTypeByTag:
+    `
+    SELECT devicetype.* 
+    FROM devicetype 
+    JOIN device ON devicetype.device = device.id 
+    WHERE devicetype.tag = ?;
+  `
 };

--- a/api/core/devicetype/deviceType.queries.js
+++ b/api/core/devicetype/deviceType.queries.js
@@ -76,5 +76,13 @@ module.exports = {
     FROM devicetype 
     JOIN device ON devicetype.device = device.id 
     WHERE devicetype.tag = ?;
+  `,
+
+  getDeviceTypeByTags:
+    `
+    SELECT devicetype.* 
+    FROM devicetype 
+    JOIN device ON devicetype.device = device.id 
+    WHERE devicetype.tag IN ( ? );
   `
 };

--- a/api/core/devicetype/index.js
+++ b/api/core/devicetype/index.js
@@ -12,3 +12,4 @@ module.exports.getByIdentifier = require('./deviceType.getByIdentifier.js');
 module.exports.getByType = require('./deviceType.getByType.js');
 module.exports.getById = require('./deviceType.getById.js');
 module.exports.update = require('./deviceType.update.js');
+module.exports.getByTag = require('./deviceType.getByTag.js');


### PR DESCRIPTION
As a member of the community asked for this, this PR adds the ability to find deviceTypes by their tag.
Note: This is implemented only in the core API, note in the HTTP.