### PR TITLE
Add clock box for dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,7 @@ stats.json
 size-plugin.json
 # VSCode
 .vscode
+# Webstorm
+.idea
 .tmp
 .DS_Store

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -37863,6 +37863,11 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wojtekmaj/date-utils": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.0.3.tgz",
+      "integrity": "sha512-1VPkkTBk07gMR1fjpBtse4G+oJqpmE+0gUFB0dg3VIL7qJmUVaBoD/vlzMm/jNeOPfvlmerl1lpnsZyBUFIRuw=="
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -49508,6 +49513,11 @@
       "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
       "dev": true
     },
+    "merge-class-names": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/merge-class-names/-/merge-class-names-1.4.2.tgz",
+      "integrity": "sha512-bOl98VzwCGi25Gcn3xKxnR5p/WrhWFQB59MS/aGENcmUc6iSm96yrFDF0XSNurX9qN4LbJm0R9kfvsQ17i8zCw=="
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -53784,6 +53794,17 @@
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
           "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
         }
+      }
+    },
+    "react-clock": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-clock/-/react-clock-3.1.0.tgz",
+      "integrity": "sha512-KLV3pDBcETc7lHPPqK6EpRaPS8NA3STAes+zIdfr7IY67vYgYc3brOAnGC9IcgA4X4xNPnLZwwaLJXmHrQ/MnQ==",
+      "requires": {
+        "@wojtekmaj/date-utils": "^1.0.0",
+        "get-user-locale": "^1.4.0",
+        "merge-class-names": "^1.1.1",
+        "prop-types": "^15.6.0"
       }
     },
     "react-datepicker": {

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -29,6 +29,7 @@
         "preact-router": "^3.2.1",
         "qrcode": "^1.4.2",
         "react-big-calendar": "^0.40.0",
+        "react-clock": "^3.1.0",
         "react-datepicker": "^3.8.0",
         "react-select": "^4.3.1",
         "unistore": "^3.5.2",
@@ -5642,6 +5643,14 @@
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@wojtekmaj/date-utils": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.0.3.tgz",
+      "integrity": "sha512-1VPkkTBk07gMR1fjpBtse4G+oJqpmE+0gUFB0dg3VIL7qJmUVaBoD/vlzMm/jNeOPfvlmerl1lpnsZyBUFIRuw==",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -15955,6 +15964,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-user-locale": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-1.5.1.tgz",
+      "integrity": "sha512-WiNpoFRcHn1qxP9VabQljzGwkAQDrcpqUtaP0rNBEkFxJdh4f3tik6MfZsMYZc+UgQJdGCxWEjL9wnCUlRQXag==",
+      "dependencies": {
+        "lodash.memoize": "^4.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
+      }
+    },
     "node_modules/get-value": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-3.0.1.tgz",
@@ -19881,8 +19901,7 @@
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -20398,6 +20417,14 @@
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
       "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
       "dev": true
+    },
+    "node_modules/merge-class-names": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/merge-class-names/-/merge-class-names-1.4.2.tgz",
+      "integrity": "sha512-bOl98VzwCGi25Gcn3xKxnR5p/WrhWFQB59MS/aGENcmUc6iSm96yrFDF0XSNurX9qN4LbJm0R9kfvsQ17i8zCw==",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/merge-class-names?sponsor=1"
+      }
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
@@ -26060,6 +26087,24 @@
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
       "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+    },
+    "node_modules/react-clock": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-clock/-/react-clock-3.1.0.tgz",
+      "integrity": "sha512-KLV3pDBcETc7lHPPqK6EpRaPS8NA3STAes+zIdfr7IY67vYgYc3brOAnGC9IcgA4X4xNPnLZwwaLJXmHrQ/MnQ==",
+      "dependencies": {
+        "@wojtekmaj/date-utils": "^1.0.0",
+        "get-user-locale": "^1.4.0",
+        "merge-class-names": "^1.1.1",
+        "prop-types": "^15.6.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-clock?sponsor=1"
+      },
+      "peerDependencies": {
+        "react": "^15.5.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.5.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/react-datepicker": {
       "version": "3.8.0",
@@ -45908,6 +45953,14 @@
         "get-intrinsic": "^1.1.1"
       }
     },
