### PR TITLE
Fix undefined module slug in the tmp folder

### DIFF
--- a/api/core/module/module.install.js
+++ b/api/core/module/module.install.js
@@ -74,7 +74,7 @@ function npmInstall(path){
 
 function copyAssets(modulePath, slug) {
   var assetsDestinationProd = './www/hooks/' + slug;
-  var assetsDestinationProdTmp = './.tmp/public/hooks/' + module.slug;
+  var assetsDestinationProdTmp = './.tmp/public/hooks/' + slug;
   var assetsDestinationDev = './assets/hooks/' + slug;
 
   // we test if the module has an assets folder


### PR DESCRIPTION
Fix undefined module slug when assets are copied in the tmp folder 🙂 