### PR TITLE
Dashboard device box showcase (demo mode)

### DIFF
--- a/front/src/components/app.jsx
+++ b/front/src/components/app.jsx
@@ -93,6 +93,9 @@ import EweLinkEditPage from '../routes/integration/all/ewelink/edit-page';
 import EweLinkDiscoverPage from '../routes/integration/all/ewelink/discover-page';
 import EweLinkSetupPage from '../routes/integration/all/ewelink/setup-page';
 
+// Showcase
+import Showcase from '../routes/showcase';
+
 const defaultState = getDefaultState();
 const store = createStore(defaultState);
 
@@ -217,6 +220,9 @@ const AppRouter = connect(
         <SettingsGateway path="/dashboard/settings/gateway" />
         <SettingsServicePage path="/dashboard/settings/service" />
         <SettingsBackup path="/dashboard/settings/backup" />
+
+        {config.demoMode && <Showcase path="/showcase" />}
+
         <Error type="404" default />
       </Router>
     </Layout>

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -1517,5 +1517,11 @@
     "informationTitle": "Your billing information",
     "stripeDescription": "Billing is handled by Stripe. We never see you credit card.",
     "stripeButton": "Edit subscription in Stripe"
+  },
+  "showcase": {
+    "title": "Showcase",
+    "sensorDevices": "Sensors",
+    "actuatorDevices": "Actuator",
+    "unitSeparator": " / "
   }
 }

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -1517,5 +1517,11 @@
     "informationTitle": "Vos informations de paiement",
     "stripeDescription": "Le paiement est géré par Stripe. Nous ne voyons jamais votre carte de crédit.",
     "stripeButton": "Gérer la facturation dans Stripe"
+  },
+  "showcase": {
+    "title": "Showcase",
+    "sensorDevices": "Capteurs",
+    "actuatorDevices": "Actionneurs",
+    "unitSeparator": " / "
   }
 }