+    "get-user-locale": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-1.5.1.tgz",
+      "integrity": "sha512-WiNpoFRcHn1qxP9VabQljzGwkAQDrcpqUtaP0rNBEkFxJdh4f3tik6MfZsMYZc+UgQJdGCxWEjL9wnCUlRQXag==",
+      "requires": {
+        "lodash.memoize": "^4.1.1"
+      }
+    },
     "get-value": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-3.0.1.tgz",
@@ -49098,8 +49151,7 @@
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/front/package.json
+++ b/front/package.json
@@ -66,6 +66,7 @@
     "preact-router": "^3.2.1",
     "qrcode": "^1.4.2",
     "react-big-calendar": "^0.40.0",
+    "react-clock": "^3.1.0",
     "react-datepicker": "^3.8.0",
     "react-select": "^4.3.1",
     "unistore": "^3.5.2",

--- a/front/src/components/boxs/clock/Clock.jsx
+++ b/front/src/components/boxs/clock/Clock.jsx
@@ -22,7 +22,7 @@ const Clock = ({ children, ...props }) => (
           <div class={style.analogSmallText}>{props.year}</div>
         </div>
         <div class={style.analogClock}>
-          <ReactClock className='react-clock' value={props.time} renderSecondHand={props.displaySecond} />
+          <ReactClock className="react-clock" value={props.time} renderSecondHand={props.displaySecond} />
         </div>
       </div>
     )}

--- a/front/src/components/boxs/clock/Clock.jsx
+++ b/front/src/components/boxs/clock/Clock.jsx
@@ -9,6 +9,7 @@ import { CLOCK_TYPES } from './ClockTypes';
 import { Text } from 'preact-i18n';
 import style from './style.css';
 import get from 'get-value';
+import cx from 'classnames';
 
 const Clock = ({ children, ...props }) => (
   <div class="card">
@@ -28,7 +29,7 @@ const Clock = ({ children, ...props }) => (
     )}
     {props.clockType === CLOCK_TYPES.DIGITAL && (
       <div class={style.padding}>
-        <div class={style.digitalTime}>{props.time}</div>
+        <div class={cx(style.digitalTime, 'text-monospace')}>{props.time}</div>
         <div class={style.digitalDate}>
           <Text
             id="dashboard.boxes.clock.date"

--- a/front/src/components/boxs/clock/Clock.jsx
+++ b/front/src/components/boxs/clock/Clock.jsx
@@ -22,7 +22,7 @@ const Clock = ({ children, ...props }) => (
           <div class={style.analogSmallText}>{props.year}</div>
         </div>
         <div class={style.analogClock}>
-          <ReactClock className={'react-clock'} value={props.time} renderSecondHand={props.displaySecond} />
+          <ReactClock className='react-clock' value={props.time} renderSecondHand={props.displaySecond} />
         </div>
       </div>
     )}

--- a/front/src/components/boxs/clock/Clock.jsx
+++ b/front/src/components/boxs/clock/Clock.jsx
@@ -1,0 +1,50 @@
+import { Component } from 'preact';
+import { connect } from 'unistore/preact';
+import dayjs from 'dayjs';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
+dayjs.extend(localizedFormat);
+
+const Clock = ({ children, ...props }) => (
+  <div class="card">
+    <div className="card-header">
+      <h3 className="card-title">{props.date}</h3>
+    </div>
+    <div
+      class="card-body o-auto"
+      style={{
+        textAlign: 'center',
+        fontSize: '30px'
+      }}
+    >
+      {props.time}
+    </div>
+  </div>
+);
+
+class ClockComponent extends Component {
+  refreshTime = () => {
+    const date = dayjs()
+      .locale(this.props.user.language)
+      .format('LL');
+    const time = dayjs()
+      .locale(this.props.user.language)
+      .format('LTS');
+    this.setState({ date, time });
+  };
+  componentDidMount() {
+    this.interval = setInterval(() => {
+      this.refreshTime();
+    }, 1000);
+    this.refreshTime();
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval);
+  }
+
+  render(props, { date, time }) {
+    return <Clock date={date} time={time} />;
+  }
+}
+
+export default connect('user', {})(ClockComponent);

--- a/front/src/components/boxs/clock/Clock.jsx
+++ b/front/src/components/boxs/clock/Clock.jsx
@@ -2,34 +2,126 @@ import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import dayjs from 'dayjs';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
+import { default as ReactClock } from 'react-clock';
 dayjs.extend(localizedFormat);
