### PR TITLE
z2m reversed binary

### DIFF
--- a/server/services/zigbee2mqtt/exposes/binaryType.js
+++ b/server/services/zigbee2mqtt/exposes/binaryType.js
@@ -1,20 +1,106 @@
 const { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } = require('../../../utils/constants');
 
+const names = {
+  alarm: {
+    feature: {
+      category: DEVICE_FEATURE_CATEGORIES.SIREN,
+      type: DEVICE_FEATURE_TYPES.SIREN.BINARY,
+    },
+  },
+  contact: {
+    feature: {
+      category: DEVICE_FEATURE_CATEGORIES.OPENING_SENSOR,
+      type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
+    },
+    reversedValue: true,
+  },
+  eco_mode: {
+    feature: {
+      category: DEVICE_FEATURE_CATEGORIES.SWITCH,
+      type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
+    },
+  },
+  occupancy: {
+    feature: {
+      category: DEVICE_FEATURE_CATEGORIES.MOTION_SENSOR,
+      type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
+    },
+  },
+  interlock: {
+    feature: {
+      category: DEVICE_FEATURE_CATEGORIES.SWITCH,
+      type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
+    },
+  },
+  carbon_monoxide: {
+    feature: {
+      category: DEVICE_FEATURE_CATEGORIES.CO_SENSOR,
+      type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
+    },
+  },
+  presence: {
+    feature: {
+      category: DEVICE_FEATURE_CATEGORIES.MOTION_SENSOR,
+      type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
+    },
+  },
+  smoke: {
+    feature: {
+      category: DEVICE_FEATURE_CATEGORIES.SMOKE_SENSOR,
+      type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
+    },
+  },
+  state: {
+    types: {
+      light: {
+        category: DEVICE_FEATURE_CATEGORIES.LIGHT,
+        type: DEVICE_FEATURE_TYPES.LIGHT.BINARY,
+      },
+      lock: {
+        category: DEVICE_FEATURE_CATEGORIES.ACCESS_CONTROL,
+        type: DEVICE_FEATURE_TYPES.ACCESS_CONTROL.MODE,
+      },
+      switch: {
+        category: DEVICE_FEATURE_CATEGORIES.SWITCH,
+        type: DEVICE_FEATURE_TYPES.SWITCH.BINARY,
+      },
+    },
+  },
+  vibration: {
+    feature: {
+      category: DEVICE_FEATURE_CATEGORIES.VIBRATION_SENSOR,
+      type: DEVICE_FEATURE_TYPES.VIBRATION_SENSOR.BINARY,
+    },
+  },
+  water_leak: {
+    feature: {
+      category: DEVICE_FEATURE_CATEGORIES.LEAK_SENSOR,
+      type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
+    },
+  },
+};
+
 module.exports = {
   type: 'binary',
   writeValue: (expose, value) => {
-    if (value === 1) {
+    const { [expose.name]: mapping = {} } = names;
+    const reversed = mapping.reversedValue || false;
+
+    if ((value === 1 && !reversed) || (value === 0 && reversed)) {
       return expose.value_on;
     }
 
     return expose.value_off;
   },
   readValue: (expose, value) => {
+    const { [expose.name]: mapping = {} } = names;
+    const reversed = mapping.reversedValue || false;
+
     switch (value) {
       case expose.value_on:
-        return 1;
+        return reversed ? 0 : 1;
       case expose.value_off:
-        return 0;
+        return reversed ? 1 : 0;
       default:
         return undefined;
     }
@@ -25,82 +111,5 @@ module.exports = {
     min: 0,
     max: 1,
   },
-  names: {
-    alarm: {
-      feature: {
-        category: DEVICE_FEATURE_CATEGORIES.SIREN,
-        type: DEVICE_FEATURE_TYPES.SIREN.BINARY,
-      },
-    },
-    contact: {
-      feature: {
-        category: DEVICE_FEATURE_CATEGORIES.OPENING_SENSOR,
-        type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
-      },
-    },
-    eco_mode: {
-      feature: {
-        category: DEVICE_FEATURE_CATEGORIES.SWITCH,
-        type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
-      },
-    },
-    occupancy: {
-      feature: {
-        category: DEVICE_FEATURE_CATEGORIES.MOTION_SENSOR,
-        type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
-      },
-    },
-    interlock: {
-      feature: {
-        category: DEVICE_FEATURE_CATEGORIES.SWITCH,
-        type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
-      },
-    },
-    carbon_monoxide: {
-      feature: {
-        category: DEVICE_FEATURE_CATEGORIES.CO_SENSOR,
-        type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
-      },
-    },
-    presence: {
-      feature: {
-        category: DEVICE_FEATURE_CATEGORIES.MOTION_SENSOR,
-        type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
-      },
-    },
-    smoke: {
-      feature: {
-        category: DEVICE_FEATURE_CATEGORIES.SMOKE_SENSOR,
-        type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
-      },
-    },
-    state: {
-      types: {
-        light: {
-          category: DEVICE_FEATURE_CATEGORIES.LIGHT,
-          type: DEVICE_FEATURE_TYPES.LIGHT.BINARY,
-        },
-        lock: {
-          category: DEVICE_FEATURE_CATEGORIES.ACCESS_CONTROL,
-          type: DEVICE_FEATURE_TYPES.ACCESS_CONTROL.MODE,
-        },
-        switch: {
-          category: DEVICE_FEATURE_CATEGORIES.SWITCH,
-          type: DEVICE_FEATURE_TYPES.SWITCH.BINARY,
-        },
-      },
-    },
-    vibration: {
-      feature: {
-        category: DEVICE_FEATURE_CATEGORIES.VIBRATION_SENSOR,
-        type: DEVICE_FEATURE_TYPES.VIBRATION_SENSOR.BINARY,
-      },
-    },
-    water_leak: {
-      feature: {
-        category: DEVICE_FEATURE_CATEGORIES.LEAK_SENSOR,
-        type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
-      },
-    },
-  },
+  names,
 };

--- a/server/test/services/zigbee2mqtt/exposes/binaryType.test.js
+++ b/server/test/services/zigbee2mqtt/exposes/binaryType.test.js
@@ -4,8 +4,14 @@ const binaryType = require('../../../../services/zigbee2mqtt/exposes/binaryType'
 
 describe('zigbee2mqtt binaryType', () => {
   const expose = {
+    name: 'state',
     value_on: 'ON',
     value_off: 7,
+  };
+  const reversedExpose = {
+    name: 'contact',
+    value_on: 'ON',
+    value_off: 'OFF',
   };
 
   it('should write 1 value', () => {
@@ -26,6 +32,26 @@ describe('zigbee2mqtt binaryType', () => {
   it('should read 0 value', () => {
     const result = binaryType.readValue(expose, 7);
     assert.equal(result, 0);
+  });
+
+  it('should write 1 value on reversed expose', () => {
+    const result = binaryType.writeValue(reversedExpose, 1);
+    assert.equal(result, 'OFF');
+  });
+
+  it('should write 0 value on reversed expose', () => {
+    const result = binaryType.writeValue(reversedExpose, 0);
+    assert.equal(result, 'ON');
+  });
+
+  it('should read 1 value on reversed expose', () => {
+    const result = binaryType.readValue(reversedExpose, 'ON');
+    assert.equal(result, 0);
+  });
+
+  it('should read 0 value on reversed expose', () => {
+    const result = binaryType.readValue(reversedExpose, 'OFF');
+    assert.equal(result, 1);
   });
 
   it('should read unknown value', () => {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- ~~[ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)~~
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.
- ~~[ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~~
- ~~[ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).~~
- ~~[ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).~~

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Reverse z2m contact values for opening_sensor
https://community.gladysassistant.com/t/message-derreur-zigbee2mqtt/6846/79?u=alextrovato

---

Gladys z2m mapping feature now declares a "reversed" attribute to reverse true/false values.