--- a/front/src/routes/showcase/ShowcaseCategory.jsx
+++ b/front/src/routes/showcase/ShowcaseCategory.jsx
@@ -1,0 +1,47 @@
+import { Component } from 'preact';
+import { Text } from 'preact-i18n';
+import cx from 'classnames';
+
+import ShowcaseFeature from './ShowcaseFeature';
+
+class ShowcaseCategory extends Component {
+  toggle = e => {
+    e.preventDefault();
+    this.setState({ collapsed: !this.state.collapsed });
+  };
+
+  render({ user, category, deviceIndex, features, readOnly, updateValue }, { collapsed = false }) {
+    return (
+      <div class={cx('card', { 'card-collapsed': collapsed })} style="display: inline-block; min-width: 300px">
+        <div class="card-header">
+          <h3 class="card-title">
+            <Text id={`deviceFeatureCategory.${category}.shortCategoryName`}>Unknown {category} category</Text>
+          </h3>
+          <div class="card-options">
+            <a href="" onClick={this.toggle} class="card-options-collapse" data-toggle="card-collapse">
+              <i class="fe fe-chevron-up" />
+            </a>
+          </div>
+        </div>
+        <div class="table-responsive">
+          <table class="table card-table table-vcenter">
+            <tbody>
+              {features.map((feature, deviceFeatureIndex) => (
+                <ShowcaseFeature
+                  feature={feature}
+                  deviceIndex={deviceIndex}
+                  deviceFeatureIndex={deviceFeatureIndex}
+                  user={user}
+                  readOnly={readOnly}
+                  updateValue={updateValue}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ShowcaseCategory;

--- a/front/src/routes/showcase/ShowcaseFeature.jsx
+++ b/front/src/routes/showcase/ShowcaseFeature.jsx
@@ -1,0 +1,44 @@
+import { Fragment } from 'preact';
+import { Text } from 'preact-i18n';
+
+import DeviceRow from '../../components/boxs/device-in-room/DeviceRow';
+
+const ShowcaseFeature = ({ user, feature, readOnly, deviceIndex, deviceFeatureIndex, updateValue }) => {
+  const props = {
+    device: {
+      name: `Device name`
+    },
+    deviceFeature: {
+      ...feature,
+      read_only: readOnly
+    },
+    roomIndex: 0,
+    deviceIndex,
+    deviceFeatureIndex,
+    updateValue,
+    user
+  };
+
+  const { category, type, unit } = feature;
+
+  return (
+    <Fragment>
+      <tr>
+        <td colSpan="3" class="bg-light py-1 text-muted">
+          <small>
+            <Text id={`deviceFeatureCategory.${category}.${type}`}>Unknown {type} type</Text>
+            {unit && (
+              <span>
+                <Text id="showcase.unitSeparator" />
+                <Text id={`deviceFeatureUnit.${unit}`}>Unknown {unit} unit</Text>
+              </span>
+            )}
+          </small>
+        </td>
+      </tr>
+      <DeviceRow {...props} />
+    </Fragment>
+  );
+};
+
+export default ShowcaseFeature;

--- a/front/src/routes/showcase/generator.js
+++ b/front/src/routes/showcase/generator.js
@@ -1,0 +1,65 @@
+import get from 'get-value';
+
+import { DeviceFeatureCategoriesIcon } from '../../utils/consts';
+import {
+  DEVICE_FEATURE_CATEGORIES,
+  DEVICE_FEATURE_TYPES,
+  DEVICE_FEATURE_CATEGORIES_LIST,
+  DEVICE_FEATURE_UNITS_BY_CATEGORY
+} from '../../../../server/utils/constants';
+
+const DEFAULT_VALUES = {
+  [DEVICE_FEATURE_CATEGORIES.LIGHT]: {
+    [DEVICE_FEATURE_TYPES.LIGHT.COLOR]: {
+      min: 0,
+      max: 65655,
+      last_value: 0
+    }
+  },
+  [DEVICE_FEATURE_CATEGORIES.SWITCH]: {
+    [DEVICE_FEATURE_TYPES.SWITCH.DIMMER]: {
+      min: 0,
+      max: 100,
+      last_value: 75
+    }
+  }
+};
+
+function generateFeatures(category, date) {
+  const features = [];
+
+  Object.keys(DeviceFeatureCategoriesIcon[category] || {}).forEach(type => {
+    const defaultValues = get(DEFAULT_VALUES, `${category}.${type}`, { default: {} });
+
+    DEVICE_FEATURE_UNITS_BY_CATEGORY[category] ||
+      [undefined].forEach(unit => {
+        features.push({
+          name: `Feature name`,
+          category,
+          type,
+          unit,
+          last_value: 1,
+          last_value_changed: date,
+          ...defaultValues
+        });
+      });
+  });
+
+  return features;
+}
+
+function generateAll() {
+  const date = new Date();
+  date.setHours(date.getHours() - 2);
+
+  return DEVICE_FEATURE_CATEGORIES_LIST.map(category => {
+    const features = generateFeatures(category, date);
+
+    return {
+      category,
+      features
+    };
+  });
+}
+
+export { generateAll };

--- a/front/src/routes/showcase/index.js
+++ b/front/src/routes/showcase/index.js
@@ -1,0 +1,93 @@
+import { Component } from 'preact';
+import { Text } from 'preact-i18n';
+import { connect } from 'unistore/preact';
+import update from 'immutability-helper';
+
+import { generateAll } from './generator';
+import ShowcaseCategory from './ShowcaseCategory';
+
+@connect('user', {})
+class Showcase extends Component {
+  updateValue = (x, y, device, deviceFeature, deviceIndex, featureIndex, action) => {
+    const newState = update(this.state, {
+      rows: {
+        [deviceIndex]: {
+          features: {
+            [featureIndex]: {
+              last_value: {
+                $set: action
+              }
+            }
+          }
+        }
+      }
+    });
+
+    this.setState(newState);
+  };
+
+  constructor(props) {
+    super(props);
+
+    const rows = generateAll();
+    this.state = {
+      columns: [
+        {
+          titleId: 'showcase.actuatorDevices',
+          options: {
+            readOnly: false
+          }
+        },
+        {
+          titleId: 'showcase.sensorDevices',
+          options: {
+            readOnly: true
+          }
+        }
+      ],
+      rows
+    };
+  }
+
+  render({ user }, { columns, rows }) {
+    return (
+      <div class="page">
+        <div class="page-main">
+          <div class="my-3 my-md-5">
+            <div class="container">
+              <div class="page-header">
+                <h1 class="page-title">
+                  <Text id="showcase.title" />
+                </h1>
+              </div>
+              <div class="d-flex flex-row flex-wrap justify-content-left">
+                {columns.map(column => (
+                  <div class="d-flex flex-column col-lg-4">
+                    <div class="card" style="display: inline-block; min-width: 300px">
+                      <div class="card-header">
+                        <h3 class="card-title">
+                          <Text id={column.titleId} />
+                        </h3>
+                      </div>
+                    </div>
+                    {rows.map((row, deviceIndex) => (
+                      <ShowcaseCategory
+                        {...row}
+                        {...column.options}
+                        deviceIndex={deviceIndex}
+                        user={user}
+                        updateValue={this.updateValue}
+                      />
+                    ))}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default Showcase;


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- ~~[ ] If your changes affects code, did your write the tests?~~
- ~~[ ] Are tests passing? (`npm test` on both front/server)~~
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- ~~[ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~~
- ~~[ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).~~
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.json`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

This is a dashboard box showcase (available at /showcase url), only on demo mode.
This provides a way to see if and how dashbord device box is displayed.

![showcase](https://user-images.githubusercontent.com/1839717/102936152-ee1c6e80-44a7-11eb-83af-8dcf6577c7ea.gif)

Fixes #922 