### PR TITLE
Add ability to use request body response in scene

### DIFF
--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -932,7 +932,10 @@
         "bodyPlaceholder": "Body",
         "headersLabel": "Headers",
         "headersKeyPlaceholder": "Name",
-        "headersValuePlaceholder": "Value"
+        "headersValuePlaceholder": "Value",
+        "responseData": "Response",
+        "tryButton": "Try request",
+        "requestError": "An error happened while making the request. Are you sure parameters are right?"
       }
     },
     "actions": {

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -932,7 +932,10 @@
         "bodyPlaceholder": "Body",
         "headersLabel": "Headers",
         "headersKeyPlaceholder": "Nom",
-        "headersValuePlaceholder": "Valeur"
+        "headersValuePlaceholder": "Valeur",
+        "responseData": "Réponse",
+        "tryButton": "Essayer",
+        "requestError": "Une erreur est survenue lors de la requête. Êtes vous sûr d'avoir bien rempli le formulaire ?"
       }
     },
     "actions": {

--- a/front/src/routes/scene/edit-scene/ActionCard.jsx
+++ b/front/src/routes/scene/edit-scene/ActionCard.jsx
@@ -183,6 +183,7 @@ const ActionCard = ({ children, ...props }) => (
             columnIndex={props.columnIndex}
             index={props.index}
             updateActionProperty={props.updateActionProperty}
+            setVariables={props.setVariables}
           />
         )}
       </div>

--- a/front/src/routes/scene/edit-scene/actions/HttpRequest.jsx
+++ b/front/src/routes/scene/edit-scene/actions/HttpRequest.jsx
@@ -1,9 +1,22 @@
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Text, Localizer } from 'preact-i18n';
+import cx from 'classnames';
 import update from 'immutability-helper';
 
 const METHOD_WITH_BODY = ['post', 'patch', 'put'];
