### PR TITLE
Add the ability to only execute trigger at threshold

### DIFF
--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -778,7 +778,8 @@
         "different": "different",
         "valuePlaceholder": "Value",
         "on": "On",
-        "off": "Off"
+        "off": "Off",
+        "onlyExecuteAtThreshold": "Execute only when threshold is passed (and not at every value sent by the device)"
       },
       "scheduledTrigger": {
         "typeLabel": "Type",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -778,7 +778,8 @@
         "different": "différent",
         "valuePlaceholder": "Valeur",
         "on": "On",
-        "off": "Off"
+        "off": "Off",
+        "onlyExecuteAtThreshold": "Exécuter seulement lorsque le seuil est passé ( et non pas à chaque valeur envoyée )"
       },
       "scheduledTrigger": {
         "typeLabel": "Type",

--- a/front/src/routes/scene/edit-scene/triggers/DeviceFeatureState.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/DeviceFeatureState.jsx
@@ -34,6 +34,9 @@ class TurnOnLight extends Component {
   handleValueChangeBinary = newValue => () => {
     this.props.updateTriggerProperty(this.props.index, 'value', newValue);
   };
+  handleThresholdOnlyModeChange = e => {
+    this.props.updateTriggerProperty(this.props.index, 'threshold_only', e.target.checked);
+  };
   getBinaryOperator = () => (
     <div class="col-2">
       <div class="text-center" style={{ marginTop: '10px' }}>
@@ -141,6 +144,19 @@ class TurnOnLight extends Component {
               </div>
             </div>
           )}
+          <div class="col-12">
+            <label class="form-check form-switch">
+              <input
+                class="form-check-input"
+                type="checkbox"
+                checked={props.trigger.threshold_only}
+                onChange={this.handleThresholdOnlyModeChange}
+              />
+              <span class="form-check-label">
+                <Text id="editScene.triggersCard.newState.onlyExecuteAtThreshold" />
+              </span>
+            </label>
+          </div>
         </div>
       </div>
     );

--- a/server/lib/device/device.saveState.js
+++ b/server/lib/device/device.saveState.js
@@ -15,6 +15,8 @@ const { EVENTS, WEBSOCKET_MESSAGE_TYPES } = require('../../utils/constants');
 async function saveState(deviceFeature, newValue) {
   logger.debug(`device.saveState of deviceFeature ${deviceFeature.selector}`);
   const now = new Date();
+  const previousDeviceFeature = this.stateManager.get('deviceFeature', deviceFeature.selector);
+  const previousDeviceFeatureValue = previousDeviceFeature ? previousDeviceFeature.last_value : null;
   // save local state in RAM
   this.stateManager.setState('deviceFeature', deviceFeature.selector, {
     last_value: newValue,
@@ -64,6 +66,7 @@ async function saveState(deviceFeature, newValue) {
   this.eventManager.emit(EVENTS.TRIGGERS.CHECK, {
     type: EVENTS.DEVICE.NEW_STATE,
     device_feature: deviceFeature.selector,
+    previous_value: previousDeviceFeatureValue,
     last_value: newValue,
     last_value_changed: now,
   });

--- a/server/lib/scene/scene.triggers.js
+++ b/server/lib/scene/scene.triggers.js
@@ -7,8 +7,14 @@ const triggersFunc = {
     if (event.device_feature !== trigger.device_feature) {
       return false;
     }
-    // we compare the value with the expected value
-    return compare(trigger.operator, event.last_value, trigger.value);
+    const newValueValidateRule = compare(trigger.operator, event.last_value, trigger.value);
+    // if the trigger is only a threshold_only, we only validate the trigger is the rule has been validated
+    // and was not validated with the previous value
+    if (trigger.threshold_only === true && !Number.isNaN(event.previous_value)) {
+      const previousValueValidateRule = compare(trigger.operator, event.previous_value, trigger.value);
+      return newValueValidateRule && !previousValueValidateRule;
+    }
+    return newValueValidateRule;
   },
   [EVENTS.TIME.CHANGED]: (event, trigger) => event.key === trigger.key,
 };

--- a/server/models/scene.js
+++ b/server/models/scene.js
@@ -50,6 +50,7 @@ const triggersSchema = Joi.array().items(
     day_of_the_month: Joi.number()
       .min(1)
       .max(31),
+    threshold_only: Joi.boolean(),
   }),
 );
 

--- a/server/test/lib/device/device.saveState.test.js
+++ b/server/test/lib/device/device.saveState.test.js
@@ -1,11 +1,14 @@
-const EventEmitter = require('events');
+const { assert, stub, useFakeTimers } = require('sinon');
 const Device = require('../../../lib/device');
 const StateManager = require('../../../lib/state');
 
-const event = new EventEmitter();
-
-describe('Device', () => {
+describe('Device.saveState', () => {
   it('should saveState and keep history', async () => {
+    const event = {
+      emit: stub().returns(null),
+      on: stub().returns(null),
+    };
+    const clock = useFakeTimers(new Date('2019-05-01T00:00:00Z').getTime());
     const stateManager = new StateManager(event);
     const device = new Device(event, {}, stateManager);
     await device.saveState(
@@ -17,8 +20,65 @@ describe('Device', () => {
       },
       12,
     );
+    assert.calledWith(event.emit.firstCall, 'websocket.send-all', {
+      payload: {
+        device_feature_selector: 'test-device-feature',
+        last_value: 12,
+        last_value_changed: new Date(),
+      },
+      type: 'device.new-state',
+    });
+    assert.calledWith(event.emit.secondCall, 'trigger.check', {
+      device_feature: 'test-device-feature',
+      last_value: 12,
+      last_value_changed: new Date(),
+      previous_value: null,
+      type: 'device.new-state',
+    });
+    clock.restore();
+  });
+  it('should saveState and keep history and emit previous value of device', async () => {
+    const event = {
+      emit: stub().returns(null),
+      on: stub().returns(null),
+    };
+    const clock = useFakeTimers(new Date('2019-05-01T00:00:00Z').getTime());
+    const stateManager = new StateManager(event);
+    const device = new Device(event, {}, stateManager);
+    stateManager.setState('deviceFeature', 'test-device-feature', {
+      last_value: 5,
+    });
+    await device.saveState(
+      {
+        id: 'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4',
+        selector: 'test-device-feature',
+        has_feedback: false,
+        keep_history: true,
+      },
+      12,
+    );
+    assert.calledWith(event.emit.firstCall, 'websocket.send-all', {
+      payload: {
+        device_feature_selector: 'test-device-feature',
+        last_value: 12,
+        last_value_changed: new Date(),
+      },
+      type: 'device.new-state',
+    });
+    assert.calledWith(event.emit.secondCall, 'trigger.check', {
+      device_feature: 'test-device-feature',
+      last_value: 12,
+      last_value_changed: new Date(),
+      previous_value: 5,
+      type: 'device.new-state',
+    });
+    clock.restore();
   });
   it('should saveState and not keep history', async () => {
+    const event = {
+      emit: stub().returns(null),
+      on: stub().returns(null),
+    };
     const stateManager = new StateManager(event);
     const device = new Device(event, {}, stateManager);
     await device.saveState(

--- a/server/test/lib/scene/scene.checkTrigger.test.js
+++ b/server/test/lib/scene/scene.checkTrigger.test.js
@@ -131,6 +131,92 @@ describe('scene.checkTrigger', () => {
       });
     });
   });
+  it('should not execute scene, threshold already passed', async () => {
+    const stateManager = new StateManager();
+    const device = {
+      setValue: fake.resolves(null),
+    };
+    const sceneManager = new SceneManager(stateManager, event, device);
+    sceneManager.addScene({
+      selector: 'my-scene',
+      actions: [
+        [
+          {
+            type: ACTIONS.LIGHT.TURN_ON,
+            devices: ['light-1'],
+          },
+        ],
+      ],
+      triggers: [
+        {
+          type: EVENTS.DEVICE.NEW_STATE,
+          device_feature: 'light-1',
+          value: 12,
+          operator: '>',
+          threshold_only: true,
+        },
+      ],
+    });
+    sceneManager.checkTrigger({
+      type: EVENTS.DEVICE.NEW_STATE,
+      device_feature: 'light-1',
+      previous_value: 14,
+      last_value: 14,
+    });
+    return new Promise((resolve, reject) => {
+      sceneManager.queue.start(() => {
+        try {
+          assert.notCalled(device.setValue);
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  });
+  it('should execute scene, threshold passed for the first time', async () => {
+    const stateManager = new StateManager();
+    const device = {
+      setValue: fake.resolves(null),
+    };
+    const sceneManager = new SceneManager(stateManager, event, device);
+    sceneManager.addScene({
+      selector: 'my-scene',
+      actions: [
+        [
+          {
+            type: ACTIONS.LIGHT.TURN_ON,
+            devices: ['light-1'],
+          },
+        ],
+      ],
+      triggers: [
+        {
+          type: EVENTS.DEVICE.NEW_STATE,
+          device_feature: 'light-1',
+          value: 12,
+          operator: '>',
+          threshold_only: true,
+        },
+      ],
+    });
+    sceneManager.checkTrigger({
+      type: EVENTS.DEVICE.NEW_STATE,
+      device_feature: 'light-1',
+      previous_value: 11,
+      last_value: 14,
+    });
+    return new Promise((resolve, reject) => {
+      sceneManager.queue.start(() => {
+        try {
+          assert.calledOnce(device.setValue);
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  });
   it('should not execute scene, event not matching', async () => {
     const stateManager = new StateManager();
     const device = {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.json`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Fix #979 
