### PR TITLE
Fix #628 - Add LWG004 Hue white spot model

### DIFF
--- a/server/services/philips-hue/lib/light/light.getLights.js
+++ b/server/services/philips-hue/lib/light/light.getLights.js
@@ -44,6 +44,7 @@ async function getLights() {
           break;
         case 'LWB010': // hue white bulb with fixed warming light (2700K)
         case 'LWB006': // Hue white lamp
+        case 'LWG004': // Hue white spot
           lightsToReturn.push(getPhilipsHueWhiteLight(philipsHueLight, serialNumber, this.serviceId));
           break;
         case 'LTW012': // hue White Ambiance E12

--- a/server/test/services/philips-hue/lights.json
+++ b/server/test/services/philips-hue/lights.json
@@ -780,6 +780,52 @@
       },
       "_id": 18,
       "id": 18
+    },
+    {
+      "state": {
+        "on": false,
+        "bri": 254,
+        "alert": "select",
+        "mode": "homeautomation",
+        "reachable": true
+      },
+      "swupdate": {
+        "state": "noupdates",
+        "lastinstall": "2019-12-08T10:01:06"
+      },
+      "type": "Dimmable light",
+      "name": "spot évier 1",
+      "modelid": "LWG004",
+      "manufacturername": "Philips",
+      "productname": "Hue white spot",
+      "_rawData": {
+        "capabilities": {
+          "certified": true,
+          "control": {
+            "mindimlevel": 2000,
+            "maxlumen": 400
+          },
+          "streaming": {
+            "renderer": false,
+            "proxy": false
+          }
+        },
+        "config": {
+          "archetype": "spotbulb",
+          "function": "functional",
+          "direction": "downwards",
+          "startup": {
+            "mode": "safety",
+            "configured": true
+          }
+        },
+        "uniqueid": "00:17:88:01:08:3c:6e:b7-0b",
+        "swversion": "1.55.7_r28193",
+        "swconfigid": "A7C27E3B",
+        "productid": "Philips-LWG004-1-GU10DLv2"
+      },
+      "_id": 19,
+      "id": 19
     }
   ]
 }


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [x] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/gladys-4-docs) and the [website](https://documentation.gladysassistant.com).
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.json`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Just adding LWG004 Hue white spot model on Hue service ligth mapping