### PR TITLE
Fix hours getDeviceFeaturesAggregates

### DIFF
--- a/server/lib/device/device.getDeviceFeaturesAggregates.js
+++ b/server/lib/device/device.getDeviceFeaturesAggregates.js
@@ -1,7 +1,12 @@
 const { Op, fn, col, literal } = require('sequelize');
 const { LTTB } = require('downsample');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+
 const db = require('../../models');
 const { NotFoundError } = require('../../utils/coreErrors');
+
+dayjs.extend(utc);
 
 /**
  * @description Get all features states aggregates.
@@ -76,7 +81,7 @@ async function getDeviceFeaturesAggregates(selector, intervalInMinutes, maxState
   }
 
   const dataForDownsampling = rows.map((deviceFeatureState) => {
-    return [new Date(deviceFeatureState.created_at), deviceFeatureState.value];
+    return [dayjs.utc(deviceFeatureState.created_at), deviceFeatureState.value];
   });
 
   const downsampled = LTTB(dataForDownsampling, maxStates);


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

DeviceStateAgregate are saved with an UTC datetime, when we load it for sampling we need to specify that it's an UTC date

~~⚠️ need to be sure that all device state agregates are always store with UTC datetime~~

Fix #1554 