### PR TITLE
Some fixes: zWave device integration and BinaryDeviceFeature component

### DIFF
--- a/front/src/components/boxs/device-in-room/device-features/BinaryDeviceFeature.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/BinaryDeviceFeature.jsx
@@ -7,7 +7,7 @@ const BinaryDeviceType = ({ children, ...props }) => {
       props.deviceFeature,
       props.deviceIndex,
       props.deviceFeatureIndex,
-      props.deviceFeature.last_value === 1 ? 0 : 1
+      !props.deviceFeature.last_value
     );
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gladys",
-  "version": "4.0.0",
+  "version": "4.0.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/server/lib/device/device.setValue.js
+++ b/server/lib/device/device.setValue.js
@@ -19,7 +19,7 @@ async function setValue(device, deviceFeature, value) {
     throw new NotFoundError(`Function device.setValue in service ${device.service.name} does not exist.`);
   }
   await service.device.setValue(device, deviceFeature, value);
-  if (!deviceFeature.has_state_feedback) {
+  if (!deviceFeature.has_feedback) {
     await this.saveState(deviceFeature, value);
   }
 }

--- a/server/lib/gateway/gateway.forwardWebsockets.js
+++ b/server/lib/gateway/gateway.forwardWebsockets.js
@@ -10,6 +10,12 @@ const logger = require('../../utils/logger');
  * });
  */
 async function forwardWebsockets(event) {
+  if (!this.connected) {
+    logger.debug('Gateway: not connected. Prevent forwarding event.');
+
+    return;
+  }
+
   logger.debug(`Gateway : Forward websocket message : ${event.type}`);
   try {
     if (event.userId) {

--- a/server/services/zwave/index.js
+++ b/server/services/zwave/index.js
@@ -35,6 +35,7 @@ module.exports = function ZwaveService(gladys, serviceId) {
   return Object.freeze({
     start,
     stop,
+    device: zwaveManager,
     controllers: ZwaveController(gladys, zwaveManager, serviceId),
   });
 };

--- a/server/services/zwave/lib/index.js
+++ b/server/services/zwave/lib/index.js
@@ -22,6 +22,7 @@ const { getInfos } = require('./commands/zwave.getInfos');
 const { getNodes } = require('./commands/zwave.getNodes');
 const { getNodeNeighbors } = require('./commands/zwave.getNodeNeighbors');
 const { removeNode } = require('./commands/zwave.removeNode');
+const { setValue } = require('./commands/zwave.setValue');
 
 const DEFAULT_ZWAVE_OPTIONS = {
   Logging: false,
@@ -74,5 +75,6 @@ ZwaveManager.prototype.getInfos = getInfos;
 ZwaveManager.prototype.getNodes = getNodes;
 ZwaveManager.prototype.getNodeNeighbors = getNodeNeighbors;
 ZwaveManager.prototype.removeNode = removeNode;
+ZwaveManager.prototype.setValue = setValue;
 
 module.exports = ZwaveManager;

--- a/server/test/lib/gateway/GladysGatewayClientMock.test.js
+++ b/server/test/lib/gateway/GladysGatewayClientMock.test.js
@@ -1,60 +1,53 @@
 const fs = require('fs');
 const { fake } = require('sinon');
 
-class GladysGatewayClientMock {}
-
-GladysGatewayClientMock.prototype.login = fake.resolves({
-  two_factor_token: 'token',
-});
-
-// AUTHENTICATION
-GladysGatewayClientMock.prototype.loginInstance = fake.resolves({});
-GladysGatewayClientMock.prototype.createInstance = fake.resolves({
-  instance: {
-    id: '25239392-debf-40c9-9363-fc8d3b9ebbbe',
-    refresh_token: 'token',
-  },
-  rsaPrivateKeyJwk: {},
-  ecdsaPrivateKeyJwk: {},
-  rsaPublicKeyJwk: {},
-  ecdsaPublicKeyJwk: {},
-});
-GladysGatewayClientMock.prototype.instanceConnect = fake.resolves({});
-
-// BACKUPS
-GladysGatewayClientMock.prototype.uploadBackup = fake.resolves({
-  success: true,
-});
-
-GladysGatewayClientMock.prototype.getBackups = fake.resolves([
-  {
-    id: '74dc8d58-3997-484a-a791-53e5b07279d7',
-    account_id: 'b2d23f66-487d-493f-8acb-9c8adb400def',
-    path: 'http://backup-url',
-    size: 1000,
-    created_at: '2018-10-16T02:21:25.901Z',
-    updated_at: '2018-10-16T02:21:25.901Z',
-    is_deleted: false,
-  },
-]);
-
-GladysGatewayClientMock.prototype.downloadBackup = (backupUrl, writeStream) => {
-  const readStream = fs.createReadStream(backupUrl);
-  readStream.pipe(writeStream);
-  return new Promise((resolve, reject) => {
-    writeStream.on('finish', resolve);
-    writeStream.on('error', reject);
-  });
+const GladysGatewayClientMock = function() {
+  return {
+    login: fake.resolves({
+      two_factor_token: 'token',
+    }),
+    loginInstance: fake.resolves({}),
+    createInstance: fake.resolves({
+      instance: {
+        id: '25239392-debf-40c9-9363-fc8d3b9ebbbe',
+        refresh_token: 'token',
+      },
+      rsaPrivateKeyJwk: {},
+      ecdsaPrivateKeyJwk: {},
+      rsaPublicKeyJwk: {},
+      ecdsaPublicKeyJwk: {},
+    }),
+    instanceConnect: fake.resolves({}),
+    uploadBackup: fake.resolves({
+      success: true,
+    }),
+    getBackups: fake.resolves([
+      {
+        id: '74dc8d58-3997-484a-a791-53e5b07279d7',
+        account_id: 'b2d23f66-487d-493f-8acb-9c8adb400def',
+        path: 'http://backup-url',
+        size: 1000,
+        created_at: '2018-10-16T02:21:25.901Z',
+        updated_at: '2018-10-16T02:21:25.901Z',
+        is_deleted: false,
+      },
+    ]),
+    downloadBackup: (backupUrl, writeStream) => {
+      const readStream = fs.createReadStream(backupUrl);
+      readStream.pipe(writeStream);
+      return new Promise((resolve, reject) => {
+        writeStream.on('finish', resolve);
+        writeStream.on('error', reject);
+      });
+    },
+    getLatestGladysVersion: fake.resolves({
+      name: 'v4.0.0-alpha',
+      created_at: '2018-10-16T02:21:25.901Z',
+    }),
+    disconnect: fake.returns(null),
+    newEventInstance: fake.returns(null),
+    generateFingerprint: fake.resolves('fingerprint'),
+  };
 };
-
-GladysGatewayClientMock.prototype.getLatestGladysVersion = fake.resolves({
-  name: 'v4.0.0-alpha',
-  created_at: '2018-10-16T02:21:25.901Z',
-});
-
-GladysGatewayClientMock.prototype.disconnect = fake.returns(null);
-
-GladysGatewayClientMock.prototype.newEventInstance = fake.returns(null);
-GladysGatewayClientMock.prototype.generateFingerprint = fake.resolves('fingerprint');
 
 module.exports = GladysGatewayClientMock;

--- a/server/test/lib/gateway/gateway.test.js
+++ b/server/test/lib/gateway/gateway.test.js
@@ -136,15 +136,25 @@ describe('gateway', () => {
     });
   });
   describe('gateway.forwardWebsockets', () => {
-    it('should forward a websocket message', async () => {
+    it('should forward a websocket message when connected', async () => {
       const gateway = new Gateway({}, event, system, sequelize, config);
-      await gateway.login('tony.stark@gladysassistant.com', 'warmachine123');
+      gateway.connected = true;
       const websocketMessage = {
         type: 'zwave.new-node',
         payload: {},
       };
       gateway.forwardWebsockets(websocketMessage);
       assert.calledWith(gateway.gladysGatewayClient.newEventInstance, websocketMessage.type, websocketMessage.payload);
+    });
+    it('should prevent forwarding a websocket message when not connected', async () => {
+      const gateway = new Gateway({}, event, system, sequelize, config);
+
+      const websocketMessage = {
+        type: 'zwave.new-node',
+        payload: {},
+      };
+      gateway.forwardWebsockets(websocketMessage);
+      assert.notCalled(gateway.gladysGatewayClient.newEventInstance);
     });
   });
 

--- a/server/test/lib/gateway/gateway.test.js
+++ b/server/test/lib/gateway/gateway.test.js
@@ -136,9 +136,10 @@ describe('gateway', () => {
     });
   });
   describe('gateway.forwardWebsockets', () => {
-    it('should forward a websocket message when connected', async () => {
+    it('should forward a websocket message when connected', () => {
       const gateway = new Gateway({}, event, system, sequelize, config);
       gateway.connected = true;
+
       const websocketMessage = {
         type: 'zwave.new-node',
         payload: {},
@@ -146,7 +147,7 @@ describe('gateway', () => {
       gateway.forwardWebsockets(websocketMessage);
       assert.calledWith(gateway.gladysGatewayClient.newEventInstance, websocketMessage.type, websocketMessage.payload);
     });
-    it('should prevent forwarding a websocket message when not connected', async () => {
+    it('should prevent forwarding a websocket message when not connected', () => {
       const gateway = new Gateway({}, event, system, sequelize, config);
 
       const websocketMessage = {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- ~[ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~
- ~[ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/gladys-4-docs) and the [website](https://documentation.gladysassistant.com).~
- ~[ ] Did you add fake requests data for the demo mode (`front/src/config/demo.json`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).~

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

This PR initially was intended to fix the Device.setValue call for zWave devices. But, making tests with a real BinarySwitch device I identified another issue with the BinarySwitch front component and the Gateway forwarder.

Changes:

 * Add the zWaveManager instance as the device property of zwave service (following the PhilipsHueService and its handler scheme)
 * An error on device feature test about setValue feedback
 * BinaryDeviceFeature: a mix between bool and int making impossible to Switch On then Switch Off the device
 * Do not try to Forward messages to the Gateway when not connected to it