### PR TITLE
Add scene box on dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,7 @@ stats.json
 size-plugin.json
 # VSCode
 .vscode
+# Webstorm
+.idea/
 .tmp
 .DS_Store

--- a/front/src/actions/dashboard/boxes/scene.js
+++ b/front/src/actions/dashboard/boxes/scene.js
@@ -1,0 +1,41 @@
+import { RequestStatus } from '../../../utils/consts';
+import createBoxActions from '../boxActions';
+
+const BOX_KEY = 'Scene';
+
+function createActions(store) {
+  const boxActions = createBoxActions(store);
+
+  const actions = {
+    async getScene(state, box, x, y) {
+      boxActions.updateBoxStatus(state, BOX_KEY, x, y, RequestStatus.Getting);
+      try {
+        const scene = await state.httpClient.get(`/api/v1/scene/${box.scene}`);
+        boxActions.mergeBoxData(state, BOX_KEY, x, y, {
+          scene
+        });
+        boxActions.updateBoxStatus(state, BOX_KEY, x, y, RequestStatus.Success);
+      } catch (e) {
+        boxActions.updateBoxStatus(state, BOX_KEY, x, y, RequestStatus.Error);
+      }
+    },
+    async switchActiveScene(state, box, x, y, active) {
+      boxActions.updateBoxStatus(state, BOX_KEY, x, y, RequestStatus.Getting);
+      try {
+        const scene = await state.httpClient.patch(`/api/v1/scene/${box.scene}`, {
+          active
+        });
+        boxActions.mergeBoxData(state, BOX_KEY, x, y, {
+          scene
+        });
+        boxActions.updateBoxStatus(state, BOX_KEY, x, y, RequestStatus.Success);
+      } catch (e) {
+        boxActions.updateBoxStatus(state, BOX_KEY, x, y, RequestStatus.Error);
+      }
+    }
+  };
+
+  return Object.assign({}, actions);
+}
+
+export default createActions;

--- a/front/src/components/boxs/scene/EditSceneBox.jsx
+++ b/front/src/components/boxs/scene/EditSceneBox.jsx
@@ -1,0 +1,96 @@
+import { Component } from 'preact';
+import { connect } from 'unistore/preact';
+import { Text } from 'preact-i18n';
+import BaseEditBox from '../baseEditBox';
+import Select from 'react-select';
+
+const updateBoxScene = (updateBoxSceneFunc, x, y) => scene => {
+  updateBoxSceneFunc(x, y, scene.selector);
+};
+
+@connect('', {})
+class EditSceneBoxComponent extends Component {
+  updateBoxScene = (x, y, scene) => {
+    this.props.updateBoxConfig(x, y, {
+      scene
+    });
+  };
+  render(props, {}) {
+    return (
+      <BaseEditBox {...props} titleKey="dashboard.boxTitle.scene">
+        <div class="form-group">
+          <label>
+            <Text id="dashboard.boxes.scene.editSceneLabel" />
+          </label>
+          <SceneSelector
+            selectedScene={props.box.scene}
+            updateSceneSelection={updateBoxScene(this.updateBoxScene, props.x, props.y)}
+          />
+        </div>
+      </BaseEditBox>
+    );
+  }
+}
+
+@connect('httpClient', {})
+class SceneSelector extends Component {
+  updateSelection = option => {
+    this.props.updateSceneSelection(option.scene);
+  };
+
+  refreshOptions = () => {
+    if (this.state.scenes) {
+      let selectedScene;
+
+      const scenesOptions = this.state.scenes.map(scene => {
+        const option = {
+          label: scene.name,
+          value: scene.selector,
+          scene
+        };
+        if (this.props.selectedScene === scene.selector) {
+          selectedScene = option;
+        }
+        return option;
+      });
+      this.setState({ scenesOptions, selectedScene });
+    }
+  };
+
+  getScenes = async () => {
+    try {
+      await this.setState({
+        pending: true
+      });
+      const params = {
+        order_dir: 'asc'
+      };
+      const scenes = await this.props.httpClient.get(`/api/v1/scene`, params);
+      await this.setState({
+        scenes,
+        pending: false,
+        error: false
+      });
+      this.refreshOptions();
+    } catch (e) {
+      this.setState({
+        pending: false,
+        error: true
+      });
+    }
+  };
+
+  componentDidMount = () => {
+    this.getScenes();
+  };
+
+  componentWillReceiveProps() {
+    this.refreshOptions();
+  }
+
+  render({}, { selectedScene, scenesOptions }) {
+    return <Select value={selectedScene} options={scenesOptions} onChange={this.updateSelection} />;
+  }
+}
+
+export default EditSceneBoxComponent;

