### PR TITLE
include checkPresence in core of Gladys

### DIFF
--- a/api/core/house/house.checkUsersPresencePerHouse.js
+++ b/api/core/house/house.checkUsersPresencePerHouse.js
@@ -12,7 +12,16 @@ const Promise = require('bluebird');
 module.exports = function checkUsersPresencePerHouse(house){
   sails.log.info(`House : checkUsersPresencePerHouse`);
 
-  return gladys.utils.sql(queries.getUserAtHomeAndNotSeenSince, [house.id, house.id, house.time_before_left])
+  return gladys.param.getValue('USER_TIME_BEFORE_CONSIDERING_LEFT_HOME')
+    .then((timeBeforeLeftInMinute) => {
+      return timeBeforeLeftInMinute;
+    })
+    .catch(() => {
+      return 10;
+    })
+    .then((timeBeforeLeftInMinute) => {
+      return gladys.utils.sql(queries.getUserAtHomeAndNotSeenSince, [house.id, house.id, timeBeforeLeftInMinute]);
+    })
     .then((usersArray) => {
 
       // foreach user in this house and not seen since, we put them left-home

--- a/api/core/house/house.checkUsersPresencePerHouse.js
+++ b/api/core/house/house.checkUsersPresencePerHouse.js
@@ -1,0 +1,24 @@
+const queries = require('./house.queries.js');
+const Promise = require('bluebird');
+
+/**
+ * @public
+ * @description This function check if an user as at home and create an event in timeline for a given house
+ * @name gladys.house.checkUserPresencePerHouse
+ * @example 
+ * gladys.house.checkUserPresencePerHouse();
+ */
+
+module.exports = function checkUsersPresencePerHouse(house){
+  sails.log.info(`House : checkUsersPresencePerHouse`);
+
+  return gladys.utils.sql(queries.getUserAtHomeAndNotSeenSince, [house.id, house.id, house.time_before_left])
+    .then((usersArray) => {
+
+      // foreach user in this house and not seen since, we put them left-home
+      return Promise.map(usersArray, function(user) {
+        sails.log.info(`House : checkUserPresencePerHouse : Putting user ${user.id} as left house : ${house.id}`);
+        return gladys.event.create({code: 'left-home', user: user.id, house: house.id});
+      });
+    });
+};

--- a/api/core/house/index.js
+++ b/api/core/house/index.js
@@ -21,3 +21,4 @@ module.exports.update = require('./house.update.js');
 module.exports.userSeen = require('./house.userSeen.js');
 module.exports.isUserAsleep = require('./house.isUserAsleep.js');
 module.exports.isMode = require('./house.isMode.js');
+module.exports.checkUsersPresencePerHouse = require('./house.checkUsersPresencePerHouse.js');

--- a/api/core/task/task.init.js
+++ b/api/core/task/task.init.js
@@ -75,13 +75,22 @@ module.exports = function(cb){
   }, sails.config.update.checkUpdateInterval);  
  
   // Run occupation check for houses if activated
-  gladys.house.getAll()
-    .then((houses) => {
+  gladys.param.getValue('USER_CHECK_PRESENCE_FREQUENCY')
+    .then((checkFrequency) => {
+      return checkFrequency;
+    })
+    .catch(() => {
+      return 1;
+    })
+    .then((checkFrequency) => {
+      return [checkFrequency, gladys.house.getAll()];
+    })
+    .spread((checkFrequency, houses) => {
       houses.map(function(house) {
-        if(house.check_interval > 0) {
+        if(house === 1) {
           setInterval(function() {
             gladys.house.checkUsersPresencePerHouse(house);
-          }, house.check_interval*60000);
+          }, checkFrequency*60000);
         }
       });
     });

--- a/api/core/task/task.init.js
+++ b/api/core/task/task.init.js
@@ -20,7 +20,7 @@ module.exports = function(cb){
   gladys.alarm.checkAllAutoWakeUp();
 
   gladys.gateway.init();
-  
+
   if(sails.config.environment !== 'production') {
     return cb();   
   }
@@ -74,4 +74,15 @@ module.exports = function(cb){
     gladys.module.checkUpdate();
   }, sails.config.update.checkUpdateInterval);  
  
+  // Run occupation check for houses if activated
+  gladys.house.getAll()
+    .then((houses) => {
+      houses.map(function(house) {
+        if(house.check_interval > 0) {
+          setInterval(function() {
+            gladys.house.checkUsersPresencePerHouse(house);
+          }, house.check_interval*60000);
+        }
+      });
+    });
 };

--- a/api/models/House.js
+++ b/api/models/House.js
@@ -41,14 +41,9 @@ module.exports = {
       required: true
     },
 
-    check_interval: {
+    check: {
       type: 'integer',
       defaultsTo: 0
-    },
-    
-    time_before_left: {
-      type: 'integer',
-      defaultsTo: 6
     }
   }
 };

--- a/api/models/House.js
+++ b/api/models/House.js
@@ -39,6 +39,16 @@ module.exports = {
     longitude: {
       type: 'float',
       required: true
+    },
+
+    check_interval: {
+      type: 'integer',
+      defaultsTo: 0
+    },
+    
+    time_before_left: {
+      type: 'integer',
+      defaultsTo: 6
     }
   }
 };