+
+import { CLOCK_TYPES } from '../../../../../server/utils/constants';
+import { Text } from 'preact-i18n';
+
+const padding = {
+  paddingLeft: '20px',
+  paddingRight: '20px',
+  paddingTop: '10px',
+  paddingBottom: '10px'
+};
 
 const Clock = ({ children, ...props }) => (
   <div class="card">
-    <div className="card-header">
-      <h3 className="card-title">{props.date}</h3>
-    </div>
-    <div
-      class="card-body o-auto"
-      style={{
-        textAlign: 'center',
-        fontSize: '30px'
-      }}
-    >
-      {props.time}
-    </div>
+    {props.clockType === CLOCK_TYPES.ANALOG && (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          width: '100%',
+          padding: '16px'
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            flex: 'auto'
+          }}
+        >
+          <div
+            style={{
+              fontSize: '18px',
+              textAlign: 'left'
+            }}
+          >
+            {props.day}
+          </div>
+          <div
+            style={{
+              fontSize: '40px',
+              textAlign: 'left'
+            }}
+          >
+            <Text id="dashboard.boxes.clock.smallDate" fields={{ month: props.month, dayNumber: props.dayNumber }} />
+          </div>
+          <div
+            style={{
+              fontSize: '18px',
+              textAlign: 'left'
+            }}
+          >
+            {props.year}
+          </div>
+        </div>
+
+        <div
+          style={{
+            alignItems: 'center',
+            justifyContent: 'center'
+          }}
+        >
+          <ReactClock className={'react-clock'} value={props.time} />
+        </div>
+      </div>
+    )}
+    {props.clockType === CLOCK_TYPES.DIGITAL && (
+      <div style={padding}>
+        <div
+          style={{
+            fontSize: '40px',
+            lineHeight: '1.2',
+            textAlign: 'center'
+          }}
+          class="font-size-40 blue-grey-700"
+        >
+          {props.time}
+        </div>
+        <div
+          style={{
+            paddingTop: '10px',
+            fontSize: '16px',
+            textAlign: 'center'
+          }}
+        >
+          <Text
+            id="dashboard.boxes.clock.date"
+            fields={{ day: props.day, month: props.month, dayNumber: props.dayNumber, year: props.year }}
+          />
+        </div>
+      </div>
+    )}
   </div>
 );
 
 class ClockComponent extends Component {
   refreshTime = () => {
-    const date = dayjs()
+    let month = dayjs()
       .locale(this.props.user.language)
-      .format('LL');
+      .format('MMMM');
+    month = month.charAt(0).toUpperCase() + month.slice(1);
+
+    let day = dayjs()
+      .locale(this.props.user.language)
+      .format('dddd');
+    day = day.charAt(0).toUpperCase() + day.slice(1);
+
+    const dayNumber = dayjs()
+      .locale(this.props.user.language)
+      .format('D');
+
+    const year = dayjs()
+      .locale(this.props.user.language)
+      .format('YYYY');
+
     const time = dayjs()
       .locale(this.props.user.language)
       .format('LTS');
-    this.setState({ date, time });
+    this.setState({ day, dayNumber, month, year, time });
   };
   componentDidMount() {
     this.interval = setInterval(() => {
@@ -42,8 +134,18 @@ class ClockComponent extends Component {
     clearInterval(this.interval);
   }
 
-  render(props, { date, time }) {
-    return <Clock date={date} time={time} />;
+  render(props, { day, dayNumber, month, year, time }) {
+    return (
+      <Clock
+        day={day}
+        dayNumber={dayNumber}
+        month={month}
+        year={year}
+        time={time}
+        clockType={props.box.clock_type}
+        language={props.user.language}
+      />
+    );
   }
 }
 

--- a/front/src/components/boxs/clock/Clock.jsx
+++ b/front/src/components/boxs/clock/Clock.jsx
@@ -7,87 +7,29 @@ dayjs.extend(localizedFormat);
 
 import { CLOCK_TYPES } from '../../../../../server/utils/constants';
 import { Text } from 'preact-i18n';
-
-const padding = {
-  paddingLeft: '20px',
-  paddingRight: '20px',
-  paddingTop: '10px',
-  paddingBottom: '10px'
-};
+import style from './style.css';
+import get from 'get-value';
 
 const Clock = ({ children, ...props }) => (
   <div class="card">
     {props.clockType === CLOCK_TYPES.ANALOG && (
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'row',
-          width: '100%',
-          padding: '16px'
-        }}
-      >
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            flex: 'auto'
-          }}
-        >
-          <div
-            style={{
-              fontSize: '18px',
-              textAlign: 'left'
-            }}
-          >
-            {props.day}
-          </div>
-          <div
-            style={{
-              fontSize: '40px',
-              textAlign: 'left'
-            }}
-          >
+      <div class={style.analogRow}>
+        <div class={style.analogCol}>
+          <div class={style.analogSmallText}>{props.day}</div>
+          <div class={style.analogBigText}>
             <Text id="dashboard.boxes.clock.smallDate" fields={{ month: props.month, dayNumber: props.dayNumber }} />
           </div>
-          <div
-            style={{
-              fontSize: '18px',
-              textAlign: 'left'
-            }}
-          >
-            {props.year}
-          </div>
+          <div class={style.analogSmallText}>{props.year}</div>
         </div>
-
-        <div
-          style={{
-            alignItems: 'center',
-            justifyContent: 'center'
-          }}
-        >
-          <ReactClock className={'react-clock'} value={props.time} />
+        <div class={style.analogClock}>
+          <ReactClock className={'react-clock'} value={props.time} renderSecondHand={props.displaySecond} />
         </div>
       </div>
     )}
     {props.clockType === CLOCK_TYPES.DIGITAL && (
-      <div style={padding}>
-        <div
-          style={{
-            fontSize: '40px',
-            lineHeight: '1.2',
-            textAlign: 'center'
-          }}
-          class="font-size-40 blue-grey-700"
-        >
-          {props.time}
-        </div>
-        <div
-          style={{
-            paddingTop: '10px',
-            fontSize: '16px',
-            textAlign: 'center'
-          }}
-        >
+      <div class={style.padding}>
+        <div class={style.digitalTime}>{props.time}</div>
+        <div class={style.digitalDate}>
           <Text
             id="dashboard.boxes.clock.date"
             fields={{ day: props.day, month: props.month, dayNumber: props.dayNumber, year: props.year }}
@@ -118,9 +60,12 @@ class ClockComponent extends Component {
       .locale(this.props.user.language)
       .format('YYYY');
 
+    const displaySecond = get(this.props, 'box.clock_display_second', false);
+
     const time = dayjs()
       .locale(this.props.user.language)
-      .format('LTS');
+      .format(displaySecond ? 'LTS' : 'LT');
+
     this.setState({ day, dayNumber, month, year, time });
   };
   componentDidMount() {
@@ -135,6 +80,8 @@ class ClockComponent extends Component {
   }
 
   render(props, { day, dayNumber, month, year, time }) {
+    const clockType = get(props, 'box.clock_type', CLOCK_TYPES.ANALOG);
+    const displaySecond = get(props, 'box.clock_display_second', false);
     return (
       <Clock
         day={day}
@@ -142,7 +89,8 @@ class ClockComponent extends Component {
         month={month}
         year={year}
         time={time}
-        clockType={props.box.clock_type}
+        clockType={clockType}
+        displaySecond={displaySecond}
         language={props.user.language}
       />
     );

--- a/front/src/components/boxs/clock/Clock.jsx
+++ b/front/src/components/boxs/clock/Clock.jsx
@@ -5,7 +5,7 @@ import localizedFormat from 'dayjs/plugin/localizedFormat';
 import { default as ReactClock } from 'react-clock';
 dayjs.extend(localizedFormat);
 
-import { CLOCK_TYPES } from '../../../../../server/utils/constants';
+import { CLOCK_TYPES } from './ClockTypes';
 import { Text } from 'preact-i18n';
 import style from './style.css';
 import get from 'get-value';

--- a/front/src/components/boxs/clock/ClockTypes.js
+++ b/front/src/components/boxs/clock/ClockTypes.js
@@ -1,0 +1,6 @@
+export const CLOCK_TYPES = {
+  ANALOG: 'analog',
+  DIGITAL: 'digital'
+};
+
+export const CLOCK_TYPES_LIST = [CLOCK_TYPES.ANALOG, CLOCK_TYPES.DIGITAL];

--- a/front/src/components/boxs/clock/EditClock.jsx
+++ b/front/src/components/boxs/clock/EditClock.jsx
@@ -2,7 +2,7 @@ import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import BaseEditBox from '../baseEditBox';
 import { Text } from 'preact-i18n';
-import { CLOCK_TYPES_LIST } from '../../../../../server/utils/constants';
+import { CLOCK_TYPES_LIST } from './ClockTypes';
 
 @connect('', {})
 class EditClock extends Component {

--- a/front/src/components/boxs/clock/EditClock.jsx
+++ b/front/src/components/boxs/clock/EditClock.jsx
@@ -6,20 +6,46 @@ import { CLOCK_TYPES_LIST } from '../../../../../server/utils/constants';
 
 @connect('', {})
 class EditClock extends Component {
-  updateSelection = e => {
+  updateClockType = e => {
     this.props.updateBoxConfig(this.props.x, this.props.y, { clock_type: e.target.value });
+  };
+  updateClockDisplaySecond = e => {
+    const valueBoolean = e.target.value === 'yes';
+    this.props.updateBoxConfig(this.props.x, this.props.y, { clock_display_second: valueBoolean });
   };
 
   render(props, {}) {
     return (
       <BaseEditBox {...props} titleKey="dashboard.boxTitle.clock">
-        <select value={props.box.clock_type} onChange={this.updateSelection} className="form-control">
-          {CLOCK_TYPES_LIST.map(clockType => (
-            <option value={clockType}>
-              <Text id={`dashboard.boxes.clock.${clockType}`} />
+        <div className="form-group">
+          <label>
+            <Text id="dashboard.boxes.clock.type" />
+          </label>
+          <select value={props.box.clock_type} onChange={this.updateClockType} className="form-control">
+            {CLOCK_TYPES_LIST.map(clockType => (
+              <option value={clockType}>
+                <Text id={`dashboard.boxes.clock.${clockType}`} />
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="form-group">
+          <label>
+            <Text id="dashboard.boxes.clock.displaySecond" />
+          </label>
+          <select
+            value={props.box.clock_display_second ? 'yes' : 'no'}
+            onChange={this.updateClockDisplaySecond}
+            className="form-control"
+          >
+            <option value="yes">
+              <Text id="dashboard.boxes.clock.yes" />
             </option>
-          ))}
-        </select>
+            <option value="no">
+              <Text id="dashboard.boxes.clock.no" />
+            </option>
+          </select>
+        </div>
       </BaseEditBox>
     );
   }

--- a/front/src/components/boxs/clock/EditClock.jsx
+++ b/front/src/components/boxs/clock/EditClock.jsx
@@ -1,0 +1,14 @@
+import { Component } from 'preact';
+import { connect } from 'unistore/preact';
+import BaseEditBox from '../baseEditBox';
+
+const UserPresenceBox = ({ children, ...props }) => <BaseEditBox {...props} titleKey="dashboard.boxTitle.clock" />;
+
+@connect('', {})
+class EditClock extends Component {
+  render(props, {}) {
+    return <UserPresenceBox {...props} />;
+  }
+}
+
+export default EditClock;

--- a/front/src/components/boxs/clock/EditClock.jsx
+++ b/front/src/components/boxs/clock/EditClock.jsx
@@ -1,13 +1,27 @@
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import BaseEditBox from '../baseEditBox';
-
-const UserPresenceBox = ({ children, ...props }) => <BaseEditBox {...props} titleKey="dashboard.boxTitle.clock" />;
+import { Text } from 'preact-i18n';
+import { CLOCK_TYPES_LIST } from '../../../../../server/utils/constants';
 
 @connect('', {})
 class EditClock extends Component {
+  updateSelection = e => {
+    this.props.updateBoxConfig(this.props.x, this.props.y, { clock_type: e.target.value });
+  };
+
   render(props, {}) {
-    return <UserPresenceBox {...props} />;
+    return (
+      <BaseEditBox {...props} titleKey="dashboard.boxTitle.clock">
+        <select value={props.box.clock_type} onChange={this.updateSelection} className="form-control">
+          {CLOCK_TYPES_LIST.map(clockType => (
+            <option value={clockType}>
+              <Text id={`dashboard.boxes.clock.${clockType}`} />
+            </option>
+          ))}
+        </select>
+      </BaseEditBox>
+    );
   }
 }
 

--- a/front/src/components/boxs/clock/style.css
+++ b/front/src/components/boxs/clock/style.css
@@ -21,7 +21,7 @@
 }
 
 .analogBigText {
-  font-size: 40px;
+  font-size: 30px;
   text-align: left;
 }
 

--- a/front/src/components/boxs/clock/style.css
+++ b/front/src/components/boxs/clock/style.css
@@ -2,7 +2,6 @@
   padding: 10px 20px 10px 20px;
 }
 
-
 .analogRow {
   display: flex;
   flex-direction: row;

--- a/front/src/components/boxs/clock/style.css
+++ b/front/src/components/boxs/clock/style.css
@@ -1,0 +1,46 @@
+.padding {
+  padding: 10px 20px 10px 20px;
+}
+
+
+.analogRow {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  padding: 16px;
+}
+
+.analogCol {
+  display: flex;
+  flex-direction: column;
+  flex: auto;
+}
+
+.analogSmallText {
+  font-size: 18px;
+  text-align: left;
+}
+
+.analogBigText {
+  font-size: 40px;
+  text-align: left;
+}
+
+.analogClock {
+  align-items: center;
+  justify-content: center;
+}
+
+.digitalTime {
+  font-size: 40px;
+  line-height: 1.2;
+  text-align: center;
+}
+
+.digitalDate {
+  padding-top: 10px;
+  font-size: 16px;
+  text-align: center;
+}
+
+

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -296,7 +296,11 @@
         "analog": "Analog",
         "digital": "Digital",
         "date": "{{day}}, {{month}} {{dayNumber}}, {{year}}",
-        "smallDate": "{{month}} {{dayNumber}}"
+        "smallDate": "{{month}} {{dayNumber}}",
+        "type": "Clock type?",
+        "displaySecond": "Display seconds?",
+        "yes": "Yes",
+        "no": "No"
       }
     }
   },

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -203,7 +203,8 @@
       "camera": "Camera",
       "devices-in-room": "Devices in room",
       "chart": "Chart",
-      "ecowatt": "Ecowatt (France)"
+      "ecowatt": "Ecowatt (France)",
+      "clock": "Clock"
     },
     "boxes": {
       "column": "Column {{index}}",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -291,6 +291,12 @@
         "ok": "Network ok",
         "warning": "Network warning",
         "critical": "Network critical"
+      },
+      "clock": {
+        "analog": "Analog",
+        "digital": "Digital",
+        "date": "{{day}}, {{month}} {{dayNumber}}, {{year}}",
+        "smallDate": "{{month}} {{dayNumber}}"
       }
     }
   },

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -291,6 +291,12 @@
         "ok": "Réseau ok",
         "warning": "Réseau tendu",
         "critical": "Réseau très tendu"
+      },
+      "clock": {
+        "analog": "Analogique",
+        "digital": "Digitale",
+        "date": "{{day}} {{dayNumber}} {{month}} {{year}}",
+        "smallDate": "{{dayNumber}} {{month}}"
       }
     }
   },

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -296,7 +296,11 @@
         "analog": "Analogique",
         "digital": "Digitale",
         "date": "{{day}} {{dayNumber}} {{month}} {{year}}",
-        "smallDate": "{{dayNumber}} {{month}}"
+        "smallDate": "{{dayNumber}} {{month}}",
+        "type": "Type de l'horloge ?",
+        "displaySecond": "Afficher les secondes ?",
+        "yes": "Oui",
+        "no": "Non"
       }
     }
   },

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -203,7 +203,8 @@
       "camera": "Caméra",
       "devices-in-room": "Appareils de la pièce",
       "chart": "Graphique",
