### PR TITLE
Disk space rounded

### DIFF
--- a/front/src/config/demo.json
+++ b/front/src/config/demo.json
@@ -1055,7 +1055,7 @@
     "size": 499313172480,
     "used": 464613756928,
     "available": 28587036672,
-    "capacity": 0.95,
+    "capacity": 0.953000005,
     "mountpoint": "/"
   },
   "get /api/v1/system/container": [

--- a/front/src/routes/settings/settings-system/SettingsSystemPage.jsx
+++ b/front/src/routes/settings/settings-system/SettingsSystemPage.jsx
@@ -37,7 +37,7 @@ const SystemPage = ({ children, ...props }) => (
               <small class="text-muted">
                 <Text
                   id="global.percentValue"
-                  fields={{ value: props.systemDiskSpace && props.systemDiskSpace.capacity * 100 }}
+                  fields={{ value: props.systemDiskSpace && Math.ceil(props.systemDiskSpace.capacity * 100) }}
                 />
               </small>
             </div>


### PR DESCRIPTION
Fixes #989
Using Math.ceil instead of rounded, to me I prefer to 26% when 25.3% is real.