--- a/assets/js/app/house/house.controller.js
+++ b/assets/js/app/house/house.controller.js
@@ -19,7 +19,6 @@
         vm.getHouses = getHouses;
         vm.getRooms = getRooms;
         vm.toggleHouseCheck = toggleHouseCheck;
-        vm.updateHouse = updateHouse;
         vm.newHouse = {};
         vm.newRoom = {};
         
@@ -93,11 +92,7 @@
         function getHouses(options) {
             return houseService.get(options)
                 .then(function(data){
-                    vm.houses = data.data.map(function(house) {
-                        // ifcheck intervail > 0 it means check is active
-                        if(house.check_interval > 0) {house.check = 1} else { house.check = 0}
-                        return house;
-                    });
+                    vm.houses = data.data;
                 });
         }
 
@@ -111,23 +106,10 @@
         function toggleHouseCheck(house) {
             if(house.check === 0) {
                 house.check = 1;
-                house.check_interval = 5;
             } else {
                 house.check = 0;
-                house.check_interval = 0
             }
-            return updateHouse(house);
-        }
-
-        function updateHouse(house) {
-            return houseService.update(house.id, house)
-                .then(function(data) {
-                    house = data.data
-                    if(house.check_interval > 0) {house.check = 1} else { house.check = 0}
-                    for(var i = 0; i < vm.houses.length; i++) {
-                        if(vm.houses[i].id === house.id) vm.houses.splice(i, 1, house)
-                    };
-                });
+            return houseService.update(house.id, house);
         }
 
         function resetNewHouseFields() {

--- a/assets/js/app/house/house.controller.js
+++ b/assets/js/app/house/house.controller.js
@@ -18,6 +18,8 @@
         vm.deleteRoom = deleteRoom;
         vm.getHouses = getHouses;
         vm.getRooms = getRooms;
+        vm.toggleHouseCheck = toggleHouseCheck;
+        vm.updateHouse = updateHouse;
         vm.newHouse = {};
         vm.newRoom = {};
         
@@ -91,7 +93,11 @@
         function getHouses(options) {
             return houseService.get(options)
                 .then(function(data){
-                    vm.houses = data.data;
+                    vm.houses = data.data.map(function(house) {
+                        // ifcheck intervail > 0 it means check is active
+                        if(house.check_interval > 0) {house.check = 1} else { house.check = 0}
+                        return house;
+                    });
                 });
         }
 
@@ -99,6 +105,28 @@
             return roomService.get(options)
                 .then(function(data){
                     vm.rooms = data.data;
+                });
+        }
+
+        function toggleHouseCheck(house) {
+            if(house.check === 0) {
+                house.check = 1;
+                house.check_interval = 5;
+            } else {
+                house.check = 0;
+                house.check_interval = 0
+            }
+            return updateHouse(house);
+        }
+
+        function updateHouse(house) {
+            return houseService.update(house.id, house)
+                .then(function(data) {
+                    house = data.data
+                    if(house.check_interval > 0) {house.check = 1} else { house.check = 0}
+                    for(var i = 0; i < vm.houses.length; i++) {
+                        if(vm.houses[i].id === house.id) vm.houses.splice(i, 1, house)
+                    };
                 });
         }
 

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -188,9 +188,11 @@
   "area-tooltip-radius": "Enter a radius in meters e. g. 25",
   "house-box-title": "Houses",
   "house-box-description": "You can define here your houses in Gladys. Latitude and longitude can be found on Google Maps, and must be entered with the format (example): Latitude = 42.1, Longitude = 40.1. Remember, all this is saved on your machine and do not leave your Gladys installation.",
