### PR TITLE
WIP: Allow services to receive websocket events

### DIFF
--- a/server/api/websockets/index.js
+++ b/server/api/websockets/index.js
@@ -122,7 +122,10 @@ function init() {
           }
           break;
         default:
-          logger.debug(`Message type not handled`);
+          this.gladys.event.emit(EVENTS.WEBSOCKET.RECEIVE, {
+            userId: user.id,
+            ...parsedMessage,
+          });
       }
     });
     setTimeout(() => {

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -143,6 +143,7 @@ const EVENTS = {
   WEBSOCKET: {
     SEND: 'websocket.send',
     SEND_ALL: 'websocket.send-all',
+    RECEIVE: 'websocket.receive',
   },
   HOUSE: {
     CREATED: 'house.created',


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [ ] If your changes affects code, did your write the tests?
- [ ] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [x] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.json`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

This allows (future) services and other areas of code to listen for websocket events.

```
gladys.event.on(EVENTS.WEBSOCKET.RECEIVE, (event) => {
  // check event.type is the desired event and act accordingly; can reply using the below if desired:
  gladys.event.emit(EVENTS.WEBSOCKET.SEND, {
    type: WEBSOCKET_MESSAGE_TYPES.SOMETHING,
    userId: event.userId,
    payload: {}
  });
})
```
