### PR TITLE
[WIP] LG TV Integration

### DIFF
--- a/front/src/actions/dashboard/boxes/mediaPlayer.js
+++ b/front/src/actions/dashboard/boxes/mediaPlayer.js
@@ -1,0 +1,44 @@
+import { RequestStatus } from '../../../utils/consts';
+import createBoxActions from '../boxActions';
+import { WEBSOCKET_MESSAGE_TYPES } from '../../../../../server/utils/constants';
+
+const BOX_KEY = 'MediaPlayer';
+
+function createActions(store) {
+  const boxActions = createBoxActions(store);
+
+  const updateHandler = sourceString => {
+    // state.device.deviceFeatures.findIndex(feature => feature.type = )
+    // boxActions.mergeBoxData(state, BOX_KEY, x, y, {
+    //   device
+    // });
+    console.log(sourceString);
+  };
+
+  const actions = {
+    async getMediaPlayer(state, box, x, y) {
+      boxActions.updateBoxStatus(state, BOX_KEY, x, y, RequestStatus.Getting);
+      try {
+        const device = await state.httpClient.get(`/api/v1/device/${box.player}`);
+        boxActions.mergeBoxData(state, BOX_KEY, x, y, {
+          device
+        });
+        boxActions.updateBoxStatus(state, BOX_KEY, x, y, RequestStatus.Success);
+      } catch (e) {
+        boxActions.mergeBoxData(state, BOX_KEY, x, y, {
+          device: null
+        });
+        boxActions.updateBoxStatus(state, BOX_KEY, x, y, RequestStatus.Error);
+      }
+    },
+    addListeners(state) {
+      state.session.dispatcher.addListener(WEBSOCKET_MESSAGE_TYPES.DEVICE.NEW_STRING_STATE, updateHandler);
+    },
+    removeListeners(state) {
+      state.session.dispatcher.removeListener(WEBSOCKET_MESSAGE_TYPES.DEVICE.NEW_STRING_STATE, updateHandler);
+    }
+  };
+  return Object.assign({}, actions);
+}
+
+export default createActions;

--- a/front/src/actions/dashboard/edit-boxes/editMediaPlayer.js
+++ b/front/src/actions/dashboard/edit-boxes/editMediaPlayer.js
@@ -1,0 +1,29 @@
+import { RequestStatus } from '../../../utils/consts';
+import createBoxActions from '../boxActions';
+
+function createActions(store) {
+  const boxActions = createBoxActions(store);
+
+  const actions = {
+    async getMediaPlayers(state) {
+      store.setState({
+        DashboardEditMediaPlayerStatus: RequestStatus.Getting
+      });
+      try {
+        const players = await state.httpClient.get('/api/v1/media-player');
+        store.setState({
+          players,
+          DashboardEditMediaPlayerStatus: RequestStatus.Success
+        });
+      } catch (e) {
+        console.log(e);
+        store.setState({
+          DashboardEditMediaPlayerStatus: RequestStatus.Error
+        });
+      }
+    }
+  };
+  return Object.assign({}, actions, boxActions);
+}
+
+export default createActions;

--- a/front/src/components/app.jsx
+++ b/front/src/components/app.jsx
@@ -72,6 +72,9 @@ import ZwaveEditPage from '../routes/integration/all/zwave/edit-page';
 import RtspCameraPage from '../routes/integration/all/rtsp-camera';
 import XiaomiPage from '../routes/integration/all/xiaomi';
 import EditXiaomiPage from '../routes/integration/all/xiaomi/edit-page';
+import LGTVDevicesPage from '../routes/integration/all/lgtv/devices';
+import LGTVAddPage from '../routes/integration/all/lgtv/add';
+import LGTVDiscoverPage from '../routes/integration/all/lgtv/discover';
 
 // MQTT integration
 import MqttDevicePage from '../routes/integration/all/mqtt/device-page';
@@ -213,6 +216,9 @@ const AppRouter = connect(
         <EweLinkEditPage path="/dashboard/integration/device/ewelink/edit/:deviceSelector" />
         <EweLinkDiscoverPage path="/dashboard/integration/device/ewelink/discover" />
         <EweLinkSetupPage path="/dashboard/integration/device/ewelink/setup" />
+        <LGTVDevicesPage path="/dashboard/integration/device/lgtv" />
+        <LGTVDiscoverPage path="/dashboard/integration/device/lgtv/discover" />
+        <LGTVAddPage path="/dashboard/integration/device/lgtv/add" />
 
         <BluetoothDevicePage path="/dashboard/integration/device/bluetooth" />
         <BluetoothEditDevicePage path="/dashboard/integration/device/bluetooth/:deviceSelector" />

--- a/front/src/components/boxs/media-player/EditMediaPlayer.jsx
+++ b/front/src/components/boxs/media-player/EditMediaPlayer.jsx
@@ -1,0 +1,48 @@
+import { Text } from 'preact-i18n';
+import { useCallback, useEffect } from 'preact/hooks';
+import { connect } from 'unistore/preact';
+import actions from '../../../actions/dashboard/edit-boxes/editMediaPlayer';
+import BaseEditBox from '../baseEditBox';
+
+const EditMediaPlayer = connect(
+  'players',
+  actions
+)(({ children, ...props }) => {
+  useEffect(() => {
+    (async () => {
+      await props.getMediaPlayers();
+    })();
+  }, []);
+
+  const onChange = useCallback(
+    e => {
+      props.updateBoxConfig(props.x, props.y, {
+        player: e.target.value
+      });
+    },
+    [props.x, props.y]
+  );
+
+  return (
+    <BaseEditBox {...props} titleKey="dashboard.boxTitle.media-player">
+      <div class="form-group">
+        <label>
+          <Text id="dashboard.boxes.mediaPlayer.editPlayerLabel" />
+        </label>
+        <select onChange={onChange} class="form-control">
+          <option value="">
+            <Text id="global.emptySelectOption" />
+          </option>
+          {props.players &&
+            props.players.map(player => (
+              <option selected={player.selector === props.box.player} value={player.selector}>
+                {player.name}
+              </option>
+            ))}
+        </select>
+      </div>
+    </BaseEditBox>
+  );
+});
+
+export default EditMediaPlayer;

--- a/front/src/components/boxs/media-player/MediaPlayer.jsx
+++ b/front/src/components/boxs/media-player/MediaPlayer.jsx
@@ -1,0 +1,81 @@
+import cx from 'classnames';
+import { connect } from 'unistore/preact';
+import { Text } from 'preact-i18n';
+import actions from '../../../actions/dashboard/boxes/mediaPlayer';
+import { DASHBOARD_BOX_STATUS_KEY, DASHBOARD_BOX_DATA_KEY, RequestStatus } from '../../../utils/consts';
+import { useEffect } from 'preact/hooks';
+import get from 'get-value';
+import style from './style.css';
+import { getDeviceFeature, getDeviceParam } from '../../../../../server/utils/device';
+import { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } from '../../../../../server/utils/constants';
+
+function detailsFromDevice(device) {
+  const source = JSON.parse(
+    getDeviceFeature(device, DEVICE_FEATURE_CATEGORIES.MEDIA_PLAYER, DEVICE_FEATURE_TYPES.MEDIA_PLAYER.SOURCE)
+      .last_value_string || '{}'
+  );
+  const power = Boolean(
+    get(
+      getDeviceFeature(device, DEVICE_FEATURE_CATEGORIES.MEDIA_PLAYER, DEVICE_FEATURE_TYPES.MEDIA_PLAYER.POWER),
+      'last_value',
+      false
+    )
+  );
+
+  return {
+    name: device.name,
+    playing: source && Object.keys(source).length > 0 && source.label,
+    power,
+    source
+  };
+}
+
+const MediaPlayer = connect(
+  'session,DashboardBoxDataMediaPlayer,DashboardBoxStatusMediaPlayer',
+  actions
+)(props => {
+  const boxStatus = get(props, `${DASHBOARD_BOX_STATUS_KEY}MediaPlayer.${props.x}_${props.y}`);
+
+  useEffect(() => {
+    (async () => {
+      props.getMediaPlayer(props.box, props.x, props.y);
+      props.addListeners();
+    })();
+
+    return () => props.removeListeners();
+  }, [props.box.player]);
+
+  if (!boxStatus || boxStatus !== RequestStatus.Success) {
+    return null;
+  }
+
+  const { name, playing, power, source } = detailsFromDevice(
+    get(props, `${DASHBOARD_BOX_DATA_KEY}MediaPlayer.${props.x}_${props.y}.device`)
+  );
+
+  return (
+    <div class="card p-3">
+      <div class="d-flex align-items-center">
+        <span class={cx('stamp', 'stamp-md', 'mr-3', power && 'bg-blue', style.stamp)}>
+          {source.image ? <img src={source.image} /> : <i class="fe fe-power" />}
+        </span>
+        <div>
+          <h4 class="m-0">{name}</h4>
+
+          {playing && (
+            <small class="text-muted">
+              <Text
+                id="dashboard.boxes.mediaPlayer.currentlyWatching"
+                fields={{
+                  media: source.label
+                }}
+              />
+            </small>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+});
+
+export default MediaPlayer;

--- a/front/src/components/boxs/media-player/style.css
+++ b/front/src/components/boxs/media-player/style.css
@@ -1,0 +1,8 @@
+.stamp {
+  width: 2.5rem;
+  display: flex;
+  overflow: hidden;
+  padding: 0;
+  justify-content: center;
+  align-items: center;
+}

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -181,7 +181,8 @@
       "humidity-in-room": "Humidity in room",
       "user-presence": "User presence",
       "camera": "Camera",
-      "devices-in-room": "Devices in room"
+      "devices-in-room": "Devices in room",
+      "media-player": "Media player"
     },
     "boxes": {
       "column": "Column {{index}}",
@@ -230,6 +231,10 @@
         "noImageToShow": "No image to show",
         "editBoxNameLabel": "Enter the name you want to give to the box:",
         "editBoxNamePlaceholder": "Name of the box"
+      },
+      "mediaPlayer": {
+        "currentlyWatching": "Currently watching {{media}}",
+        "editPlayerLabel": "Select the device you want to display here"
       }
     }
   },
@@ -310,6 +315,40 @@
       "deleteButton": "Delete",
       "saveError": "There was an error saving the camera.",
       "testConnectionError": "There was an error while getting the RTSP Flux. Are you sure the provided URL is right and accessible from Gladys instance?"
+    },
+    "lgtv": {
+      "title": "LG TV",
+      "or": "or",
+      "new": "Add manually",
+      "description": "LG WebOS TVs in Gladys.",
+      "deviceTab": "TVs",
+      "discoverTab": "Discover",
+      "discoverButton": "Discover",
+      "setUpManually": "set up manually",
+      "scanning": "Scanning",
+      "addDetectedDevice": "Add {{modelName}}",
+      "addDetectedDeviceNoModel": "Add TV",
+      "requestPrompt": "Authenticate with TV",
+      "promptError": "An error occured showing the prompt, please try again.",
+      "prompt": "Please accept the prompt on your TV",
+      "deviceFound": "Discovered LG {{modelName}} on the network",
+      "deviceFoundNoModel": "Discovered an LG TV on the network",
+      "discover": {
+        "title": "Discover"
+      },
+      "device": {
+        "title": "Your TVs",
+        "saveButton": "Save",
+        "deleteButton": "Delete",
+        "nameLabel": "Device Name",
+        "roomLabel": "Room",
+        "ipLabel": "Hostname/IP"
+      },
+      "add": {
+        "title": "Add an LG TV",
+        "name": "Name",
+        "namePlaceholder": "Living room LG OLED65GX"
+      }
     },
     "tasmota": {
       "title": "Tasmota",

--- a/front/src/config/integrations/devices.json
+++ b/front/src/config/integrations/devices.json
@@ -41,5 +41,9 @@
   {
     "key": "eWeLink",
     "img": "/assets/integrations/cover/ewelink.jpg"
+  },
+  {
+    "key": "lgtv",
+    "img": "/assets/integrations/cover/lgtv.jpg"
   }
 ]

