### PR TITLE
Fix #1331 : In scene, add OR condition to check-time action

### DIFF
--- a/server/lib/scene/scene.actions.js
+++ b/server/lib/scene/scene.actions.js
@@ -177,7 +177,7 @@ const actionsFunc = {
       }
     }
 
-    // if the beforeDate is not before the afterDate
+    // if the afterDate is not before the beforeDate
     // It means the user is trying to do a cross-day time check
     // Example: AFTER 23:00 and BEFORE 8:00.
     // This means H > 23 OR h < 8

--- a/server/lib/scene/scene.actions.js
+++ b/server/lib/scene/scene.actions.js
@@ -188,12 +188,16 @@ const actionsFunc = {
       const conditionVerified = isBeforeCondition || isAfterCondition;
       if (!conditionVerified) {
         throw new AbortScene('CONDITION_BEFORE_OR_AFTER_NOT_VERIFIED');
+      } else {
+        logger.debug(`Check time: Condition OR verified.`);
       }
     } else {
       // Otherwise, the condition is a AND
       const conditionVerified = isBeforeCondition && isAfterCondition;
       if (!conditionVerified) {
         throw new AbortScene('CONDITION_BEFORE_AND_AFTER_NOT_VERIFIED');
+      } else {
+        logger.debug(`Check time: Condition AND verified.`);
       }
     }
     if (action.days_of_the_week) {

--- a/server/lib/scene/scene.actions.js
+++ b/server/lib/scene/scene.actions.js
@@ -149,28 +149,51 @@ const actionsFunc = {
   },
   [ACTIONS.CONDITION.CHECK_TIME]: async (self, action, scope) => {
     const now = dayjs.tz(dayjs(), self.timezone);
+    let beforeDate;
+    let afterDate;
+    let isBeforeCondition = true;
+    let isAfterCondition = true;
+
     if (action.before) {
-      const beforeDate = dayjs.tz(`${now.format('YYYY-MM-DD')} ${action.before}`, self.timezone);
-      const isBeforeCondition = now.isBefore(beforeDate);
+      beforeDate = dayjs.tz(`${now.format('YYYY-MM-DD')} ${action.before}`, self.timezone);
+      isBeforeCondition = now.isBefore(beforeDate);
       if (!isBeforeCondition) {
         logger.debug(
-          `Check time before: ${now.format('HH:mm')} > ${beforeDate.format('HH:mm')} condition is not verified.`,
+          `Check time before: ${now.format('HH:mm')} < ${beforeDate.format('HH:mm')} condition is not verified.`,
         );
-        throw new AbortScene('CONDITION_IS_BEFORE_HOUR_NOT_VERIFIED');
       } else {
         logger.debug(`Check time before: ${now.format('HH:mm')} < ${beforeDate.format('HH:mm')} condition is valid.`);
       }
     }
     if (action.after) {
-      const afterDate = dayjs.tz(`${now.format('YYYY-MM-DD')} ${action.after}`, self.timezone);
-      const isAfterCondition = now.isAfter(afterDate);
+      afterDate = dayjs.tz(`${now.format('YYYY-MM-DD')} ${action.after}`, self.timezone);
+      isAfterCondition = now.isAfter(afterDate);
       if (!isAfterCondition) {
         logger.debug(
           `Check time after: ${now.format('HH:mm')} > ${afterDate.format('HH:mm')} condition is not verified.`,
         );
-        throw new AbortScene('CONDITION_IS_AFTER_HOUR_NOT_VERIFIED');
       } else {
         logger.debug(`Check time after: ${now.format('HH:mm')} > ${afterDate.format('HH:mm')} condition is valid.`);
+      }
+    }
+
+    // if the beforeDate is not before the afterDate
+    // It means the user is trying to do a cross-day time check
+    // Example: AFTER 23:00 and BEFORE 8:00.
+    // This means H > 23 OR h < 8
+    // Putting a AND has no sense because it'll simply not work
+    // Example: H > 23 AND H < 8 is always wrong.
+    if (action.before && action.after && !afterDate.isBefore(beforeDate)) {
+      // So the condition is a OR in this case
+      const conditionVerified = isBeforeCondition || isAfterCondition;
+      if (!conditionVerified) {
+        throw new AbortScene('CONDITION_BEFORE_OR_AFTER_NOT_VERIFIED');
+      }
+    } else {
+      // Otherwise, the condition is a AND
+      const conditionVerified = isBeforeCondition && isAfterCondition;
+      if (!conditionVerified) {
+        throw new AbortScene('CONDITION_BEFORE_AND_AFTER_NOT_VERIFIED');
       }
     }
     if (action.days_of_the_week) {

--- a/server/test/lib/scene/actions/scene.action.checkTime.test.js
+++ b/server/test/lib/scene/actions/scene.action.checkTime.test.js
@@ -1,0 +1,181 @@
+const { assert, fake, useFakeTimers } = require('sinon');
+const chaiAssert = require('chai').assert;
+const dayjs = require('dayjs');
+const EventEmitter = require('events');
+const { ACTIONS } = require('../../../../utils/constants');
+const { AbortScene } = require('../../../../utils/coreErrors');
+const { executeActions } = require('../../../../lib/scene/scene.executeActions');
+
+const StateManager = require('../../../../lib/state');
+
+const event = new EventEmitter();
+
+describe('scene.action.checkTime', () => {
+  it('should execute condition.check-time, and send message because condition is true', async () => {
+    const stateManager = new StateManager(event);
+    const message = {
+      sendToUser: fake.resolves(null),
+    };
+    const scope = {};
+    const todayAt12 = dayjs()
+      .hour(12)
+      .minute(0);
+    const fiveMinutesAgo = todayAt12.subtract(5, 'minute');
+    const inFiveMinutes = todayAt12.add(5, 'minute');
+    const clock = useFakeTimers(todayAt12.valueOf());
+    await executeActions(
+      { stateManager, event, message },
+      [
+        [
+          {
+            type: ACTIONS.CONDITION.CHECK_TIME,
+            after: fiveMinutesAgo.format('HH:mm'),
+            before: inFiveMinutes.format('HH:mm'),
+            days_of_the_week: [todayAt12.format('dddd').toLowerCase()],
+          },
+        ],
+        [
+          {
+            type: ACTIONS.MESSAGE.SEND,
+            user: 'pepper',
+            text: 'hello',
+          },
+        ],
+      ],
+      scope,
+    );
+    assert.calledWith(message.sendToUser, 'pepper', 'hello');
+    clock.restore();
+  });
+  it('should abort scene because condition is not verified', async () => {
+    const stateManager = new StateManager(event);
+    const scope = {};
+    const todayAt12 = dayjs()
+      .hour(12)
+      .minute(0);
+    const fiveMinutesAgo = todayAt12.subtract(5, 'minute');
+    const clock = useFakeTimers(todayAt12.valueOf());
+    const promise = executeActions(
+      { stateManager, event },
+      [
+        [
+          {
+            type: ACTIONS.CONDITION.CHECK_TIME,
+            before: fiveMinutesAgo.format('HH:mm'),
+          },
+        ],
+      ],
+      scope,
+    );
+    await chaiAssert.isRejected(promise, AbortScene);
+    clock.restore();
+  });
+  it('should abort scene because condition is not verified', async () => {
+    const stateManager = new StateManager(event);
+    const scope = {};
+    const todayAt12 = dayjs()
+      .hour(12)
+      .minute(0);
+    const inFiveMinutes = todayAt12.add(5, 'minute');
+    const clock = useFakeTimers(todayAt12.valueOf());
+    const promise = executeActions(
+      { stateManager, event },
+      [
+        [
+          {
+            type: ACTIONS.CONDITION.CHECK_TIME,
+            after: inFiveMinutes.format('HH:mm'),
+          },
+        ],
+      ],
+      scope,
+    );
+    await chaiAssert.isRejected(promise, AbortScene);
+    clock.restore();
+  });
+  it('should abort scene because condition is not verified', async () => {
+    const stateManager = new StateManager(event);
+    const scope = {};
+    const todayAt19 = dayjs()
+      .hour(19)
+      .minute(0);
+    const eightPm = dayjs()
+      .hour(20)
+      .minute(0);
+    const nineAm = dayjs()
+      .hour(9)
+      .minute(0);
+    const clock = useFakeTimers(todayAt19.valueOf());
+    const promise = executeActions(
+      { stateManager, event },
+      [
+        [
+          {
+            type: ACTIONS.CONDITION.CHECK_TIME,
+            after: eightPm.format('HH:mm'),
+            before: nineAm.format('HH:mm'),
+          },
+        ],
+      ],
+      scope,
+    );
+    await chaiAssert.isRejected(promise, AbortScene);
+    clock.restore();
+  });
+  it('should not abort scene because condition is verified', async () => {
+    const stateManager = new StateManager(event);
+    const scope = {};
+    const todayAt20 = dayjs()
+      .hour(20)
+      .minute(0);
+    const sevenPm = dayjs()
+      .hour(19)
+      .minute(0);
+    const nineAm = dayjs()
+      .hour(9)
+      .minute(0);
+    const clock = useFakeTimers(todayAt20.valueOf());
+    try {
+      await executeActions(
+        { stateManager, event },
+        [
+          [
+            {
+              type: ACTIONS.CONDITION.CHECK_TIME,
+              after: sevenPm.format('HH:mm'),
+              before: nineAm.format('HH:mm'),
+            },
+          ],
+        ],
+        scope,
+      );
+    } catch (e) {
+      console.log(e);
+      throw e;
+    }
+    clock.restore();
+  });
+  it('should abort scene because condition is not verified', async () => {
+    const stateManager = new StateManager(event);
+    const scope = {};
+    const todayAt12 = dayjs()
+      .hour(12)
+      .minute(0);
+    const tomorrow = todayAt12.add(1, 'day');
+    const clock = useFakeTimers(todayAt12.valueOf());
+    const promise = executeActions(
+      { stateManager, event },
+      [
+        [
+          {
+            type: ACTIONS.CONDITION.CHECK_TIME,
+            days_of_the_week: [tomorrow.format('dddd').toLowerCase()],
+          },
+        ],
+      ],
+      scope,
+    );
+    await chaiAssert.isRejected(promise, AbortScene);
+    clock.restore();
+  });
+});

--- a/server/test/lib/scene/scene.executeActions.test.js
+++ b/server/test/lib/scene/scene.executeActions.test.js
@@ -1,7 +1,6 @@
-const { assert, fake, useFakeTimers } = require('sinon');
+const { assert, fake } = require('sinon');
 const chaiAssert = require('chai').assert;
 const { expect } = require('chai');
-const dayjs = require('dayjs');
 const EventEmitter = require('events');
 const cloneDeep = require('lodash.clonedeep');
 const { ACTIONS } = require('../../../utils/constants');
@@ -11,6 +10,9 @@ const { executeActions } = require('../../../lib/scene/scene.executeActions');
 const StateManager = require('../../../lib/state');
 
 const event = new EventEmitter();
+
+// WE ARE SLOWLY MOVING ALL TESTS FROM THIS BIG FILE
+// TO A SMALLER SET OF FILE IN THE "ACTIONS" FOLDER.
 
 describe('scene.executeActions', () => {
   it('should execute light turn on', async () => {
@@ -618,111 +620,6 @@ describe('scene.executeActions', () => {
       scope,
     );
     assert.calledWith(message.sendToUser, 'pepper', 'Temperature in the living room is 15 °C.');
-  });
-  it('should execute condition.check-time, and send message because condition is true', async () => {
-    const stateManager = new StateManager(event);
-    const message = {
-      sendToUser: fake.resolves(null),
-    };
-    const scope = {};
-    const todayAt12 = dayjs()
-      .hour(12)
-      .minute(0);
-    const fiveMinutesAgo = todayAt12.subtract(5, 'minute');
-    const inFiveMinutes = todayAt12.add(5, 'minute');
-    const clock = useFakeTimers(todayAt12.valueOf());
-    await executeActions(
-      { stateManager, event, message },
-      [
-        [
-          {
-            type: ACTIONS.CONDITION.CHECK_TIME,
-            after: fiveMinutesAgo.format('hh:mm'),
-            before: inFiveMinutes.format('hh:mm'),
-            days_of_the_week: [todayAt12.format('dddd').toLowerCase()],
-          },
-        ],
-        [
-          {
-            type: ACTIONS.MESSAGE.SEND,
-            user: 'pepper',
-            text: 'hello',
-          },
-        ],
-      ],
-      scope,
-    );
-    assert.calledWith(message.sendToUser, 'pepper', 'hello');
-    clock.restore();
-  });
-  it('should abort scene because condition is not verified', async () => {
-    const stateManager = new StateManager(event);
-    const scope = {};
-    const todayAt12 = dayjs()
-      .hour(12)
-      .minute(0);
-    const fiveMinutesAgo = todayAt12.subtract(5, 'minute');
-    const clock = useFakeTimers(todayAt12.valueOf());
-    const promise = executeActions(
-      { stateManager, event },
-      [
-        [
-          {
-            type: ACTIONS.CONDITION.CHECK_TIME,
-            before: fiveMinutesAgo.format('hh:mm'),
-          },
-        ],
-      ],
-      scope,
-    );
-    await chaiAssert.isRejected(promise, AbortScene);
-    clock.restore();
-  });
-  it('should abort scene because condition is not verified', async () => {
-    const stateManager = new StateManager(event);
-    const scope = {};
-    const todayAt12 = dayjs()
-      .hour(12)
-      .minute(0);
-    const inFiveMinutes = todayAt12.add(5, 'minute');
-    const clock = useFakeTimers(todayAt12.valueOf());
-    const promise = executeActions(
-      { stateManager, event },
-      [
-        [
-          {
-            type: ACTIONS.CONDITION.CHECK_TIME,
-            after: inFiveMinutes.format('hh:mm'),
-          },
-        ],
-      ],
-      scope,
-    );
-    await chaiAssert.isRejected(promise, AbortScene);
-    clock.restore();
-  });
-  it('should abort scene because condition is not verified', async () => {
-    const stateManager = new StateManager(event);
-    const scope = {};
-    const todayAt12 = dayjs()
-      .hour(12)
-      .minute(0);
-    const tomorrow = todayAt12.add(1, 'day');
-    const clock = useFakeTimers(todayAt12.valueOf());
-    const promise = executeActions(
-      { stateManager, event },
-      [
-        [
-          {
-            type: ACTIONS.CONDITION.CHECK_TIME,
-            days_of_the_week: [tomorrow.format('dddd').toLowerCase()],
-          },
-        ],
-      ],
-      scope,
-    );
-    await chaiAssert.isRejected(promise, AbortScene);
-    clock.restore();
   });
 
   it('should execute action scene.start', async () => {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.
- [x] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [x] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

This let the user use conditional time check when after time is before the before time.
