### PR TITLE
Specify utf8 when creating mysql db for dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To do so, you'll have to create a `.env` file at the root of this project. The c
 **Note :** You will need to create the database as well in MySQL:
 
 ```sql
-CREATE DATABASE gladys; -- or whatever name you've set in your .env file.`
+CREATE DATABASE gladys CHARACTER SET utf8 COLLATE utf8_general_ci; -- or whatever name you've set in your .env file.`
 ```
 
 #### Compile assets


### PR DESCRIPTION
### Gladys Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [_not applicable_] If your changes affects code, did your write the tests?
- [_not applicable_] Are tests passing?
- [_not applicable_] Is the linter (eslint) passing?
- [_not applicable_] If your changes modify the API (REST or Node.js), did you modify the documentation?

### Description of change

Update of the README file. When we create a mysql database for the dev mode, we have to specify `utf8` to avoid an error like `ER_TOO_LONG_KEY: Specified key was too long; max key length is 767 bytes` or as [seen here](https://community.gladysproject.com/t/erreur-lors-de-linstallation-gladys-access-denied-mysql/2551).
