### PR TITLE
Check missing unit / feature translations

### DIFF
--- a/front/cli/check_translations.js
+++ b/front/cli/check_translations.js
@@ -1,0 +1,49 @@
+const {
+  DEVICE_FEATURE_UNITS,
+  DEVICE_FEATURE_CATEGORIES,
+  DEVICE_FEATURE_TYPES
+} = require('../../server/utils/constants');
+const i18n = require('../src/config/i18n/en.json');
+const get = require('get-value');
+
+const missingKeys = [];
+
+const checkTranslation = (i18nKey, dataType, dataKey) => {
+  const value = get(i18n, i18nKey);
+
+  if (!value) {
+    missingKeys.push(`${dataType} ${dataKey} ==> ${i18nKey}`);
+  }
+};
+
+// Check units
+const unitParentKeys = ['deviceFeatureUnit', 'deviceFeatureUnitShort'];
+unitParentKeys.forEach(parentKey => {
+  Object.keys(DEVICE_FEATURE_UNITS).forEach(unitKey => {
+    const unit = DEVICE_FEATURE_UNITS[unitKey];
+    checkTranslation(`${parentKey}.${unit}`, 'unit', unitKey);
+  });
+});
+
+// Check device categories / features
+const featureParentKey = ['deviceFeatureCategory'];
+featureParentKey.forEach(parentKey => {
+  Object.keys(DEVICE_FEATURE_CATEGORIES).forEach(categoryKey => {
+    const category = DEVICE_FEATURE_CATEGORIES[categoryKey];
+    checkTranslation(`${parentKey}.${category}.shortCategoryName`, 'category', categoryKey);
+
+    Object.keys(DEVICE_FEATURE_TYPES[categoryKey] || {}).forEach(featureKey => {
+      const feature = DEVICE_FEATURE_TYPES[categoryKey][featureKey];
+      checkTranslation(`${parentKey}.${category}.${feature}`, 'feature', `${categoryKey}.${featureKey}`);
+    });
+  });
+});
+
+if (missingKeys.length > 0) {
+  console.error(
+    `\x1b[31m\u001B[1m${missingKeys.length} translations are missing:`,
+    missingKeys.map(key => `\n  - ${key}`).join(''),
+    '\u001B[22m\x1b[0m'
+  );
+  throw new Error(`${missingKeys.length} translations are missing, please check upper list.`);
+}

--- a/front/package.json
+++ b/front/package.json
@@ -15,7 +15,7 @@
     "serve": "sirv build --port 8080 --cors --single",
     "dev": "preact watch -p 1444 --template src/template.html",
     "eslint": "eslint src cypress --ext .json --ext .js --ext .jsx",
-    "compare-translations": "comparejson -e ./src/config/i18n/*.json",
+    "compare-translations": "comparejson -e ./src/config/i18n/*.json && node ./cli/check_translations.js",
     "prettier-check": "prettier --check '**/*.js' '**/*.jsx' '**/*.json'",
     "prettier": "prettier --write '**/*.js' '**/*.jsx' '**/*.json'",
     "test": "jest --coverage",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -1515,7 +1515,7 @@
     "fahrenheit": "Fahrenheit (°F)",
     "percent": "Percent (%)",
     "pascal": "Pascal (Pa)",
-    "hectoPascal": "Hectopascal (hPa)",
+    "hPa": "Hectopascal (hPa)",
     "lux": "Lux",
     "watt": "Watt (W)",
     "kilowatt": "Kilowatt (kW)",
@@ -1532,7 +1532,7 @@
     "fahrenheit": "°F",
     "percent": "%",
     "pascal": "Pa",
-    "hectoPascal": "hPa",
+    "hPa": "hPa",
     "lux": "lx",
     "watt": "W",
     "kilowatt": "kW",
@@ -1659,6 +1659,10 @@
       "acceleration-y": "Acceleration Y",
       "acceleration-z": "Acceleration Z",
       "bed-activity": "Bed Activity"
+    },
+    "signal": {
+      "shortCategoryName": "Signal",
+      "integer": "Signal strength"
     },
     "unknown": {
       "shortCategoryName": "Unknown",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -1515,7 +1515,7 @@
     "fahrenheit": "Fahrenheit (°F)",
     "percent": "Pourcent (%)",
     "pascal": "Pascal (Pa)",
-    "hectoPascal": "Hectopascal (hPa)",
+    "hPa": "Hectopascal (hPa)",
     "lux": "Lux",
     "watt": "Watt",
     "kilowatt": "Kilowatt",
@@ -1532,7 +1532,7 @@
     "fahrenheit": "°F",
     "percent": "%",
     "pascal": "Pa",
-    "hectoPascal": "hPa",
+    "hPa": "hPa",
     "lux": "lx",
     "watt": "W",
     "kilowatt": "kW",
@@ -1659,6 +1659,10 @@
       "acceleration-y": "Accélération Y",
       "acceleration-z": "Accélération Z",
       "bed-activity": "Activité Lit"
+    },
+    "signal": {
+      "shortCategoryName": "Signal",
+      "integer": "Intensité du signal"
     },
     "unknown": {
       "shortCategoryName": "Inconnu",

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -339,7 +339,6 @@ const DEVICE_FEATURE_TYPES = {
   SWITCH: {
     BINARY: 'binary',
     POWER: 'power',
-    POWERHOUR: 'power-hour',
     ENERGY: 'energy',
     VOLTAGE: 'voltage',
     CURRENT: 'current',


### PR DESCRIPTION
Add a build tool to check translations for units and features.
If a translation is missing, build will fail with:
![image](https://user-images.githubusercontent.com/1839717/141646123-7029b4ef-b2ea-46aa-9965-9bb8e5459a09.png)
