### PR TITLE
fix #650 - Add IKEA TRADFRI lights 

### DIFF
--- a/server/services/philips-hue/lib/light/light.getLights.js
+++ b/server/services/philips-hue/lib/light/light.getLights.js
@@ -45,6 +45,8 @@ async function getLights() {
         case 'LWB010': // hue white bulb with fixed warming light (2700K)
         case 'LWB006': // Hue white lamp
         case 'LWG004': // Hue white spot
+        case 'TRADFRI bulb E14 W op/ch 400lm': // IKEA white spot
+        case 'TRADFRI bulb E27 W opal 1000lm': // IKEA white lamp
           lightsToReturn.push(getPhilipsHueWhiteLight(philipsHueLight, serialNumber, this.serviceId));
           break;
         case 'LTW012': // hue White Ambiance E12

--- a/server/test/services/philips-hue/lights.json
+++ b/server/test/services/philips-hue/lights.json
@@ -826,6 +826,80 @@
       },
       "_id": 19,
       "id": 19
+    },
+    {
+      "state": {
+        "on": false,
+        "bri": 1,
+        "alert": "select",
+        "mode": "homeautomation",
+        "reachable": true
+      },
+      "swupdate": {
+        "state": "notupdatable",
+        "lastinstall": null
+      },
+      "type": "Dimmable light",
+      "name": "Couloir 1",
+      "modelid": "TRADFRI bulb E27 W opal 1000lm",
+      "manufacturername": "IKEA of Sweden",
+      "productname": "Dimmable light",
+      "_rawData": {
+        "capabilities": {
+          "certified": false,
+          "control": {},
+          "streaming": {
+            "renderer": false,
+            "proxy": false
+          }
+        },
+        "config": {
+          "archetype": "classicbulb",
+          "function": "functional",
+          "direction": "omnidirectional"
+        },
+        "uniqueid": "00:0b:57:ff:fe:b7:e9:fd-01",
+        "swversion": "1.2.214"
+      },
+      "_id": 20,
+      "id": 20
+    },
+    {
+      "state": {
+        "on": true,
+        "bri": 86,
+        "alert": "select",
+        "mode": "homeautomation",
+        "reachable": false
+      },
+      "swupdate": {
+        "state": "notupdatable",
+        "lastinstall": "2019-07-13T18:43:10"
+      },
+      "type": "Dimmable light",
+      "name": "E14 1 sdb",
+      "modelid": "TRADFRI bulb E14 W op/ch 400lm",
+      "manufacturername": "IKEA of Sweden",
+      "productname": "Dimmable light",
+      "_rawData": {
+        "capabilities": {
+          "certified": false,
+          "control": {},
+          "streaming": {
+            "renderer": false,
+            "proxy": false
+          }
+        },
+        "config": {
+          "archetype": "candlebulb",
+          "function": "functional",
+          "direction": "omnidirectional"
+        },
+        "uniqueid": "00:0d:6f:ff:fe:a9:33:90-01",
+        "swversion": "1.2.214"
+      },
+      "_id": 21,
+      "id": 21
     }
   ]
 }


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [x] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/gladys-4-docs) and the [website](https://documentation.gladysassistant.com).
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.json`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Just adding TRADFRI bulb E14 model and TRADFRI bulb E27 model on Hue service ligth mapping