+
+const getAllPropertiesObject = (obj, path = '', results = []) => {
+  Object.keys(obj).forEach(key => {
+    const value = obj[key];
+    if (typeof value === 'object' && !Array.isArray(value)) {
+      getAllPropertiesObject(value, `${path}${key}.`, results);
+    } else {
+      results.push(path + key);
+    }
+  });
+  return results;
+};
 
 class Header extends Component {
   updateHeaderKey = e => {
@@ -57,7 +70,7 @@ class Header extends Component {
   }
 }
 
-@connect('', {})
+@connect('httpClient', {})
 class HttpRequestAction extends Component {
   handleChangeMethod = e => {
     this.props.updateActionProperty(this.props.columnIndex, this.props.index, 'method', e.target.value);
@@ -97,6 +110,45 @@ class HttpRequestAction extends Component {
     });
     this.props.updateActionProperty(this.props.columnIndex, this.props.index, 'headers', newHeaderArray);
   };
+  tryRequest = async e => {
+    e.preventDefault();
+    try {
+      await this.setState({ error: false, pending: true });
+      const { data, headers } = await this.props.httpClient.post('/api/v1/http/request', this.props.action);
+      let responseData = data;
+      const isJsonResponse = headers['content-type'].indexOf('application/json') !== -1;
+      if (isJsonResponse) {
+        responseData = JSON.stringify(data, null, 2);
+      }
+      this.setState({
+        apiTestResponse: responseData
+      });
+      if (isJsonResponse) {
+        const keys = getAllPropertiesObject(data);
+        const { columnIndex, index } = this.props;
+        const keysVariables = keys.map(key => {
+          const keyWithData = `data.${key}`;
+          return {
+            name: keyWithData,
+            type: 'http_request',
+            ready: true,
+            label: keyWithData
+          };
+        });
+        keysVariables.push({
+          name: 'status',
+          type: 'http_request',
+          ready: true,
+          label: 'status'
+        });
+        this.props.setVariables(columnIndex, index, keysVariables);
+      }
+      await this.setState({ error: false, pending: false });
+    } catch (e) {
+      console.error(e);
+      await this.setState({ error: true, pending: false });
+    }
+  };
   componentDidMount() {
     if (!this.props.action.method) {
       this.props.updateActionProperty(this.props.columnIndex, this.props.index, 'method', 'post');
@@ -109,93 +161,120 @@ class HttpRequestAction extends Component {
     const displayBody = METHOD_WITH_BODY.includes(props.action.method);
     return (
       <div>
-        <p>
-          <Text id="editScene.actionsCard.httpRequest.description" />
-        </p>
-        <form>
-          <div class="form-group">
-            <label class="form-label">
-              <Text id="editScene.actionsCard.httpRequest.methodLabel" />
-              <span class="form-required">
-                <Text id="global.requiredField" />
-              </span>
-            </label>
-            <select class="custom-select" value={props.action.method} onChange={this.handleChangeMethod}>
-              <option value="post">
-                <Text id="editScene.actionsCard.httpRequest.post" />
-              </option>
-              <option value="get">
-                <Text id="editScene.actionsCard.httpRequest.get" />
-              </option>
-              <option value="put">
-                <Text id="editScene.actionsCard.httpRequest.put" />
-              </option>
-              <option value="patch">
-                <Text id="editScene.actionsCard.httpRequest.patch" />
-              </option>
-              <option value="delete">
-                <Text id="editScene.actionsCard.httpRequest.delete" />
-              </option>
-            </select>
+        <div
+          class={cx('dimmer', {
+            active: this.state.pending
+          })}
+        >
+          <div class="loader" />
+          <div class="dimmer-content">
+            <p>
+              <Text id="editScene.actionsCard.httpRequest.description" />
+            </p>
+            <form>
+              <div class="form-group">
+                <label class="form-label">
+                  <Text id="editScene.actionsCard.httpRequest.methodLabel" />
+                  <span class="form-required">
+                    <Text id="global.requiredField" />
+                  </span>
+                </label>
+                <select class="custom-select" value={props.action.method} onChange={this.handleChangeMethod}>
+                  <option value="post">
+                    <Text id="editScene.actionsCard.httpRequest.post" />
+                  </option>
+                  <option value="get">
+                    <Text id="editScene.actionsCard.httpRequest.get" />
+                  </option>
+                  <option value="put">
+                    <Text id="editScene.actionsCard.httpRequest.put" />
+                  </option>
+                  <option value="patch">
+                    <Text id="editScene.actionsCard.httpRequest.patch" />
+                  </option>
+                  <option value="delete">
+                    <Text id="editScene.actionsCard.httpRequest.delete" />
+                  </option>
+                </select>
+              </div>
+              <div class="form-group">
+                <label class="form-label">
+                  <Text id="editScene.actionsCard.httpRequest.urlLabel" />
+                  <span class="form-required">
+                    <Text id="global.requiredField" />
+                  </span>
+                </label>
+                <Localizer>
+                  <input
+                    type="text"
+                    class="form-control"
+                    value={props.action.url}
+                    onChange={this.handleChangeUrl}
+                    placeholder={<Text id="editScene.actionsCard.httpRequest.urlPlaceholder" />}
+                  />
+                </Localizer>
+              </div>
+              <div class="form-group">
+                <label class="form-label">
+                  <Text id="editScene.actionsCard.httpRequest.headersLabel" />
+                  <span class="form-required">
+                    <Text id="global.requiredField" />
+                  </span>
+                </label>
+                {props.action.headers &&
+                  props.action.headers.map((header, index) => (
+                    <Header
+                      header={header}
+                      index={index}
+                      updateHeader={this.updateHeader}
+                      deleteHeader={this.deleteHeader}
+                      lastItem={index === props.action.headers.length - 1}
+                    />
+                  ))}
+                <button class="btn btn-secondary" onClick={this.addNewHeader}>
+                  <i class="fe fe-plus" />
+                </button>
+              </div>
+              {displayBody && (
+                <div class="form-group">
+                  <label class="form-label">
+                    <Text id="editScene.actionsCard.httpRequest.bodyLabel" />
+                    <span class="form-required">
+                      <Text id="global.requiredField" />
+                    </span>
+                  </label>
+                  <Localizer>
+                    <textarea
+                      type="text"
+                      class="form-control"
+                      value={props.action.body}
+                      onChange={this.handleChangeBody}
+                      placeholder={<Text id="editScene.actionsCard.httpRequest.bodyPlaceholder" />}
+                    />
+                  </Localizer>
+                </div>
+              )}
+              {this.state.apiTestResponse && (
+                <div>
+                  <label class="form-label">
+                    <Text id="editScene.actionsCard.httpRequest.responseData" />
+                  </label>
+                  <pre>
+                    <code>{this.state.apiTestResponse}</code>
+                  </pre>
+                </div>
+              )}
+              {this.state.error && (
+                <div class="alert alert-danger">
+                  <Text id="editScene.actionsCard.httpRequest.requestError" />
+                </div>
+              )}
+              <button class="btn btn-primary" onClick={this.tryRequest}>
+                <Text id="editScene.actionsCard.httpRequest.tryButton" />
+              </button>
+            </form>
           </div>
-          <div class="form-group">
-            <label class="form-label">
-              <Text id="editScene.actionsCard.httpRequest.urlLabel" />
-              <span class="form-required">
-                <Text id="global.requiredField" />
-              </span>
-            </label>
-            <Localizer>
-              <input
-                type="text"
-                class="form-control"
-                value={props.action.url}
-                onChange={this.handleChangeUrl}
-                placeholder={<Text id="editScene.actionsCard.httpRequest.urlPlaceholder" />}
-              />
-            </Localizer>
-          </div>
-          <div class="form-group">
-            <label class="form-label">
-              <Text id="editScene.actionsCard.httpRequest.headersLabel" />
-              <span class="form-required">
-                <Text id="global.requiredField" />
-              </span>
-            </label>
-            {props.action.headers &&
-              props.action.headers.map((header, index) => (
-                <Header
-                  header={header}
-                  index={index}
-                  updateHeader={this.updateHeader}
-                  deleteHeader={this.deleteHeader}
-                  lastItem={index === props.action.headers.length - 1}
-                />
-              ))}
-            <button class="btn btn-secondary" onClick={this.addNewHeader}>
-              <i class="fe fe-plus" />
-            </button>
-          </div>
-          {displayBody && (
-            <div class="form-group">
-              <label class="form-label">
-                <Text id="editScene.actionsCard.httpRequest.bodyLabel" />
-                <span class="form-required">
-                  <Text id="global.requiredField" />
-                </span>
-              </label>
-              <Localizer>
-                <textarea
-                  type="text"
-                  class="form-control"
-                  value={props.action.body}
-                  onChange={this.handleChangeBody}
-                  placeholder={<Text id="editScene.actionsCard.httpRequest.bodyPlaceholder" />}
-                />
-              </Localizer>
-            </div>
-          )}
-        </form>
+        </div>
       </div>
     );
   }

--- a/front/src/routes/scene/edit-scene/actions/HttpRequest.jsx
+++ b/front/src/routes/scene/edit-scene/actions/HttpRequest.jsx
@@ -9,10 +9,11 @@ const METHOD_WITH_BODY = ['post', 'patch', 'put'];
 const getAllPropertiesObject = (obj, path = '', results = []) => {
   Object.keys(obj).forEach(key => {
     const value = obj[key];
-    if (typeof value === 'object' && !Array.isArray(value)) {
-      getAllPropertiesObject(value, `${path}${key}.`, results);
+    const keyFormatted = Number.isInteger(parseInt(key, 10)) ? `[${key}]` : key;
+    if (typeof value === 'object') {
+      getAllPropertiesObject(value, `${path}${keyFormatted}.`, results);
     } else {
-      results.push(path + key);
+      results.push(path + keyFormatted);
     }
   });
   return results;

--- a/front/src/routes/scene/edit-scene/actions/HttpRequest.jsx
+++ b/front/src/routes/scene/edit-scene/actions/HttpRequest.jsx
@@ -110,6 +110,25 @@ class HttpRequestAction extends Component {
     });
     this.props.updateActionProperty(this.props.columnIndex, this.props.index, 'headers', newHeaderArray);
   };
+  loadVariables = keys => {
+    const { columnIndex, index } = this.props;
+    const keysVariables = keys.map(key => {
+      const keyWithData = `data.${key}`;
+      return {
+        name: keyWithData,
+        type: 'http_request',
+        ready: true,
+        label: keyWithData
+      };
+    });
+    keysVariables.push({
+      name: 'status',
+      type: 'http_request',
+      ready: true,
+      label: 'status'
+    });
+    this.props.setVariables(columnIndex, index, keysVariables);
+  };
   tryRequest = async e => {
     e.preventDefault();
     try {
@@ -125,23 +144,8 @@ class HttpRequestAction extends Component {
       });
       if (isJsonResponse) {
         const keys = getAllPropertiesObject(data);
-        const { columnIndex, index } = this.props;
-        const keysVariables = keys.map(key => {
-          const keyWithData = `data.${key}`;
-          return {
-            name: keyWithData,
-            type: 'http_request',
-            ready: true,
-            label: keyWithData
-          };
-        });
-        keysVariables.push({
-          name: 'status',
-          type: 'http_request',
-          ready: true,
-          label: 'status'
-        });
-        this.props.setVariables(columnIndex, index, keysVariables);
+        this.props.updateActionProperty(this.props.columnIndex, this.props.index, 'request_response_keys', keys);
+        this.loadVariables(keys);
       }
       await this.setState({ error: false, pending: false });
     } catch (e) {
@@ -155,6 +159,9 @@ class HttpRequestAction extends Component {
     }
     if (!this.props.action.headers) {
       this.props.updateActionProperty(this.props.columnIndex, this.props.index, 'headers', []);
+    }
+    if (this.props.action.request_response_keys) {
+      this.loadVariables(this.props.action.request_response_keys);
     }
   }
   render(props) {

--- a/server/api/controllers/http.controller.js
+++ b/server/api/controllers/http.controller.js
@@ -1,0 +1,27 @@
+const asyncMiddleware = require('../middlewares/asyncMiddleware');
+
+module.exports = function HttpController(gladys) {
+  /**
+   * @api {post} /api/v1/http/request
+   * @apiName httpRequest
+   * @apiGroup Http
+   * @apiParam {String} method Method of the request
+   * @apiParam {String} url Url of the request
+   * @apiParam {String} [body] Body of the request
+   * @apiParam {Array} [headers] Headers of the request
+   * @apiSuccessExample {json} Success-Example
+   * {
+   *   "data": {}
+   *   "status": 200,
+   *   "headers": ["content-type": "application/json"]
+   * }
+   */
+  async function request(req, res) {
+    const response = await gladys.http.request(req.body.method, req.body.url, req.body.body, req.body.headers);
+    res.json(response);
+  }
+
+  return Object.freeze({
+    request: asyncMiddleware(request),
+  });
+};

--- a/server/api/routes.js
+++ b/server/api/routes.js
@@ -7,6 +7,7 @@ const UserController = require('./controllers/user.controller');
 const PingController = require('./controllers/ping.controller');
 const GatewayController = require('./controllers/gateway.controller');
 const HouseController = require('./controllers/house.controller');
+const HttpController = require('./controllers/http.controller');
 const LightController = require('./controllers/light.controller');
 const LocationController = require('./controllers/location.controller');
 const MessageController = require('./controllers/message.controller');
@@ -35,6 +36,7 @@ function getRoutes(gladys) {
   const locationController = LocationController(gladys);
   const userController = UserController(gladys);
   const houseController = HouseController(gladys);
+  const httpController = HttpController(gladys);
   const messageController = MessageController(gladys);
   const pingController = PingController();
   const gatewayController = GatewayController(gladys);
@@ -234,6 +236,12 @@ function getRoutes(gladys) {
     'post /api/v1/house/:house_selector/user/:user_selector/seen': {
       authenticated: true,
       controller: houseController.userSeen,
+    },
+    // http
+    'post /api/v1/http/request': {
+      authenticated: true,
+      admin: true,
+      controller: httpController.request,
     },
     // gateway
     'get /api/v1/gateway/status': {

--- a/server/lib/http/http.request.js
+++ b/server/lib/http/http.request.js
@@ -18,7 +18,7 @@ async function request(method, url, body, headers) {
     url,
     timeout: DEFAULT_TIMEOUT,
     headers: { 'user-agent': `GladysAssistant/${this.system.gladysVersion}` },
-    validateStatus: (status) => true,
+    validateStatus: null, // we don't want axios to throw an error
   };
   if (body) {
     options.data = body;

--- a/server/lib/http/http.request.js
+++ b/server/lib/http/http.request.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 
-const DEFAULT_TIMEOUT = 60 * 1000;
+const DEFAULT_TIMEOUT = 20 * 1000;
+
 /**
  * @public
  * @description Make an HTTP request
@@ -17,6 +18,7 @@ async function request(method, url, body, headers) {
     url,
     timeout: DEFAULT_TIMEOUT,
     headers: { 'user-agent': `GladysAssistant/${this.system.gladysVersion}` },
+    validateStatus: (status) => true,
   };
   if (body) {
     options.data = body;
@@ -25,8 +27,12 @@ async function request(method, url, body, headers) {
     options.headers = Object.assign(options.headers, headers);
   }
   // @ts-ignore
-  const { data } = await axios.request(options);
-  return data;
+  const response = await axios.request(options);
+  return {
+    data: response.data,
+    status: response.status,
+    headers: response.headers,
+  };
 }
 
 module.exports = {

--- a/server/lib/index.js
+++ b/server/lib/index.js
@@ -74,6 +74,7 @@ function Gladys(params = {}) {
     dashboard,
     event,
     house,
+    http,
     gateway,
     location,
     message,

--- a/server/models/scene.js
+++ b/server/models/scene.js
@@ -22,6 +22,7 @@ const actionSchema = Joi.array().items(
       url: Joi.string().uri(),
       body: Joi.string(),
       method: Joi.string().valid('get', 'post', 'patch', 'put', 'delete'),
+      request_response_keys: Joi.array().items(Joi.string()),
       headers: Joi.array().items(
         Joi.object().keys({
           key: Joi.string(),

--- a/server/test/controllers/http/http.test.js
+++ b/server/test/controllers/http/http.test.js
@@ -1,0 +1,78 @@
+const { expect } = require('chai');
+const nock = require('nock');
+const { authenticatedRequest } = require('../request.test');
+
+describe('POST /api/v1/http/request', () => {
+  it('should make GET HTTP request', async () => {
+    const scope = nock('http://test-http-request.com')
+      .get('/test/request')
+      .reply(200, {
+        hey: 'you',
+      });
+    await authenticatedRequest
+      .post('/api/v1/http/request')
+      .send({
+        method: 'get',
+        url: 'http://test-http-request.com/test/request',
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then((res) => {
+        expect(res.body).to.deep.equal({
+          data: { hey: 'you' },
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      });
+    expect(scope.isDone()).to.equal(true);
+  });
+  it('should make GET HTTP request on non json route', async () => {
+    const scope = nock('http://test-http-request.com')
+      .get('/test/html')
+      .reply(200, '<html></html>', { 'content-type': 'text/html; charset=utf-8' });
+    await authenticatedRequest
+      .post('/api/v1/http/request')
+      .send({
+        method: 'get',
+        url: 'http://test-http-request.com/test/html',
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then((res) => {
+        expect(res.body).to.deep.equal({
+          data: '<html></html>',
+          status: 200,
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        });
+      });
+    expect(scope.isDone()).to.equal(true);
+  });
+  it('should make POST HTTP request', async () => {
+    const scope = nock('http://test-http-request.com')
+      .post('/test/request/post', {
+        yo: 'yo',
+      })
+      .reply(201, {
+        oh: 'uh',
+      });
+    await authenticatedRequest
+      .post('/api/v1/http/request')
+      .send({
+        method: 'post',
+        url: 'http://test-http-request.com/test/request/post',
+        body: {
+          yo: 'yo',
+        },
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then((res) => {
+        expect(res.body).to.deep.equal({
+          data: { oh: 'uh' },
+          status: 201,
+          headers: { 'content-type': 'application/json' },
+        });
+      });
+    expect(scope.isDone()).to.equal(true);
+  });
+});

--- a/server/test/lib/http/AxiosMock.test.js
+++ b/server/test/lib/http/AxiosMock.test.js
@@ -1,7 +1,7 @@
 const { fake } = require('sinon');
 
 const axios = {
-  request: fake.resolves({ data: { success: true }, status: 200 }),
+  request: fake.resolves({ data: { success: true }, status: 200, headers: { 'content-type': 'application/json' } }),
 };
 
 module.exports = axios;

--- a/server/test/lib/http/http.test.js
+++ b/server/test/lib/http/http.test.js
@@ -16,21 +16,30 @@ describe('http.request', () => {
   it('should make a GET request', async () => {
     const response = await http.request('get', 'http://test.test');
     expect(response).to.deep.equal({
-      success: true,
+      data: {
+        success: true,
+      },
+      headers: { 'content-type': 'application/json' },
+      status: 200,
     });
     assert.calledWith(AxiosMock.request, {
       method: 'get',
       url: 'http://test.test',
-      timeout: 60000,
+      timeout: 20000,
       headers: {
         'user-agent': `GladysAssistant/v${packageJson.version}`,
       },
+      validateStatus: null,
     });
   });
   it('should make a POST request', async () => {
     const response = await http.request('post', 'http://test.test', { toto: 'toto' }, { authorization: 'TOKEN' });
     expect(response).to.deep.equal({
-      success: true,
+      data: {
+        success: true,
+      },
+      headers: { 'content-type': 'application/json' },
+      status: 200,
     });
     assert.calledWith(AxiosMock.request, {
       method: 'post',
@@ -42,7 +51,8 @@ describe('http.request', () => {
         authorization: 'TOKEN',
         'user-agent': `GladysAssistant/v${packageJson.version}`,
       },
-      timeout: 60000,
+      timeout: 20000,
+      validateStatus: null,
     });
   });
 });


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [ ] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.json`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

The user is now able to use the try a request in scene, and use the API response in other boxes of the scene

Example with Bitcoin price:

https://user-images.githubusercontent.com/7365207/115101178-8cab6e80-9f74-11eb-8fb1-bde193514a1b.mp4