+  "house-box-check-occupation-description": "You can ask Gladys to check if your house is occupied by inhabitants at a given frequency. You need to tell Gladys that you are at home with, for exemple, the gladys-bluetooth module which can check your presence with a smartband or any smart bluetooth device. One setup, you have to fix the frequency Gladys will check occupation, and the time between the last time user has been seen and the moment Gladys consider this user has left house.",
   "room-box-title": "Rooms",
   "mode-box-title": "Modes",
   "mode-box-description": "Modes are states the house can take. A house can be in one and only one mode at the same time.",
+  "room-box-check-occupation": "House occupation control",
   "mode-code": "Code",
   "mode-name": "Name",
   "mode-description": "Description",
@@ -338,6 +340,7 @@
   "tooltip-machine-name":"Give your machine a name",
   "tooltip-machine-house-choice":"Select the house in which the machine is located",
   "tooltip-machine-host":"Enter the IP address of your machine",
+  "tooltip-machine-room-choice": "Select the room in which the machine is located",
   "tooltip-mode-code":"Assign a code to your state, it must be unique and spaceless",
   "tooltip-mode-name":"Give it a name.",
   "tooltip-mode-description":"Add a description for you",
@@ -429,5 +432,7 @@
   "gateway-connecting": "Generating keys and connecting...",
   "gateway-login-error": "Your email/password/two-factor code is invalid.",
   "gateway-users-list": "Users",
-  "gateway-users-explanation": "You need to authorize users here before they can control Gladys. With this security, MITM attack is not possible. If the Gladys Gateway is compromised, your instance is not."
+  "gateway-users-explanation": "You need to authorize users here before they can control Gladys. With this security, MITM attack is not possible. If the Gladys Gateway is compromised, your instance is not.",
+  "Time before considering user left": "Time before considering user's left",
+  "Verification frequency": "Verification frequency"
 }

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -188,7 +188,7 @@
   "area-tooltip-radius": "Enter a radius in meters e. g. 25",
   "house-box-title": "Houses",
   "house-box-description": "You can define here your houses in Gladys. Latitude and longitude can be found on Google Maps, and must be entered with the format (example): Latitude = 42.1, Longitude = 40.1. Remember, all this is saved on your machine and do not leave your Gladys installation.",
-  "house-box-check-occupation-description": "You can ask Gladys to check if your house is occupied by inhabitants at a given frequency. You need to tell Gladys that you are at home with, for exemple, the gladys-bluetooth module which can check your presence with a smartband or any smart bluetooth device. One setup, you have to fix the frequency Gladys will check occupation, and the time between the last time user has been seen and the moment Gladys consider this user has left house.",
+  "house-box-check-occupation-description": "You can ask Gladys to check if your house is occupied by inhabitants at a given frequency. You need to tell Gladys that you are at home with, for exemple, the gladys-bluetooth module which can check your presence with a smartband or any smart bluetooth device. By default, Gladys will check every minute, and consider user has left house after 10min missing. Those values can be modified by parameters USER_CHECK_PRESENCE_FREQUENCY and USER_TIME_BEFORE_CONSIDERING_LEFT_HOME.",
   "room-box-title": "Rooms",
   "mode-box-title": "Modes",
   "mode-box-description": "Modes are states the house can take. A house can be in one and only one mode at the same time.",
@@ -432,7 +432,5 @@
   "gateway-connecting": "Generating keys and connecting...",
   "gateway-login-error": "Your email/password/two-factor code is invalid.",
   "gateway-users-list": "Users",
-  "gateway-users-explanation": "You need to authorize users here before they can control Gladys. With this security, MITM attack is not possible. If the Gladys Gateway is compromised, your instance is not.",
-  "Time before considering user left": "Time before considering user's left",
-  "Verification frequency": "Verification frequency"
+  "gateway-users-explanation": "You need to authorize users here before they can control Gladys. With this security, MITM attack is not possible. If the Gladys Gateway is compromised, your instance is not."
 }

