### PR TITLE
Fix #858 - No loader if image already there on camera dashboard box

### DIFF
--- a/front/src/components/boxs/camera/Camera.jsx
+++ b/front/src/components/boxs/camera/Camera.jsx
@@ -20,7 +20,7 @@ const CameraBox = ({ children, ...props }) => (
       </div>
     )}
     <div class="card-body d-flex flex-column">
-      {props.boxStatus === RequestStatus.Getting && (
+      {!props.image && props.boxStatus === RequestStatus.Getting && (
         <div class="dimmer active">
           <div class="dimmer-content" style={{ height: '100px' }} />
           <div class="loader" />


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- ~~[ ] If your changes affects code, did your write the tests?~~
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- ~~[ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)~~
- ~~[ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~~
- ~~[ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).~~
- ~~[ ] Did you add fake requests data for the demo mode (`front/src/config/demo.json`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).~~

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

No loader on camera box when an image already exists.
