### PR TITLE
Remove VTODO only calendar

### DIFF
--- a/server/services/caldav/lib/calendar/calendar.requests.js
+++ b/server/services/caldav/lib/calendar/calendar.requests.js
@@ -22,7 +22,7 @@ function getElementsByTagRegex(container, regex) {
  * requestCalendars(xhr, homeUrl)
  */
 async function requestCalendars(xhr, homeUrl) {
-  const ICAL_OBJS = new Set(['VEVENT', 'VTODO', 'VJOURNAL', 'VFREEBUSY', 'VTIMEZONE', 'VALARM']);
+  const ICAL_OBJS = new Set(['VEVENT', 'VFREEBUSY', 'VALARM']);
 
   const req = this.dav.request.propfind({
     props: [


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [ ] If your changes affects code, did your write the tests?
- [ ] Are tests passing? (`npm test` on both front/server)
- [ ] Is the linter passing? (`npm run eslint` on both front/server)
- [ ] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Fix error on Nextcloud instance when Deck app is installed & used https://community.gladysassistant.com/t/debutant-gladys-tests-avant-de-pourquoi-pas-migrer-depuis-domoticz/7281/6

I removed calendar synchronization when calendar are only `VTODO`, `VJOURNAL` or `VTIMEZONE` some type not used in our calendars