### PR TITLE
Allow to use "long" event for sonoff-snzb-01

### DIFF
--- a/server/services/zigbee2mqtt/utils/convertValue.js
+++ b/server/services/zigbee2mqtt/utils/convertValue.js
@@ -35,6 +35,9 @@ function convertValue(feature, value) {
         case 'hold':
           result = BUTTON_STATUS.LONG_CLICK;
           break;
+        case 'long':
+          result = BUTTON_STATUS.LONG_CLICK;
+          break;
         default:
           result = value;
       }


### PR DESCRIPTION
As requested here:
https://community.gladysassistant.com/t/bouton-sonoff-snzb-01/6812/8

### Description of change

Adding another case for devices with "long" events (equivalent to existing "hold" event).
