### PR TITLE
Dashboard MQTT display the feature name Fixes #787

### DIFF
--- a/front/src/components/boxs/device-in-room/device-features/BinaryDeviceFeature.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/BinaryDeviceFeature.jsx
@@ -1,3 +1,5 @@
+import { getDeviceName } from './utils';
+
 const BinaryDeviceType = ({ children, ...props }) => {
   function updateValue() {
     props.updateValue(
@@ -16,7 +18,7 @@ const BinaryDeviceType = ({ children, ...props }) => {
       <td>
         <i class="fe fe-toggle-right" />
       </td>
-      <td>{props.device.name}</td>
+      <td>{getDeviceName(props.device, props.deviceFeature)}</td>
       <td class="text-right">
         <label class="custom-switch">
           <input

--- a/front/src/components/boxs/device-in-room/device-features/utils.js
+++ b/front/src/components/boxs/device-in-room/device-features/utils.js
@@ -1,0 +1,12 @@
+import get from 'get-value';
+
+const DISPLAY_FEATURE_NAME_SERVICES = ['mqtt'];
+
+export const getDeviceName = (device, feature) => {
+  const service = get(device, 'service.name');
+  if (service && DISPLAY_FEATURE_NAME_SERVICES.includes(service)) {
+    return feature.name;
+  }
+
+  return device.name;
+};

--- a/front/src/config/demo.json
+++ b/front/src/config/demo.json
@@ -111,7 +111,8 @@
         },
         {
           "type": "devices-in-room",
-          "room": "living-room"
+          "room": "living-room",
+          "device_features": ["main-lamp-binary", "tv-lamp-binary", "mqtt-living-room-switch", "mqtt-living-room-temp"]
         }
       ],
       [
@@ -224,8 +225,8 @@
         "selector": "tv-lamp",
         "features": [
           {
-            "name": "TV Lamp",
-            "selector": "main-lamp-binary",
+            "name": "TV Lamp feature",
+            "selector": "tv-lamp-binary",
             "category": "light",
             "type": "binary",
             "min": 0,
@@ -243,6 +244,39 @@
           {
             "name": "Temperature",
             "selector": "temperature-living-room-celsius",
+            "category": "temperature-sensor",
+            "type": "decimal",
+            "unit": "celsius",
+            "min": -200,
+            "max": 200,
+            "read_only": true,
+            "last_value": 27,
+            "last_value_changed": "2019-02-12 07:49:07.556 +00:00"
+          }
+        ]
+      },
+      {
+        "id": "81d637d2-b7f5-4cc3-a39e-2270fd069ee2",
+        "selector": "mqtt-living-room",
+        "name": "MQTT device",
+        "service": {
+          "name": "mqtt"
+        },
+        "features": [
+          {
+            "name": "Main Plug",
+            "selector": "mqtt-living-room-switch",
+            "category": "switch",
+            "type": "binary",
+            "min": 0,
+            "max": 1,
+            "read_only": false,
+            "last_value": 1,
+            "last_value_changed": "2019-02-12 07:49:07.556 +00:00"
+          },
+          {
+            "name": "Window Temp",
+            "selector": "mqtt-living-room-temp",
             "category": "temperature-sensor",
             "type": "decimal",
             "unit": "celsius",

--- a/server/lib/room/room.getBySelector.js
+++ b/server/lib/room/room.getBySelector.js
@@ -18,6 +18,7 @@ const DEVICE_FEATURES_ATTRIBUTES = [
   'last_value',
   'last_value_changed',
 ];
+const SERVICE_ATTRIBUTES = ['name'];
 
 /**
  * @description Get a room by selector
@@ -34,11 +35,18 @@ async function getBySelector(selector, options) {
       model: db.Device,
       as: 'devices',
       attributes: DEVICE_ATTRIBUTES,
-      include: {
-        model: db.DeviceFeature,
-        as: 'features',
-        attributes: DEVICE_FEATURES_ATTRIBUTES,
-      },
+      include: [
+        {
+          model: db.DeviceFeature,
+          as: 'features',
+          attributes: DEVICE_FEATURES_ATTRIBUTES,
+        },
+        {
+          model: db.Service,
+          as: 'service',
+          attributes: SERVICE_ATTRIBUTES,
+        },
+      ],
     });
   }
   const room = await db.Room.findOne({

--- a/server/test/controllers/room/room.test.js
+++ b/server/test/controllers/room/room.test.js
@@ -82,6 +82,18 @@ describe('GET /api/v1/room/:room_selector', () => {
         });
       });
   });
+  it('should get a room by selector with expanded devices', async () => {
+    await authenticatedRequest
+      .get('/api/v1/room/test-room?expand=devices')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then((res) => {
+        expect(res.body).to.have.property('devices');
+        res.body.devices.forEach((device) => {
+          expect(device).to.have.property('service');
+        });
+      });
+  });
 });
 
 describe('GET /api/v1/room', () => {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- ~~[ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)~~
- ~~[ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~~
- ~~[ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).~~
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.json`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Force feature name usage (instead of device name) for MQTT device, on "devices in the room" box on dashboard.