--- a/front/src/components/boxs/scene/SceneBox.jsx
+++ b/front/src/components/boxs/scene/SceneBox.jsx
@@ -1,0 +1,94 @@
+import { Component } from 'preact';
+import { connect } from 'unistore/preact';
+import { Text } from 'preact-i18n';
+import actions from '../../../actions/dashboard/boxes/scene';
+import { DASHBOARD_BOX_STATUS_KEY, DASHBOARD_BOX_DATA_KEY } from '../../../utils/consts';
+import get from 'get-value';
+import dayjs from 'dayjs';
+
+const isNotNullOrUndefined = value => value !== undefined && value !== null;
+
+const SceneBox = ({ children, ...props }) => (
+  <div class="card p-3">
+    <div class="d-flex align-items-center list-separated">
+      <div class=" mr-3 col-auto">
+        <i className={`fe fe-${props.icon}`} />
+      </div>
+      <div class="col">
+        <h4 class="m-0">{props.name}</h4>
+        {isNotNullOrUndefined(props.lastExecuted) && (
+          <small className="m-0">
+            <Text
+              id="dashboard.boxes.scene.lastExecution"
+              fields={{
+                dateLastExecution: dayjs(props.lastExecuted)
+                  .locale(props.user.language)
+                  .fromNow()
+              }}
+            />
+          </small>
+        )}
+      </div>
+      <div class="col-auto">
+        <div>
+          <label className="custom-switch m-0" style={{ display: 'flex' }}>
+            <input
+              type="checkbox"
+              name="active"
+              value="1"
+              className="custom-switch-input"
+              checked={props.active}
+              onClick={props.switchActiveScene}
+            />
+            <span className="custom-switch-indicator" />
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+class SceneBoxComponent extends Component {
+  refreshData = () => {
+    this.props.getScene(this.props.box, this.props.x, this.props.y);
+  };
+
+  switchActiveScene = () => {
+    const boxData = get(this.props, `${DASHBOARD_BOX_DATA_KEY}Scene.${this.props.x}_${this.props.y}`);
+    const active = get(boxData, 'scene.active');
+    this.props.switchActiveScene(this.props.box, this.props.x, this.props.y, !active);
+  };
+
+  componentDidMount() {
+    this.refreshData();
+  }
+
+  componentDidUpdate(previousProps) {
+    const sceneChanged = get(previousProps, 'box.scene') !== get(this.props, 'box.scene');
+    if (sceneChanged) {
+      this.refreshData();
+    }
+  }
+
+  render(props, {}) {
+    const boxData = get(props, `${DASHBOARD_BOX_DATA_KEY}Scene.${props.x}_${props.y}`);
+    const boxStatus = get(props, `${DASHBOARD_BOX_STATUS_KEY}Scene.${props.x}_${props.y}`);
+    const active = get(boxData, 'scene.active');
+    const lastExecuted = get(boxData, 'scene.last_executed');
+    const icon = get(boxData, 'scene.icon');
+    const name = get(boxData, 'scene.name');
+    return (
+      <SceneBox
+        {...props}
+        icon={icon}
+        lastExecuted={lastExecuted}
+        active={active}
+        boxStatus={boxStatus}
+        name={name}
+        switchActiveScene={this.switchActiveScene}
+      />
+    );
+  }
+}
+
+export default connect('DashboardBoxDataScene,DashboardBoxStatusScene,user', actions)(SceneBoxComponent);

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -201,7 +201,8 @@
       "user-presence": "User presence",
       "camera": "Camera",
       "devices-in-room": "Devices in room",
-      "chart": "Chart"
+      "chart": "Chart",
+      "scene": "Scene"
     },
     "boxes": {
       "column": "Column {{index}}",
@@ -276,6 +277,10 @@
         "no": "No",
         "preview": "Preview",
         "showPreviewButton": "Show preview"
+      },
+      "scene": {
+        "editSceneLabel": "Select the scene you want to display here.",
+        "lastExecution": "Last execution: {{dateLastExecution}}"
       }
     }
   },

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -201,7 +201,8 @@
       "user-presence": "Utilisateurs présent",
       "camera": "Caméra",
       "devices-in-room": "Appareils de la pièce",
