### PR TITLE
fix(zigbee2mqtt): Fix USB listing

### DIFF
--- a/front/src/routes/integration/all/zigbee2mqtt/settings-page/SettingsTab.jsx
+++ b/front/src/routes/integration/all/zigbee2mqtt/settings-page/SettingsTab.jsx
@@ -51,9 +51,11 @@ const SettingsTab = ({ children, ...props }) => (
               {props.usbPorts &&
                 props.usbPorts.map(
                   usbPort =>
-                    usbPort.comVID && (
+                    usbPort.comPath && (
                       <option value={usbPort.comPath} selected={props.zigbee2mqttDriverPath === usbPort.comPath}>
-                        {`${usbPort.comPath} - ${usbPort.comName} - ${usbPort.comVID}`}
+                        {usbPort.comPath}
+                        {usbPort.comName ? ` - ${usbPort.comName}` : ''}
+                        {usbPort.comVID ? ` - ${usbPort.comVID}` : ''}
                       </option>
                     )
                 )}


### PR DESCRIPTION
comVid (vendorId) is sometimes empty from serialports/list library

https://community.gladysassistant.com/t/gladys-assistant-4-2-est-disponible-avec-la-compatibilite-zigbee2mqtt/6225/20