### PR TITLE
Fix #576 Map - Fit zoom to markers

### DIFF
--- a/front/src/routes/map/Map.jsx
+++ b/front/src/routes/map/Map.jsx
@@ -89,7 +89,7 @@ class MapComponent extends Component {
     this.displayUsers();
     if (markerArray.length >= 1) {
     var group = leaflet.featureGroup(markerArray);
-    this.leafletMap.fitBounds(group.getBounds(), {padding: [25, 25]});
+    this.leafletMap.fitBounds(group.getBounds(), { padding: [25, 25] });
     }
   }
 

--- a/front/src/routes/map/Map.jsx
+++ b/front/src/routes/map/Map.jsx
@@ -42,7 +42,7 @@ class MapComponent extends Component {
               zIndexOffset: 1000
             })
             .addTo(this.leafletMap);
-            markerArray.push(this.userMarkers[user.id]);
+          markerArray.push(this.userMarkers[user.id]);
         }
       });
     }
@@ -64,7 +64,7 @@ class MapComponent extends Component {
               })
             })
             .addTo(this.leafletMap);
-            markerArray.push(this.houseMarkers[house.id]);
+          markerArray.push(this.houseMarkers[house.id]);
         }
       });
     }
@@ -88,8 +88,8 @@ class MapComponent extends Component {
     this.displayHouses();
     this.displayUsers();
     if (markerArray.length >= 1) {
-    var group = leaflet.featureGroup(markerArray);
-    this.leafletMap.fitBounds(group.getBounds(), { padding: [25, 25] });
+      var group = leaflet.featureGroup(markerArray);
+      this.leafletMap.fitBounds(group.getBounds(), { padding: [25, 25] });
     }
   }
 

--- a/front/src/routes/map/Map.jsx
+++ b/front/src/routes/map/Map.jsx
@@ -4,6 +4,7 @@ import 'leaflet/dist/leaflet.css';
 import style from './style.css';
 
 const DEFAULT_COORDS = [48.8583, 2.2945];
+var markerArray = [];
 
 class MapComponent extends Component {
   initMap = () => {
@@ -41,6 +42,7 @@ class MapComponent extends Component {
               zIndexOffset: 1000
             })
             .addTo(this.leafletMap);
+            markerArray.push(this.userMarkers[user.id]);
         }
       });
     }
@@ -62,6 +64,7 @@ class MapComponent extends Component {
               })
             })
             .addTo(this.leafletMap);
+            markerArray.push(this.houseMarkers[house.id]);
         }
       });
     }
@@ -84,6 +87,10 @@ class MapComponent extends Component {
   componentDidUpdate() {
     this.displayHouses();
     this.displayUsers();
+    if (markerArray.length >= 1) {
+    var group = leaflet.featureGroup(markerArray);
+    this.leafletMap.fitBounds(group.getBounds(),{padding: [25, 25]});
+    }
   }
 
   componentWillUnmount() {

--- a/front/src/routes/map/Map.jsx
+++ b/front/src/routes/map/Map.jsx
@@ -89,7 +89,7 @@ class MapComponent extends Component {
     this.displayUsers();
     if (markerArray.length >= 1) {
     var group = leaflet.featureGroup(markerArray);
-    this.leafletMap.fitBounds(group.getBounds(),{padding: [25, 25]});
+    this.leafletMap.fitBounds(group.getBounds(), {padding: [25, 25]});
     }
   }
 


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [X] Is the linter passing? (`npm run eslint` on both front/server)
- [X] Did you run prettier? (`npm run prettier` on both front/server)

### Description of change

Resolves #576

Leaflet map now use `fitBounds` to auto zoom on markers.
Only active if marker >= 1
