### PR TITLE
[MQTT] User must know if connected or not

### DIFF
--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -819,7 +819,7 @@
         "passwordPlaceholder": "Entrez le mot de passe du broker MQTT",
         "saveLabel": "Sauvegarder la configuration",
         "error": "Une erreur s'est produite lors de l'enregistrement de la configuration.",
-        "connecting": "Configuration enregistrée. Maintenant, connectez-vous à votre broker MQTT...",
+        "connecting": "Configuration enregistrée. Connexion au broker MQTT en cours...",
         "connected": "Connecté au broker MQTT avec succès !",
         "connectionError": "Erreur lors de la connexion, veuillez vérifier votre configuration.",
         "disconnected": "Déconnecté du broker MQTT."

--- a/front/src/routes/integration/all/mqtt/setup-page/SetupTab.jsx
+++ b/front/src/routes/integration/all/mqtt/setup-page/SetupTab.jsx
@@ -16,6 +16,49 @@ class SetupTab extends Component {
   };
 
   render(props) {
+    let alertMessage = null;
+
+    const { connectMqttStatus, mqttConnected, mqttConnectionError } = props;
+    switch (connectMqttStatus) {
+      case RequestStatus.Error:
+        // Error while updating setup
+        alertMessage = (
+          <p class="alert alert-danger">
+            <Text id="integration.mqtt.setup.error" />
+          </p>
+        );
+        break;
+      case RequestStatus.Success:
+        // Updating setup with success = connecting...
+        alertMessage = (
+          <p class="alert alert-info">
+            <Text id="integration.mqtt.setup.connecting" />
+          </p>
+        );
+        break;
+      default:
+        if (mqttConnectionError === 'DISCONNECTED') {
+          alertMessage = (
+            <p class="alert alert-info">
+              <Text id="integration.mqtt.setup.disconnected" />
+            </p>
+          );
+        } else if (mqttConnectionError || mqttConnected === false) {
+          alertMessage = (
+            <p class="alert alert-danger">
+              <Text id="integration.mqtt.setup.connectionError" />
+            </p>
+          );
+        } else if (mqttConnected) {
+          // Well connected
+          alertMessage = (
+            <p class="alert alert-success">
+              <Text id="integration.mqtt.setup.connected" />
+            </p>
+          );
+        }
+    }
+
     return (
       <div class="card">
         <div class="card-header">
@@ -34,32 +77,7 @@ class SetupTab extends Component {
               <p>
                 <MarkupText id="integration.mqtt.setup.mqttDescription" />
               </p>
-              {props.connectMqttStatus === RequestStatus.Error && (
-                <p class="alert alert-danger">
-                  <Text id="integration.mqtt.setup.error" />
-                </p>
-              )}
-              {props.connectMqttStatus === RequestStatus.Success && !props.mqttConnected && (
-                <p class="alert alert-info">
-                  <Text id="integration.mqtt.setup.connecting" />
-                </p>
-              )}
-              {props.mqttConnected && (
-                <p class="alert alert-success">
-                  <Text id="integration.mqtt.setup.connected" />
-                </p>
-              )}
-              {props.mqttConnectionError && props.mqttConnectionError !== 'DISCONNECTED' && (
-                <p class="alert alert-danger">
-                  <Text id="integration.mqtt.setup.connectionError" />
-                </p>
-              )}
-
-              {props.mqttConnectionError === 'DISCONNECTED' && (
-                <p class="alert alert-info">
-                  <Text id="integration.mqtt.setup.disconnected" />
-                </p>
-              )}
+              {alertMessage}
 
               <div class="form-group">
                 <label for="embeddedBroker" class="form-label">

--- a/front/src/routes/integration/all/mqtt/setup-page/actions.js
+++ b/front/src/routes/integration/all/mqtt/setup-page/actions.js
@@ -4,6 +4,18 @@ import { RequestStatus } from '../../../../../utils/consts';
 const createActions = store => {
   const integrationActions = createActionsIntegration(store);
   const actions = {
+    async loadStatus(state) {
+      let mqttStatus = {
+        connected: false
+      };
+      try {
+        mqttStatus = await state.httpClient.get('/api/v1/service/mqtt/status');
+      } finally {
+        store.setState({
+          mqttConnected: mqttStatus.connected
+        });
+      }
+    },
     async loadProps(state) {
       let configuration = {};
       try {
@@ -44,8 +56,6 @@ const createActions = store => {
         store.setState({
           connectMqttStatus: RequestStatus.Success
         });
-
-        setTimeout(() => store.setState({ connectMqttStatus: undefined }), 3000);
       } catch (e) {
         store.setState({
           connectMqttStatus: RequestStatus.Error,
@@ -57,16 +67,9 @@ const createActions = store => {
       // display 3 seconds a message "MQTT connected"
       store.setState({
         mqttConnected: true,
+        connectMqttStatus: undefined,
         mqttConnectionError: undefined
       });
-      setTimeout(
-        () =>
-          store.setState({
-            mqttConnected: false,
-            connectMqttStatus: undefined
-          }),
-        3000
-      );
     },
     displayMqttError(state, error) {
       store.setState({

--- a/front/src/routes/integration/all/mqtt/setup-page/index.js
+++ b/front/src/routes/integration/all/mqtt/setup-page/index.js
@@ -13,12 +13,20 @@ class MqttNodePage extends Component {
   componentWillMount() {
     this.props.getIntegrationByName('mqtt');
     this.props.loadProps();
-    this.props.session.dispatcher.addListener(WEBSOCKET_MESSAGE_TYPES.MQTT.CONNECTED, () =>
-      this.props.displayConnectedMessage()
+    this.props.loadStatus();
+    this.props.session.dispatcher.addListener(
+      WEBSOCKET_MESSAGE_TYPES.MQTT.CONNECTED,
+      this.props.displayConnectedMessage
     );
-    this.props.session.dispatcher.addListener(WEBSOCKET_MESSAGE_TYPES.MQTT.ERROR, payload =>
-      this.props.displayMqttError(payload)
+    this.props.session.dispatcher.addListener(WEBSOCKET_MESSAGE_TYPES.MQTT.ERROR, this.props.displayMqttError);
+  }
+
+  componentWillUnmount() {
+    this.props.session.dispatcher.removeListener(
+      WEBSOCKET_MESSAGE_TYPES.MQTT.CONNECTED,
+      this.props.displayConnectedMessage
     );
+    this.props.session.dispatcher.removeListener(WEBSOCKET_MESSAGE_TYPES.MQTT.ERROR, this.props.displayMqttError);
   }
 
   render(props, {}) {


### PR DESCRIPTION
Fixes #1016

### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- ~~[ ] If your changes affects code, did your write the tests?~~
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- ~~[ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)~~
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.
- ~~[ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~~
- ~~[ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).~~
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Display connection status on setup page.

![image](https://user-images.githubusercontent.com/1839717/141497654-3f00732e-1a29-4947-88e7-c1c4b8c8710c.png)
