### PR TITLE
✨ add device Philips Hue LWA001

### DIFF
--- a/server/services/philips-hue/lib/light/light.getLights.js
+++ b/server/services/philips-hue/lib/light/light.getLights.js
@@ -44,6 +44,7 @@ async function getLights() {
           lightsToReturn.push(getPhilipsHueColorLight(philipsHueLight, serialNumber, this.serviceId));
           break;
         case 'LWO001': // Hue White Filament Bulb G93 E27
+        case 'LWA001': // Hue White Bulb E27 (Dimmable light 2700K)
         case 'LWB010': // Hue white bulb with fixed warming light (2700K)
         case 'LWB006': // Hue white lamp
         case 'LWG004': // Hue white spot

--- a/server/test/services/philips-hue/lights.json
+++ b/server/test/services/philips-hue/lights.json
@@ -1182,6 +1182,68 @@
       },
       "_id": 25,
       "id": 25
+    },
+    {
+      "state": {
+        "on": true,
+        "bri": 254,
+        "alert": "select",
+        "mode": "homeautomation",
+        "reachable": true
+      },
+      "swupdate": {
+        "state": "transferring",
+        "lastinstall": null
+      },
+      "type": "Dimmable light",
+      "name": "Hue white lamp 2",
+      "modelid": "LWA001",
+      "manufacturername": "Signify Netherlands B.V.",
+      "productname": "Hue white lamp",
+      "_rawData": {
+        "state": {
+          "on": true,
+          "bri": 254,
+          "alert": "select",
+          "mode": "homeautomation",
+          "reachable": true
+        },
+        "swupdate": {
+          "state": "transferring",
+          "lastinstall": null
+        },
+        "type": "Dimmable light",
+        "name": "Hue white lamp 2",
+        "modelid": "LWA001",
+        "manufacturername": "Signify Netherlands B.V.",
+        "productname": "Hue white lamp",
+        "capabilities": {
+          "certified": true,
+          "control": {
+            "mindimlevel": 5000,
+            "maxlumen": 800
+          },
+          "streaming": {
+            "renderer": false,
+            "proxy": false
+          }
+        },
+        "config": {
+          "archetype": "classicbulb",
+          "function": "functional",
+          "direction": "omnidirectional",
+          "startup": {
+            "mode": "safety",
+            "configured": true
+          }
+        },
+        "uniqueid": "00:17:88:01:08:9f:97:bd-0c",
+        "swversion": "1.53.3_r27175",
+        "swconfigid": "D6781B83",
+        "productid": "Philips-LWA001-1-A19DLv5"
+      },
+      "_id": 26,
+      "id": 26
     }
   ]
 }


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?  
  I just added the JSON data 
- [x] Are tests passing? (`npm test` on both front/server). 
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.json`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

This pull request adds the compatibility for the Philips Hue LWA001 #851 