--- a/front/src/routes/dashboard/Box.jsx
+++ b/front/src/routes/dashboard/Box.jsx
@@ -3,6 +3,7 @@ import RoomTemperatureBox from '../../components/boxs/room-temperature/RoomTempe
 import RoomHumidityBox from '../../components/boxs/room-humidity/RoomHumidity';
 import CameraBox from '../../components/boxs/camera/Camera';
 import AtHomeBox from '../../components/boxs/user-presence/UserPresence';
+import MediaPlayer from '../../components/boxs/media-player/MediaPlayer';
 import DevicesInRoomsBox from '../../components/boxs/device-in-room/DevicesInRoomsBox';
 
 const Box = ({ children, ...props }) => {
@@ -19,6 +20,8 @@ const Box = ({ children, ...props }) => {
       return <RoomHumidityBox {...props} />;
     case 'devices-in-room':
       return <DevicesInRoomsBox {...props} />;
+    case 'media-player':
+      return <MediaPlayer {...props} />;
   }
 };
 

--- a/front/src/routes/dashboard/EditBox.jsx
+++ b/front/src/routes/dashboard/EditBox.jsx
@@ -4,6 +4,7 @@ import EditRoomTemperatureBox from '../../components/boxs/room-temperature/EditR
 import EditRoomHumidityBox from '../../components/boxs/room-humidity/EditRoomHumidityBox';
 import EditCameraBox from '../../components/boxs/camera/EditCamera';
 import EditAtHomeBox from '../../components/boxs/user-presence/EditUserPresenceBox';
+import EditMediaPlayer from '../../components/boxs/media-player/EditMediaPlayer';
 import EditDevicesInRoom from '../../components/boxs/device-in-room/EditDeviceInRoom';
 
 const Box = ({ children, ...props }) => {
@@ -20,6 +21,8 @@ const Box = ({ children, ...props }) => {
       return <EditRoomHumidityBox {...props} />;
     case 'devices-in-room':
       return <EditDevicesInRoom {...props} />;
+    case 'media-player':
+      return <EditMediaPlayer {...props} />;
   }
 };
 

