### PR TITLE
Import OpenZwave DB from Github

### DIFF
--- a/.circleci/build-image.sh
+++ b/.circleci/build-image.sh
@@ -15,6 +15,12 @@ fi
 # </qemu-support>
 # ============
 
+# ============
+# <zwave-db>
+git clone https://github.com/OpenZWave/open-zwave.git open-zwave
+# </zwave-db>
+# ============
+
 # Replace the repo's Dockerfile with our own.
 docker build -f ./docker/Dockerfile \
   -t ${IMAGE_ID} \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,10 @@ COPY qemu-* /usr/bin/
 # System dependencies
 RUN apk add --no-cache tzdata nmap openzwave-dev openzwave-libs openzwave ffmpeg sqlite openssl gzip
 
+# Update Open-zWave DB
+RUN rm -rf /etc/openzwave/* 
+COPY open-zwave/config/* /etc/openzwave/
+
 RUN mkdir /src
 WORKDIR /src
 ADD . /src


### PR DESCRIPTION
### Description of change

Following the 2 comments in #614 here is a first PR about upgrading the OpenZwave DB but staying on the 1.4 OpenZwave version.
I don't think it would impact anything in code... just newer and recent devices will now be recognized.

Another PR is coming (tomorrow or after) to move on OpenZWave 1.6 (or not...);

I don't know where your script to generate the RPI Image reside. Let me know so I can update it too.

Thanks!