--- a/config/locales/fr.json
+++ b/config/locales/fr.json
@@ -350,7 +350,7 @@
   "area-delete": "Supprimer",
   "house-box-title": "Maisons",
   "house-box-description": "Vous pouvez définir ici votre maison dans Gladys. Pour la latitude et la longitude, vous pouvez utiliser Google Maps pour trouver la latitude et la longitude votre maison, et la rentrer au format (par exemple) : latitude = 42.1, longitude = 43.2. Rappel: Toutes ces données restent en locale sur votre machine, et ne sont jamais envoyées nulle part.",
-  "house-box-check-occupation-description": "Vous pouvez définir une fréquence de vérification de la présence d'habitant dans votre/vos maison(s).</br>Pour cela, il faut dispoer d'une une solution pour indiquer à Gladys votre présence régulière dans la maison. Par exemple, le module gladys-bluetooth permet cela au moyen d'équipement bluetooth. Il faut ensuite déclarer la fréquence de contrôle ainsi que le temps entre la dernière fois que Gladys a vu l'utilisateur à la maison et le moment ou Gladys considère que cet utilisateur a quitté la maison.",
+  "house-box-check-occupation-description": "Vous pouvez définir une fréquence de vérification de la présence d'habitant dans votre/vos maison(s). Pour cela, il faut dispoer d'une une solution pour indiquer à Gladys votre présence régulière dans la maison. Par exemple, le module gladys-bluetooth permet cela au moyen d'équipement bluetooth. Il faut ensuite déclarer la fréquence de contrôle ainsi que le temps entre la dernière fois que Gladys a vu l'utilisateur à la maison et le moment ou Gladys considère que cet utilisateur a quitté la maison.",
   "room-box-title": "Pièces",
   "mode-box-title": "Modes",
   "mode-box-description": "Les modes sont des états que la maison peut prendre. Une maison peut être dans un et un seul mode à la fois.",

--- a/config/locales/fr.json
+++ b/config/locales/fr.json
@@ -350,7 +350,7 @@
   "area-delete": "Supprimer",
   "house-box-title": "Maisons",
   "house-box-description": "Vous pouvez définir ici votre maison dans Gladys. Pour la latitude et la longitude, vous pouvez utiliser Google Maps pour trouver la latitude et la longitude votre maison, et la rentrer au format (par exemple) : latitude = 42.1, longitude = 43.2. Rappel: Toutes ces données restent en locale sur votre machine, et ne sont jamais envoyées nulle part.",
-  "house-box-check-occupation-description": "Vous pouvez définir une fréquence de vérification de la présence d'habitant dans votre/vos maison(s). Pour cela, il faut dispoer d'une une solution pour indiquer à Gladys votre présence régulière dans la maison. Par exemple, le module gladys-bluetooth permet cela au moyen d'équipement bluetooth. Il faut ensuite déclarer la fréquence de contrôle ainsi que le temps entre la dernière fois que Gladys a vu l'utilisateur à la maison et le moment ou Gladys considère que cet utilisateur a quitté la maison.",
+  "house-box-check-occupation-description": "Vous pouvez activer la vérification cyclique de présence d'habitant dans votre/vos maison(s). Pour cela, il faut au paravant dispoer d'une une solution pour indiquer à Gladys votre présence régulière dans la maison. Par exemple, le module gladys-bluetooth permet cela au moyen d'équipement bluetooth. Cette vérification a lieu toutes les minutes par défaut, et Gladys consiidère qu'un habitant a quitté la maison s'il n'a pas été vu depuis 10min. Ces 2 valeurs peuvent être changé par des paramètres USER_CHECK_PRESENCE_FREQUENCY et USER_TIME_BEFORE_CONSIDERING_LEFT_HOME.",
   "room-box-title": "Pièces",
   "mode-box-title": "Modes",
   "mode-box-description": "Les modes sont des états que la maison peut prendre. Une maison peut être dans un et un seul mode à la fois.",
@@ -597,7 +597,5 @@
   "gateway-connecting": "Génération des clés et connexion en cours...",
   "gateway-login-error": "Votre email/mot de passe/code d'authentification à deux facteurs est invalide.",
   "gateway-users-list": "Utilisateurs",
