### PR TITLE
Feature component

### DIFF
--- a/front/src/components/device/UpdateDeviceForm.jsx
+++ b/front/src/components/device/UpdateDeviceForm.jsx
@@ -1,8 +1,8 @@
 import { Component } from 'preact';
 import { Text, Localizer } from 'preact-i18n';
-import { DeviceFeatureCategoriesIcon } from '../../utils/consts';
-import get from 'get-value';
+
 import { DEVICE_POLL_FREQUENCIES } from '../../../../server/utils/constants';
+import DeviceFeatures from './view/DeviceFeatures';
 
 const maxWidth = {
   maxWidth: '400px'
@@ -83,19 +83,7 @@ class UpdateDeviceForm extends Component {
           <label class="form-label">
             <Text id="editDeviceForm.featuresLabel" />
           </label>
-          <div class="tags">
-            {props.device &&
-              props.device.features &&
-              props.device.features.map(feature => (
-                <span class="tag">
-                  <Text id={`deviceFeatureCategory.${feature.category}.${feature.type}`} />
-                  <div class="tag-addon">
-                    <i class={`fe fe-${get(DeviceFeatureCategoriesIcon, `${feature.category}.${feature.type}`)}`} />
-                  </div>
-                </span>
-              ))}
-            {(!props.device.features || props.device.features.length === 0) && <Text id="editDeviceForm.noFeatures" />}
-          </div>
+          <DeviceFeatures features={props.device.features} />
         </div>
       </div>
     );

--- a/front/src/components/device/view/BatteryLevelFeature.jsx
+++ b/front/src/components/device/view/BatteryLevelFeature.jsx
@@ -1,0 +1,19 @@
+import cx from 'classnames';
+import { Text } from 'preact-i18n';
+
+const BatteryLevelFeature = ({ batteryLevel }) => (
+  <div
+    class={cx('tag', {
+      'tag-green': batteryLevel >= 25,
+      'tag-warning': batteryLevel < 25 && batteryLevel >= 10,
+      'tag-danger': batteryLevel < 10
+    })}
+  >
+    <Text id="global.percentValue" fields={{ value: batteryLevel }} />
+    <span class="tag-addon">
+      <i class="fe fe-battery" />
+    </span>
+  </div>
+);
+
+export default BatteryLevelFeature;

--- a/front/src/components/device/view/DeviceFeature.jsx
+++ b/front/src/components/device/view/DeviceFeature.jsx
@@ -1,0 +1,15 @@
+import get from 'get-value';
+import { Text } from 'preact-i18n';
+
+import { DeviceFeatureCategoriesIcon } from '../../../utils/consts';
+
+const DeviceFeature = ({ feature }) => (
+  <span class="tag">
+    <Text id={`deviceFeatureCategory.${feature.category}.${feature.type}`} />
+    <div class="tag-addon">
+      <i class={`fe fe-${get(DeviceFeatureCategoriesIcon, `${feature.category}.${feature.type}`)}`} />
+    </div>
+  </span>
+);
+
+export default DeviceFeature;

--- a/front/src/components/device/view/DeviceFeatures.jsx
+++ b/front/src/components/device/view/DeviceFeatures.jsx
@@ -1,0 +1,23 @@
+import { Text } from 'preact-i18n';
+
+import DeviceFeature from './DeviceFeature';
+
+const DeviceFeatures = ({ features = [] }) => {
+  if (features.length > 0) {
+    return (
+      <div class="tags device-features">
+        {features.map(feature => (
+          <DeviceFeature feature={feature} />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div class="font-italic device-features">
+      <Text id="device.noFeatures" />
+    </div>
+  );
+};
+
+export default DeviceFeatures;

--- a/front/src/config/demo.js
+++ b/front/src/config/demo.js
@@ -1918,6 +1918,7 @@ const data = {
       external_id: 'bluetooth:0011223341',
       service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
       selector: 'bluetooth-0011223341',
+      features: [],
       params: [
         {
           name: 'loaded',
@@ -1930,6 +1931,7 @@ const data = {
       model: 'smlc9',
       external_id: 'bluetooth:0011223342',
       selector: 'bluetooth-0011223342',
+      features: [],
       params: [
         {
           name: 'loaded',
@@ -1988,6 +1990,7 @@ const data = {
     name: 'BLE Device 1',
     external_id: 'bluetooth:0011223341',
     selector: 'bluetooth-0011223341',
+    features: [],
     params: [
       {
         name: 'loaded',
@@ -2000,6 +2003,7 @@ const data = {
     model: 'smlc9',
     external_id: 'bluetooth:0011223342',
     selector: 'bluetooth-0011223342',
+    features: [],
     params: [
       {
         name: 'loaded',

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -41,6 +41,9 @@
     "event": "Event",
     "noEventsInRange": "There are no events in this range."
   },
+  "device": {
+    "noFeatures": "No features"
+  },
   "login": {
     "title": "Gladys Assistant",
     "welcome": "Welcome",
@@ -433,7 +436,6 @@
         "noNameLabel": "No name",
         "roomLabel": "Room",
         "featuresLabel": "Features",
-        "noFeatures": "No features",
         "search": "Search devices",
         "connectButton": "Connect/Reconnect",
         "scanButton": "Scan network",
@@ -553,7 +555,6 @@
         "nameLabel": "Name",
         "roomLabel": "Room",
         "featuresLabel": "Features",
-        "noFeatures": "No features",
         "saveButton": "Save",
         "deleteButton": "Delete",
         "editButton": "Edit",
@@ -575,7 +576,6 @@
         "createDeviceInGladys": "Connect in Gladys",
         "features": "Features",
         "params": "Params",
-        "noFeatures": "No features",
         "nodeId": "Node",
         "zwaveNotConfiguredError": "Z-wave is not configured. Please select the USB port where you Z-Wave key is plugged in settings.",
         "createDeviceError": "There was an error while creating this device in Gladys.",
@@ -645,7 +645,6 @@
         "externalIdLabel": "External ID",
         "roomLabel": "Room",
         "featuresLabel": "Features",
-        "noFeatures": "No features",
         "saveButton": "Save",
         "deleteButton": "Delete",
         "returnButton": "Return back",
@@ -714,8 +713,7 @@
         "featuresLabel": "Features",
         "saveButton": "Save",
         "deleteButton": "Delete",
-        "editButton": "Edit details",
-        "noFeatures": "No features"
+        "editButton": "Edit details"
       },
       "setup": {
         "title": "Xiaomi devices not in Gladys",
@@ -812,7 +810,6 @@
         "title": "Bluetooth Devices",
         "search": "Search devices",
         "noDevices": "No Bluetooth devices added yet.",
-        "noFeatures": "No features",
         "nameLabel": "Name",
         "namePlaceholder": "Enter device name",
         "roomLabel": "Room",
@@ -821,7 +818,6 @@
         "modelLabel": "Model",
         "presenceSensorLabel": "Use this device as presence sensor",
         "featuresLabel": "Features",
-        "noFeatureDiscovered": "No features discovered.",
         "featureNamePlaceholder": "Enter feature name",
         "saveButton": "Save",
         "deleteButton": "Delete",
@@ -1717,7 +1713,6 @@
     "roomLabel": "Room",
     "featuresLabel": "Features",
     "featureCategoryLabel": "Category",
-    "noFeatures": "No features",
     "namePlaceholder": "Enter name",
     "externalIdLabel": "External ID",
     "externalIdPlaceholder": "Enter external ID",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -41,6 +41,9 @@
     "event": "événement",
     "noEventsInRange": "Aucuns évènements trouvés dans cette période."
   },
+  "device": {
+    "noFeatures": "Aucune fonctionnalité"
+  },
   "login": {
     "title": "Gladys Assistant",
     "welcome": "Bienvenue",
@@ -381,7 +384,6 @@
         "title": "Appareils Bluetooth",
         "search": "Chercher un appareil",
         "noDevices": "Aucun appareil Bluetooth n'a encore été ajouté.",
-        "noFeatures": "Aucune fonctionnalité",
         "nameLabel": "Nom de l'appareil",
         "namePlaceholder": "Entrez le nom de votre appareil",
         "roomLabel": "Pièce",
@@ -390,7 +392,6 @@
         "modelLabel": "Modèle",
         "presenceSensorLabel": "Utiliser cet appareil comme un détecteur de présence",
         "featuresLabel": "Fonctionnalités",
-        "noFeatureDiscovered": "Aucune fonctionnalité détectée.",
         "featureNamePlaceholder": "Nom de la fonctionnalité",
         "saveButton": "Sauvegarder",
         "deleteButton": "Supprimer",
@@ -560,7 +561,6 @@
         "noNameLabel": "Pas de nom",
         "roomLabel": "Pièce",
         "featuresLabel": "Fonctionnalités",
-        "noFeatures": "Aucune fonctionnalité",
         "search": "Recherche d'appareils",
         "connectButton": "Connecter/Reconnecter",
         "scanButton": "Recherche sur le réseau",
@@ -680,7 +680,6 @@
         "nameLabel": "Nom",
         "roomLabel": "Pièce",
         "featuresLabel": "Fonctionnalités",
-        "noFeatures": "Pas de fonctionnalités",
         "saveButton": "Sauvegarder",
         "deleteButton": "Supprimer",
         "editButton": "Editer",
@@ -702,7 +701,6 @@
         "createDeviceInGladys": "Connecter dans Gladys",
         "features": "Fonctionnalités",
         "params": "Paramètre",
-        "noFeatures": "Aucune fonctionnalité",
         "nodeId": "Noeud",
         "zwaveNotConfiguredError": "Ce service Z-wave n'est pas configuré. Veuillez sélectionner le port USB où votre clé Z-Wave est branchée dans les paramètres.",
         "createDeviceError": "Une erreur s'est produite lors de la création de cet appareil dans Gladys.",
@@ -772,7 +770,6 @@
         "externalIdLabel": "ID externe",
         "roomLabel": "Pièce",
         "featuresLabel": "Fonctionnalités",
-        "noFeatures": "Aucune fonctionnalité",
         "saveButton": "Sauvegarder",
         "deleteButton": "Supprimer",
         "returnButton": "Retour",
@@ -841,8 +838,7 @@
         "featuresLabel": "Fonctionnalités",
         "saveButton": "Sauvegarder",
         "deleteButton": "Supprimer",
-        "editButton": "Editer les détails",
-        "noFeatures": "Aucune fonctionnalité"
+        "editButton": "Editer les détails"
       },
       "setup": {
         "title": "Aucun appareil Xiaomi dans Gladys",
@@ -1717,7 +1713,6 @@
     "roomLabel": "Pièce",
     "featuresLabel": "Fonctionnalités",
     "featureCategoryLabel": "Catégorie",
-    "noFeatures": "Aucune fonctionnalité",
     "namePlaceholder": "Entrez un nom",
     "externalIdLabel": "ID externe",
     "externalIdPlaceholder": "Entrez une ID externe",

--- a/front/src/routes/integration/all/bluetooth/device-page/BluetoothDevice.jsx
+++ b/front/src/routes/integration/all/bluetooth/device-page/BluetoothDevice.jsx
@@ -5,9 +5,9 @@ import get from 'get-value';
 import { Link } from 'preact-router';
 
 import { DEVICE_FEATURE_CATEGORIES } from '../../../../../../../server/utils/constants';
-import { RequestStatus, DeviceFeatureCategoriesIcon } from '../../../../../utils/consts';
-
-import style from '../style.css';
+import { RequestStatus } from '../../../../../utils/consts';
+import BatteryLevelFeature from '../../../../../components/device/view/BatteryLevelFeature';
+import DeviceFeatures from '../../../../../components/device/view/DeviceFeatures';
 
 class BluetoothDevice extends Component {
   refreshDeviceProperty = () => {
@@ -62,12 +62,7 @@ class BluetoothDevice extends Component {
             {device.name}
             {batteryLevel && (
               <div class="page-options d-flex">
-                <div class="tag tag-green">
-                  <Text id="global.percentValue" fields={{ value: batteryLevel }} />
-                  <span class="tag-addon">
-                    <i class="fe fe-battery" />
-                  </span>
-                </div>
+                <BatteryLevelFeature batteryLevel={batteryLevel} />
               </div>
             )}
           </div>
@@ -117,25 +112,7 @@ class BluetoothDevice extends Component {
                   <label>
                     <Text id="integration.bluetooth.device.featuresLabel" />
                   </label>
-                  {device.features && (
-                    <div class="tags">
-                      {device.features.map(feature => (
-                        <span class="tag">
-                          <Text id={`deviceFeatureCategory.${feature.category}.${feature.type}`} />
-                          <div class="tag-addon">
-                            <i
-                              class={`fe fe-${get(DeviceFeatureCategoriesIcon, `${feature.category}.${feature.type}`)}`}
-                            />
-                          </div>
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                  {(!device.features || device.features.length === 0) && (
-                    <div class={cx('text-center', 'font-italic', 'mt-3', style.featureListBody)}>
-                      <Text id="integration.bluetooth.device.noFeatureDiscovered" />
-                    </div>
-                  )}
+                  <DeviceFeatures features={device.features} />
                 </div>
                 <div class="form-group">
                   <button onClick={this.saveDevice} class="btn btn-success mr-2">

--- a/front/src/routes/integration/all/bluetooth/setup-page/BluetoothPeripheralFeatures.jsx
+++ b/front/src/routes/integration/all/bluetooth/setup-page/BluetoothPeripheralFeatures.jsx
@@ -1,7 +1,6 @@
 import { Text } from 'preact-i18n';
-import get from 'get-value';
 
-import { DeviceFeatureCategoriesIcon } from '../../../../../utils/consts';
+import DeviceFeatures from '../../../../../components/device/view/DeviceFeatures';
 
 const BluetoothPeripheralFeatures = ({ children, device }) => {
   const { features = [] } = device;
@@ -11,26 +10,7 @@ const BluetoothPeripheralFeatures = ({ children, device }) => {
       <label class="form-label">
         <Text id="integration.bluetooth.device.featuresLabel" />
       </label>
-      <div>
-        {features.length === 0 && (
-          <div class="text-center font-italic">
-            <Text id="integration.bluetooth.device.noFeatureDiscovered" />
-          </div>
-        )}
-        {features.length > 0 &&
-          (children || (
-            <div class="tags">
-              {features.map(feature => (
-                <span class="tag">
-                  <Text id={`deviceFeatureCategory.${feature.category}.${feature.type}`} />
-                  <div class="tag-addon">
-                    <i class={`fe fe-${get(DeviceFeatureCategoriesIcon, `${feature.category}.${feature.type}`)}`} />
-                  </div>
-                </span>
-              ))}
-            </div>
-          ))}
-      </div>
+      <div>{children || <DeviceFeatures features={features} />}</div>
     </div>
   );
 };

--- a/front/src/routes/integration/all/bluetooth/style.css
+++ b/front/src/routes/integration/all/bluetooth/style.css
@@ -6,7 +6,3 @@
 .bluetoothListBody {
   min-height: 200px;
 }
-
-.featureListBody {
-  min-height: 50px;
-}

--- a/front/src/routes/integration/all/ewelink/EweLinkDeviceBox.jsx
+++ b/front/src/routes/integration/all/ewelink/EweLinkDeviceBox.jsx
@@ -1,10 +1,10 @@
 import { Component } from 'preact';
 import { Text, Localizer } from 'preact-i18n';
 import cx from 'classnames';
-import { DEVICE_FIRMWARE, DEVICE_ONLINE } from '../../../../../../server/services/ewelink/lib/utils/constants';
-import { DeviceFeatureCategoriesIcon } from '../../../../utils/consts';
-import get from 'get-value';
 import { Link } from 'preact-router';
+
+import { DEVICE_FIRMWARE, DEVICE_ONLINE } from '../../../../../../server/services/ewelink/lib/utils/constants';
+import DeviceFeatures from '../../../../components/device/view/DeviceFeatures';
 
 class EweLinkDeviceBox extends Component {
   updateName = e => {
@@ -148,18 +148,7 @@ class EweLinkDeviceBox extends Component {
                     <label class="form-label">
                       <Text id="integration.eWeLink.device.featuresLabel" />
                     </label>
-                    <div class="tags">
-                      {device.features.map(feature => (
-                        <span class="tag">
-                          <Text id={`deviceFeatureCategory.${feature.category}.${feature.type}`} />
-                          <div class="tag-addon">
-                            <i
-                              class={`fe fe-${get(DeviceFeatureCategoriesIcon, `${feature.category}.${feature.type}`)}`}
-                            />
-                          </div>
-                        </span>
-                      ))}
-                    </div>
+                    <DeviceFeatures features={device.features} />
                   </div>
                 )}
 

--- a/front/src/routes/integration/all/mqtt/device-page/Device.jsx
+++ b/front/src/routes/integration/all/mqtt/device-page/Device.jsx
@@ -7,6 +7,7 @@ import get from 'get-value';
 import { RequestStatus } from '../../../../../utils/consts';
 import { DEVICE_FEATURE_CATEGORIES } from '../../../../../../../server/utils/constants';
 import MqttDeviceForm from './DeviceForm';
+import BatteryLevelFeature from '../../../../../components/device/view/BatteryLevelFeature';
 
 class MqttDeviceBox extends Component {
   saveDevice = async () => {
@@ -58,12 +59,7 @@ class MqttDeviceBox extends Component {
             {props.device.name || <Text id="integration.mqtt.device.noNameLabel" />}{' '}
             {batteryLevel && (
               <div class="page-options d-flex">
-                <div class="tag tag-green">
-                  <Text id="global.percentValue" fields={{ value: batteryLevel }} />
-                  <span class="tag-addon">
-                    <i class="fe fe-battery" />
-                  </span>
-                </div>
+                <BatteryLevelFeature batteryLevel={batteryLevel} />
               </div>
             )}
           </div>

--- a/front/src/routes/integration/all/mqtt/device-page/DeviceForm.jsx
+++ b/front/src/routes/integration/all/mqtt/device-page/DeviceForm.jsx
@@ -1,8 +1,8 @@
 import { Text, Localizer } from 'preact-i18n';
 import { Component } from 'preact';
-import { DeviceFeatureCategoriesIcon } from '../../../../../utils/consts';
-import get from 'get-value';
 import dayjs from 'dayjs';
+
+import DeviceFeatures from '../../../../../components/device/view/DeviceFeatures';
 
 class MqttDeviceForm extends Component {
   updateName = e => {
@@ -77,21 +77,7 @@ class MqttDeviceForm extends Component {
           <label class="form-label">
             <Text id="integration.mqtt.device.featuresLabel" />
           </label>
-          <div class="tags">
-            {props.device &&
-              props.device.features &&
-              props.device.features.map(feature => (
-                <span class="tag">
-                  <Text id={`deviceFeatureCategory.${feature.category}.${feature.type}`} />
-                  <div class="tag-addon">
-                    <i class={`fe fe-${get(DeviceFeatureCategoriesIcon, `${feature.category}.${feature.type}`)}`} />
-                  </div>
-                </span>
-              ))}
-            {(!props.device.features || props.device.features.length === 0) && (
-              <Text id="integration.mqtt.device.noFeatures" />
-            )}
-          </div>
+          <DeviceFeatures features={props.device.features} />
           <p class="mt-4">
             {props.mostRecentValueAt ? (
               <Text

--- a/front/src/routes/integration/all/philips-hue/device-page/DeviceForm.jsx
+++ b/front/src/routes/integration/all/philips-hue/device-page/DeviceForm.jsx
@@ -1,7 +1,7 @@
 import { Text, Localizer } from 'preact-i18n';
 import { Component } from 'preact';
-import { DeviceFeatureCategoriesIcon } from '../../../../../utils/consts';
-import get from 'get-value';
+
+import DeviceFeatures from '../../../../../components/device/view/DeviceFeatures';
 
 class PhilipsHueDeviceForm extends Component {
   updateName = e => {
@@ -60,21 +60,7 @@ class PhilipsHueDeviceForm extends Component {
           <label class="form-label">
             <Text id="integration.mqtt.device.featuresLabel" />
           </label>
-          <div class="tags">
-            {props.device &&
-              props.device.features &&
-              props.device.features.map(feature => (
-                <span class="tag">
-                  <Text id={`deviceFeatureCategory.${feature.category}.${feature.type}`} />
-                  <div class="tag-addon">
-                    <i class={`fe fe-${get(DeviceFeatureCategoriesIcon, `${feature.category}.${feature.type}`)}`} />
-                  </div>
-                </span>
-              ))}
-            {(!props.device.features || props.device.features.length === 0) && (
-              <Text id="integration.mqtt.device.noFeatures" />
-            )}
-          </div>
+          <DeviceFeatures features={props.device.features} />
         </div>
       </div>
     );

--- a/front/src/routes/integration/all/tasmota/TasmotaDeviceBox.jsx
+++ b/front/src/routes/integration/all/tasmota/TasmotaDeviceBox.jsx
@@ -1,9 +1,9 @@
 import { Component } from 'preact';
 import { Text, Localizer } from 'preact-i18n';
 import cx from 'classnames';
-import { DeviceFeatureCategoriesIcon } from '../../../../utils/consts';
-import get from 'get-value';
 import { Link } from 'preact-router';
+
+import DeviceFeatures from '../../../../components/device/view/DeviceFeatures';
 
 class TasmotaDeviceBox extends Component {
   updateName = e => {
@@ -270,18 +270,7 @@ class TasmotaDeviceBox extends Component {
                     <label class="form-label">
                       <Text id="integration.tasmota.device.featuresLabel" />
                     </label>
-                    <div class="tags">
-                      {device.features.map(feature => (
-                        <span class="tag">
-                          <Text id={`deviceFeatureCategory.${feature.category}.${feature.type}`} />
-                          <div class="tag-addon">
-                            <i
-                              class={`fe fe-${get(DeviceFeatureCategoriesIcon, `${feature.category}.${feature.type}`)}`}
-                            />
-                          </div>
-                        </span>
-                      ))}
-                    </div>
+                    <DeviceFeatures features={device.features} />
                   </div>
                 )}
 

--- a/front/src/routes/integration/all/tp-link/device-page/DeviceForm.jsx
+++ b/front/src/routes/integration/all/tp-link/device-page/DeviceForm.jsx
@@ -1,7 +1,7 @@
 import { Text, Localizer } from 'preact-i18n';
 import { Component } from 'preact';
-import { DeviceFeatureCategoriesIcon } from '../../../../../utils/consts';
-import get from 'get-value';
+
+import DeviceFeatures from '../../../../../components/device/view/DeviceFeatures';
 
 class TpLinkDeviceForm extends Component {
   updateName = e => {
@@ -60,21 +60,7 @@ class TpLinkDeviceForm extends Component {
           <label class="form-label">
             <Text id="integration.tpLink.device.featuresLabel" />
           </label>
-          <div class="tags">
-            {props.device &&
-              props.device.features &&
-              props.device.features.map(feature => (
-                <span class="tag">
-                  <Text id={`deviceFeatureCategory.${feature.category}.${feature.type}`} />
-                  <div class="tag-addon">
-                    <i class={`fe fe-${get(DeviceFeatureCategoriesIcon, `${feature.category}.${feature.type}`)}`} />
-                  </div>
-                </span>
-              ))}
-            {(!props.device.features || props.device.features.length === 0) && (
-              <Text id="integration.tpLink.device.noFeatures" />
-            )}
-          </div>
+          <DeviceFeatures features={props.device.features} />
         </div>
       </div>
     );

--- a/front/src/routes/integration/all/xiaomi/Device.jsx
+++ b/front/src/routes/integration/all/xiaomi/Device.jsx
@@ -3,8 +3,11 @@ import { Component } from 'preact';
 import { Link } from 'preact-router/match';
 import cx from 'classnames';
 import get from 'get-value';
+
 import { DEVICE_FEATURE_CATEGORIES } from '../../../../../../server/utils/constants';
-import { RequestStatus, DeviceFeatureCategoriesIcon } from '../../../../utils/consts';
+import { RequestStatus } from '../../../../utils/consts';
+import BatteryLevelFeature from '../../../../components/device/view/BatteryLevelFeature';
+import DeviceFeatures from '../../../../components/device/view/DeviceFeatures';
 
 class XiaomiDeviceBox extends Component {
   refreshDeviceProperty = () => {
@@ -69,12 +72,7 @@ class XiaomiDeviceBox extends Component {
             <h3 class="card-title">{props.device.name}</h3>
             {batteryLevel && (
               <div class="page-options d-flex">
-                <div class="tag tag-green">
-                  <Text id="global.percentValue" fields={{ value: batteryLevel }} />
-                  <span class="tag-addon">
-                    <i class="fe fe-battery" />
-                  </span>
-                </div>
+                <BatteryLevelFeature batteryLevel={batteryLevel} />
               </div>
             )}
           </div>
@@ -124,23 +122,7 @@ class XiaomiDeviceBox extends Component {
                   <label>
                     <Text id="integration.xiaomi.device.featuresLabel" />
                   </label>
-                  <div class="tags">
-                    {props.device &&
-                      props.device.features &&
-                      props.device.features.map(feature => (
-                        <span class="tag">
-                          <Text id={`deviceFeatureCategory.${feature.category}.${feature.type}`} />
-                          <div class="tag-addon">
-                            <i
-                              class={`fe fe-${get(DeviceFeatureCategoriesIcon, `${feature.category}.${feature.type}`)}`}
-                            />
-                          </div>
-                        </span>
-                      ))}
-                    {(!props.device.features || props.device.features.length === 0) && (
-                      <Text id="integration.xiaomi.device.noFeatures" />
-                    )}
-                  </div>
+                  <DeviceFeatures features={props.device.features} />
                 </div>
                 <div class="form-group">
                   <button onClick={this.saveDevice} class="btn btn-success mr-2">

--- a/front/src/routes/integration/all/xiaomi/XiaomiSensor.jsx
+++ b/front/src/routes/integration/all/xiaomi/XiaomiSensor.jsx
@@ -1,10 +1,9 @@
 import { Text } from 'preact-i18n';
 import { Component } from 'preact';
 import cx from 'classnames';
-import get from 'get-value';
 
-import style from './style.css';
-import { RequestStatus, DeviceFeatureCategoriesIcon } from '../../../../utils/consts';
+import { RequestStatus } from '../../../../utils/consts';
+import DeviceFeatures from '../../../../components/device/view/DeviceFeatures';
 
 class XiaomiSensor extends Component {
   createDevice = async () => {
@@ -45,18 +44,7 @@ class XiaomiSensor extends Component {
               <div class="card-body">
                 {props.sensor.features.length > 0 && (
                   <div class="form-group">
-                    <div class={cx('tags', style.tagsList)}>
-                      {props.sensor.features.map(feature => (
-                        <span class="tag">
-                          <Text id={`deviceFeatureCategory.${feature.category}.${feature.type}`} />
-                          <div class="tag-addon">
-                            <i
-                              class={`fe fe-${get(DeviceFeatureCategoriesIcon, `${feature.category}.${feature.type}`)}`}
-                            />
-                          </div>
-                        </span>
-                      ))}
-                    </div>
+                    <DeviceFeatures features={props.sensor.features} />
                   </div>
                 )}
                 <div class="form-group">

--- a/front/src/routes/integration/all/xiaomi/style.css
+++ b/front/src/routes/integration/all/xiaomi/style.css
@@ -1,7 +1,3 @@
 .emptyDiv {
   min-height: 200px;
 }
-
-.tagsList {
-  min-height: 70px;
-}

--- a/front/src/routes/integration/all/zigbee2mqtt/device-page/Zigbee2mqttBox.jsx
+++ b/front/src/routes/integration/all/zigbee2mqtt/device-page/Zigbee2mqttBox.jsx
@@ -1,9 +1,10 @@
 import { Text, Localizer } from 'preact-i18n';
 import { Component } from 'preact';
 import cx from 'classnames';
-import get from 'get-value';
 import { Link } from 'preact-router/match';
-import { DeviceFeatureCategoriesIcon, RequestStatus } from '../../../../../utils/consts';
+
+import { RequestStatus } from '../../../../../utils/consts';
+import DeviceFeatures from '../../../../../components/device/view/DeviceFeatures';
 
 class Zigbee2mqttBox extends Component {
   updateName = e => {
@@ -126,20 +127,7 @@ class Zigbee2mqttBox extends Component {
                   <label class="form-label">
                     <Text id="integration.zigbee2mqtt.featuresLabel" />
                   </label>
-                  <div class="tags">
-                    {props.device &&
-                      props.device.features &&
-                      props.device.features.map(feature => (
-                        <span class="tag">
-                          <Text id={`deviceFeatureCategory.${feature.category}.${feature.type}`} />
-                          <div class="tag-addon">
-                            <i
-                              class={`fe fe-${get(DeviceFeatureCategoriesIcon, `${feature.category}.${feature.type}`)}`}
-                            />
-                          </div>
-                        </span>
-                      ))}
-                  </div>
+                  <DeviceFeatures features={props.device.features} />
                 </div>
 
                 <div class="form-group">

--- a/front/src/routes/integration/all/zigbee2mqtt/discover-page/DiscoveredBox.jsx
+++ b/front/src/routes/integration/all/zigbee2mqtt/discover-page/DiscoveredBox.jsx
@@ -1,8 +1,9 @@
 import { Text, Localizer } from 'preact-i18n';
 import { Component } from 'preact';
 import cx from 'classnames';
-import { DeviceFeatureCategoriesIcon, RequestStatus } from '../../../../../utils/consts';
-import get from 'get-value';
+
+import { RequestStatus } from '../../../../../utils/consts';
+import DeviceFeatures from '../../../../../components/device/view/DeviceFeatures';
 
 const GITHUB_BASE_URL = 'https://github.com/GladysAssistant/Gladys/issues/new';
 
@@ -131,23 +132,7 @@ class DiscoveredBox extends Component {
                       <label class="form-label">
                         <Text id="integration.zigbee2mqtt.featuresLabel" />
                       </label>
-                      <div class="tags">
-                        {props.device &&
-                          props.device.features &&
-                          props.device.features.map(feature => (
-                            <span class="tag">
-                              <Text id={`deviceFeatureCategory.${feature.category}.${feature.type}`} />
-                              <div class="tag-addon">
-                                <i
-                                  class={`fe fe-${get(
-                                    DeviceFeatureCategoriesIcon,
-                                    `${feature.category}.${feature.type}`
-                                  )}`}
-                                />
-                              </div>
-                            </span>
-                          ))}
-                      </div>
+                      <DeviceFeatures features={props.device.features} />
                     </div>
 
                     <div class="form-group">

--- a/front/src/routes/integration/all/zwave/node-page/Device.jsx
+++ b/front/src/routes/integration/all/zwave/node-page/Device.jsx
@@ -9,7 +9,9 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 dayjs.extend(relativeTime);
 
 import { DEVICE_FEATURE_CATEGORIES } from '../../../../../../../server/utils/constants';
-import { RequestStatus, DeviceFeatureCategoriesIcon } from '../../../../../utils/consts';
+import { RequestStatus } from '../../../../../utils/consts';
+import BatteryLevelFeature from '../../../../../components/device/view/BatteryLevelFeature';
+import DeviceFeatures from '../../../../../components/device/view/DeviceFeatures';
 
 class ZWaveDeviceBox extends Component {
   refreshDeviceProperty = () => {
@@ -71,12 +73,7 @@ class ZWaveDeviceBox extends Component {
             {props.device.name}
             {batteryLevel && (
               <div class="page-options d-flex">
-                <div class="tag tag-green">
-                  <Text id="global.percentValue" fields={{ value: batteryLevel }} />
-                  <span class="tag-addon">
-                    <i class="fe fe-battery" />
-                  </span>
-                </div>
+                <BatteryLevelFeature batteryLevel={batteryLevel} />
               </div>
             )}
           </div>
@@ -127,23 +124,7 @@ class ZWaveDeviceBox extends Component {
                   <label>
                     <Text id="integration.zwave.device.featuresLabel" />
                   </label>
-                  <div class="tags">
-                    {props.device &&
-                      props.device.features &&
-                      props.device.features.map(feature => (
-                        <span class="tag">
-                          <Text id={`deviceFeatureCategory.${feature.category}.${feature.type}`} />
-                          <div class="tag-addon">
-                            <i
-                              class={`fe fe-${get(DeviceFeatureCategoriesIcon, `${feature.category}.${feature.type}`)}`}
-                            />
-                          </div>
-                        </span>
-                      ))}
-                    {(!props.device.features || props.device.features.length === 0) && (
-                      <Text id="integration.zwave.device.noFeatures" />
-                    )}
-                  </div>
+                  <DeviceFeatures features={props.device.features} />
                   <p class="mt-4">
                     {mostRecentValueAt ? (
                       <Text

--- a/front/src/routes/integration/all/zwave/setup-page/Node.jsx
+++ b/front/src/routes/integration/all/zwave/setup-page/Node.jsx
@@ -3,7 +3,8 @@ import { Component } from 'preact';
 import cx from 'classnames';
 import get from 'get-value';
 
-import { RequestStatus, DeviceFeatureCategoriesIcon } from '../../../../../utils/consts';
+import { RequestStatus } from '../../../../../utils/consts';
+import DeviceFeatures from '../../../../../components/device/view/DeviceFeatures';
 
 const GITHUB_BASE_URL = 'https://github.com/GladysAssistant/Gladys/issues/new';
 
@@ -108,21 +109,7 @@ class ZwaveNode extends Component {
                         <Text id="integration.zwave.setup.features" />
                       </label>
 
-                      <div class="tags">
-                        {props.node.features.map(feature => (
-                          <span class="tag">
-                            <Text id={`deviceFeatureCategory.${feature.category}.${feature.type}`} />
-                            <div class="tag-addon">
-                              <i
-                                class={`fe fe-${get(
-                                  DeviceFeatureCategoriesIcon,
-                                  `${feature.category}.${feature.type}`
-                                )}`}
-                              />
-                            </div>
-                          </span>
-                        ))}
-                      </div>
+                      <DeviceFeatures features={props.node.features} />
                     </div>
                   )}
                   <div class="form-group">

--- a/front/src/style/index.css
+++ b/front/src/style/index.css
@@ -230,3 +230,6 @@ body {
   pointer-events: auto;
   cursor: pointer;
 }
+.device-features {
+  min-height: 70px;
+}


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- ~~[ ] If your changes affects code, did your write the tests?~~
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.
- ~~[ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~~
- ~~[ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).~~
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Introduce common "DeviceFeatures" and "BatteryLevelFeature" components.

---

### Battery Level Component

Use same component for battery level display.
Add color according to battery level:
- level < 10
![image](https://user-images.githubusercontent.com/1839717/140915462-5c1b01a2-e400-4630-a515-b184a29dc9b8.png)

- 10 <= level < 25
![image](https://user-images.githubusercontent.com/1839717/140915296-2697dc03-549f-4650-aa45-7c56394f7f7b.png)

- level >= 25
![image](https://user-images.githubusercontent.com/1839717/140915557-17f685e0-a7e7-44b7-9935-b42d04d75de7.png)

---

### Device feature components
- Use same component for single feature with icon and text
- Use same component for feature list
  - Unify height (70px min)
  - Add common "no feature" message (maybe we want to change display)

![image](https://user-images.githubusercontent.com/1839717/140915940-1f2e88f6-6d3e-46d8-84a9-f8d06dbdb671.png)
