### PR TITLE
add event purge by type

### DIFF
--- a/api/core/event/event.purgeByEventtype.js
+++ b/api/core/event/event.purgeByEventtype.js
@@ -22,7 +22,7 @@ var queries = require('./event.queries.js');
 
 module.exports = function purge(options) {
 
-    options.days = parseInt(options.days) || 10;
-    return gladys.utils.sql(queries.purgeByEventType, [options.days, options.eventtype]);
+  options.days = parseInt(options.days) || 10;
+  return gladys.utils.sql(queries.purgeByEventType, [options.days, options.eventtype]);
 };
 

--- a/api/core/event/event.purgeByEventtype.js
+++ b/api/core/event/event.purgeByEventtype.js
@@ -1,0 +1,28 @@
+var queries = require('./event.queries.js');
+
+/**
+ * @public
+ * @description This function purge all events on a specific eventtype code and older than days 
+ * @name gladys.event.purgeByEventType
+ * @param {Object} options
+ * @param {integer} options.eventtype The code of eventtype we want to purge
+ * @param {integer} options.days The days we want to keep for this kind of event (optionnal)
+ * @returns {event} event
+ * @example
+ * var options = {
+ *      days: 2,
+ *      eventtype: 'devicetype-new-value'
+ * }
+ * gladys.event.purgeByEventType(options)
+ *      .then(function(events){
+ *          // do something
+ *      })
+ */
+
+
+module.exports = function purge(options) {
+
+    options.days = parseInt(options.days) || 10;
+    return gladys.utils.sql(queries.purgeByEventType, [options.days, options.eventtype]);
+};
+

--- a/api/core/event/event.queries.js
+++ b/api/core/event/event.queries.js
@@ -14,5 +14,13 @@ module.exports = {
   purge: `
         DELETE FROM event
         WHERE datetime < NOW() - INTERVAL ? DAY;
+    `,
+  purgeByEventType: `
+        DELETE FROM event
+        USING event, eventtype
+        WHERE event.eventtype = eventtype.id
+        AND event.datetime < NOW() - INTERVAL ? DAY
+        AND eventtype.code = ?
     `
+
 };

--- a/api/core/event/index.js
+++ b/api/core/event/index.js
@@ -11,3 +11,4 @@ module.exports.get = require('./event.get.js');
 module.exports.getByEventType = require('./event.getByEventtype.js');
 module.exports.update = require('./event.update.js');
 module.exports.purge = require('./event.purge.js');
+module.exports.purgeByEventType = require('./event.purgeByEventtype.js');

--- a/test/fixtures/eventtype.json
+++ b/test/fixtures/eventtype.json
@@ -1,6 +1,6 @@
 [
 	{ 
-        "id": 1,
+                "id": 1,
 		"code": "test", 
 		"name": "test", 
 		"service": "test",
@@ -9,7 +9,7 @@
 		"iconColor": "bg-black"
 	},
 	{ 
-        "id": 2,
+                "id": 2,
 		"code": "wakeup", 
 		"name": "Gladys updated", 
 		"service": "test",

--- a/test/unit/api/core/event/event.purgeByEventtype.test.js
+++ b/test/unit/api/core/event/event.purgeByEventtype.test.js
@@ -2,8 +2,8 @@
 var validateEvent = require('../../validator/eventValidator.js');
 
 describe('Event', function() {
-  describe('purge', function() {
-    it('should return 1 event', function(done) {
+  describe('purgeByEventType', function() {
+    it('should return 6 events', function(done) {
       var event = {
         params: {
           eventtype: 3,
@@ -17,10 +17,11 @@ describe('Event', function() {
         .create(event)
         .then(function(result) {
           var options = {
-            days: 1
+            days: 1,
+            eventtype: 'devicetype-new-value'
           };
 
-          return gladys.event.purge(options);
+          return gladys.event.purgeByEventType(options);
         })
         .then(function() {
           return gladys.event.get({
@@ -32,7 +33,7 @@ describe('Event', function() {
         .then(function(result) {
           validateEvent(result);
           result.should.be.instanceof(Array);
-          result.should.have.length(1);
+          result.should.have.length(6);
           done();
         })
         .catch(done);


### PR DESCRIPTION
### Gladys Pull Request check-list

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing?
- [x] Is the linter (eslint) passing?
- [x] If your changes modify the API (REST or Node.js), did you modify the documentation?

### Description of change

I've added a event.purgeByEventType because we don't always want to purge all events with the same rules.