### PR TITLE
CI FIX

### DIFF
--- a/.github/workflows/docker-dev-build.yml
+++ b/.github/workflows/docker-dev-build.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build-front:
     name: Front build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - 
         name: ⬇️ Checkout code
@@ -47,7 +47,7 @@ jobs:
   docker:
     needs: build-front
     name: Docker magic !
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       DOCKERHUB_USER: ${{secrets.DOCKERHUB_USER}}
       DOCKERHUB_PASSWORD: ${{secrets.DOCKERHUB_PASSWORD}}

--- a/.github/workflows/docker-dev-build.yml
+++ b/.github/workflows/docker-dev-build.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@v2
       - 
         name: 💽 Setup nodejs
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: '12'
       - 
         name: 📇 Use npm cache
         uses: c-hive/gha-npm-cache@v1
@@ -40,7 +40,7 @@ jobs:
           npm run build
       - 
         name: ↗️ Upload build artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: static
           path: front/build
@@ -75,7 +75,7 @@ jobs:
           version: latest
       - 
         name: ↙️ Download build artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v2
         with:
           name: static
       - 

--- a/.github/workflows/docker-dev-build.yml
+++ b/.github/workflows/docker-dev-build.yml
@@ -78,6 +78,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: static
+          path: static
       - 
         name: 🔑 Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/docker-master-test.yml
+++ b/.github/workflows/docker-master-test.yml
@@ -1,0 +1,105 @@
+name: Master branch tests
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  test-front:
+    name: Front test
+    runs-on: ubuntu-20.04
+    steps:
+      - 
+        name: ⬇️ Checkout Gladys code
+        uses: actions/checkout@v2
+      - 
+        name: 💽 Setup nodejs
+        uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+      - 
+        name: 📇 Use npm cache
+        uses: c-hive/gha-npm-cache@v1
+      - 
+        name: 📦 Install Global NPM Packages
+        run: |
+          sudo npm install typescript node-gyp npm@latest -g
+      - 
+        name: 📦 Install NPM front packages
+        working-directory: ./front
+        run: |
+          npm ci
+      - 
+        name: 🧐 Prettier check
+        working-directory: ./front
+        run: |
+          npm run prettier-check
+      - 
+        name: 👕 ESlint
+        working-directory: ./front
+        run: |
+          npm run eslint
+      - 
+        name: 🌐 Integration comparison
+        working-directory: ./front
+        run: |
+          npm run compare-translations
+  test-server:
+    name: Server test
+    runs-on: ubuntu-20.04
+    steps:
+      - 
+        name: ⬇️ Checkout Gladys code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - 
+        name: 💽 Setup nodejs
+        uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+      - 
+        name: 📇 Use npm cache
+        uses: c-hive/gha-npm-cache@v1
+      - 
+        name: 🖥️ Setup OZW
+        run: |
+          docker create -ti --name dummy chrisns/openzwave:ubuntu-1.6.1714 bash
+          sudo docker cp dummy:/usr/local/include/openzwave /usr/local/include/openzwave
+          sudo docker cp dummy:/openzwave/libopenzwave.so /usr/local/lib
+          sudo docker cp dummy:/openzwave/libopenzwave.so.1.6 /usr/local/lib
+          sudo docker cp dummy:/openzwave/config /usr/local/etc/openzwave
+          sudo ldconfig
+          docker rm -f dummy
+      - 
+        name: 💽 Install System Dependencies
+        run: |
+          sudo apt update
+          sudo apt-get install -y libudev-dev sqlite3 openssl python-is-python3
+      - 
+        name: 📦 Install Global NPM Packages
+        run: |
+          sudo npm install typescript node-gyp npm@latest -g
+      - 
+        name: 📦 Install NPM server packages
+        working-directory: ./server
+        run: |
+          npm ci
+      - 
+        name: 🧐 Prettier check
+        working-directory: ./server
+        run: |
+          npm run prettier-check
+      - 
+        name: 👕 ESlint
+        working-directory: ./server
+        run: |
+          npm run eslint
+      - 
+        name: ✅ Test with coverage
+        working-directory: ./server
+        run: |
+          npm run coverage
+      - 
+        name: 📄 Codecov report upload
+        uses: codecov/codecov-action@v1

--- a/.github/workflows/docker-pr-build.yml
+++ b/.github/workflows/docker-pr-build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test-front:
     name: Front test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - 
         name: ⬇️ Checkout Gladys code
@@ -47,7 +47,7 @@ jobs:
           npm run compare-translations
   test-server:
     name: Server test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - 
         name: ⬇️ Checkout Gladys code
@@ -108,7 +108,7 @@ jobs:
     needs:
       - test-front
       - test-server
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - 
         name: ⬇️ Checkout code
@@ -141,7 +141,7 @@ jobs:
     if: github.event.pull_request.draft == false
     needs: build-front
     name: Docker magic !
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - 
         name: ⬇️ Checkout code

