### PR TITLE
Open/close on scenes #1423

### DIFF
--- a/front/src/config/demo.js
+++ b/front/src/config/demo.js
@@ -632,6 +632,24 @@ const data = {
               last_value_changed: '2019-02-12 07:49:07.556 +00:00'
             }
           ]
+        },
+        {
+          id: '284d8f68-220c-45fd-a73a-eccb547aff24',
+          name: 'Window sensor',
+          selector: 'opening-sensor',
+          features: [
+            {
+              name: 'Window',
+              selector: 'kitchen-opening-sensor',
+              category: 'opening-sensor',
+              type: 'binary',
+              min: 0,
+              max: 1,
+              read_only: true,
+              last_value: 1,
+              last_value_changed: '2019-02-12 07:49:07.556 +00:00'
+            }
+          ]
         }
       ]
     }

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -1596,6 +1596,13 @@
       }
     },
     "category": {
+      "opening-sensor": {
+        "binary": {
+          "other": "No value received",
+          "zero": "Closed",
+          "one": "Opened"
+        }
+      },
       "co-sensor": {
         "binary": {
           "other": "No value received",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -1596,6 +1596,13 @@
       }
     },
     "category": {
+      "opening-sensor": {
+        "binary": {
+          "other": "Aucune valeur reçue",
+          "zero": "Fermé",
+          "one": "Ouvert"
+        }
+      },
       "co-sensor": {
         "binary": {
           "other": "Aucune valeur reçue",

--- a/front/src/routes/scene/edit-scene/triggers/DeviceFeatureState.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/DeviceFeatureState.jsx
@@ -56,34 +56,28 @@ class TurnOnLight extends Component {
       </div>
     </div>
   );
-  getBinaryButtons = () => (
+  getBinaryButton = (category, value) => (
+    <div class="col-6">
+      <button
+        class={cx('btn', 'btn-block', 'p-1', {
+          'btn-primary': this.props.trigger.value === value,
+          'btn-outline-primary': this.props.trigger.value !== value,
+          active: this.props.trigger.value === value
+        })}
+        onClick={this.handleValueChangeBinary(value)}
+      >
+        <Text id={`deviceFeatureValue.category.${category}.binary`} plural={value}>
+          <Text id={`editScene.triggersCard.newState.${value ? 'on' : 'off'}`} />
+        </Text>
+      </button>
+    </div>
+  );
+  getBinaryButtons = category => (
     <div class="col-4">
       <div class="form-group">
         <div class="row">
-          <div class="col-6">
-            <button
-              class={cx('btn btn-block', {
-                'btn-primary': this.props.trigger.value === 1,
-                'btn-outline-primary': this.props.trigger.value !== 1,
-                active: this.props.trigger.value === 1
-              })}
-              onClick={this.handleValueChangeBinary(1)}
-            >
-              <Text id="editScene.triggersCard.newState.on" />
-            </button>
-          </div>
-          <div class="col-6">
-            <button
-              class={cx('btn btn-block', {
-                'btn-primary': this.props.trigger.value === 0,
-                'btn-outline-primary': this.props.trigger.value !== 0,
-                active: this.props.trigger.value === 0
-              })}
-              onClick={this.handleValueChangeBinary(0)}
-            >
-              <Text id="editScene.triggersCard.newState.off" />
-            </button>
-          </div>
+          {this.getBinaryButton(category, 1)}
+          {this.getBinaryButton(category, 0)}
         </div>
       </div>
     </div>
@@ -113,7 +107,7 @@ class TurnOnLight extends Component {
             this.getBinaryOperator()}
           {selectedDeviceFeature &&
             selectedDeviceFeature.type === DEVICE_FEATURE_TYPES.SWITCH.BINARY &&
-            this.getBinaryButtons()}
+            this.getBinaryButtons(selectedDeviceFeature.category)}
           {selectedDeviceFeature &&
             selectedDeviceFeature.category === DEVICE_FEATURE_CATEGORIES.PRESENCE_SENSOR &&
             this.getPresenceSensor()}


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- ~~[ ] If your changes affects code, did your write the tests?~~
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- ~~[ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.~~
- ~~[ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~~
- ~~[ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).~~
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Allow to override default On/Off label on scene page according to binary category.

![scenes-binary-sensors](https://user-images.githubusercontent.com/1839717/158011737-1c9053df-0704-4973-b451-7c24a5c6805f.gif)


Fixes #1423 