### PR TITLE
Create Dockerfile.arm32v7

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,0 +1,20 @@
+FROM arm32v7/node:8
+
+# Add tzdata for timezone settings
+RUN apt-get update && apt-get install -y tzdata
+
+# Create src folder
+RUN mkdir /src
+
+WORKDIR /src
+ADD . /src
+
+RUN apt-get update && apt-get install -y make gcc g++ python git && \
+    yarn install --production && npm install -g grunt-cli && grunt buildProd && npm uninstall -g grunt-cli \
+    apt-get remove -y make gcc g++ pyton git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Export listening port
+EXPOSE 8080
+
+CMD ["node" ,"app.js"]

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,4 +1,4 @@
-FROM arm32v7/node:8
+FROM arm32v7/node:8.12-stretch
 
 # Add tzdata for timezone settings
 RUN apt-get update && apt-get install -y tzdata


### PR DESCRIPTION
### Description of change

Since the `Dockerfile` use the alpine image of Node, It's not multi-arch compliant. So here is a Dockerfile for arm32v7 platform (like raspberry).


A better option IMO would be to base the `Dockerfile` on `node:8` instead of `node:8-alpine`, it will make it multi-arch compliant automatically. But i may understand if you don't wish to double the image size.

**EDIT**: i deliberately choosed stretch version to allow libopenzwave installation (if needed)