-  "gateway-users-explanation": "Avant de pouvoir contrôler votre Gladys, vous devez accepter ci-dessous les différents utilisateurs et leur clé publique. Grâce à cette sécurité, si le Gateway est compromit, votre instance Gladys n'est pas compromise car aucunes clés n'ayant pas été acceptée ici ne peut contrôler votre instance.",
-  "Time before considering user left": "Durée pour considérer que l'utilisateur a quitté la maison",
-  "Verification frequency": "Fréquence de vérification"
+  "gateway-users-explanation": "Avant de pouvoir contrôler votre Gladys, vous devez accepter ci-dessous les différents utilisateurs et leur clé publique. Grâce à cette sécurité, si le Gateway est compromit, votre instance Gladys n'est pas compromise car aucunes clés n'ayant pas été acceptée ici ne peut contrôler votre instance."
 }

--- a/config/locales/fr.json
+++ b/config/locales/fr.json
@@ -350,9 +350,11 @@
   "area-delete": "Supprimer",
   "house-box-title": "Maisons",
   "house-box-description": "Vous pouvez définir ici votre maison dans Gladys. Pour la latitude et la longitude, vous pouvez utiliser Google Maps pour trouver la latitude et la longitude votre maison, et la rentrer au format (par exemple) : latitude = 42.1, longitude = 43.2. Rappel: Toutes ces données restent en locale sur votre machine, et ne sont jamais envoyées nulle part.",
+  "house-box-check-occupation-description": "Vous pouvez définir une fréquence de vérification de la présence d'habitant dans votre/vos maison(s).</br>Pour cela, il faut dispoer d'une une solution pour indiquer à Gladys votre présence régulière dans la maison. Par exemple, le module gladys-bluetooth permet cela au moyen d'équipement bluetooth. Il faut ensuite déclarer la fréquence de contrôle ainsi que le temps entre la dernière fois que Gladys a vu l'utilisateur à la maison et le moment ou Gladys considère que cet utilisateur a quitté la maison.",
   "room-box-title": "Pièces",
   "mode-box-title": "Modes",
   "mode-box-description": "Les modes sont des états que la maison peut prendre. Une maison peut être dans un et un seul mode à la fois.",
+  "room-box-check-occupation": "Vérification de la présence des habitants",
   "mode-code": "Code",
   "mode-name": "Nom",
   "mode-description": "Description",
@@ -500,6 +502,7 @@
   "tooltip-machine-name": "Donnez un nom à votre machine",
   "tooltip-machine-house-choice": "Sélectionnez la maison dans laquelle se trouve la machine",
   "tooltip-machine-host": "Renseignez l'adresse IP de votre machine",
+  "tooltip-machine-room-choice": "Sélectionnez la pièce dans laquelle se trouve la machine",
   "tooltip-mode-code": "Attribuez un code à votre état, il doit être unique et sans espace",
   "tooltip-mode-name": "Donnez lui un nom",
   "tooltip-mode-description": "Ajoutez une description pour vous",
@@ -549,6 +552,7 @@
   "Edit": "Editer",
   "Create-event": "Créer un événement",
   "New-event": "Nouvel événement",
+  "Never": "Jamais",
   "manage-area": "Gérer les zones",
   "how-create-area": "Comment créer une zone ?",
   "how-create-area-text": "Pour créer une zone faite un clic droit sur la carte à l'endroit où vous souhaitez créer cette zone et cliquez sur le bouton nouvelle zone, puis remplissez les champs.",
@@ -593,5 +597,7 @@
   "gateway-connecting": "Génération des clés et connexion en cours...",
   "gateway-login-error": "Votre email/mot de passe/code d'authentification à deux facteurs est invalide.",
   "gateway-users-list": "Utilisateurs",
-  "gateway-users-explanation": "Avant de pouvoir contrôler votre Gladys, vous devez accepter ci-dessous les différents utilisateurs et leur clé publique. Grâce à cette sécurité, si le Gateway est compromit, votre instance Gladys n'est pas compromise car aucunes clés n'ayant pas été acceptée ici ne peut contrôler votre instance."
+  "gateway-users-explanation": "Avant de pouvoir contrôler votre Gladys, vous devez accepter ci-dessous les différents utilisateurs et leur clé publique. Grâce à cette sécurité, si le Gateway est compromit, votre instance Gladys n'est pas compromise car aucunes clés n'ayant pas été acceptée ici ne peut contrôler votre instance.",
+  "Time before considering user left": "Durée pour considérer que l'utilisateur a quitté la maison",
+  "Verification frequency": "Fréquence de vérification"
 }

