### PR TITLE
Replace device in the right poll frequency array when updated

### DIFF
--- a/server/lib/device/device.add.js
+++ b/server/lib/device/device.add.js
@@ -18,7 +18,15 @@ function add(device) {
     if (!this.devicesByPollFrequency[device.poll_frequency]) {
       this.devicesByPollFrequency[device.poll_frequency] = [];
     }
-    this.devicesByPollFrequency[device.poll_frequency].push(device);
+    // we only add the device to the poll frequency if the device was not in
+    const deviceAlreadyInFrequencyIndex = this.devicesByPollFrequency[device.poll_frequency].findIndex(
+      (d) => d.id === device.id,
+    );
+    if (deviceAlreadyInFrequencyIndex === -1) {
+      this.devicesByPollFrequency[device.poll_frequency].push(device);
+    } else {
+      this.devicesByPollFrequency[device.poll_frequency][deviceAlreadyInFrequencyIndex] = device;
+    }
 
     // foreach frequency
     Object.keys(DEVICE_POLL_FREQUENCIES).forEach((frequency) => {

--- a/server/lib/device/device.create.js
+++ b/server/lib/device/device.create.js
@@ -157,7 +157,10 @@ async function create(device) {
   // if the new device should be polled, poll
   if (newDevice.should_poll) {
     this.poll(newDevice);
-  } else if (oldPollFrequency) {
+  }
+  const pollingWasDisabled = newDevice.should_poll === false && oldPollFrequency;
+  const pollingWasUpdated = oldPollFrequency !== newDevice.poll_frequency;
+  if (oldPollFrequency && (pollingWasDisabled || pollingWasUpdated)) {
     // Remove from poll
     const { [oldPollFrequency]: devices } = this.devicesByPollFrequency;
     const deviceIndex = devices.findIndex((d) => d.external_id === device.external_id);

--- a/server/test/lib/device/device.create.test.js
+++ b/server/test/lib/device/device.create.test.js
@@ -1,5 +1,7 @@
 const { expect } = require('chai');
 const EventEmitter = require('events');
+
+const { DEVICE_POLL_FREQUENCIES } = require('../../../utils/constants');
 const Device = require('../../../lib/device');
 const StateManager = require('../../../lib/state');
 const ServiceManager = require('../../../lib/service');
@@ -253,7 +255,7 @@ describe('Device', () => {
     expect(newDevice).to.have.property('features');
     expect(newDevice).to.have.property('params');
   });
-  it('should update device and remove polling', async () => {
+  it('should update device and remove polling when polling is disabled', async () => {
     const stateManager = new StateManager(event);
     stateManager.setState('deviceByExternalId', 'test-device-external', {
       id: '7f85c2f8-86cc-4600-84db-6c074dadb4e8',
@@ -319,5 +321,139 @@ describe('Device', () => {
     });
 
     expect(device.devicesByPollFrequency['60000']).to.have.lengthOf(0);
+  });
+  it('should update device and verify that it wasnt added 2 time to polling array', async () => {
+    const stateManager = new StateManager(event);
+    stateManager.setState('deviceByExternalId', 'test-device-external', {
+      id: '7f85c2f8-86cc-4600-84db-6c074dadb4e8',
+      name: 'Test device',
+      selector: 'test-remove-poll',
+      params: [],
+    });
+    const serviceManager = new ServiceManager({}, stateManager);
+    const device = new Device(event, {}, stateManager, serviceManager);
+    await device.create({
+      id: 'f3525782-f513-4068-9f64-f3429756f99d',
+      name: 'RENAMED_DEVICE',
+      selector: 'test-remove-poll',
+      external_id: 'test-remove-poll',
+      should_poll: true,
+      poll_frequency: 60000,
+      service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
+      room_id: '2398c689-8b47-43cc-ad32-e98d9be098b5',
+      created_at: '2019-02-12 07:49:07.556 +00:00',
+      updated_at: '2019-02-12 07:49:07.556 +00:00',
+      features: [
+        {
+          name: 'On/Off',
+          external_id: 'philips-hue:1:binary',
+          category: 'light',
+          type: 'binary',
+          read_only: false,
+          keep_history: true,
+          has_feedback: false,
+          min: 0,
+          max: 1,
+        },
+      ],
+    });
+
+    expect(device.devicesByPollFrequency).to.have.key('60000');
+    expect(device.devicesByPollFrequency['60000']).to.have.lengthOf(1);
+
+    await device.create({
+      id: 'f3525782-f513-4068-9f64-f3429756f99d',
+      name: 'UPDATED_DEVICE',
+      selector: 'test-remove-poll',
+      external_id: 'test-remove-poll',
+      should_poll: true,
+      poll_frequency: 60000,
+      service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
+      room_id: '2398c689-8b47-43cc-ad32-e98d9be098b5',
+      created_at: '2019-02-12 07:49:07.556 +00:00',
+      updated_at: '2019-02-12 07:49:07.556 +00:00',
+      features: [
+        {
+          name: 'On/Off',
+          external_id: 'philips-hue:1:binary',
+          category: 'light',
+          type: 'binary',
+          read_only: false,
+          keep_history: true,
+          has_feedback: false,
+          min: 0,
+          max: 1,
+        },
+      ],
+    });
+
+    expect(device.devicesByPollFrequency['60000']).to.have.lengthOf(1);
+  });
+  it('should update device and remove previous polling when polling has changed', async () => {
+    const stateManager = new StateManager(event);
+    stateManager.setState('deviceByExternalId', 'test-device-external', {
+      id: '7f85c2f8-86cc-4600-84db-6c074dadb4e8',
+      name: 'Test device',
+      selector: 'test-remove-poll',
+      params: [],
+    });
+    const serviceManager = new ServiceManager({}, stateManager);
+    const device = new Device(event, {}, stateManager, serviceManager);
+    await device.create({
+      id: 'f3525782-f513-4068-9f64-f3429756f99d',
+      name: 'RENAMED_DEVICE',
+      selector: 'test-remove-poll',
+      external_id: 'test-remove-poll',
+      should_poll: true,
+      poll_frequency: DEVICE_POLL_FREQUENCIES.EVERY_MINUTES,
+      service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
+      room_id: '2398c689-8b47-43cc-ad32-e98d9be098b5',
+      created_at: '2019-02-12 07:49:07.556 +00:00',
+      updated_at: '2019-02-12 07:49:07.556 +00:00',
+      features: [
+        {
+          name: 'On/Off',
+          external_id: 'philips-hue:1:binary',
+          category: 'light',
+          type: 'binary',
+          read_only: false,
+          keep_history: true,
+          has_feedback: false,
+          min: 0,
+          max: 1,
+        },
+      ],
+    });
+
+    expect(device.devicesByPollFrequency[DEVICE_POLL_FREQUENCIES.EVERY_MINUTES]).to.have.lengthOf(1);
+
+    await device.create({
+      id: 'f3525782-f513-4068-9f64-f3429756f99d',
+      name: 'UPDATED_DEVICE',
+      selector: 'test-remove-poll',
+      external_id: 'test-remove-poll',
+      should_poll: true,
+      poll_frequency: DEVICE_POLL_FREQUENCIES.EVERY_30_SECONDS,
+      service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
+      room_id: '2398c689-8b47-43cc-ad32-e98d9be098b5',
+      created_at: '2019-02-12 07:49:07.556 +00:00',
+      updated_at: '2019-02-12 07:49:07.556 +00:00',
+      features: [
+        {
+          name: 'On/Off',
+          external_id: 'philips-hue:1:binary',
+          category: 'light',
+          type: 'binary',
+          read_only: false,
+          keep_history: true,
+          has_feedback: false,
+          min: 0,
+          max: 1,
+        },
+      ],
+    });
+
+    expect(device.devicesByPollFrequency[DEVICE_POLL_FREQUENCIES.EVERY_MINUTES]).to.have.lengthOf(0);
+    expect(device.devicesByPollFrequency[DEVICE_POLL_FREQUENCIES.EVERY_30_SECONDS]).to.have.lengthOf(1);
   });
 });


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [ ] If your changes affects code, did your write the tests?
- [ ] Are tests passing? (`npm test` on both front/server)
- [ ] Is the linter passing? (`npm run eslint` on both front/server)
- [ ] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Fix bug when updating a device, it would be added multiple time to the poll array