--- a/.github/workflows/docker-pr-build.yml
+++ b/.github/workflows/docker-pr-build.yml
@@ -74,7 +74,7 @@ jobs:
         name: 💽 Install System Dependencies
         run: |
           sudo apt update
-          sudo apt-get install -y libudev-dev sqlite3 openssl
+          sudo apt-get install -y libudev-dev sqlite3 openssl python-is-python3
       - 
         name: 📦 Install Global NPM Packages
         run: |

--- a/.github/workflows/docker-pr-build.yml
+++ b/.github/workflows/docker-pr-build.yml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@v2
       - 
         name: 💽 Setup nodejs
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: '12'
       - 
         name: 📇 Use npm cache
         uses: c-hive/gha-npm-cache@v1
@@ -52,11 +52,13 @@ jobs:
       - 
         name: ⬇️ Checkout Gladys code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - 
         name: 💽 Setup nodejs
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: '12'
       - 
         name: 📇 Use npm cache
         uses: c-hive/gha-npm-cache@v1
@@ -115,9 +117,9 @@ jobs:
         uses: actions/checkout@v2
       - 
         name: 💽 Setup nodejs
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: '12'
       - 
         name: 📇 Use npm cache
         uses: c-hive/gha-npm-cache@v1
@@ -133,7 +135,7 @@ jobs:
           npm run build
       - 
         name: ↗️ Upload build artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: static
           path: front/build
@@ -157,7 +159,7 @@ jobs:
           version: latest
       - 
         name: ↙️ Download build artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v2
         with:
           name: static
       - 

--- a/.github/workflows/docker-pr-build.yml
+++ b/.github/workflows/docker-pr-build.yml
@@ -162,6 +162,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: static
+          path: static
       - 
         name: 🐳 Build AMD64 images
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker-release-build.yml
+++ b/.github/workflows/docker-release-build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test-front:
     name: Front test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - 
         name: ⬇️ Checkout Gladys code
@@ -47,7 +47,7 @@ jobs:
           npm run compare-translations
   test-server:
     name: Server test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - 
         name: ⬇️ Checkout Gladys code
@@ -107,7 +107,7 @@ jobs:
     needs:
       - test-front
       - test-server
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - 
         name: ⬇️ Checkout code
@@ -139,7 +139,7 @@ jobs:
   docker:
     needs: build-front
     name: Docker magic !
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       DOCKERHUB_USER: ${{secrets.DOCKERHUB_USER}}
       DOCKERHUB_PASSWORD: ${{secrets.DOCKERHUB_PASSWORD}}

--- a/.github/workflows/docker-release-build.yml
+++ b/.github/workflows/docker-release-build.yml
@@ -74,7 +74,7 @@ jobs:
         name: 💽 Install System Dependencies
         run: |
           sudo apt update
-          sudo apt-get install -y libudev-dev sqlite3 openssl
+          sudo apt-get install -y libudev-dev sqlite3 openssl python-is-python3
       - 
         name: 📦 Install Global NPM Packages
         run: |

--- a/.github/workflows/docker-release-build.yml
+++ b/.github/workflows/docker-release-build.yml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@v2
       - 
         name: 💽 Setup nodejs
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: '12'
       - 
         name: 📇 Use npm cache
         uses: c-hive/gha-npm-cache@v1
@@ -52,11 +52,13 @@ jobs:
       - 
         name: ⬇️ Checkout Gladys code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - 
         name: 💽 Setup nodejs
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: '12'
       - 
         name: 📇 Use npm cache
         uses: c-hive/gha-npm-cache@v1
@@ -114,9 +116,9 @@ jobs:
         uses: actions/checkout@v2
       - 
         name: 💽 Setup nodejs
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: '12'
       - 
         name: 📇 Use npm cache
         uses: c-hive/gha-npm-cache@v1
@@ -132,7 +134,7 @@ jobs:
           npm run build
       - 
         name: ↗️ Upload build artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: static
           path: front/build
@@ -171,7 +173,7 @@ jobs:
           version: latest
       - 
         name: ↙️ Download build artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v2
         with:
           name: static
       - 

--- a/.github/workflows/docker-release-build.yml
+++ b/.github/workflows/docker-release-build.yml
@@ -176,6 +176,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: static
+          path: static
       - 
         name: 🔑 Login to DockerHub
         uses: docker/login-action@v1


### PR DESCRIPTION
Github are going to switch builder image to Ubuntu 20.04 , python command is missing is this release ( even if python 3 is provisionned )
Because sqlite3 need to be build ( with python ) , we need a package python-is-python3 that symlink python to python3 executable.

Some reading => https://techsparx.com/nodejs/install/bootstrap-drops-jquery.html


This is an attempt to fix netatmo ci => https://github.com/GladysAssistant/Gladys/runs/1775420206?check_suite_focus=true#step:8:16 ( that use 18.04 ) 

**Workaround:**

* Force using UBuntu LTS ( 20.04 )
* Install python-is-python3 package

I have also bump some github actions to latest major version