--- a/test/unit/api/core/house/house.checkUsersPresencePerHouse.test.js
+++ b/test/unit/api/core/house/house.checkUsersPresencePerHouse.test.js
@@ -1,0 +1,16 @@
+
+describe('House', function() {
+  describe('checkUserPresencePerHouse', function() {
+    it('should check if user is present and not seen since a given time in a given house', function(done) {
+
+      house = {'id': 1};
+
+      gladys.house
+        .checkUsersPresencePerHouse(house)
+        .then(function(result) {
+          done();
+        })
+        .catch(done);
+    });
+  });
+});

--- a/views/partials/houses.ejs
+++ b/views/partials/houses.ejs
@@ -69,31 +69,25 @@
           <%= __('house-box-check-occupation-description') %>
         </p>
 
-        <table id="check_interval" class="table table-bordered table-hover">
-            <thead>
-                <tr>
-                    <th><%= __('Name') %></th>
-                    <th><%= __('Verification') %></th>
-                    <th><%= __('Verification frequency') %></th>
-                    <th><%= __('Time before considering user left') %></th>
+        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
+            <table id="check_interval" class="table table-bordered table-hover">
+                <thead>
+                    <tr>
+                        <th><%= __('Name') %></th>
+                        <th><%= __('Verification') %></th>
+                    </tr>
+                </thead>
+                <tr ng-repeat="house in vm.houses" class="ng-cloak">
+                    <td>{{house.name}}</td>
+                    <td>
+                        <div class="toogle" ng-click="vm.toggleHouseCheck(house)">
+                           <input type="checkbox" ng-model="house.check" class="toogle-checkbox toogle-blue" ng-true-value="1" ng-false-value="0"/>
+                            <label class="toogle-label" for="mytoogle"></label>
+                        </div>
+                    </td>
                 </tr>
-            </thead>
-            <tr ng-repeat="house in vm.houses" class="ng-cloak">
-                <td>{{house.name}}</td>
-                <td>
-                    <div class="toogle" ng-click="vm.toggleHouseCheck(house)">
-                       <input type="checkbox" ng-model="house.check" class="toogle-checkbox toogle-blue" ng-true-value="1" ng-false-value="0"/>
-                        <label class="toogle-label" for="mytoogle"></label>
-                    </div>
-                </td>
-                <td>
-                    <input type="text" class="form-control" ng-disabled="!house.check" ng-change="vm.updateHouse(house)" ng-model="house.check_interval" />
-                </td>
-                <td>
-                    <input type="text" class="form-control" ng-disabled="!house.check" ng-change="vm.updateHouse(house)" ng-model="house.time_before_left" />
-                </td>
-            </tr>
-        </table>
+            </table>
+        </div>
     </div>
 </div>
 

--- a/views/partials/houses.ejs
+++ b/views/partials/houses.ejs
@@ -69,36 +69,31 @@
           <%= __('house-box-check-occupation-description') %>
         </p>
 
-        <div class="row">
-            <div class="col-sm-12 col-xs-12 col-md-8 col-lg-6">
-            
-                <table id="check_interval" class="table table-bordered table-hover">
-                    <thead>
-                        <tr>
-                            <th><%= __('Name') %></th>
-                            <th><%= __('Verification') %></th>
-                            <th><%= __('Verification frequency') %></th>
-                            <th><%= __('Time before considering user left') %></th>
-                        </tr>
-                    </thead>
-                    <tr ng-repeat="house in vm.houses" class="ng-cloak">
-                        <td>{{house.name}}</td>
-                        <td>
-                            <div class="toogle" ng-click="vm.toggleHouseCheck(house)">
-                               <input type="checkbox" ng-model="house.check" class="toogle-checkbox toogle-blue" ng-true-value="1" ng-false-value="0"/>
-                                <label class="toogle-label" for="mytoogle"></label>
-                            </div>
-                        </td>
-                        <td>
-                            <input type="text" class="form-control" ng-disabled="!house.check" ng-change="vm.updateHouse(house)" ng-model="house.check_interval" />
-                        </td>
-                        <td>
-                            <input type="text" class="form-control" ng-disabled="!house.check" ng-change="vm.updateHouse(house)" ng-model="house.time_before_left" />
-                        </td>
-                    </tr>
-                </table>
-            </div>
-        </div>
+        <table id="check_interval" class="table table-bordered table-hover">
+            <thead>
+                <tr>
+                    <th><%= __('Name') %></th>
+                    <th><%= __('Verification') %></th>
+                    <th><%= __('Verification frequency') %></th>
+                    <th><%= __('Time before considering user left') %></th>
+                </tr>
+            </thead>
+            <tr ng-repeat="house in vm.houses" class="ng-cloak">
+                <td>{{house.name}}</td>
+                <td>
+                    <div class="toogle" ng-click="vm.toggleHouseCheck(house)">
+                       <input type="checkbox" ng-model="house.check" class="toogle-checkbox toogle-blue" ng-true-value="1" ng-false-value="0"/>
+                        <label class="toogle-label" for="mytoogle"></label>
+                    </div>
+                </td>
+                <td>
+                    <input type="text" class="form-control" ng-disabled="!house.check" ng-change="vm.updateHouse(house)" ng-model="house.check_interval" />
+                </td>
+                <td>
+                    <input type="text" class="form-control" ng-disabled="!house.check" ng-change="vm.updateHouse(house)" ng-model="house.time_before_left" />
+                </td>
+            </tr>
+        </table>
     </div>
 </div>
 

