### PR TITLE
Fix #1267: New scene should not have the previous scene name prefilled

### DIFF
--- a/front/src/actions/createScene.js
+++ b/front/src/actions/createScene.js
@@ -52,7 +52,7 @@ function createActions(store) {
     initScene(state) {
       store.setState({
         newScene: {
-          name: null,
+          name: '',
           icon: null,
           actions: [[]]
         },

--- a/front/src/routes/scene/new-scene/index.js
+++ b/front/src/routes/scene/new-scene/index.js
@@ -3,9 +3,8 @@ import { connect } from 'unistore/preact';
 import actions from '../../../actions/createScene';
 import NewScenePage from './NewScenePage';
 
-@connect('newScene,newSceneErrors,createSceneStatus', actions)
 class NewScene extends Component {
-  componentWillMount() {
+  componentDidMount() {
     this.props.initScene();
   }
 
@@ -14,4 +13,4 @@ class NewScene extends Component {
   }
 }
 
-export default NewScene;
+export default connect('newScene,newSceneErrors,createSceneStatus', actions)(NewScene);


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [x] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.json`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Please provide a description of the change here. It's always best with screenshots, so don't hesitate to add some!