-      "chart": "Graphique"
+      "chart": "Graphique",
+      "scene": "Scene"
     },
     "boxes": {
       "column": "Colonne {{index}}",
@@ -276,6 +277,10 @@
         "no": "Non",
         "preview": "Prévisualisation",
         "showPreviewButton": "Afficher une prévisualisation"
+      },
+      "scene": {
+        "editSceneLabel": "Sélectionnez la scène que vous souhaitez afficher ici.",
+        "lastExecution": "Dernière execution : {{lastExecution}}"
       }
     }
   },

--- a/front/src/routes/dashboard/Box.jsx
+++ b/front/src/routes/dashboard/Box.jsx
@@ -5,6 +5,7 @@ import CameraBox from '../../components/boxs/camera/Camera';
 import AtHomeBox from '../../components/boxs/user-presence/UserPresence';
 import DevicesInRoomsBox from '../../components/boxs/device-in-room/DevicesInRoomsBox';
 import ChartBox from '../../components/boxs/chart/Chart';
+import SceneBox from '../../components/boxs/scene/SceneBox';
 
 const Box = ({ children, ...props }) => {
   switch (props.box.type) {
@@ -22,6 +23,8 @@ const Box = ({ children, ...props }) => {
       return <DevicesInRoomsBox {...props} />;
     case 'chart':
       return <ChartBox {...props} />;
+    case 'scene':
+      return <SceneBox {...props} />;
   }
 };
 

--- a/front/src/routes/dashboard/EditBox.jsx
+++ b/front/src/routes/dashboard/EditBox.jsx
@@ -5,6 +5,7 @@ import EditCameraBox from '../../components/boxs/camera/EditCamera';
 import EditAtHomeBox from '../../components/boxs/user-presence/EditUserPresenceBox';
 import EditDevicesInRoom from '../../components/boxs/device-in-room/EditDeviceInRoom';
 import EditChart from '../../components/boxs/chart/EditChart';
+import EditSceneBox from '../../components/boxs/scene/EditSceneBox';
 
 const Box = ({ children, ...props }) => {
   switch (props.box.type) {
@@ -22,6 +23,8 @@ const Box = ({ children, ...props }) => {
       return <EditDevicesInRoom {...props} />;
     case 'chart':
       return <EditChart {...props} />;
+    case 'scene':
+      return <EditSceneBox {...props} />;
   }
 };
 

--- a/server/models/dashboard.js
+++ b/server/models/dashboard.js
@@ -23,6 +23,7 @@ const boxesSchema = Joi.array().items(
       display_variation: Joi.boolean(),
       chart_type: Joi.string(),
       users: Joi.array().items(Joi.string()),
+      scene: Joi.string(),
     }),
   ),
 );

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -567,6 +567,7 @@ const DASHBOARD_BOX_TYPE = {
   CAMERA: 'camera',
   DEVICES_IN_ROOM: 'devices-in-room',
   CHART: 'chart',
+  SCENE: 'scene',
 };
 
 const ERROR_MESSAGES = {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Proposal for this feature request : https://community.gladysassistant.com/t/dashboard-activer-ou-desactiver-une-scene/7072/3
Add new boxes to display scene. We can activate or deactivate scene from this new box
<img width="559" alt="Screenshot 2022-04-18 at 18 08 37" src="https://user-images.githubusercontent.com/11317212/163838161-95a0a61c-224d-4d08-8b70-1743a2464cef.png">
<img width="549" alt="Screenshot 2022-04-18 at 18 21 20" src="https://user-images.githubusercontent.com/11317212/163838942-af770f42-a5ec-4583-9abd-c87e7bd1c13a.png">