--- a/views/partials/houses.ejs
+++ b/views/partials/houses.ejs
@@ -9,7 +9,7 @@
 <div class="box-body table-responsive">
 
     <p>
-        <%= __('house-box-description') %>
+      <%= __('house-box-description') %>
     </p>
 
     <table id="example2" class="table table-bordered table-hover">
@@ -51,12 +51,58 @@
             </tr>
         </tbody>
     </table>
-    
   </div>
   
 </div>
 
 <!-- END OF HOUSE BOX -->
+
+<!-- CHECK OCCUPATION IN HOUSE BOX -->
+ <div class="box skin-box box-primary">
+    <div class="box-header with-border">
+        <h3 class="box-title"><%= __('room-box-check-occupation') %></h3>
+    </div>
+
+    <div class="box-body table-responsive">
+
+        <p>
+          <%= __('house-box-check-occupation-description') %>
+        </p>
+
+        <div class="row">
+            <div class="col-sm-12 col-xs-12 col-md-8 col-lg-6">
+            
+                <table id="check_interval" class="table table-bordered table-hover">
+                    <thead>
+                        <tr>
+                            <th><%= __('Name') %></th>
+                            <th><%= __('Verification') %></th>
+                            <th><%= __('Verification frequency') %></th>
+                            <th><%= __('Time before considering user left') %></th>
+                        </tr>
+                    </thead>
+                    <tr ng-repeat="house in vm.houses" class="ng-cloak">
+                        <td>{{house.name}}</td>
+                        <td>
+                            <div class="toogle" ng-click="vm.toggleHouseCheck(house)">
+                               <input type="checkbox" ng-model="house.check" class="toogle-checkbox toogle-blue" ng-true-value="1" ng-false-value="0"/>
+                                <label class="toogle-label" for="mytoogle"></label>
+                            </div>
+                        </td>
+                        <td>
+                            <input type="text" class="form-control" ng-disabled="!house.check" ng-change="vm.updateHouse(house)" ng-model="house.check_interval" />
+                        </td>
+                        <td>
+                            <input type="text" class="form-control" ng-disabled="!house.check" ng-change="vm.updateHouse(house)" ng-model="house.time_before_left" />
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!--END OF BOX OCCUPATION -->
 
 <!-- NEW BOX -->
 <div class="box skin-box box-primary">


### PR DESCRIPTION
### Gladys Pull Request check-list

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing?
- [x Is the linter (eslint) passing?
- [-] If your changes modify the API (REST or Node.js), did you modify the documentation?

### Description of change

I've included the check user presence in house, by adding 2 parameters in house model (check frequency and time before considering left), and can be different per house.

User won't need anymore to add an alarm, triggering a scenario which run a script  (with a specific  parameter set).

User just have to activate the check on a house, and change the value if needed.

By the way, I let the old feature active so nobody gonna loose working stuff.

Here is a screen on how it's implemented in the house view:
![screenshot_20181030_223443](https://user-images.githubusercontent.com/14221237/47752190-13c8d700-dc94-11e8-9dc2-40e26e29de14.png)
