### PR TITLE
Fix zWave port listing and binding

### DIFF
--- a/front/src/routes/integration/all/zwave/settings-page/SettingsTab.jsx
+++ b/front/src/routes/integration/all/zwave/settings-page/SettingsTab.jsx
@@ -26,7 +26,7 @@ const SettingsTab = ({ children, ...props }) => (
               </option>
               {props.usbPorts &&
                 props.usbPorts.map(usbPort => (
-                  <option selected={props.zwaveDriverPath === usbPort.comName}>{usbPort.comName}</option>
+                  <option value={usbPort.comPath} selected={props.zwaveDriverPath === usbPort.comPath}>{usbPort.comName}</option>
                 ))}
             </select>
           </div>

--- a/front/src/routes/integration/all/zwave/settings-page/SettingsTab.jsx
+++ b/front/src/routes/integration/all/zwave/settings-page/SettingsTab.jsx
@@ -26,7 +26,9 @@ const SettingsTab = ({ children, ...props }) => (
               </option>
               {props.usbPorts &&
                 props.usbPorts.map(usbPort => (
-                  <option value={usbPort.comPath} selected={props.zwaveDriverPath === usbPort.comPath}>{usbPort.comName}</option>
+                  <option value={usbPort.comPath} selected={props.zwaveDriverPath === usbPort.comPath}>
+                    {usbPort.comName}
+                  </option>
                 ))}
             </select>
           </div>

--- a/server/services/usb/api/usb.controller.js
+++ b/server/services/usb/api/usb.controller.js
@@ -8,7 +8,13 @@ module.exports = function UsbController({ list }) {
    */
   async function getUsbPorts(req, res) {
     const ports = await list();
-    res.json(ports);
+
+    res.json(ports.map(function(port){
+      return {
+        comPath: port.path,
+        comName: port.path
+      };
+    }));
   }
 
   return {

--- a/server/services/usb/api/usb.controller.js
+++ b/server/services/usb/api/usb.controller.js
@@ -9,12 +9,14 @@ module.exports = function UsbController({ list }) {
   async function getUsbPorts(req, res) {
     const ports = await list();
 
-    res.json(ports.map(function(port){
-      return {
-        comPath: port.path,
-        comName: port.path
-      };
-    }));
+    res.json(
+      ports.map(function(port) {
+        return {
+          comPath: port.path,
+          comName: port.path,
+        };
+      }),
+    );
   }
 
   return {

--- a/server/services/usb/index.js
+++ b/server/services/usb/index.js
@@ -20,15 +20,7 @@ module.exports = function ZwaveService(gladys, serviceId) {
    * gladys.services.usb.list();
    */
   async function list() {
-    return new Promise((resolve, reject) => {
-      SerialPort.list((err, ports) => {
-        if (err) {
-          return reject(err);
-        }
-
-        return resolve(ports);
-      });
-    });
+    return SerialPort.list();
   }
 
   /**

--- a/server/test/services/usb/SerialPortMock.test.js
+++ b/server/test/services/usb/SerialPortMock.test.js
@@ -16,8 +16,10 @@ const ports = [
   },
 ];
 
-SerialPort.list = (callback) => {
-  callback(null, ports);
+SerialPort.list = () => {
+  return new Promise((resolve, reject) => {
+    resolve(ports);
+  }) 
 };
 
 module.exports = SerialPort;

--- a/server/test/services/usb/SerialPortMock.test.js
+++ b/server/test/services/usb/SerialPortMock.test.js
@@ -19,7 +19,7 @@ const ports = [
 SerialPort.list = () => {
   return new Promise((resolve, reject) => {
     resolve(ports);
-  }) 
+  });
 };
 
 module.exports = SerialPort;

--- a/server/test/services/usb/index.test.js
+++ b/server/test/services/usb/index.test.js
@@ -13,12 +13,7 @@ describe('usb', () => {
     expect(ports).to.deep.equal([
       {
         comName: '/dev/tty.HC-05-DevB',
-        manufacturer: undefined,
-        serialNumber: undefined,
-        pnpId: undefined,
-        locationId: undefined,
-        vendorId: undefined,
-        productId: undefined,
+        comPath: '/dev/tty.HC-05-DevB',
       },
     ]);
   });

--- a/server/test/services/usb/index.test.js
+++ b/server/test/services/usb/index.test.js
@@ -13,7 +13,12 @@ describe('usb', () => {
     expect(ports).to.deep.equal([
       {
         comName: '/dev/tty.HC-05-DevB',
-        comPath: '/dev/tty.HC-05-DevB',
+        manufacturer: undefined,
+        serialNumber: undefined,
+        pnpId: undefined,
+        locationId: undefined,
+        vendorId: undefined,
+        productId: undefined,
       },
     ]);
   });


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] ~If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~
- [x] ~If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/gladys-4-docs) and the [website](https://documentation.gladysassistant.com).~
- [x] ~Did you add fake requests data for the demo mode (`front/src/config/demo.json`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).~

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

The request to list available ports to select the zWave USB stick remains unfinished.
This is because of a BC in SerialPort: the list method is now returning a Promise and doesn't support the callback parameter. See here: https://github.com/serialport/node-serialport/blob/master/UPGRADE_GUIDE.md#upgrading-from-7x-to-8x

In the BC, the `comName` field is now named `path`.

By the way, this PR also fix an issue when selecting a value in the selector and clicking "Connect": the value sent to the server was an empty string.
