### PR TITLE
Fix NaN device state

### DIFF
--- a/server/lib/device/device.saveState.js
+++ b/server/lib/device/device.saveState.js
@@ -1,6 +1,7 @@
 const db = require('../../models');
 const logger = require('../../utils/logger');
 const { EVENTS, WEBSOCKET_MESSAGE_TYPES } = require('../../utils/constants');
+const { BadParameters } = require('../../utils/coreErrors');
 
 /**
  * @description Save new device feature state in DB.
@@ -13,6 +14,10 @@ const { EVENTS, WEBSOCKET_MESSAGE_TYPES } = require('../../utils/constants');
  * }, 12);
  */
 async function saveState(deviceFeature, newValue) {
+  if (Number.isNaN(newValue)) {
+    throw new BadParameters(`device.saveState of NaN value on ${deviceFeature.selector}`);
+  }
+
   logger.debug(`device.saveState of deviceFeature ${deviceFeature.selector}`);
   const now = new Date();
   const previousDeviceFeature = this.stateManager.get('deviceFeature', deviceFeature.selector);

--- a/server/migrations/20211204080815-clean-nan-device-states.js
+++ b/server/migrations/20211204080815-clean-nan-device-states.js
@@ -1,0 +1,12 @@
+const db = require('../models');
+
+module.exports = {
+  up: async () => {
+    await db.DeviceFeatureState.destroy({
+      where: {
+        value: Number.NaN,
+      },
+    });
+  },
+  down: async () => {},
+};

--- a/server/services/zigbee2mqtt/utils/convertValue.js
+++ b/server/services/zigbee2mqtt/utils/convertValue.js
@@ -47,8 +47,7 @@ function convertValue(feature, value) {
           result = value ? 1 : 0;
           break;
         }
-        case 'number':
-        case 'string': {
+        case 'number': {
           result = value;
           break;
         }

--- a/server/test/lib/device/device.saveState.test.js
+++ b/server/test/lib/device/device.saveState.test.js
@@ -1,6 +1,8 @@
+const { expect } = require('chai');
 const { assert, stub, useFakeTimers } = require('sinon');
 const Device = require('../../../lib/device');
 const StateManager = require('../../../lib/state');
+const { BadParameters } = require('../../../utils/coreErrors');
 
 describe('Device.saveState', () => {
   it('should saveState and keep history', async () => {
@@ -115,5 +117,29 @@ describe('Device.saveState', () => {
       );
     }
     await Promise.all(promises);
+  });
+  it('should not save NaN as state', async () => {
+    const event = {
+      on: stub().returns(null),
+    };
+    const stateManager = new StateManager(event);
+    const device = new Device(event, {}, stateManager);
+
+    const nanValue = parseInt('NaN value', 10);
+
+    try {
+      await device.saveState(
+        {
+          id: 'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4',
+          selector: 'test-device-feature',
+          has_feedback: false,
+          keep_history: false,
+        },
+        nanValue,
+      );
+      assert.fail('NaN device state should fail');
+    } catch (e) {
+      expect(e).instanceOf(BadParameters);
+    }
   });
 });

--- a/server/test/services/zigbee2mqtt/utils/convertValue.test.js
+++ b/server/test/services/zigbee2mqtt/utils/convertValue.test.js
@@ -43,9 +43,12 @@ describe('zigbee2mqtt convertValue', () => {
     const result = convertValue('unknown feature', 4);
     return assert.deepEqual(result, 4);
   });
-  it('should return unknown feature string', () => {
-    const result = convertValue('unknown feature', 'closed');
-    return assert.equal(result, 'closed');
+  it('should throw exception on string value', () => {
+    assert.throw(
+      () => convertValue('unknown feature', 'closed'),
+      Error,
+      `Zigbee2mqqt don't handle value "closed" for feature "unknown feature".`,
+    );
   });
   it('should throw Exception', () => {
     assert.throw(


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- ~~[ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)~~
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.
- ~~[ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~~
- ~~[ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).~~
- ~~[ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).~~

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Avoid NaN on device state number value.

Fixes: https://github.com/GladysAssistant/Gladys/issues/1392