### PR TITLE
Truncate y axis if needed

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -10,7 +10,7 @@
         "@gladysassistant/theme-optimized": "^1.0.3",
         "@jaames/iro": "^5.5.2",
         "@yaireo/tagify": "^4.5.0",
-        "apexcharts": "^3.29.0",
+        "apexcharts": "^3.40.0",
         "axios": "^0.21.1",
         "classnames": "^2.3.1",
         "cropperjs": "^1.5.12",
@@ -6280,9 +6280,9 @@
       }
     },
     "node_modules/apexcharts": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.29.0.tgz",
-      "integrity": "sha512-PhI17VayidYAbLb5/g+7WOeirgFrVopzt0qGwLq8V+cd6NXx4CeHYq3S0pDZiUGO7UFQ4YIrT8+ie9/Fnler+w==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.40.0.tgz",
+      "integrity": "sha512-dSi3BUfCJkFd67uFp+xffrJVd3lDT7AAUUyRp0qPYiglJ76CeZLddVhM3FAk1P9GCzf8VewqGYUPCYQvXm+b9A==",
       "dependencies": {
         "svg.draggable.js": "^2.2.2",
         "svg.easing.js": "^2.0.0",
@@ -36191,9 +36191,9 @@
       }
     },
     "apexcharts": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.29.0.tgz",
-      "integrity": "sha512-PhI17VayidYAbLb5/g+7WOeirgFrVopzt0qGwLq8V+cd6NXx4CeHYq3S0pDZiUGO7UFQ4YIrT8+ie9/Fnler+w==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.40.0.tgz",
+      "integrity": "sha512-dSi3BUfCJkFd67uFp+xffrJVd3lDT7AAUUyRp0qPYiglJ76CeZLddVhM3FAk1P9GCzf8VewqGYUPCYQvXm+b9A==",
       "requires": {
         "svg.draggable.js": "^2.2.2",
         "svg.easing.js": "^2.0.0",

--- a/front/package.json
+++ b/front/package.json
@@ -48,7 +48,7 @@
     "@gladysassistant/theme-optimized": "^1.0.3",
     "@jaames/iro": "^5.5.2",
     "@yaireo/tagify": "^4.5.0",
-    "apexcharts": "^3.29.0",
+    "apexcharts": "^3.40.0",
     "axios": "^0.21.1",
     "classnames": "^2.3.1",
     "cropperjs": "^1.5.12",

--- a/front/src/components/boxs/chart/ApexChartAreaOptions.js
+++ b/front/src/components/boxs/chart/ApexChartAreaOptions.js
@@ -50,6 +50,7 @@ const getApexChartAreaOptions = ({ displayAxes, height, series, COLORS, locales,
       type: 'datetime'
     },
     yaxis: {
+      decimalsInFloat: 0,
       labels: {
         padding: 4
       }

--- a/front/src/components/boxs/chart/ApexChartBarOptions.js
+++ b/front/src/components/boxs/chart/ApexChartBarOptions.js
@@ -58,6 +58,7 @@ const getApexChartBarOptions = ({ displayAxes, series, COLORS, locales, defaultL
       type: 'datetime'
     },
     yaxis: {
+      decimalsInFloat: 0,
       labels: {
         padding: 4
       }

--- a/front/src/components/boxs/chart/ApexChartLineOptions.js
+++ b/front/src/components/boxs/chart/ApexChartLineOptions.js
@@ -49,6 +49,7 @@ const getApexChartLineOptions = ({ height, displayAxes, series, COLORS, locales,
       type: 'datetime'
     },
     yaxis: {
+      decimalsInFloat: 0,
       labels: {
         padding: 4
       }

--- a/front/src/components/boxs/chart/ApexChartStepLineOptions.js
+++ b/front/src/components/boxs/chart/ApexChartStepLineOptions.js
@@ -48,6 +48,7 @@ const getApexChartStepLineOptions = ({ height, displayAxes, series, COLORS, loca
       type: 'datetime'
     },
     yaxis: {
+      decimalsInFloat: 0,
       labels: {
         padding: 4
       }

--- a/front/src/config/demo.js
+++ b/front/src/config/demo.js
@@ -169,7 +169,8 @@ const data = {
           interval: 'last-month',
           unit: 'celsius',
           title: 'Temperature',
-          display_variation: true
+          display_variation: true,
+          display_axes: true
         },
         {
           type: 'user-presence'
@@ -3221,7 +3222,7 @@ const data = {
           created_at: dayjs()
             .subtract(1, 'day')
             .toDate(),
-          value: 33
+          value: 33.0001
         },
         {
           created_at: dayjs()


### PR DESCRIPTION
Fixes #1565

### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [ ] If your changes affects code, did your write the tests?
- [ ] Are tests passing? (`npm test` on both front/server)
- [ ] Is the linter passing? (`npm run eslint` on both front/server)
- [ ] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Try to improve Y axis labels on charts: #1565 
Display 2 decimals if presents, neither integer part only.

@Pierre-Gilles @VonOx 
I'm not able to reproduce the bug, so I'm not sure I well fixed it.