### PR TITLE
Bluetooth add info

### DIFF
--- a/server/services/bluetooth/lib/commands/bluetooth.scan.js
+++ b/server/services/bluetooth/lib/commands/bluetooth.scan.js
@@ -15,7 +15,13 @@ const { TIMERS } = require('../utils/bluetooth.constants');
  */
 async function scan(state, peripheralUuid = undefined) {
   if (state) {
-    logger.trace(`Bluetooth: scanning for ${peripheralUuid} peripheral`);
+    if (peripheralUuid) {
+      logger.trace(`Bluetooth: scanning for ${peripheralUuid} peripheral`);
+    } else {
+      logger.trace(`Bluetooth: scanning for all peripherals`);
+      this.discoveredDevices = {};
+    }
+
     this.scanCounter += 1;
 
     if (this.scanPromise && this.scanPromise.isPending()) {

--- a/server/services/bluetooth/lib/device/bluetooth.transformToDevice.js
+++ b/server/services/bluetooth/lib/device/bluetooth.transformToDevice.js
@@ -12,11 +12,12 @@ const { encodeParamValue } = require('./bluetooth.information');
  * transformToDevice({});
  */
 function transformToDevice(peripheral) {
-  const { uuid, address, advertisement, connectable } = peripheral;
+  const { uuid, address, advertisement = {}, connectable } = peripheral;
+  const { localName, manufacturerData } = advertisement;
   const externalId = `bluetooth:${uuid}`;
 
   const device = {
-    name: (advertisement && encodeParamValue(advertisement.localName)) || address || uuid,
+    name: encodeParamValue(localName) || address || uuid,
     external_id: externalId,
     selector: externalId,
     features: [],
@@ -25,6 +26,10 @@ function transformToDevice(peripheral) {
 
   if (!connectable) {
     setDeviceParam(device, PARAMS.LOADED, true);
+  }
+
+  if (manufacturerData) {
+    setDeviceParam(device, PARAMS.MANUFACTURER_DATA, manufacturerData.toString('hex'));
   }
 
   addSelector(device);

--- a/server/services/bluetooth/lib/utils/bluetooth.constants.js
+++ b/server/services/bluetooth/lib/utils/bluetooth.constants.js
@@ -10,6 +10,7 @@ const PARAMS = {
   CONNECTABLE: 'connectable',
   LOADED: 'loaded',
   MANUFACTURER: 'manufacturer',
+  MANUFACTURER_DATA: 'manufacturer_data',
 };
 
 module.exports = { TIMERS, PARAMS };

--- a/server/test/services/bluetooth/lib/device/bluetooth.transformToDevice.test.js
+++ b/server/test/services/bluetooth/lib/device/bluetooth.transformToDevice.test.js
@@ -9,6 +9,7 @@ describe('bluetooth.transformToDevice', () => {
       address: 'address',
       advertisement: {
         localName: 'LocalName',
+        manufacturerData: Buffer.from([0x01, 0x0d]),
       },
       connectable: true,
     };
@@ -18,7 +19,12 @@ describe('bluetooth.transformToDevice', () => {
       external_id: 'bluetooth:uuid',
       selector: 'bluetooth-uuid',
       features: [],
-      params: [],
+      params: [
+        {
+          name: 'manufacturer_data',
+          value: '010d',
+        },
+      ],
     };
     expect(result).deep.eq(expectedResult);
   });


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- ~~[ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)~~
- ~~[ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~~
- ~~[ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).~~
- ~~[ ] Did you add fake requests data for the demo mode (`front/src/config/demo.json`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).~~

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Store more Bluetooth peripheral information into Gladys device.
It will be very useful for Bluetooth sub-services, to easily identity matching brand devices.
