### PR TITLE
Fix random tests

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ WORKDIR /src
 ADD . /src
 COPY ./static /src/server/static
 WORKDIR /src/server
-RUN apk add --no-cache --virtual .build-deps make gcc g++ python git libffi-dev linux-headers \
+RUN apk add --no-cache --virtual .build-deps make gcc g++ python3 git libffi-dev linux-headers \
     && npm ci --unsafe-perm --production \
     && npm cache clean --force \
     && apk del .build-deps

--- a/docker/Dockerfile.buildx
+++ b/docker/Dockerfile.buildx
@@ -37,7 +37,7 @@ ENV LD_LIBRARY_PATH /lib
 
 WORKDIR /src/server
 
-RUN apk add --no-cache --virtual .build-deps make gcc g++ python git libffi-dev linux-headers \
+RUN apk add --no-cache --virtual .build-deps make gcc g++ python3 git libffi-dev linux-headers \
     && npm ci --unsafe-perm --production \
     && npm cache clean --force \
     && apk del .build-deps

--- a/server/test/lib/device/device.calculateAggregate.test.js
+++ b/server/test/lib/device/device.calculateAggregate.test.js
@@ -1,7 +1,9 @@
 const { expect } = require('chai');
 const uuid = require('uuid');
 const EventEmitter = require('events');
-const { fake } = require('sinon');
+const sinon = require('sinon');
+
+const { fake } = sinon;
 const db = require('../../../models');
 const Device = require('../../../lib/device');
 const Job = require('../../../lib/job');
@@ -29,6 +31,7 @@ const insertStates = async (fixedHour = true) => {
 
 describe('Device.calculateAggregate', function Before() {
   this.timeout(60000);
+  let clock;
   beforeEach(async () => {
     const queryInterface = db.sequelize.getQueryInterface();
     await queryInterface.bulkDelete('t_device_feature_state');
@@ -41,6 +44,12 @@ describe('Device.calculateAggregate', function Before() {
       },
       { where: {} },
     );
+    clock = sinon.useFakeTimers({
+      now: 1635131280000,
+    });
+  });
+  afterEach(() => {
+    clock.restore();
   });
   it('should calculate hourly aggregate', async () => {
     await insertStates(false);

--- a/server/test/lib/device/device.getDeviceFeaturesAggregates.test.js
+++ b/server/test/lib/device/device.getDeviceFeaturesAggregates.test.js
@@ -1,5 +1,6 @@
 const EventEmitter = require('events');
 const { expect, assert } = require('chai');
+const sinon = require('sinon');
 const uuid = require('uuid');
 const { fake } = require('sinon');
 const db = require('../../../models');
@@ -28,6 +29,8 @@ const insertStates = async (intervalInMinutes) => {
 
 describe('Device.getDeviceFeaturesAggregates', function Describe() {
   this.timeout(15000);
+
+  let clock;
   beforeEach(async () => {
     const queryInterface = db.sequelize.getQueryInterface();
     await queryInterface.bulkDelete('t_device_feature_state');
@@ -40,6 +43,13 @@ describe('Device.getDeviceFeaturesAggregates', function Describe() {
       },
       { where: {} },
     );
+
+    clock = sinon.useFakeTimers({
+      now: 1635131280000,
+    });
+  });
+  afterEach(() => {
+    clock.restore();
   });
   it('should return last hour states', async () => {
     await insertStates(120);


### PR DESCRIPTION
Sometimes, device aggration tests fail due to current date.
This fix current date to same date (taken from merge date).