### PR TITLE
🐳 Update .dockerignore to fix docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,4 +19,3 @@ node.d.ts
 .git
 .npmrc
 docker
-docker_tmp


### PR DESCRIPTION
### Description of change

This is a fix for docker build in travis, behavior have changed in latest version of docker.

So removed `docker_tmp` from .dockerignore to prevent COPY error when building image

https://travis-ci.org/VonOx/Gladys-trytravis/jobs/489605650