--- a/front/src/routes/integration/all/ewelink/discover-page/DiscoverTab.jsx
+++ b/front/src/routes/integration/all/ewelink/discover-page/DiscoverTab.jsx
@@ -13,12 +13,8 @@ const DeviceTab = ({ children, ...props }) => (
         <Text id="integration.eWeLink.discover.title" />
       </h1>
       <div class="page-options d-flex">
-        <button
-          onClick={props.getDiscoveredEweLinkDevices}
-          class="btn btn-outline-primary ml-2"
-          disabled={props.loading}
-        >
-          <Text id="integration.eWeLink.discover.scan" /> <i class="fe fe-radio" />
+        <button onClick={props.discover} class="btn btn-outline-primary ml-2" disabled={props.loading}>
+          <Text id="integration.lgtv.scan" /> <i class="fe fe-radio" />
         </button>
       </div>
     </div>

--- a/front/src/routes/integration/all/lgtv/Device.jsx
+++ b/front/src/routes/integration/all/lgtv/Device.jsx
@@ -1,0 +1,85 @@
+import { useState, useCallback } from 'preact/hooks';
+import { Text, Localizer } from 'preact-i18n';
+import { Component } from 'preact';
+import cx from 'classnames';
+
+import { RoomInput } from './common';
+
+import get from 'get-value';
+import { Link } from 'preact-router';
+
+import { RequestStatus, DeviceFeatureCategoriesIcon } from '../../../../utils/consts';
+
+import style from './style.css';
+
+const LGTVDevice = ({
+  device,
+  showTitle,
+  showDeleteButton,
+  houses,
+  onDeviceUpdate,
+  onDeviceDelete,
+  updateDeviceProperty
+}) => {
+  const [isLoading, setLoading] = useState(false);
+
+  const onUpdate = useCallback(async () => {
+    await onDeviceUpdate(device);
+  });
+  const onDelete = useCallback(async () => {
+    await onDeviceDelete(device);
+  });
+
+  const updateRoom = useCallback(e => updateDeviceProperty(device, 'room_id', e.target.value));
+  const updateName = useCallback(e => updateDeviceProperty(device, 'name', e.target.value));
+  const ipAddressParam = device.params.find(param => param.name === 'address');
+  const { value: address } = ipAddressParam;
+
+  return (
+    <div class="col-md-6">
+      <div class="card">
+        {showTitle && <div class="card-header">{device.name}</div>}
+        <div
+          class={cx('dimmer', {
+            active: isLoading
+          })}
+        >
+          <div class="loader" />
+          <div class="dimmer-content">
+            <div class="card-body">
+              <div class="form-group">
+                <label>
+                  <Text id="integration.lgtv.device.ipLabel" />
+                </label>
+                <Localizer>
+                  <input type="text" value={address} class="form-control" />
+                </Localizer>
+              </div>
+              <div class="form-group">
+                <label>
+                  <Text id="integration.lgtv.device.nameLabel" />
+                </label>
+                <Localizer>
+                  <input type="text" value={device.name} onInput={updateName} class="form-control" />
+                </Localizer>
+              </div>
+              <RoomInput onChange={updateRoom} houses={houses} selectedRoomId={device.room_id} />
+              <div class="form-group">
+                <button onClick={onUpdate} class="btn btn-success mr-2">
+                  <Text id="integration.lgtv.device.saveButton" />
+                </button>
+                {showDeleteButton && (
+                  <button onClick={onDelete} class="btn btn-danger">
+                    <Text id="integration.lgtv.device.deleteButton" />
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LGTVDevice;

--- a/front/src/routes/integration/all/lgtv/EmptyState.jsx
+++ b/front/src/routes/integration/all/lgtv/EmptyState.jsx
@@ -1,0 +1,14 @@
+import cx from 'classnames';
+import style from './style.css';
+import { NewLink, ScanButton } from './common';
+
+const EmptyState = ({ onScan, onAdd, scanStatus }) => (
+  <div class="col-md-12">
+    <div class={cx('text-center', style.emptyStateDivBox)}>
+      <ScanButton onClick={onScan} scanStatus={scanStatus} />
+      <NewLink />
+    </div>
+  </div>
+);
+
+export default EmptyState;

--- a/front/src/routes/integration/all/lgtv/LGTVPage.jsx
+++ b/front/src/routes/integration/all/lgtv/LGTVPage.jsx
@@ -1,0 +1,49 @@
+import { Text } from 'preact-i18n';
+import { Link } from 'preact-router/match';
+
+const LGTVPage = ({ children }) => (
+  <div class="page">
+    <div class="page-main">
+      <div class="my-3 my-md-5">
+        <div class="container">
+          <div class="row">
+            <div class="col-lg-3">
+              <h3 class="page-title mb-5">
+                <Text id="integration.lgtv.title" />
+              </h3>
+              <div>
+                <div class="list-group list-group-transparent mb-0">
+                  <Link
+                    href="/dashboard/integration/device/lgtv"
+                    activeClassName="active"
+                    class="list-group-item list-group-item-action d-flex align-items-center"
+                  >
+                    <span class="icon mr-3">
+                      <i class="fe fe-tv" />
+                    </span>
+                    <Text id="integration.lgtv.deviceTab" />
+                  </Link>
+
+                  <Link
+                    href="/dashboard/integration/device/lgtv/discover"
+                    activeClassName="active"
+                    class="list-group-item list-group-item-action d-flex align-items-center"
+                  >
+                    <span class="icon mr-3">
+                      <i class="fe fe-radio" />
+                    </span>
+                    <Text id="integration.lgtv.discoverTab" />
+                  </Link>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-9">{children}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default LGTVPage;

--- a/front/src/routes/integration/all/lgtv/actions.js
+++ b/front/src/routes/integration/all/lgtv/actions.js
@@ -1,0 +1,104 @@
+import { RequestStatus } from '../../../../utils/consts';
+import update from 'immutability-helper';
+import uuid from 'uuid';
+import { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } from '../../../../../../server/utils/constants';
+import createActionsIntegration from '../../../../actions/integration';
+import UpdateDevice from '../../../../components/device/UpdateDevice';
+import createActionsHouse from '../../../../actions/house';
+
+function createActions(store) {
+  const integrationActions = createActionsIntegration(store);
+  const houseActions = createActionsHouse(store);
+  const actions = {
+    async getLGTVDevices(state) {
+      store.setState({
+        getLGTVDevicesStatus: RequestStatus.Getting
+      });
+      try {
+        const lgtvDevices = await state.httpClient.get('/api/v1/service/lgtv/device');
+
+        store.setState({
+          lgtvDevices,
+          getLGTVDevicesStatus: RequestStatus.Success
+        });
+      } catch (e) {
+        store.setState({
+          getLGTVDevicesStatus: RequestStatus.Error
+        });
+      }
+    },
+    async scan(state) {
+      store.setState({
+        scanLGTVDevicesStatus: RequestStatus.Getting
+      });
+      try {
+        const allScannedDevices = await state.httpClient.post('/api/v1/service/lgtv/scan');
+        const existingDeviceIDs = state.lgtvDevices.map(device => device.external_id);
+
+        const scannedDevices = allScannedDevices.filter(device => !existingDeviceIDs.includes(device.deviceExternalID));
+
+        store.setState({
+          scannedDevices,
+          scanLGTVDevicesStatus: RequestStatus.Success
+        });
+      } catch (e) {
+        store.setState({
+          scanLGTVDevicesStatus: RequestStatus.Error
+        });
+      }
+    },
+    updateDeviceProperty(state, device, property, value) {
+      const index = state.lgtvDevices.findIndex(haystack => haystack.id === device.id);
+      const newState = update(state, {
+        lgtvDevices: {
+          [index]: {
+            [property]: {
+              $set: value
+            }
+          }
+        }
+      });
+      store.setState(newState);
+    },
+    async createDevice(state, lgDevice) {
+      const createdDevice = await state.httpClient.post('/api/v1/service/lgtv/device', lgDevice);
+      const lgtvDevices = update(state.lgtvDevices, {
+        $push: [createdDevice]
+      });
+
+      store.setState({
+        lgtvDevices,
+        scannedDevices: []
+      });
+    },
+
+    async updateDevice(state, device) {
+      console.log(device);
+      const savedDevice = await state.httpClient.post('/api/v1/device', device);
+      const index = state.lgtvDevices.findIndex(haystack => haystack.id === device.id);
+      const newState = update(state, {
+        lgtvDevices: {
+          $splice: [[index, 1, savedDevice]]
+        }
+      });
+      store.setState(newState);
+    },
+    async deleteDevice(state, device) {
+      console.log(device);
+      await state.httpClient.delete(`/api/v1/device/${device.selector}`);
+
+      const index = state.lgtvDevices.findIndex(haystack => haystack.id === device.id);
+
+      const newState = update(state, {
+        lgtvDevices: {
+          $splice: [[index, 1]]
+        }
+      });
+      store.setState(newState);
+    }
+  };
+
+  return Object.assign({}, houseActions, integrationActions, actions);
+}
+
+export default createActions;

--- a/front/src/routes/integration/all/lgtv/add/AddTab.jsx
+++ b/front/src/routes/integration/all/lgtv/add/AddTab.jsx
@@ -1,0 +1,61 @@
+import { useCallback, useState } from 'preact/hooks';
+
+import { Text } from 'preact-i18n';
+import cx from 'classnames';
+
+import Device from '../Device';
+
+const AddTab = ({ houses, createDevice }) => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [device, setDevice] = useState({
+    room_id: null,
+    name: ''
+  });
+
+  const updateDeviceProperty = useCallback((device, property, value) => {
+    setDevice({
+      ...device,
+      [property]: value
+    });
+  });
+
+  const onDeviceUpdate = useCallback(device => {
+    (async () => {
+      setIsLoading(true);
+      await createDevice(device);
+      setIsLoading(false);
+    })();
+  });
+
+  return (
+    <div class="card">
+      <div class="card-header">
+        <h1 class="card-title">
+          <Text id="integration.lgtv.add.title" />
+        </h1>
+      </div>
+      <div class="card-body">
+        <div
+          class={cx('dimmer', {
+            active: isLoading
+          })}
+        >
+          <div class="loader" />
+          <div class={cx('dimmer-content')}>
+            <div class="row">
+              <Device
+                updateDeviceProperty={updateDeviceProperty}
+                onDeviceUpdate={onDeviceUpdate}
+                houses={houses}
+                device={device}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AddTab;

--- a/front/src/routes/integration/all/lgtv/add/index.jsx
+++ b/front/src/routes/integration/all/lgtv/add/index.jsx
@@ -1,0 +1,23 @@
+import { connect } from 'unistore/preact';
+import actions from '../actions';
+import AddTab from './AddTab';
+import LGTVPage from '../LGTVPage';
+import { useEffect } from 'preact/hooks';
+
+const LGTVDiscoverPage = connect(
+  'user,houses',
+  actions
+)(props => {
+  useEffect(() => {
+    props.getHouses();
+    props.getIntegrationByName('lgtv');
+  }, []);
+
+  return (
+    <LGTVPage user={props.user}>
+      <AddTab {...props} />
+    </LGTVPage>
+  );
+});
+
+export default LGTVDiscoverPage;

--- a/front/src/routes/integration/all/lgtv/common.jsx
+++ b/front/src/routes/integration/all/lgtv/common.jsx
@@ -1,0 +1,59 @@
+import { useCallback } from 'preact/hooks';
+import { Text } from 'preact-i18n';
+import { route } from 'preact-router';
+import { RequestStatus } from '../../../../utils/consts';
+
+export const NewLink = ({ onClick }) => (
+  <span class="ml-2">
+    <Text id="integration.lgtv.or" />{' '}
+    <a href="/dashboard/integration/device/lgtv/add" onClick={onClick}>
+      <Text id="integration.lgtv.setUpManually" />
+    </a>
+  </span>
+);
+
+export const NewButton = () => {
+  const onClick = useCallback(() => {
+    route('/dashboard/integration/device/lgtv/discover');
+  });
+  return (
+    <button onClick={onClick} class="btn btn-secondary ml-2">
+      <Text id="integration.lgtv.new" />
+      <i class="fe fe-plus" />
+    </button>
+  );
+};
+
+export const RoomInput = ({ houses, onChange, selectedRoomId }) => (
+  <div class="form-group">
+    <label>
+      <Text id="integration.lgtv.device.roomLabel" />
+    </label>
+    <select onChange={onChange} class="form-control">
+      <option value="">
+        <Text id="global.emptySelectOption" />
+      </option>
+      {houses &&
+        houses.map(house => (
+          <optgroup label={house.name}>
+            {house.rooms.map(room => (
+              <option selected={room.id === selectedRoomId} value={room.id}>
+                {room.name}
+              </option>
+            ))}
+          </optgroup>
+        ))}
+    </select>
+  </div>
+);
+
+export const ScanButton = ({ onClick, scanStatus }) => (
+  <button onClick={onClick} class="btn btn-primary ml-2" disabled={scanStatus === RequestStatus.Getting}>
+    {scanStatus === RequestStatus.Getting ? (
+      <Text id="integration.lgtv.scanning" />
+    ) : (
+      <Text id="integration.lgtv.discoverButton" />
+    )}{' '}
+    <i class="fe fe-radio" />
+  </button>
+);

--- a/front/src/routes/integration/all/lgtv/devices/DeviceTab.jsx
+++ b/front/src/routes/integration/all/lgtv/devices/DeviceTab.jsx
@@ -1,0 +1,51 @@
+import { Text } from 'preact-i18n';
+import cx from 'classnames';
+
+import EmptyState from '../EmptyState';
+import { RequestStatus } from '../../../../../utils/consts';
+import Device from '../Device';
+
+const DeviceTab = ({ children, ...props }) => (
+  <div class="card">
+    <div class="card-header">
+      <h1 class="card-title">
+        <tr>
+          <td class="text-right">
+            <Text id="integration.lgtv.device.title" />
+          </td>
+          <td>{props.lgtvDevices && <div>&nbsp;{`(${props.lgtvDevices.length})`}</div>}</td>
+        </tr>
+      </h1>
+    </div>
+    <div class="card-body">
+      <div
+        class={cx('dimmer', {
+          active: props.getLGTVDevicesStatus === RequestStatus.Getting
+        })}
+      >
+        <div class="loader" />
+        <div class={cx('dimmer-content')}>
+          <div class="row">
+            {props.lgtvDevices &&
+              props.lgtvDevices.map((device, index) => (
+                <Device
+                  updateDeviceProperty={props.updateDeviceProperty}
+                  onDeviceUpdate={props.updateDevice}
+                  onDeviceDelete={props.deleteDevice}
+                  houses={props.houses}
+                  device={device}
+                  showDeleteButton
+                  showTitle
+                />
+              ))}
+            {props.lgtvDevices && props.lgtvDevices.length === 0 && (
+              <EmptyState onScan={props.onScan} onAdd={props.onAdd} />
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default DeviceTab;

--- a/front/src/routes/integration/all/lgtv/devices/index.jsx
+++ b/front/src/routes/integration/all/lgtv/devices/index.jsx
@@ -1,0 +1,31 @@
+import { Component } from 'preact';
+import { connect } from 'unistore/preact';
+import actions from '../actions';
+import DeviceTab from './DeviceTab';
+import LGTVPage from '../LGTVPage';
+import { route } from 'preact-router';
+import { useCallback, useEffect } from 'preact/hooks';
+
+const LGTVDevicesPage = connect(
+  'user,houses,lgtvDevices,getLGTVDevicesStatus',
+  actions
+)(props => {
+  useEffect(() => {
+    props.getLGTVDevices();
+    props.getHouses();
+    props.getIntegrationByName('lgtv');
+  }, []);
+
+  const onScan = useCallback(() => {
+    props.scan();
+    route('/dashboard/integration/device/lgtv/discover');
+  });
+
+  return (
+    <LGTVPage user={props.user}>
+      <DeviceTab onScan={onScan} onAdd={() => {}} {...props} />
+    </LGTVPage>
+  );
+});
+
+export default LGTVDevicesPage;

--- a/front/src/routes/integration/all/lgtv/discover/DiscoverTab.jsx
+++ b/front/src/routes/integration/all/lgtv/discover/DiscoverTab.jsx
@@ -1,0 +1,36 @@
+import { Text } from 'preact-i18n';
+import cx from 'classnames';
+
+import EmptyState from '../EmptyState';
+import { RequestStatus } from '../../../../../utils/consts';
+import ScannedDevices from './ScannedDevices';
+
+const DiscoverTab = ({ children, ...props }) => (
+  <div class="card">
+    <div class="card-header">
+      <h1 class="card-title">
+        <Text id="integration.lgtv.discover.title" />
+      </h1>
+    </div>
+    <div class="card-body">
+      <div
+        class={cx('dimmer', {
+          active: props.scanLGTVDevicesStatus === RequestStatus.Getting
+        })}
+      >
+        <div class="loader" />
+        <div class={cx('dimmer-content')}>
+          <div class="row">
+            {!props.scannedDevices || props.scannedDevices.length === 0 ? (
+              <EmptyState onScan={props.onScan} onAdd={props.onAdd} />
+            ) : (
+              <ScannedDevices devices={props.scannedDevices} onAddScannedDevice={props.onAddScannedDevice} />
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default DiscoverTab;

--- a/front/src/routes/integration/all/lgtv/discover/ScannedDevices.jsx
+++ b/front/src/routes/integration/all/lgtv/discover/ScannedDevices.jsx
@@ -1,0 +1,119 @@
+import { useEffect, useState, useCallback } from 'preact/hooks';
+import { Text } from 'preact-i18n';
+import cx from 'classnames';
+import style from './style.css';
+import { connect } from 'unistore/preact';
+import { WEBSOCKET_MESSAGE_TYPES } from '../../../../../../../server/utils/constants';
+import uuid from 'uuid';
+
+import { STATE } from '../../../../../../../server/services/lgtv/lib/tv/consts';
+
+const DiscoveredText = ({ modelName }) =>
+  modelName ? (
+    <Text id="integration.lgtv.deviceFound" fields={{ modelName }} />
+  ) : (
+    <Text id="integration.lgtv.deviceFoundNoModel" />
+  );
+
+const Prompt = ({ device, state, onPromptRequested, isPending, countdown }) => {
+  return (
+    <div class="col-md-12">
+      <div class={cx('text-center')}>
+        <div>
+          <h4 class={style.heading}>
+            <DiscoveredText modelName={device.modelName} />
+          </h4>
+          {status === STATE.PROMPT_ERROR && <Text id="integration.lgtv.promptError" />}
+          <button onClick={onPromptRequested} disabled={isPending} class="btn btn-primary ml-2">
+            {isPending ? <Text id="integration.lgtv.prompt" /> : <Text id="integration.lgtv.requestPrompt" />}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const Connected = ({ onAddScannedDevice, device }) => {
+  const onClick = useCallback(() => {
+    onAddScannedDevice(device);
+  });
+  return (
+    <div class="col-md-12">
+      <div class={cx('text-center', style.scanResults)}>
+        <h4 class={style.heading}>
+          <DiscoveredText modelName={device.modelName} />
+        </h4>
+
+        <button onClick={onClick} class="btn btn-primary ml-2">
+          {device.modelName ? (
+            <Text id="integration.lgtv.addDetectedDevice" fields={{ modelName: device.modelName }} />
+          ) : (
+            <Text id="integration.lgtv.addDetectedDeviceNoModel" />
+          )}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const ScannedDevices = connect('session')(({ onAddScannedDevice, devices, session }) => {
+  const device = devices[0];
+
+  const [state, setState] = useState(device.state);
+  const [isPending, setIsPending] = useState(false);
+
+  const id = useCallback(() => uuid.v4());
+
+  useEffect(() => {
+    const onConnect = () => {
+      setState(STATE.CONNECTED);
+      setIsPending(false);
+      onAddScannedDevice(device);
+    };
+
+    const onTimeout = () => {
+      setState(STATE.PROMPT_TIMEOUT);
+      setIsPending(false);
+    };
+
+    const onPromptError = () => {
+      setState(STATE.ERROR);
+      setIsPending(false);
+    };
+
+    session.dispatcher.addListener(WEBSOCKET_MESSAGE_TYPES.LGTV.CONNECTED, onConnect);
+    session.dispatcher.addListener(WEBSOCKET_MESSAGE_TYPES.LGTV.PROMPT_ERROR, onPromptError);
+    session.dispatcher.addListener(WEBSOCKET_MESSAGE_TYPES.LGTV.PROMPT_TIMEOUT, onTimeout);
+
+    return function cleanup() {
+      session.dispatcher.removeListener(WEBSOCKET_MESSAGE_TYPES.LGTV.CONNECTED, onConnect);
+      session.dispatcher.removeListener(WEBSOCKET_MESSAGE_TYPES.LGTV.PROMPT_ERROR, onPromptError);
+      session.dispatcher.removeListener(WEBSOCKET_MESSAGE_TYPES.LGTV.PROMPT_TIMEOUT, onTimeout);
+    };
+  }, [device]);
+
+  const onPromptRequested = useCallback(() => {
+    session.ws.send(
+      JSON.stringify({
+        type: WEBSOCKET_MESSAGE_TYPES.LGTV.PROMPT,
+        payload: {
+          uuid: id()
+        }
+      })
+    );
+    setIsPending(true);
+  });
+
+  switch (state) {
+    case STATE.PROMPT:
+    case STATE.PROMPT_TIMEOUT:
+    case STATE.PROMPT_ERROR:
+      return <Prompt device={device} state={state} onPromptRequested={onPromptRequested} isPending={isPending} />;
+    case STATE.CONNECTED:
+      return <Connected onAddScannedDevice={onAddScannedDevice} device={device} />;
+  }
+
+  return null;
+});
+
+export default ScannedDevices;

--- a/front/src/routes/integration/all/lgtv/discover/index.jsx
+++ b/front/src/routes/integration/all/lgtv/discover/index.jsx
@@ -1,0 +1,32 @@
+import { connect } from 'unistore/preact';
+import actions from '../actions';
+import DiscoverTab from './DiscoverTab';
+import LGTVPage from '../LGTVPage';
+import { route } from 'preact-router';
+import { useCallback, useEffect } from 'preact/hooks';
+
+const LGTVDiscoverPage = connect(
+  'user,houses,scanLGTVDevicesStatus,scannedDevices',
+  actions
+)(props => {
+  useEffect(() => {
+    props.getLGTVDevices();
+    props.getHouses();
+    props.getIntegrationByName('lgtv');
+  }, []);
+
+  const onAddScannedDevice = useCallback(device => {
+    (async () => {
+      await props.createDevice(device);
+      route('/dashboard/integration/device/lgtv');
+    })();
+  });
+
+  return (
+    <LGTVPage user={props.user}>
+      <DiscoverTab onAddScannedDevice={onAddScannedDevice} onScan={props.scan} onAdd={() => {}} {...props} />
+    </LGTVPage>
+  );
+});
+
+export default LGTVDiscoverPage;

--- a/front/src/routes/integration/all/lgtv/discover/style.css
+++ b/front/src/routes/integration/all/lgtv/discover/style.css
@@ -1,0 +1,18 @@
+.emptyStateDivBox {
+  margin-top: 35px;
+  margin-bottom: 35px;
+}
+
+.scanResults {
+  margin-bottom: 40px;
+  padding-top: 20px;
+}
+
+.additionalScannedDevice {
+  border-bottom: 1px solid #0028641f;
+  margin-bottom: 40px;
+}
+
+.heading {
+  margin-bottom: 40px;
+}

--- a/front/src/routes/integration/all/lgtv/style.css
+++ b/front/src/routes/integration/all/lgtv/style.css
@@ -1,0 +1,26 @@
+.emptyStateDivBox {
+  margin-top: 35px;
+  margin-bottom: 35px;
+}
+
+.deviceListBody {
+  min-height: 200px;
+}
+
+.featureListBody {
+  min-height: 50px;
+}
+
+.scanResults {
+  margin-bottom: 40px;
+  padding-top: 20px;
+}
+
+.additionalScannedDevice {
+  border-bottom: 1px solid #0028641f;
+  margin-bottom: 40px;
+}
+
+.heading {
+  margin-bottom: 40px;
+}

--- a/front/src/utils/Dispatcher.js
+++ b/front/src/utils/Dispatcher.js
@@ -12,6 +12,7 @@ export class Dispatcher {
 
     // Check if the event is not a string
     if (typeof event !== 'string') {
+      console.log(event);
       console.error(`The event name must be a string, the given type is ${typeof event}`);
       return false;
     }

--- a/server/api/controllers/media-player.controller.js
+++ b/server/api/controllers/media-player.controller.js
@@ -44,8 +44,45 @@ module.exports = function LightController(gladys) {
     res.json(action);
   }
 
+  /**
+   * @api {get} /api/v1/media-player get
+   * @apiName get
+   * @apiGroup MediaPlayer
+   *
+   * @apiSuccessExample {json} Success-Response:
+   * [
+   *   {
+   *     "id": "fbedb47f-4d25-4381-8923-2633b23192a0",
+   *     "service_id": "a810b8db-6d04-4697-bed3-c4b72c996279",
+   *     "room_id": "2398c689-8b47-43cc-ad32-e98d9be098b5",
+   *     "name": "Test media player",
+   *     "selector": "test-camera",
+   *     "external_id": "test-camera-external",
+   *     "should_poll": false,
+   *     "poll_frequency": null,
+   *     "created_at": "2019-02-12T07:49:07.556Z",
+   *     "updated_at": "2019-02-12T07:49:07.556Z",
+   *     "features": [
+   *       {
+   *         "name": "Test camera image",
+   *         "selector": "test-camera-image"
+   *       }
+   *     ],
+   *     "room": {
+   *       "name": "Test room",
+   *       "selector": "test-room"
+   *     }
+   *   }
+   * ]
+   */
+  async function get(req, res) {
+    const players = await gladys.device.mediaPlayerManager.get();
+    res.json(players);
+  }
+
   return Object.freeze({
     turnOn: asyncMiddleware(turnOn),
     turnOff: asyncMiddleware(turnOff),
+    get: asyncMiddleware(get),
   });
 };

--- a/server/api/controllers/media-player.controller.js
+++ b/server/api/controllers/media-player.controller.js
@@ -1,0 +1,51 @@
+const asyncMiddleware = require('../middlewares/asyncMiddleware');
+const { EVENTS, ACTIONS, ACTIONS_STATUS } = require('../../utils/constants');
+
+module.exports = function LightController(gladys) {
+  /**
+   * @api {post} /api/v1/media-player/:device_selector/on Turn On
+   * @apiName TurnOn
+   * @apiGroup MediaPlayer
+   * @apiSuccessExample {json} Success-Example
+   * {
+   *   "type": "media-player.turn-on",
+   *   "device": "test",
+   *   "status": "pending"
+   * }
+   */
+  async function turnOn(req, res) {
+    const action = {
+      type: ACTIONS.MEDIA_PLAYER.TURN_ON,
+      device: req.params.device_selector,
+      status: ACTIONS_STATUS.PENDING,
+    };
+    gladys.event.emit(EVENTS.ACTION.TRIGGERED, action);
+    res.json(action);
+  }
+
+  /**
+   * @api {post} /api/v1/media-player/:device_selector/off Turn Off
+   * @apiName TurnOff
+   * @apiGroup MediaPlayer
+   * @apiSuccessExample {json} Success-Example
+   * {
+   *   "type": "media-player.turn-off",
+   *   "device": "test",
+   *   "status": "pending"
+   * }
+   */
+  async function turnOff(req, res) {
+    const action = {
+      type: ACTIONS.MEDIA_PLAYER.TURN_OFF,
+      device: req.params.device_selector,
+      status: ACTIONS_STATUS.PENDING,
+    };
+    gladys.event.emit(EVENTS.ACTION.TRIGGERED, action);
+    res.json(action);
+  }
+
+  return Object.freeze({
+    turnOn: asyncMiddleware(turnOn),
+    turnOff: asyncMiddleware(turnOff),
+  });
+};

--- a/server/api/routes.js
+++ b/server/api/routes.js
@@ -10,6 +10,7 @@ const HouseController = require('./controllers/house.controller');
 const HttpController = require('./controllers/http.controller');
 const LightController = require('./controllers/light.controller');
 const LocationController = require('./controllers/location.controller');
+const MediaPlayerController = require('./controllers/media-player.controller');
 const MessageController = require('./controllers/message.controller');
 const RoomController = require('./controllers/room.controller');
 const SessionController = require('./controllers/session.controller');
@@ -33,6 +34,7 @@ function getRoutes(gladys) {
   const dashboardController = DashboardController(gladys);
   const deviceController = DeviceController(gladys);
   const lightController = LightController(gladys);
+  const mediaPlayerController = MediaPlayerController(gladys);
   const locationController = LocationController(gladys);
   const userController = UserController(gladys);
   const houseController = HouseController(gladys);
@@ -424,6 +426,16 @@ function getRoutes(gladys) {
     'post /api/v1/light/:device_selector/on': {
       authenticated: true,
       controller: lightController.turnOn,
+    },
+    // media-player
+    'post /api/v1/media-player/:device_selector/on': {
+      authenticated: true,
+      controller: mediaPlayerController.turnOn,
+    },
+    // media-player
+    'post /api/v1/media-player/:device_selector/off': {
+      authenticated: true,
+      controller: mediaPlayerController.turnOff,
     },
     // scene
     'post /api/v1/scene': {

--- a/server/api/routes.js
+++ b/server/api/routes.js
@@ -432,10 +432,13 @@ function getRoutes(gladys) {
       authenticated: true,
       controller: mediaPlayerController.turnOn,
     },
-    // media-player
     'post /api/v1/media-player/:device_selector/off': {
       authenticated: true,
       controller: mediaPlayerController.turnOff,
+    },
+    'get /api/v1/media-player': {
+      authenticated: true,
+      controller: mediaPlayerController.get,
     },
     // scene
     'post /api/v1/scene': {

--- a/server/api/websockets/index.js
+++ b/server/api/websockets/index.js
@@ -122,7 +122,10 @@ function init() {
           }
           break;
         default:
-          logger.debug(`Message type not handled`);
+          this.gladys.event.emit(EVENTS.WEBSOCKET.RECEIVE, {
+            userId: user.id,
+            ...parsedMessage,
+          });
       }
     });
     setTimeout(() => {

--- a/server/lib/device/device.newStateEvent.js
+++ b/server/lib/device/device.newStateEvent.js
@@ -13,7 +13,7 @@ async function newStateEvent(event) {
   try {
     const deviceFeature = this.stateManager.get('deviceFeatureByExternalId', event.device_feature_external_id);
     if (deviceFeature === null) {
-      throw new NotFoundError('DeviceFeature not found');
+      throw new NotFoundError(`DeviceFeature "${event.device_feature_external_id}" not found`);
     }
     await this.saveState(deviceFeature, event.state);
   } catch (e) {

--- a/server/lib/device/index.js
+++ b/server/lib/device/index.js
@@ -6,6 +6,7 @@ const CameraManager = require('./camera');
 const LightManager = require('./light');
 const TemperatureSensorManager = require('./temperature-sensor');
 const HumiditySensorManager = require('./humidity-sensor');
+const MediaPlayerManager = require('./media-player');
 
 // Functions
 const { add } = require('./device.add');
@@ -47,6 +48,7 @@ const DeviceManager = function DeviceManager(
   this.lightManager = new LightManager(eventManager, messageManager, this);
   this.temperatureSensorManager = new TemperatureSensorManager(eventManager, messageManager, this);
   this.humiditySensorManager = new HumiditySensorManager(eventManager, messageManager, this);
+  this.mediaPlayerManager = new MediaPlayerManager(eventManager, messageManager, this);
 
   this.devicesByPollFrequency = {};
   // listen to events

--- a/server/lib/device/media-player/index.js
+++ b/server/lib/device/media-player/index.js
@@ -3,6 +3,7 @@ const { buildMediaPlayerObject } = require('./media-player.buildMediaPlayerObjec
 const { command } = require('./media-player.command');
 const { init } = require('./media-player.init');
 const { getDevice } = require('./media-player.getDevice');
+const { get } = require('./media-player.get');
 const { turnOn } = require('./media-player.turnOn');
 const { turnOff } = require('./media-player.turnOff');
 
@@ -17,6 +18,7 @@ const MediaPlayerManager = function MediaPlayerManager(eventManager, messageMana
 MediaPlayerManager.prototype.buildMediaPlayerObject = buildMediaPlayerObject;
 MediaPlayerManager.prototype.command = command;
 MediaPlayerManager.prototype.init = init;
+MediaPlayerManager.prototype.get = get;
 MediaPlayerManager.prototype.getDevice = getDevice;
 MediaPlayerManager.prototype.turnOn = turnOn;
 MediaPlayerManager.prototype.turnOff = turnOff;

--- a/server/lib/device/media-player/index.js
+++ b/server/lib/device/media-player/index.js
@@ -1,0 +1,24 @@
+const { INTENTS } = require('../../../utils/constants');
+const { buildMediaPlayerObject } = require('./media-player.buildMediaPlayerObject');
+const { command } = require('./media-player.command');
+const { init } = require('./media-player.init');
+const { getDevice } = require('./media-player.getDevice');
+const { turnOn } = require('./media-player.turnOn');
+const { turnOff } = require('./media-player.turnOff');
+
+const MediaPlayerManager = function MediaPlayerManager(eventManager, messageManager, deviceManager) {
+  this.eventManager = eventManager;
+  this.messageManager = messageManager;
+  this.deviceManager = deviceManager;
+  this.eventManager.on(INTENTS.MEDIA_PLAYER.TURN_ON, this.command.bind(this));
+  this.eventManager.on(INTENTS.MEDIA_PLAYER.TURN_OFF, this.command.bind(this));
+};
+
+MediaPlayerManager.prototype.buildMediaPlayerObject = buildMediaPlayerObject;
+MediaPlayerManager.prototype.command = command;
+MediaPlayerManager.prototype.init = init;
+MediaPlayerManager.prototype.getDevice = getDevice;
+MediaPlayerManager.prototype.turnOn = turnOn;
+MediaPlayerManager.prototype.turnOff = turnOff;
+
+module.exports = MediaPlayerManager;

--- a/server/lib/device/media-player/media-player.buildMediaPlayerObject.js
+++ b/server/lib/device/media-player/media-player.buildMediaPlayerObject.js
@@ -1,0 +1,29 @@
+const { DEVICE_FEATURE_TYPES } = require('../../../utils/constants');
+
+/**
+ * @description Add functions to media player object.
+ * @param {Object} device - The device to build the media player object from.
+ * @returns {Object} Return a device with functions.
+ * @example
+ * buildMediaPlayerObject({
+ *    id: '3d8496a6-bfff-4920-8f12-4767d93fd67f',
+ *    selector: 'test-player',
+ *    features: []
+ * });
+ */
+function buildMediaPlayerObject(device) {
+  const self = this;
+  // find binary deviceType
+  const binaryDeviceFeature = device.features.find(
+    (deviceFeature) => deviceFeature.type === DEVICE_FEATURE_TYPES.MEDIA_PLAYER.BINARY,
+  );
+  if (binaryDeviceFeature) {
+    device.turnOn = async () => self.turnOn(device, binaryDeviceFeature);
+    device.turnOff = async () => self.turnOff(device, binaryDeviceFeature);
+  }
+  return device;
+}
+
+module.exports = {
+  buildMediaPlayerObject,
+};

--- a/server/lib/device/media-player/media-player.command.js
+++ b/server/lib/device/media-player/media-player.command.js
@@ -1,0 +1,62 @@
+const { INTENTS } = require('../../../utils/constants');
+
+const { getDeviceFeature } = require('../../../utils/device');
+const logger = require('../../../utils/logger');
+const { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } = require('../../../utils/constants');
+
+/**
+ * @description Command a media player, like a TV.
+ * @param {Object} message - The message sent by the user.
+ * @param {Object} classification - The classification calculated by the brain.
+ * @param {Object} context - The context object containing found variables in question.
+ * @example
+ * mediaPlayer.command(message, classification, context);
+ */
+async function command(message, classification, context) {
+  try {
+    const device = await this.getDevice(context.id);
+    switch (classification.intent) {
+      case INTENTS.MEDIA_PLAYER.TURN_ON: {
+        // Get the binary feature
+        const deviceFeature = getDeviceFeature(
+          device,
+          DEVICE_FEATURE_CATEGORIES.MEDIA_PLAYER,
+          DEVICE_FEATURE_TYPES.MEDIA_PLAYER.BINARY,
+        );
+        // and if the binary feature exists, call it
+        if (deviceFeature) {
+          await this.turnOn(device, deviceFeature);
+          this.messageManager.replyByIntent(message, `${INTENTS.MEDIA_PLAYER.TURN_ON}.success`, context);
+        }
+        break;
+      }
+      case INTENTS.MEDIA_PLAYER.TURN_OFF: {
+        // Get the binary feature
+        const deviceFeature = getDeviceFeature(
+          device,
+          DEVICE_FEATURE_CATEGORIES.MEDIA_PLAYER,
+          DEVICE_FEATURE_TYPES.MEDIA_PLAYER.BINARY,
+        );
+        // and if the binary feature exists, call it
+        if (deviceFeature) {
+          await this.turnOn(device, deviceFeature);
+          this.messageManager.replyByIntent(message, `${INTENTS.MEDIA_PLAYER.TURN_OFF}.success`, context);
+        }
+        break;
+      }
+      default:
+        throw new Error(`Media intent ${classification.intent} was not handled`);
+    }
+  } catch (e) {
+    logger.debug(e);
+    this.messageManager.replyByIntent(
+      message,
+      `${classification.intent || INTENTS.MEDIA_PLAYER.TURN_ON}.error`,
+      context,
+    );
+  }
+}
+
+module.exports = {
+  command,
+};

--- a/server/lib/device/media-player/media-player.get.js
+++ b/server/lib/device/media-player/media-player.get.js
@@ -1,0 +1,33 @@
+const db = require('../../../models');
+const { DEVICE_FEATURE_CATEGORIES } = require('../../../utils/constants');
+
+/**
+ * @description Get list of media players.
+ * @returns {Promise} Resolve with array of cameras.
+ * @example
+ * camera.get();
+ */
+async function get() {
+  const players = await db.Device.findAll({
+    include: [
+      {
+        model: db.DeviceFeature,
+        as: 'features',
+        attributes: ['name', 'selector'],
+        where: {
+          category: DEVICE_FEATURE_CATEGORIES.MEDIA_PLAYER,
+        },
+      },
+      {
+        model: db.Room,
+        as: 'room',
+        attributes: ['name', 'selector'],
+      },
+    ],
+  });
+  return players.map((player) => player.get({ plain: true }));
+}
+
+module.exports = {
+  get,
+};

--- a/server/lib/device/media-player/media-player.getDevice.js
+++ b/server/lib/device/media-player/media-player.getDevice.js
@@ -1,0 +1,39 @@
+const logger = require('../../../utils/logger');
+const db = require('../../../models');
+const { DEVICE_FEATURE_CATEGORIES } = require('../../../utils/constants');
+
+/**
+ * @description Return a device that matches the id passed
+ * @param {string} id - The uuid of the media player.
+ * @returns {Promise<Object>} - Resolve with an array of devices.
+ * @example
+ * const player = await getDevice('d65deccf-d8fc-4674-ac50-3d98d1d87aba');
+ */
+async function getDevice(id) {
+  logger.debug(`Getting media player device ${id}`);
+
+  const device = await db.Device.findOne({
+    include: [
+      {
+        model: db.DeviceFeature,
+        as: 'features',
+        where: {
+          category: DEVICE_FEATURE_CATEGORIES.MEDIA_PLAYER,
+        },
+      },
+      {
+        model: db.Service,
+        as: 'service',
+      },
+    ],
+    where: {
+      id,
+    },
+  });
+
+  return device.get({ plain: true });
+}
+
+module.exports = {
+  getDevice,
+};

--- a/server/lib/device/media-player/media-player.init.js
+++ b/server/lib/device/media-player/media-player.init.js
@@ -1,0 +1,43 @@
+const db = require('../../../models');
+const logger = require('../../../utils/logger');
+const { DEVICE_FEATURE_CATEGORIES } = require('../../../utils/constants');
+
+/**
+ * @description Get all media players and store them in memory.
+ * @returns {Promise} Resolve with media player objects added.
+ * @example
+ * mediaPlayer.init();
+ */
+async function init() {
+  const players = await db.Device.findAll({
+    include: [
+      {
+        model: db.DeviceFeature,
+        as: 'features',
+        where: {
+          category: DEVICE_FEATURE_CATEGORIES.MEDIA_PLAYER,
+        },
+      },
+      {
+        model: db.Room,
+        as: 'room',
+      },
+      {
+        model: db.Service,
+        as: 'service',
+      },
+    ],
+  });
+  logger.debug(`Media player : init : Found ${players.length} media player devices`);
+  const plainPlayers = players.map((player) => {
+    const device = player.get({ plain: true });
+    const deviceWithFunctions = this.buildMediaPlayerObject(device);
+    this.deviceManager.add(deviceWithFunctions);
+    return device;
+  });
+  return plainPlayers;
+}
+
+module.exports = {
+  init,
+};

--- a/server/lib/device/media-player/media-player.turnOff.js
+++ b/server/lib/device/media-player/media-player.turnOff.js
@@ -1,0 +1,19 @@
+const logger = require('../../../utils/logger');
+const { STATE, EVENTS } = require('../../../utils/constants');
+
+/**
+ * @description TurnOff a given deviceFeature.
+ * @param {Object} device - The device to turnOff.
+ * @param {Object} deviceFeature - The deviceFeature to turnOff.
+ * @example
+ * mediaPlayer.turnOff(device, deviceFeature);
+ */
+async function turnOff(device, deviceFeature) {
+  logger.debug(`Turning off the media player of deviceFeature "${deviceFeature.selector}"`);
+  await this.deviceManager.setValue(device, deviceFeature, STATE.OFF);
+  this.eventManager.emit(EVENTS.MEDIA_PLAYER.TURNED_OFF, { device, deviceFeature });
+}
+
+module.exports = {
+  turnOff,
+};

--- a/server/lib/device/media-player/media-player.turnOn.js
+++ b/server/lib/device/media-player/media-player.turnOn.js
@@ -1,0 +1,19 @@
+const logger = require('../../../utils/logger');
+const { STATE, EVENTS } = require('../../../utils/constants');
+
+/**
+ * @description TurnOn a given deviceFeature.
+ * @param {Object} device - The device to turnOn.
+ * @param {Object} deviceFeature - The deviceFeature to turnOn.
+ * @example
+ * mediaPlayer.turnOn(device, deviceFeature);
+ */
+async function turnOn(device, deviceFeature) {
+  logger.debug(`Turning on the media player of deviceFeature "${deviceFeature.selector}"`);
+  await this.deviceManager.setValue(device, deviceFeature, STATE.ON);
+  this.eventManager.emit(EVENTS.MEDIA_PLAYER.TURNED_ON, { device, deviceFeature });
+}
+
+module.exports = {
+  turnOn,
+};

--- a/server/lib/index.js
+++ b/server/lib/index.js
@@ -102,15 +102,15 @@ function Gladys(params = {}) {
       if (!params.disableBrainLoading) {
         await brain.load();
       }
+      if (!params.disableDeviceLoading) {
+        await device.init();
+      }
       if (!params.disableService) {
         await service.load(gladys);
         await service.startAll();
       }
       if (!params.disableSceneLoading) {
         await scene.init();
-      }
-      if (!params.disableDeviceLoading) {
-        await device.init();
       }
       if (!params.disableUserLoading) {
         await user.init();

--- a/server/models/dashboard.js
+++ b/server/models/dashboard.js
@@ -13,6 +13,7 @@ const boxesSchema = Joi.array().items(
       camera: Joi.string(),
       name: Joi.string(),
       modes: Joi.object(),
+      player: Joi.string(),
       device_features: Joi.array().items(Joi.string()),
     }),
   ),

--- a/server/services/index.js
+++ b/server/services/index.js
@@ -13,3 +13,4 @@ module.exports.bluetooth = require('./bluetooth');
 module.exports.ewelink = require('./ewelink');
 module.exports['tp-link'] = require('./tp-link');
 module.exports.zigbee2mqtt = require('./zigbee2mqtt');
+module.exports.lgtv = require('./lgtv');

--- a/server/services/lgtv/api/lgtv.controller.js
+++ b/server/services/lgtv/api/lgtv.controller.js
@@ -1,0 +1,36 @@
+const asyncMiddleware = require('../../../api/middlewares/asyncMiddleware');
+
+module.exports = function LGTVController(lgtvHandler) {
+  /**
+   * @api {post} /api/v1/service/lgtv/scan
+   * @apiName Scan
+   * @apiGroup LGTV
+   */
+  async function scan(req, res) {
+    const foundDevices = await lgtvHandler.scan();
+    res.send(foundDevices);
+  }
+
+  /**
+   * @api {post} /api/v1/service/lgtv/device create
+   * @apiName create
+   * @apiGroup Device
+   */
+  async function create(req, res) {
+    const device = await lgtvHandler.create(req.body);
+    res.json(device);
+  }
+
+  return {
+    'post /api/v1/service/lgtv/scan': {
+      authenticated: true,
+      admin: true,
+      controller: asyncMiddleware(scan),
+    },
+    'post /api/v1/service/lgtv/device': {
+      authenticated: true,
+      admin: true,
+      controller: asyncMiddleware(create),
+    },
+  };
+};

--- a/server/services/lgtv/index.js
+++ b/server/services/lgtv/index.js
@@ -1,0 +1,40 @@
+const { EVENTS } = require('../../utils/constants');
+const logger = require('../../utils/logger');
+const LGTVController = require('./api/lgtv.controller.js');
+const LGTVHandler = require('./lib/tv');
+
+module.exports = function LGTVService(gladys) {
+  const lgtvHandler = new LGTVHandler(gladys);
+
+  /**
+   * @public
+   * @description This function starts the ExampleService service
+   * @example
+   * gladys.services.example.start();
+   */
+  async function start() {
+    logger.info('Starting LGTV service');
+
+    gladys.event.on(EVENTS.WEBSOCKET.RECEIVE, lgtvHandler.promptListener.bind(lgtvHandler));
+
+    await lgtvHandler.connectAll();
+  }
+
+  /**
+   * @public
+   * @description This function stops the ExampleService service
+   * @example
+   * gladys.services.example.stop();
+   */
+  async function stop() {
+    logger.info('Stopping LGTV service');
+    await lgtvHandler.disconnectAll();
+  }
+
+  return Object.freeze({
+    start,
+    stop,
+    device: lgtvHandler,
+    controllers: LGTVController(lgtvHandler),
+  });
+};

--- a/server/services/lgtv/lib/tv/connect.js
+++ b/server/services/lgtv/lib/tv/connect.js
@@ -1,0 +1,154 @@
+const { promisify } = require('util');
+const LGTV = require('lgtv2');
+const { getDeviceID, timeout } = require('./utils');
+const { STATE } = require('./consts');
+const logger = require('../../../../utils/logger');
+const { DEVICE_FEATURE_TYPES, EVENTS, DEVICE_FEATURE_CATEGORIES } = require('../../../../utils/constants');
+const { getDeviceParam, getDeviceFeature } = require('../../../../utils/device');
+
+const TIMEOUT = 10000; // ms
+
+const connect = async function connect(device) {
+  logger.info(`LGTV ${device.id} connecting...`);
+  if (this.connections.has(device.id)) {
+    const existing = this.connections.get(device.id);
+
+    if (existing.status === STATE.CONNECTED) {
+      logger.info(`LGTV ${device.id} already connected`);
+      return;
+    }
+
+    if (![STATE.PROMPT, STATE.RECONNECT, STATE.TIMEOUT].includes(existing.state)) {
+      logger.warn(`LGTV connection failed. Entity in unexpected state ${existing.state}`);
+      return;
+    }
+  }
+  const address = device.params.find((param) => param.name === 'address').value;
+  const connection = {
+    handler: LGTV({
+      url: `ws://${address}:3000`,
+      timeout: 5000,
+      reconnect: 10000,
+    }),
+    state: STATE.CONNECTING,
+  };
+
+  connection.handler.on('connect', () => {
+    logger.info(`LGTV ${device.id} connected`);
+    connection.state = STATE.CONNECTED;
+
+    this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: `${device.id}:${DEVICE_FEATURE_TYPES.MEDIA_PLAYER.POWER}`,
+      state: 1,
+    });
+
+    connection.handler.subscribe('ssap://audio/getVolume', (err, res) => {
+      if (res.changed.indexOf('volume') !== -1) {
+        this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
+          device_feature_external_id: `${device.id}:${DEVICE_FEATURE_TYPES.MEDIA_PLAYER.VOLUME}`,
+          state: res.volume,
+        });
+      }
+
+      if (res.changed.indexOf('muted') !== -1) {
+        this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
+          device_feature_external_id: `${device.id}:${DEVICE_FEATURE_TYPES.MEDIA_PLAYER.MUTED}`,
+          state: res.muted,
+        });
+      }
+    });
+
+    connection.handler.subscribe('ssap://com.webos.applicationManager/getForegroundAppInfo', (err, res) => {
+      const sourceList = getDeviceParam(device, 'source_list');
+
+      const source = {
+        id: res.appId,
+        label: null,
+        image: null,
+      };
+
+      if (sourceList) {
+        const correspondingSourceListItem = JSON.parse(sourceList).find((sl) => sl.id === source.id);
+
+        if (correspondingSourceListItem) {
+          source.label = correspondingSourceListItem.label;
+          source.image = correspondingSourceListItem.image;
+        }
+      }
+
+      (async () => {
+        await this.gladys.device.saveStringState(
+          device,
+          getDeviceFeature(device, DEVICE_FEATURE_CATEGORIES.MEDIA_PLAYER, DEVICE_FEATURE_TYPES.MEDIA_PLAYER.SOURCE),
+          JSON.stringify(source),
+        );
+      })();
+    });
+
+    connection.handler.subscribe('ssap://tv/getExternalInputList', (err, res) => {
+      this.gladys.event.emit(EVENTS.DEVICE.ADD_PARAM, device.selector, {
+        name: `source_list`,
+        value: JSON.stringify(
+          res.devices.map((d) => ({
+            id: d.appId,
+            label: d.label,
+            image: d.icon,
+            connected: d.connected,
+          })),
+        ),
+      });
+
+      const source = getDeviceParam(device, 'source');
+
+      if (!source) {
+        return;
+      }
+
+      const sourceValue = JSON.parse(source);
+      const currentSource = res.devices.find((d) => d.appId === sourceValue.id) || {};
+
+      (async () => {
+        await this.gladys.device.saveStringState(
+          device,
+          getDeviceFeature(device, DEVICE_FEATURE_CATEGORIES.MEDIA_PLAYER, DEVICE_FEATURE_TYPES.MEDIA_PLAYER.SOURCE),
+          JSON.stringify({
+            ...sourceValue,
+            label: currentSource.label || null,
+            image: currentSource.icon || null,
+          }),
+        );
+      })();
+    });
+  });
+
+  connection.handler.on('prompt', () => {
+    logger.info(`LGTV ${device.id} prompt`);
+    connection.state = STATE.PROMPT;
+  });
+
+  connection.handler.on('error', (e) => {
+    logger.info(`LGTV ${device.id} error`, e);
+
+    this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: `${device.id}:${DEVICE_FEATURE_TYPES.MEDIA_PLAYER.POWER}`,
+      state: 0,
+    });
+
+    if (e.code === 'ETIMEDOUT') {
+      connection.state = STATE.TIMEOUT;
+    } else {
+      connection.state = STATE.ERROR;
+    }
+  });
+
+  connection.handler.on('close', () => {
+    this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: `${device.id}:${DEVICE_FEATURE_TYPES.MEDIA_PLAYER.POWER}`,
+      state: 0,
+    });
+  });
+
+  this.connections.set(device.id, connection);
+};
+
+module.exports = connect;

--- a/server/services/lgtv/lib/tv/connectAll.js
+++ b/server/services/lgtv/lib/tv/connectAll.js
@@ -1,0 +1,10 @@
+const connectAll = async function connectAll() {
+  const params = {
+    service: 'lgtv',
+  };
+  const devices = await this.gladys.device.get(params);
+
+  await Promise.all(devices.map((device) => this.connect(device)));
+};
+
+module.exports = connectAll;

--- a/server/services/lgtv/lib/tv/consts.js
+++ b/server/services/lgtv/lib/tv/consts.js
@@ -1,0 +1,12 @@
+const STATE = {
+  PROMPT: 'prompt',
+  CONNECTED: 'connected',
+  ERROR: 'error',
+  TIMEOUT: 'timeout',
+  CONNECTING: 'connecting',
+  RECONNECT: 'reconnect',
+};
+
+module.exports = {
+  STATE,
+};

--- a/server/services/lgtv/lib/tv/create.js
+++ b/server/services/lgtv/lib/tv/create.js
@@ -1,0 +1,86 @@
+const uuid = require('uuid');
+const { DEVICE_FEATURE_TYPES, DEVICE_FEATURE_CATEGORIES } = require('../../../../utils/constants');
+
+const create = async function create(lgDevice) {
+  const service = await this.gladys.service.getByName('lgtv');
+
+  const uniqueId = uuid.v4();
+  const device = {
+    id: uniqueId,
+    name: lgDevice.modelName,
+    model: lgDevice.modelName,
+    service_id: service.id,
+    external_id: lgDevice.deviceExternalID,
+    features: [
+      {
+        name: DEVICE_FEATURE_TYPES.MEDIA_PLAYER.CHANNEL,
+        category: DEVICE_FEATURE_CATEGORIES.MEDIA_PLAYER,
+        type: DEVICE_FEATURE_TYPES.MEDIA_PLAYER.CHANNEL,
+        read_only: false,
+        keep_history: true,
+        has_feedback: false,
+        external_id: `${uniqueId}:${DEVICE_FEATURE_TYPES.MEDIA_PLAYER.CHANNEL}`,
+        min: 0,
+        max: 999,
+      },
+      {
+        name: DEVICE_FEATURE_TYPES.MEDIA_PLAYER.POWER,
+        category: DEVICE_FEATURE_CATEGORIES.MEDIA_PLAYER,
+        type: DEVICE_FEATURE_TYPES.MEDIA_PLAYER.POWER,
+        read_only: false,
+        keep_history: true,
+        has_feedback: false,
+        external_id: `${uniqueId}:${DEVICE_FEATURE_TYPES.MEDIA_PLAYER.POWER}`,
+        min: 0,
+        max: 1,
+      },
+      {
+        name: DEVICE_FEATURE_TYPES.MEDIA_PLAYER.VOLUME,
+        category: DEVICE_FEATURE_CATEGORIES.MEDIA_PLAYER,
+        type: DEVICE_FEATURE_TYPES.MEDIA_PLAYER.VOLUME,
+        read_only: false,
+        keep_history: false,
+        has_feedback: false,
+        external_id: `${uniqueId}:${DEVICE_FEATURE_TYPES.MEDIA_PLAYER.VOLUME}`,
+        min: 0,
+        max: 100,
+      },
+      {
+        name: DEVICE_FEATURE_TYPES.MEDIA_PLAYER.MUTED,
+        category: DEVICE_FEATURE_CATEGORIES.MEDIA_PLAYER,
+        type: DEVICE_FEATURE_TYPES.MEDIA_PLAYER.MUTED,
+        read_only: false,
+        keep_history: false,
+        has_feedback: false,
+        external_id: `${uniqueId}:${DEVICE_FEATURE_TYPES.MEDIA_PLAYER.MUTED}`,
+        min: 0,
+        max: 1,
+      },
+      {
+        name: DEVICE_FEATURE_TYPES.MEDIA_PLAYER.SOURCE,
+        category: DEVICE_FEATURE_CATEGORIES.MEDIA_PLAYER,
+        type: DEVICE_FEATURE_TYPES.MEDIA_PLAYER.SOURCE,
+        read_only: false,
+        keep_history: false,
+        has_feedback: false,
+        external_id: `${uniqueId}:${DEVICE_FEATURE_TYPES.MEDIA_PLAYER.SOURCE}`,
+        min: 0,
+        max: 1,
+      },
+    ],
+    params: [
+      {
+        name: 'address',
+        value: lgDevice.address,
+      },
+      {
+        name: 'source_list',
+        value: JSON.stringify([]),
+      },
+    ],
+  };
+
+  return this.gladys.device.create(device);
+};
+
+module.exports = create;

--- a/server/services/lgtv/lib/tv/disconnect.js
+++ b/server/services/lgtv/lib/tv/disconnect.js
@@ -1,0 +1,16 @@
+const logger = require('../../../../utils/logger');
+
+const disconnect = function disconnect(device) {
+  logger.info(`LGTV Disconnecting ${device.id}`);
+  const connection = this.connections.get(device.external_id);
+
+  if (!connection) {
+    return;
+  }
+
+  connection.handler.disconnect();
+  this.connections.delete(device.id);
+  logger.info(`LGTV Disconnected ${device.external_id}`);
+};
+
+module.exports = disconnect;

--- a/server/services/lgtv/lib/tv/disconnectAll.js
+++ b/server/services/lgtv/lib/tv/disconnectAll.js
@@ -1,0 +1,10 @@
+const disconnectAll = async function disconnectAll() {
+  const params = {
+    service: 'lgtv',
+  };
+  const devices = await this.gladys.device.get(params);
+
+  await Promise.all(devices.map((device) => this.disconnect(device)));
+};
+
+module.exports = disconnectAll;

--- a/server/services/lgtv/lib/tv/getState.js
+++ b/server/services/lgtv/lib/tv/getState.js
@@ -1,0 +1,5 @@
+const getState = function getState() {
+  return {};
+};
+
+module.exports = getState;

--- a/server/services/lgtv/lib/tv/index.js
+++ b/server/services/lgtv/lib/tv/index.js
@@ -1,0 +1,44 @@
+const turnOn = require('./turnOn');
+const turnOff = require('./turnOff');
+const getState = require('./getState');
+const scan = require('./scan');
+const connectAll = require('./connectAll');
+const disconnectAll = require('./disconnectAll');
+const connect = require('./connect');
+const create = require('./create');
+const prompt = require('./prompt');
+const postCreate = require('./postCreate');
+const postUpdate = require('./postUpdate');
+const postDelete = require('./postDelete');
+const disconnect = require('./disconnect');
+const promptListener = require('./promptListener');
+
+/**
+ * @description Add ability to control LG TVs
+ * @param {Object} gladys - Gladys instance.
+ * @param {Object} client - Third-part client object.
+ * @example
+ * const exampleLightHandler = new ExampleLightHandler(gladys, client);
+ */
+const LGTVHandler = function LGTVHandler(gladys, client) {
+  this.client = client;
+  this.gladys = gladys;
+  this.connections = new Map();
+};
+
+LGTVHandler.prototype.postCreate = postCreate;
+LGTVHandler.prototype.postUpdate = postUpdate;
+LGTVHandler.prototype.postDelete = postDelete;
+LGTVHandler.prototype.turnOn = turnOn;
+LGTVHandler.prototype.turnOff = turnOff;
+LGTVHandler.prototype.getState = getState;
+LGTVHandler.prototype.scan = scan;
+LGTVHandler.prototype.connectAll = connectAll;
+LGTVHandler.prototype.disconnectAll = disconnectAll;
+LGTVHandler.prototype.connect = connect;
+LGTVHandler.prototype.disconnect = disconnect;
+LGTVHandler.prototype.create = create;
+LGTVHandler.prototype.prompt = prompt;
+LGTVHandler.prototype.promptListener = promptListener;
+
+module.exports = LGTVHandler;

--- a/server/services/lgtv/lib/tv/postCreate.js
+++ b/server/services/lgtv/lib/tv/postCreate.js
@@ -1,0 +1,5 @@
+const postCreate = function postCreate(device) {
+  this.connect(device);
+};
+
+module.exports = postCreate;

--- a/server/services/lgtv/lib/tv/postDelete.js
+++ b/server/services/lgtv/lib/tv/postDelete.js
@@ -1,0 +1,5 @@
+const postDelete = function postDelete(device) {
+  this.disconnect(device);
+};
+
+module.exports = postDelete;

--- a/server/services/lgtv/lib/tv/postUpdate.js
+++ b/server/services/lgtv/lib/tv/postUpdate.js
@@ -1,0 +1,6 @@
+const postUpdate = function postUpdate(device) {
+  this.disconnect(device);
+  this.connect(device);
+};
+
+module.exports = postUpdate;

--- a/server/services/lgtv/lib/tv/prompt.js
+++ b/server/services/lgtv/lib/tv/prompt.js
@@ -1,0 +1,52 @@
+const { promisify } = require('util');
+const LGTV = require('lgtv2');
+const logger = require('../../../../utils/logger');
+const { STATE } = require('./consts');
+const { getModelName, getDeviceID, timeout } = require('./utils');
+
+const TIMEOUT = 5000; // ms
+
+const prompt = async function prompt(address = null) {
+  let connection;
+  try {
+    logger.debug(`LGTV : Connecting to TV to show prompt...`);
+
+    connection = LGTV({
+      url: `ws://${address !== null ? address : 'lgwebostv'}:3000`,
+    });
+
+    const addListener = promisify(connection.on).bind(connection);
+
+    const error = addListener('error').then((e) => {
+      throw new Error(`LGTV scan error ${e.message}`);
+    });
+
+    await Promise.race([error, addListener('connect'), timeout(TIMEOUT)]);
+
+    const modelName = await getModelName(connection);
+    const deviceExternalID = await getDeviceID(connection);
+
+    return {
+      address,
+      state: STATE.CONNECTED,
+      modelName,
+      deviceExternalID,
+    };
+  } catch (e) {
+    if (e === STATE.TIMEOUT) {
+      return {
+        state: STATE.TIMEOUT,
+      };
+    }
+    logger.error(e);
+    return {
+      state: STATE.ERROR,
+    };
+  } finally {
+    if (connection) {
+      connection.disconnect();
+    }
+  }
+};
+
+module.exports = prompt;

--- a/server/services/lgtv/lib/tv/promptListener.js
+++ b/server/services/lgtv/lib/tv/promptListener.js
@@ -1,0 +1,45 @@
+const { EVENTS, WEBSOCKET_MESSAGE_TYPES } = require('../../../../utils/constants');
+const { STATE } = require('./consts');
+
+const eventFromState = (state, uuid, userId) => {
+  switch (state) {
+    case STATE.CONNECTED:
+      return {
+        type: WEBSOCKET_MESSAGE_TYPES.LGTV.CONNECTED,
+        userId,
+        payload: {
+          uuid,
+        },
+      };
+    case STATE.TIMEOUT:
+      return {
+        type: WEBSOCKET_MESSAGE_TYPES.LGTV.PROMPT_TIMEOUT,
+        userId,
+        payload: {
+          uuid,
+        },
+      };
+    case STATE.ERROR:
+      return {
+        type: WEBSOCKET_MESSAGE_TYPES.LGTV.PROMPT_ERROR,
+        userId,
+        payload: {
+          uuid,
+        },
+      };
+    default:
+      throw new Error('State not implemented');
+  }
+};
+
+const promptListener = function promptListener(event) {
+  if (event.type === WEBSOCKET_MESSAGE_TYPES.LGTV.PROMPT) {
+    (async () => {
+      const { state } = await this.prompt();
+
+      this.gladys.event.emit(EVENTS.WEBSOCKET.SEND, eventFromState(state, event.payload.uuid, event.userId));
+    })();
+  }
+};
+
+module.exports = promptListener;

--- a/server/services/lgtv/lib/tv/scan.js
+++ b/server/services/lgtv/lib/tv/scan.js
@@ -1,0 +1,63 @@
+const dns = require('dns');
+const LGTV = require('lgtv2');
+const { promisify } = require('util');
+const logger = require('../../../../utils/logger');
+const { STATE } = require('./consts');
+const { onboardingState, getModelName, getDeviceID } = require('./utils');
+
+const lookup = promisify(dns.lookup);
+
+const scan = async function scan() {
+  let connection;
+  try {
+    logger.debug('LGTV : Scanning...');
+    logger.debug('LGTV : DNS lookup for lgwebostv (standard hostname for TVs)...');
+    // return [
+    //   {
+    //     address: '192.168.30.51',
+    //     state: STATE.PROMPT,
+    //     modelName: 'my model',
+    //     deviceExternalID: '12345',
+    //   },
+    // ];
+    const { address } = await lookup('lgwebostv');
+
+    if (!address) {
+      logger.debug(`LGTV : Could not find TV on network via DNS`);
+      return [];
+    }
+    logger.debug(`LGTV : Found TV at ${address}`);
+    logger.debug(`LGTV : Connecting to TV...`);
+    connection = LGTV({
+      url: 'ws://lgwebostv:3000',
+    });
+
+    const state = await onboardingState(connection);
+
+    if (state === STATE.TIMEOUT) {
+      logger.debug(`LGTV : Found DNS record "lgwebostv" but got timeout trying to connect`);
+      return [];
+    }
+
+    const modelName = await getModelName(connection);
+    const deviceExternalID = await getDeviceID(connection);
+
+    return [
+      {
+        address: 'lgwebostv',
+        state,
+        modelName,
+        deviceExternalID,
+      },
+    ];
+  } catch (e) {
+    logger.info('LGTV scan didnt find anything - last state: ', e);
+    return [];
+  } finally {
+    if (connection) {
+      connection.disconnect();
+    }
+  }
+};
+
+module.exports = scan;

--- a/server/services/lgtv/lib/tv/setValue.js
+++ b/server/services/lgtv/lib/tv/setValue.js
@@ -1,0 +1,36 @@
+const { DEVICE_FEATURE_TYPES } = require('../../../../utils/constants');
+
+const logger = require('../../../../utils/logger');
+
+/**
+ * @description Change value of a Philips hue
+ * @param {Object} device - The device to control.
+ * @param {Object} deviceFeature - The binary deviceFeature to control.
+ * @param {number} value - The new value.
+ * @example
+ * turnOff(device, deviceFeature, value);
+ */
+async function setValue(device, deviceFeature, value) {
+  switch (deviceFeature.type) {
+    case DEVICE_FEATURE_TYPES.MEDIA_PLAYER.BINARY:
+      if (value === 1) {
+        this.turnOn(device);
+      } else {
+        this.turnOff(device);
+      }
+      break;
+    // case DEVICE_FEATURE_TYPES.MEDIA_PLAYER.SOURCE:
+    //   state = new this.LightState().rgb(intToRgb(value));
+    //   break;
+    //   case DEVICE_FEATURE_TYPES.MEDIA_PLAYER.CHANNEL:
+    //   state = new this.LightState().brightness(value);
+    //   break;
+    default:
+      logger.debug(`Media player : Feature type = "${deviceFeature.type}" not handled`);
+      break;
+  }
+}
+
+module.exports = {
+  setValue,
+};

--- a/server/services/lgtv/lib/tv/turnOff.js
+++ b/server/services/lgtv/lib/tv/turnOff.js
@@ -1,0 +1,3 @@
+const turnOff = function turnOff() {};
+
+module.exports = turnOff;

--- a/server/services/lgtv/lib/tv/turnOn.js
+++ b/server/services/lgtv/lib/tv/turnOn.js
@@ -1,0 +1,3 @@
+const turnOn = function turnOn() {};
+
+module.exports = turnOn;

--- a/server/services/lgtv/lib/tv/utils.js
+++ b/server/services/lgtv/lib/tv/utils.js
@@ -1,0 +1,66 @@
+const { promisify } = require('util');
+const logger = require('../../../../utils/logger');
+const { STATE } = require('./consts');
+
+const onboardingState = async (connection) => {
+  return new Promise((resolve, reject) => {
+    connection.on('connect', (err) => {
+      if (err) {
+        logger.debug(`LGTV : Connection event error`);
+        reject(err);
+      }
+
+      logger.debug(`LGTV : Connected`);
+
+      resolve(STATE.CONNECTED);
+    });
+    connection.on('prompt', (err) => {
+      if (err) {
+        logger.debug(`LGTV : Prompt event error`);
+        reject(err);
+      }
+
+      logger.debug(`LGTV : This user needs to authenticate via a prompt`);
+      resolve(STATE.PROMPT);
+    });
+    connection.on('error', (err) => {
+      logger.debug(`LGTV : Error connecting to TV: ${err}`);
+      resolve(STATE.ERROR);
+    });
+
+    setTimeout(() => resolve(STATE.TIMEOUT), 1000);
+  });
+};
+
+const getModelName = async (connection) => {
+  try {
+    return (await promisify(connection.request).bind(connection)('ssap://system/getSystemInfo')).modelName;
+  } catch (e) {
+    return null;
+  }
+};
+
+const getDeviceID = async (connection) => {
+  try {
+    return (await promisify(connection.request).bind(connection)(
+      'ssap://com.webos.service.update/getCurrentSWInformation',
+    )).device_id;
+  } catch (e) {
+    return null;
+  }
+};
+
+const timeout = (ms) =>
+  new Promise((resolve, reject) => {
+    const id = setTimeout(() => {
+      clearTimeout(id);
+      reject(STATE.TIMEOUT);
+    }, ms);
+  });
+
+module.exports = {
+  getDeviceID,
+  getModelName,
+  onboardingState,
+  timeout,
+};

--- a/server/services/lgtv/lib/tv/validate.js
+++ b/server/services/lgtv/lib/tv/validate.js
@@ -1,0 +1,30 @@
+const Joi = require('@hapi/joi');
+
+const schema = Joi.object().keys({
+  id: Joi.string(),
+  service_id: Joi.string(),
+  room_id: Joi.valid(null),
+  name: Joi.string(),
+  selector: Joi.string(),
+  model: Joi.string(),
+  external_id: Joi.string(),
+  should_poll: Joi.valid(false),
+  poll_frequency: Joi.valid(null),
+  created_at: Joi.date(),
+  updated_at: Joi.date(),
+  device_features: Joi.array().items(Joi.string()),
+  params: Joi.array().items(
+    Joi.object().keys({
+      id: Joi.string(),
+      device_id: Joi.string(),
+      name: Joi.string(),
+      value: Joi.string(),
+      created_at: Joi.date(),
+      updated_at: Joi.date(),
+    }),
+  ),
+});
+
+const validate = (device) => {};
+
+module.exports = { validate };

--- a/server/services/lgtv/package-lock.json
+++ b/server/services/lgtv/package-lock.json
@@ -1,0 +1,155 @@
+{
+  "name": "gladys-example",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "bufferutil": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
+      "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
+      "requires": {
+        "node-gyp-build": "^4.2.0"
+      }
+    },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
+          "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw=="
+        }
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "lgtv2": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/lgtv2/-/lgtv2-1.6.3.tgz",
+      "integrity": "sha512-iinwKz9MzxS7H78tBycwCBV/Y8lD7hVWs8zGjEJoi4xRk05SLUU4Xct/Y1VaspfMOgDZ3c0VRF1gA8mLMorqZg==",
+      "requires": {
+        "mkdirp": "^1.0.4",
+        "persist-path": "^1.0.2",
+        "websocket": "^1.0.32"
+      }
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "node-gyp-build": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+    },
+    "persist-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/persist-path/-/persist-path-1.0.2.tgz",
+      "integrity": "sha1-t7lHU2W1zPA4qvpVrxKw3YxBjXo="
+    },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "utf-8-validate": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.4.tgz",
+      "integrity": "sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==",
+      "requires": {
+        "node-gyp-build": "^4.2.0"
+      }
+    },
+    "websocket": {
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.33.tgz",
+      "integrity": "sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==",
+      "requires": {
+        "bufferutil": "^4.0.1",
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "typedarray-to-buffer": "^3.1.5",
+        "utf-8-validate": "^5.0.2",
+        "yaeti": "^0.0.6"
+      }
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
+    }
+  }
+}

--- a/server/services/lgtv/package.json
+++ b/server/services/lgtv/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "gladys-example",
+  "main": "index.js",
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "cpu": [
+    "x64",
+    "arm",
+    "arm64"
+  ],
+  "scripts": {},
+  "dependencies": {
+    "lgtv2": "^1.6.3"
+  },
+  "devDependencies": {}
+}

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -143,6 +143,7 @@ const EVENTS = {
   WEBSOCKET: {
     SEND: 'websocket.send',
     SEND_ALL: 'websocket.send-all',
+    RECEIVE: 'websocket.receive',
   },
   HOUSE: {
     CREATED: 'house.created',
@@ -154,8 +155,10 @@ const EVENTS = {
   MEDIA_PLAYER: {
     TURNED_ON: 'media-player.turned-on',
     TURNED_OFF: 'media-player.turned-off',
-    SOURCE_CHANGED: 'media-player.source-changed',
-    CURRENT_MEDIA_CHANGED: 'media-player.current-media-changed',
+    VOLUME: 'media-player.volume',
+    MUTE: 'media-player.mute',
+    SOURCE: 'media-player.source-changed',
+    CURRENT_MEDIA: 'media-player.current-media-changed',
   },
 };
 
@@ -377,9 +380,11 @@ const DEVICE_FEATURE_TYPES = {
     CLICK: 'click',
   },
   MEDIA_PLAYER: {
-    BINARY: 'binary',
+    POWER: 'power',
     SOURCE: 'source',
-    CURRENTLY_PLAYING: 'currently-playing',
+    CHANNEL: 'channel',
+    VOLUME: 'volume',
+    MUTED: 'muted',
   },
   UNKNOWN: {
     UNKNOWN: 'unknown',
@@ -401,6 +406,7 @@ const DEVICE_FEATURE_UNITS = {
   PPM: 'ppm',
   MM: 'mm',
   CM: 'cm',
+  INTEGER: 'integer',
 };
 
 const WEATHER_UNITS = {
@@ -499,6 +505,12 @@ const WEBSOCKET_MESSAGE_TYPES = {
     NEW_DEVICE: 'ewelink.new-device',
     ERROR: 'ewelink.error',
   },
+  LGTV: {
+    PROMPT: 'lgtv.prompt',
+    PROMPT_ERROR: 'lgtv.prompt.error',
+    PROMPT_TIMEOUT: 'lgtv.prompt.timeout',
+    STATUS: 'lgtv.status',
+  },
 };
 
 const DASHBOARD_TYPE = {
@@ -512,6 +524,7 @@ const DASHBOARD_BOX_TYPE = {
   USER_PRESENCE: 'user-presence',
   CAMERA: 'camera',
   DEVICES_IN_ROOM: 'devices-in-room',
+  MEDIA_PLAYER: 'media-player',
 };
 
 const ERROR_MESSAGES = {

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -151,6 +151,12 @@ const EVENTS = {
     EMPTY: 'house.empty',
     NO_LONGER_EMPTY: 'house.no-longer-empty',
   },
+  MEDIA_PLAYER: {
+    TURNED_ON: 'media-player.turned-on',
+    TURNED_OFF: 'media-player.turned-off',
+    SOURCE_CHANGED: 'media-player.source-changed',
+    CURRENT_MEDIA_CHANGED: 'media-player.current-media-changed',
+  },
 };
 
 const LIFE_EVENTS = {
@@ -245,6 +251,15 @@ const ACTIONS = {
   HTTP: {
     REQUEST: 'http.request',
   },
+  MEDIA_PLAYER: {
+    PLAY_MEDIA: 'intent.media-player.play-media',
+    PLAY: 'intent.media-player.play',
+    STOP: 'intent.media-player.stop',
+    PAUSE: 'intent.media-player.pause',
+    SELECT_SOURCE: 'intent.media-player.select-source',
+    TURN_ON: 'intent.media-player.turn-on',
+    TURN_OFF: 'intent.media-player.turn-off',
+  },
 };
 
 const INTENTS = {
@@ -266,6 +281,15 @@ const INTENTS = {
   },
   CAMERA: {
     GET_IMAGE_ROOM: 'intent.camera.get-image-room',
+  },
+  MEDIA_PLAYER: {
+    PLAY_MEDIA: 'intent.media-player.play-media',
+    PLAY: 'intent.media-player.play',
+    STOP: 'intent.media-player.stop',
+    PAUSE: 'intent.media-player.pause',
+    SELECT_SOURCE: 'intent.media-player.select-source',
+    TURN_ON: 'intent.media-player.turn-on',
+    TURN_OFF: 'intent.media-player.turn-off',
   },
 };
 
@@ -292,6 +316,7 @@ const DEVICE_FEATURE_CATEGORIES = {
   ACCESS_CONTROL: 'access-control',
   CUBE: 'cube',
   BUTTON: 'button',
+  MEDIA_PLAYER: 'media-player',
   UNKNOWN: 'unknown',
 };
 
@@ -350,6 +375,11 @@ const DEVICE_FEATURE_TYPES = {
   },
   BUTTON: {
     CLICK: 'click',
+  },
+  MEDIA_PLAYER: {
+    BINARY: 'binary',
+    SOURCE: 'source',
+    CURRENTLY_PLAYING: 'currently-playing',
   },
   UNKNOWN: {
     UNKNOWN: 'unknown',


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [ ] If your changes affects code, did your write the tests?
- [ ] Are tests passing? (`npm test` on both front/server)
- [ ] Is the linter passing? (`npm run eslint` on both front/server)
- [ ] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.json`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Closes #1144 
Closes #1130 

- Adds a "Media Device" model which is an abstraction of a radio/tv/console
- LGTV integration can scan for devices on the network (currently using a well-known hostname, in future via mdns too)
- LGTV integration connects via a socket per device
- LGTV pushes state changes via websocket to gladys


TODO 
- [ ] Add media player dashboard component
  - [ ] Add dropdown to select media devices
  - [ ] Add ability to power on/off media device
  - [ ] Show current source
  - [ ] Show currently playing media
- [ ] add unit tests to server
- [ ] Split out media player into a separate PR
