### PR TITLE
Fix #1200: calling a scene from a scene should duplicate the scope object to avoid context pollution

### DIFF
--- a/server/lib/scene/scene.actions.js
+++ b/server/lib/scene/scene.actions.js
@@ -1,5 +1,6 @@
 const Promise = require('bluebird');
 const Handlebars = require('handlebars');
+const cloneDeep = require('lodash.clonedeep');
 const set = require('set-value');
 const get = require('get-value');
 const dayjs = require('dayjs');
@@ -116,8 +117,9 @@ const actionsFunc = {
       );
       return;
     }
-
-    self.execute(action.scene, scope);
+    // we clone the scope so that the new scene is not polluting
+    // other scenes writing on the same scope: it needs to be a fresh object
+    self.execute(action.scene, cloneDeep(scope));
   },
   [ACTIONS.MESSAGE.SEND]: async (self, action, scope) => {
     const textWithVariables = Handlebars.compile(action.text)(scope);

--- a/server/test/lib/scene/scene.execute.test.js
+++ b/server/test/lib/scene/scene.execute.test.js
@@ -177,8 +177,12 @@ describe('SceneManager', () => {
       sceneManager.queue.start(() => {
         try {
           assert.calledTwice(executeSpy);
-          assert.calledWith(executeSpy.firstCall, 'my-scene', scope);
-          assert.calledWith(executeSpy.secondCall, 'second-scene', scope);
+          assert.calledWith(executeSpy.firstCall, 'my-scene', {
+            alreadyExecutedScenes: new Set(['my-scene']),
+          });
+          assert.calledWith(executeSpy.secondCall, 'second-scene', {
+            alreadyExecutedScenes: new Set(['my-scene', 'second-scene']),
+          });
           resolve();
         } catch (e) {
           reject(e);
@@ -187,7 +191,7 @@ describe('SceneManager', () => {
     });
   });
 
-  it('should deduplicate calls to other scenes', async () => {
+  it('should prevent infinite loop', async () => {
     const stateManager = new StateManager(event);
     const sceneManager = new SceneManager(stateManager, event);
 
@@ -198,20 +202,6 @@ describe('SceneManager', () => {
       triggers: [],
       actions: [
         [
-          {
-            type: ACTIONS.SCENE.START,
-            scene: 'second-scene',
-          },
-          {
-            type: ACTIONS.SCENE.START,
-            scene: 'second-scene',
-          },
-        ],
-        [
-          {
-            type: ACTIONS.SCENE.START,
-            scene: 'second-scene',
-          },
           {
             type: ACTIONS.SCENE.START,
             scene: 'second-scene',
@@ -228,10 +218,6 @@ describe('SceneManager', () => {
             type: ACTIONS.SCENE.START,
             scene: 'my-scene',
           },
-          {
-            type: ACTIONS.SCENE.START,
-            scene: 'my-scene',
-          },
         ],
       ],
     };
@@ -242,8 +228,12 @@ describe('SceneManager', () => {
       sceneManager.queue.start(() => {
         try {
           assert.calledTwice(executeSpy);
-          assert.calledWith(executeSpy.firstCall, 'my-scene', scope);
-          assert.calledWith(executeSpy.secondCall, 'second-scene', scope);
+          assert.calledWith(executeSpy.firstCall, 'my-scene', {
+            alreadyExecutedScenes: new Set(['my-scene']),
+          });
+          assert.calledWith(executeSpy.secondCall, 'second-scene', {
+            alreadyExecutedScenes: new Set(['my-scene', 'second-scene']),
+          });
           resolve();
         } catch (e) {
           reject(e);

--- a/server/test/lib/scene/scene.executeActions.test.js
+++ b/server/test/lib/scene/scene.executeActions.test.js
@@ -3,6 +3,7 @@ const chaiAssert = require('chai').assert;
 const { expect } = require('chai');
 const dayjs = require('dayjs');
 const EventEmitter = require('events');
+const cloneDeep = require('lodash.clonedeep');
 const { ACTIONS } = require('../../../utils/constants');
 const { AbortScene } = require('../../../utils/coreErrors');
 const { executeActions } = require('../../../lib/scene/scene.executeActions');
@@ -659,7 +660,11 @@ describe('scene.executeActions', () => {
       ],
       scope,
     );
-    assert.calledWith(execute, 'other_scene_selector', scope);
+    const clonedScope = cloneDeep(scope);
+    // we try to pollute the scope, and see if the called scene was affected by this pollution
+    // it should not affect a running scene
+    scope.test = 1;
+    assert.calledWith(execute, 'other_scene_selector', clonedScope);
   });
 
   it('should not execute action scene.start when the scene has already been called as part of this chain', async () => {


### PR DESCRIPTION


### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [ ] If your changes affects code, did your write the tests?
- [ ] Are tests passing? (`npm test` on both front/server)
- [ ] Is the linter passing? (`npm run eslint` on both front/server)
- [ ] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.json`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Please provide a description of the change here. It's always best with screenshots, so don't hesitate to add some!
