### PR TITLE
Fix python dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ WORKDIR /src
 ADD . /src
 COPY ./static /src/server/static
 WORKDIR /src/server
-RUN apk add --no-cache --virtual .build-deps make gcc g++ python git libffi-dev linux-headers \
+RUN apk add --no-cache --virtual .build-deps make gcc g++ python3 git libffi-dev linux-headers \
     && npm ci --unsafe-perm --production \
     && npm cache clean --force \
     && apk del .build-deps

--- a/docker/Dockerfile.buildx
+++ b/docker/Dockerfile.buildx
@@ -37,7 +37,7 @@ ENV LD_LIBRARY_PATH /lib
 
 WORKDIR /src/server
 
-RUN apk add --no-cache --virtual .build-deps make gcc g++ python git libffi-dev linux-headers \
+RUN apk add --no-cache --virtual .build-deps make gcc g++ python3 git libffi-dev linux-headers \
     && npm ci --unsafe-perm --production \
     && npm cache clean --force \
     && apk del .build-deps


### PR DESCRIPTION
Use `python3` to build docker image.