### PR TITLE
Fix #661: no value for motion on dashboard

### DIFF
--- a/front/src/components/boxs/device-in-room/device-features/SensorDeviceFeature.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/SensorDeviceFeature.jsx
@@ -48,9 +48,11 @@ const SensorDeviceType = ({ children, ...props }) => (
     )}
     {props.deviceFeature.category === DEVICE_FEATURE_CATEGORIES.MOTION_SENSOR && (
       <td class="text-right">
-        {dayjs(props.deviceFeature.last_value_changed)
-          .locale(props.user.language)
-          .fromNow()}
+        {!props.deviceFeature.last_value_changed && <Text id="dashboard.boxes.devicesInRoom.noValue" />}
+        {props.deviceFeature.last_value_changed &&
+          dayjs(props.deviceFeature.last_value_changed)
+            .locale(props.user.language)
+            .fromNow()}
       </td>
     )}
   </tr>


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- ~~[ ] If your changes affects code, did your write the tests?~~
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- ~~[ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~~
- ~~[ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/gladys-4-docs) and the [website](https://documentation.gladysassistant.com).~~
- ~~[ ] Did you add fake requests data for the demo mode (`front/src/config/demo.json`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).~~

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Fix missing value for motion sensor on dashboard.

![image](https://user-images.githubusercontent.com/1839717/76702596-2b5b0100-66cb-11ea-84b2-593395c47ea9.png)
