### PR TITLE
Push docker images to GHCR

### DIFF
--- a/.github/workflows/docker-release-build.yml
+++ b/.github/workflows/docker-release-build.yml
@@ -148,7 +148,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ secrets.DOCKERHUB_REPO }}
+          images: ${{ secrets.DOCKERHUB_REPO }},ghcr.io/${{ secrets.DOCKERHUB_REPO }}
           labels: |
             org.opencontainers.image.title=Gladys Assistant Production Image
           tags: |
@@ -172,6 +172,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      -
+        name: 🔑 Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: 🐳 Build and push
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
Updating CI to push image to Github Container Registry
Good bandwidth and no request limitation.

For those using watchtower with a lot of container its a good choice.

Tested here => https://github.com/VonOx/gh-test-ci/pkgs/container/gladys

