### PR TITLE
Merge devices, keep name and room

### DIFF
--- a/server/services/tasmota/lib/mqtt/tasmota.mqtt.handleMessage.js
+++ b/server/services/tasmota/lib/mqtt/tasmota.mqtt.handleMessage.js
@@ -28,10 +28,9 @@ function handleMessage(topic, message) {
     }
     // Device secondary features
     case 'STATUS8': {
-      let device = this.pendingDevices[deviceExternalId];
+      const device = this.pendingDevices[deviceExternalId];
       if (device) {
         this.subStatus(device, message);
-        device = this.tasmotaHandler.mergeWithExistingDevice(device);
 
         this.discoveredDevices[deviceExternalId] = device;
         delete this.pendingDevices[deviceExternalId];

--- a/server/services/tasmota/lib/tasmota.mergeWithExistingDevice.js
+++ b/server/services/tasmota/lib/tasmota.mergeWithExistingDevice.js
@@ -1,4 +1,4 @@
-const { hasDeviceChanged } = require('../../../utils/device');
+const { mergeDevices } = require('../../../utils/device');
 
 /**
  * @description Get all discovered devices, and if device already created, the Gladys device.
@@ -9,17 +9,7 @@ const { hasDeviceChanged } = require('../../../utils/device');
  */
 function mergeWithExistingDevice(tasmotaDevice) {
   const existing = this.gladys.stateManager.get('deviceByExternalId', tasmotaDevice.external_id);
-  if (existing) {
-    const device = { ...existing, ...tasmotaDevice };
-    const updatable = hasDeviceChanged(device, existing);
-    if (updatable) {
-      device.updatable = updatable;
-    }
-
-    return device;
-  }
-
-  return tasmotaDevice;
+  return mergeDevices(tasmotaDevice, existing);
 }
 
 module.exports = {

--- a/server/services/tasmota/lib/tasmota.notifyNewDevice.js
+++ b/server/services/tasmota/lib/tasmota.notifyNewDevice.js
@@ -8,9 +8,10 @@ const { EVENTS } = require('../../../utils/constants');
  * notifyNewDevice(discorveredDevice)
  */
 function notifyNewDevice(device, event) {
+  const payload = this.mergeWithExistingDevice(device);
   this.gladys.event.emit(EVENTS.WEBSOCKET.SEND_ALL, {
     type: event,
-    payload: device,
+    payload,
   });
 }
 

--- a/server/services/zigbee2mqtt/lib/getDiscoveredDevices.js
+++ b/server/services/zigbee2mqtt/lib/getDiscoveredDevices.js
@@ -1,4 +1,4 @@
-const { hasDeviceChanged } = require('../../../utils/device');
+const { mergeDevices } = require('../../../utils/device');
 const { convertDevice } = require('../utils/convertDevice');
 
 /**
@@ -13,13 +13,9 @@ function getDiscoveredDevices() {
       // Convert to Gladys device
       .map((d) => convertDevice(d, this.serviceId))
       .map((d) => {
-        // Check if updatable
         const existingDevice = this.gladys.stateManager.get('deviceByExternalId', d.external_id);
-        const device = { ...(existingDevice || {}), ...d };
-        if (existingDevice) {
-          device.updatable = hasDeviceChanged(device, existingDevice);
-        }
-        return device;
+        // Merge with existing device.
+        return mergeDevices(d, existingDevice);
       })
   );
 }

--- a/server/test/services/tasmota/lib/http/tasmota.http.status.test.js
+++ b/server/test/services/tasmota/lib/http/tasmota.http.status.test.js
@@ -49,6 +49,9 @@ const gladys = {
   event: {
     emit: fake.returns(null),
   },
+  stateManager: {
+    get: fake.returns(null),
+  },
 };
 const serviceId = 'service-uuid-random';
 

--- a/server/test/services/tasmota/lib/http/tasmota.http.subStatus.test.js
+++ b/server/test/services/tasmota/lib/http/tasmota.http.subStatus.test.js
@@ -44,6 +44,9 @@ const gladys = {
   event: {
     emit: fake.returns(null),
   },
+  stateManager: {
+    get: fake.returns(null),
+  },
 };
 const serviceId = 'service-uuid-random';
 

--- a/server/test/services/tasmota/lib/tasmota.getDiscoveredDevices.test.js
+++ b/server/test/services/tasmota/lib/tasmota.getDiscoveredDevices.test.js
@@ -7,6 +7,7 @@ const existingDevice = {
   external_id: 'alreadyExists',
   name: 'alreadyExists',
   model: 'sonoff-basic',
+  room_id: 'room_id',
   features: [
     {
       name: 'feature 1',
@@ -57,13 +58,10 @@ describe('Tasmota - MQTT - getDiscoveredDevices', () => {
   });
 
   it('discovered already in Gladys', () => {
-    protocolHandler.discoveredDevices.alreadyExists = {
-      external_id: 'alreadyExists',
-      model: 'sonoff-basic',
-    };
+    protocolHandler.discoveredDevices.alreadyExists = existingDevice;
     const result = tasmotaHandler.getDiscoveredDevices(protocol);
     expect(result).to.be.lengthOf(1);
-    expect(result).deep.eq([existingDevice]);
+    expect(result).deep.eq([{ ...existingDevice, updatable: false }]);
   });
 
   it('discovered already in Gladys, but updated (basic to pow)', () => {
@@ -82,6 +80,7 @@ describe('Tasmota - MQTT - getDiscoveredDevices', () => {
           type: 'type 2',
           category: 'category 2',
           external_id: 'external_id:2',
+          min: 10,
         },
         {
           name: 'feature 3',
@@ -98,6 +97,7 @@ describe('Tasmota - MQTT - getDiscoveredDevices', () => {
       external_id: 'alreadyExists',
       model: 'sonoff-pow',
       name: 'alreadyExists',
+      room_id: 'room_id',
       features: [
         {
           name: 'feature 1',
@@ -106,10 +106,11 @@ describe('Tasmota - MQTT - getDiscoveredDevices', () => {
           external_id: 'external_id:1',
         },
         {
-          name: 'feature 2 bis',
+          name: 'feature 2',
           type: 'type 2',
           category: 'category 2',
           external_id: 'external_id:2',
+          min: 10,
         },
         {
           name: 'feature 3',
@@ -118,10 +119,10 @@ describe('Tasmota - MQTT - getDiscoveredDevices', () => {
           external_id: 'external_id:3',
         },
       ],
+      updatable: true,
       params: [],
     };
-    expectedDevice.updatable = true;
-    expectedDevice.name = 'alreadyExists';
+
     expect(result).deep.eq([expectedDevice]);
   });
 
@@ -152,13 +153,10 @@ describe('Tasmota - HTTP - getDiscoveredDevices', () => {
   });
 
   it('discovered already in Gladys', () => {
-    protocolHandler.discoveredDevices.alreadyExists = {
-      external_id: 'alreadyExists',
-      model: 'sonoff-basic',
-    };
+    protocolHandler.discoveredDevices.alreadyExists = existingDevice;
     const result = tasmotaHandler.getDiscoveredDevices(protocol);
     expect(result).to.be.lengthOf(1);
-    expect(result).deep.eq([existingDevice]);
+    expect(result).deep.eq([{ ...existingDevice, updatable: false }]);
   });
 
   it('discovered already in Gladys, but updated (basic to pow)', () => {
@@ -177,6 +175,7 @@ describe('Tasmota - HTTP - getDiscoveredDevices', () => {
           type: 'type 2',
           category: 'category 2',
           external_id: 'external_id:2',
+          min: 0,
         },
         {
           name: 'feature 3',
@@ -193,6 +192,8 @@ describe('Tasmota - HTTP - getDiscoveredDevices', () => {
       external_id: 'alreadyExists',
       model: 'sonoff-pow',
       name: 'alreadyExists',
+      updatable: true,
+      room_id: 'room_id',
       features: [
         {
           name: 'feature 1',
@@ -201,10 +202,11 @@ describe('Tasmota - HTTP - getDiscoveredDevices', () => {
           external_id: 'external_id:1',
         },
         {
-          name: 'feature 2 bis',
+          name: 'feature 2',
           type: 'type 2',
           category: 'category 2',
           external_id: 'external_id:2',
+          min: 0,
         },
         {
           name: 'feature 3',
@@ -215,8 +217,7 @@ describe('Tasmota - HTTP - getDiscoveredDevices', () => {
       ],
       params: [],
     };
-    expectedDevice.updatable = true;
-    expectedDevice.name = 'alreadyExists';
+
     expect(result).deep.eq([expectedDevice]);
   });
 
@@ -253,6 +254,8 @@ describe('Tasmota - HTTP - getDiscoveredDevices', () => {
       external_id: 'alreadyExists',
       name: 'alreadyExists',
       model: 'sonoff-basic',
+      updatable: true,
+      room_id: 'room_id',
       features: [
         {
           name: 'feature 1',
@@ -274,8 +277,7 @@ describe('Tasmota - HTTP - getDiscoveredDevices', () => {
         },
       ],
     };
-    expectedDevice.updatable = true;
-    expectedDevice.name = 'alreadyExists';
+
     expect(result).deep.eq([expectedDevice]);
   });
 

--- a/server/test/services/zigbee2mqtt/lib/getDiscoveredDevices.test.js
+++ b/server/test/services/zigbee2mqtt/lib/getDiscoveredDevices.test.js
@@ -39,7 +39,7 @@ describe('zigbee2mqtt getDiscoveredDevices', () => {
     // PREPARE
     gladys.stateManager.get
       .onFirstCall()
-      .returns(true)
+      .returns({ room_id: 'room_id', name: 'device-name' })
       .onSecondCall()
       .returns(false)
       .onThirdCall()

--- a/server/test/services/zigbee2mqtt/lib/handleMqttMessage.test.js
+++ b/server/test/services/zigbee2mqtt/lib/handleMqttMessage.test.js
@@ -48,11 +48,11 @@ describe('zigbee2mqtt handleMqttMessage', () => {
     stateManagerGetStub = sinon.stub();
     stateManagerGetStub
       .onFirstCall()
-      .returns(true)
+      .returns({ room_id: 'room_id', name: 'device-name' })
       .onSecondCall()
-      .returns(false)
+      .returns(null)
       .onThirdCall()
-      .returns(false);
+      .returns(null);
     zigbee2mqttManager.gladys.stateManager.get = stateManagerGetStub;
     // EXECUTE
     await zigbee2mqttManager.handleMqttMessage('zigbee2mqtt/bridge/devices', JSON.stringify(zigbeeDevices));

--- a/server/test/services/zigbee2mqtt/lib/payloads/event_device_result.json
+++ b/server/test/services/zigbee2mqtt/lib/payloads/event_device_result.json
@@ -52,7 +52,8 @@
       }
     ],
     "model": "WXKG01LM",
-    "name": "0x00158d00033e88d5",
+    "name": "device-name",
+    "room_id": "room_id",
     "service_id": "f87b7af2-ca8e-44fc-b754-444354b42fee",
     "should_poll": false,
     "updatable": true


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- ~~[ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)~~
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.
- ~~[ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~~
- ~~[ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).~~
- ~~[ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).~~

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Fixes #1573 
With z2m and Tasmota services, Gladys allows to update stored devices with discovered once. But it erase manually defined room and names.
This PR allows to merge existing device and newly discovered device, keeping some already stored attributes.