-      "ecowatt": "Ecowatt ( France )"
+      "ecowatt": "Ecowatt ( France )",
+      "clock": "Horloge"
     },
     "boxes": {
       "column": "Colonne {{index}}",

--- a/front/src/routes/dashboard/Box.jsx
+++ b/front/src/routes/dashboard/Box.jsx
@@ -6,6 +6,7 @@ import AtHomeBox from '../../components/boxs/user-presence/UserPresence';
 import DevicesInRoomsBox from '../../components/boxs/device-in-room/DevicesInRoomsBox';
 import ChartBox from '../../components/boxs/chart/Chart';
 import EcowattBox from '../../components/boxs/ecowatt/Ecowatt';
+import ClockBox from '../../components/boxs/clock/Clock';
 
 const Box = ({ children, ...props }) => {
   switch (props.box.type) {
@@ -25,6 +26,8 @@ const Box = ({ children, ...props }) => {
       return <ChartBox {...props} />;
     case 'ecowatt':
       return <EcowattBox {...props} />;
+    case 'clock':
+      return <ClockBox {...props} />;
   }
 };
 

--- a/front/src/routes/dashboard/EditBox.jsx
+++ b/front/src/routes/dashboard/EditBox.jsx
@@ -6,6 +6,7 @@ import EditAtHomeBox from '../../components/boxs/user-presence/EditUserPresenceB
 import EditDevicesInRoom from '../../components/boxs/device-in-room/EditDeviceInRoom';
 import EditChart from '../../components/boxs/chart/EditChart';
 import EditEcowatt from '../../components/boxs/ecowatt/EditEcowatt';
+import EditClock from '../../components/boxs/clock/EditClock';
 
 const Box = ({ children, ...props }) => {
   switch (props.box.type) {
@@ -25,6 +26,8 @@ const Box = ({ children, ...props }) => {
       return <EditChart {...props} />;
     case 'ecowatt':
       return <EditEcowatt {...props} />;
+    case 'clock':
+      return <EditClock {...props} />;
   }
 };
 

--- a/front/src/style/index.css
+++ b/front/src/style/index.css
@@ -236,12 +236,11 @@ body {
 .loading-border {
   animation: borderBlink 2s infinite;
 }
-@keyframes borderBlink { 
+@keyframes borderBlink {
   50% {
-    border-color: #45aaf2 ; 
+    border-color: #45aaf2 ;
   }
 }
-
 
 .react-clock {
   display: block;
@@ -308,5 +307,3 @@ body {
 .react-clock__second-hand {
   transition: transform cubic-bezier(0.68, 0, 0.27, 1.55) 0.2s;
 }
-
-

--- a/front/src/style/index.css
+++ b/front/src/style/index.css
@@ -241,3 +241,72 @@ body {
     border-color: #45aaf2 ; 
   }
 }
+
+
+.react-clock {
+  display: block;
+  position: relative;
+}
+.react-clock,
+.react-clock *,
+.react-clock *:before,
+.react-clock *:after {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+.react-clock__face {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border: 1px solid rgb(73, 80,87);
+  border-radius: 50%;
+}
+.react-clock__hand {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  right: 50%;
+}
+.react-clock__hand__body {
+  position: absolute;
+  background-color: rgb(73, 80,87);
+  transform: translateX(-50%);
+}
+.react-clock__mark {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  right: 50%;
+}
+.react-clock__mark__body {
+  position: absolute;
+  background-color: rgb(73, 80,87);
+  transform: translateX(-50%);
+}
+.react-clock__mark__number {
+  position: absolute;
+  left: -40px;
+  width: 80px;
+  text-align: center;
+}
+.react-clock__second-hand__body {
+  background-color: rgb(205,32,31);
+}
+
+.react-clock {
+  background-color: white;
+  border-radius: 50%;
+}
+.react-clock__face {
+  border: 1px solid white;
+}
+.react-clock__second-hand {
+  transition: transform cubic-bezier(0.68, 0, 0.27, 1.55) 0.2s;
+}
+
+

--- a/server/models/dashboard.js
+++ b/server/models/dashboard.js
@@ -24,6 +24,7 @@ const boxesSchema = Joi.array().items(
       chart_type: Joi.string(),
       users: Joi.array().items(Joi.string()),
       clock_type: Joi.string(),
+      clock_display_second: Joi.boolean(),
     }),
   ),
 );

--- a/server/models/dashboard.js
+++ b/server/models/dashboard.js
@@ -23,6 +23,7 @@ const boxesSchema = Joi.array().items(
       display_variation: Joi.boolean(),
       chart_type: Joi.string(),
       users: Joi.array().items(Joi.string()),
+      clock_type: Joi.string(),
     }),
   ),
 );

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -793,6 +793,7 @@ const DASHBOARD_BOX_TYPE = {
   DEVICES_IN_ROOM: 'devices-in-room',
   CHART: 'chart',
   ECOWATT: 'ecowatt',
+  CLOCK: 'clock',
 };
 
 const ERROR_MESSAGES = {

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -836,6 +836,11 @@ const JOB_ERROR_TYPES = {
   UNKNOWN_ERROR: 'unknown-error',
 };
 
+const CLOCK_TYPES = {
+  ANALOG: 'analog',
+  DIGITAL: 'digital',
+};
+
 const createList = (obj) => {
   const list = [];
   Object.keys(obj).forEach((key) => {
@@ -867,6 +872,7 @@ const DEVICE_FEATURE_STATE_AGGREGATE_TYPES_LIST = createList(DEVICE_FEATURE_STAT
 const JOB_TYPES_LIST = createList(JOB_TYPES);
 const JOB_STATUS_LIST = createList(JOB_STATUS);
 const JOB_ERROR_TYPES_LIST = createList(JOB_ERROR_TYPES);
+const CLOCK_TYPES_LIST = createList(CLOCK_TYPES);
 
 module.exports.STATE = STATE;
 module.exports.BUTTON_STATUS = BUTTON_STATUS;
@@ -928,3 +934,6 @@ module.exports.JOB_STATUS = JOB_STATUS;
 module.exports.JOB_STATUS_LIST = JOB_STATUS_LIST;
 module.exports.JOB_ERROR_TYPES = JOB_ERROR_TYPES;
 module.exports.JOB_ERROR_TYPES_LIST = JOB_ERROR_TYPES_LIST;
+
+module.exports.CLOCK_TYPES = CLOCK_TYPES;
+module.exports.CLOCK_TYPES_LIST = CLOCK_TYPES_LIST;

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -836,11 +836,6 @@ const JOB_ERROR_TYPES = {
   UNKNOWN_ERROR: 'unknown-error',
 };
 
-const CLOCK_TYPES = {
-  ANALOG: 'analog',
-  DIGITAL: 'digital',
-};
-
 const createList = (obj) => {
   const list = [];
   Object.keys(obj).forEach((key) => {
@@ -872,7 +867,6 @@ const DEVICE_FEATURE_STATE_AGGREGATE_TYPES_LIST = createList(DEVICE_FEATURE_STAT
 const JOB_TYPES_LIST = createList(JOB_TYPES);
 const JOB_STATUS_LIST = createList(JOB_STATUS);
 const JOB_ERROR_TYPES_LIST = createList(JOB_ERROR_TYPES);
-const CLOCK_TYPES_LIST = createList(CLOCK_TYPES);
 
 module.exports.STATE = STATE;
 module.exports.BUTTON_STATUS = BUTTON_STATUS;
@@ -934,6 +928,3 @@ module.exports.JOB_STATUS = JOB_STATUS;
 module.exports.JOB_STATUS_LIST = JOB_STATUS_LIST;
 module.exports.JOB_ERROR_TYPES = JOB_ERROR_TYPES;
 module.exports.JOB_ERROR_TYPES_LIST = JOB_ERROR_TYPES_LIST;
-
-module.exports.CLOCK_TYPES = CLOCK_TYPES;
-module.exports.CLOCK_TYPES_LIST = CLOCK_TYPES_LIST;


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

The purpose of this PR is a proposal to add box on dashboard to display a clock.

![Screenshot 2022-05-08 at 12 41 07](https://user-images.githubusercontent.com/11317212/167292485-8ed60ffe-f5d5-46d7-8c55-99bc9ca841fe.png)
![Screenshot 2022-05-08 at 12 41 29](https://user-images.githubusercontent.com/11317212/167292486-edc816ca-f378-413d-96a9-41358ecaef50.png)



Settings: 
![Screenshot 2022-05-08 at 12 42 20](https://user-images.githubusercontent.com/11317212/167292496-19cfcb49-167e-4fec-a81c-d2ec0ac7c8f7.png)
![Screenshot 2022-05-08 at 12 43 43](https://user-images.githubusercontent.com/11317212/167292513-ea89f632-5273-4ef1-833f-07e31972cfcf.png)


