### PR TITLE
Fix #1310: In box "temperature in room" & "humidity in room", when value is 0, it should not display weird state

### DIFF
--- a/front/src/components/boxs/room-humidity/RoomHumidity.jsx
+++ b/front/src/components/boxs/room-humidity/RoomHumidity.jsx
@@ -5,6 +5,8 @@ import actions from '../../../actions/dashboard/boxes/humidityInRoom';
 import { DASHBOARD_BOX_STATUS_KEY, DASHBOARD_BOX_DATA_KEY } from '../../../utils/consts';
 import get from 'get-value';
 
+const isNotNullOrUndefined = value => value !== undefined && value !== null;
+
 const RoomHumidityBox = ({ children, ...props }) => (
   <div class="card p-3">
     <div class="d-flex align-items-center">
@@ -24,12 +26,12 @@ const RoomHumidityBox = ({ children, ...props }) => (
         </span>
       )}
       <div>
-        {props.humidity && (
+        {isNotNullOrUndefined(props.humidity) && (
           <h4 class="m-0">
             <Text id="global.percentValue" fields={{ value: Math.round(props.humidity) }} />
           </h4>
         )}
-        {!props.humidity && (
+        {!isNotNullOrUndefined(props.humidity) && (
           <p class="m-0">
             <Text id="dashboard.boxes.humidityInRoom.noHumidityRecorded" />
           </p>

--- a/front/src/components/boxs/room-temperature/RoomTemperature.jsx
+++ b/front/src/components/boxs/room-temperature/RoomTemperature.jsx
@@ -5,6 +5,8 @@ import actions from '../../../actions/dashboard/boxes/temperatureInRoom';
 import { DASHBOARD_BOX_STATUS_KEY, DASHBOARD_BOX_DATA_KEY } from '../../../utils/consts';
 import get from 'get-value';
 
+const isNotNullOrUndefined = value => value !== undefined && value !== null;
+
 const RoomTemperatureBox = ({ children, ...props }) => (
   <div class="card p-3">
     <div class="d-flex align-items-center">
@@ -12,13 +14,13 @@ const RoomTemperatureBox = ({ children, ...props }) => (
         <i class="fe fe-thermometer" />
       </span>
       <div>
-        {props.temperature && (
+        {isNotNullOrUndefined(props.temperature) && (
           <h4 class="m-0">
             <Text id="global.degreeValue" fields={{ value: Math.round(props.temperature) }} />
             {props.unit === 'celsius' ? 'C' : 'F'}
           </h4>
         )}
-        {!props.temperature && (
+        {!isNotNullOrUndefined(props.temperature) && (
           <p class="m-0">
             <Text id="dashboard.boxes.temperatureInRoom.noTemperatureRecorded" />
           </p>


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [ ] If your changes affects code, did your write the tests?
- [ ] Are tests passing? (`npm test` on both front/server)
- [ ] Is the linter passing? (`npm run eslint` on both front/server)
- [ ] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.json`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Please provide a description of the change here. It's always best with screenshots, so don't hesitate to add some!
