### PR TITLE
Add message to warn user that a device has lots of states before deleting

### DIFF
--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -43,7 +43,8 @@
     "noCalendarsConnected": "No calendars connected. To connect an external calendar, go to the integrations page or ask a user in your Gladys instance to share you his calendars."
   },
   "device": {
-    "noFeatures": "No features"
+    "noFeatures": "No features",
+    "tooMuchStatesToDelete": "This device has {{count}} states in database. To prevent your Gladys instance to be slow while deleting them, we've started a delete of those states slowly in background. You can come back to delete this device later when the device will not have any states anymore."
   },
   "login": {
     "title": "Gladys Assistant",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -44,7 +44,7 @@
   },
   "device": {
     "noFeatures": "No features",
-    "tooMuchStatesToDelete": "This device has {{count}} states in database. To prevent your Gladys instance to be slow while deleting them, we've started a delete of those states slowly in background. You can come back to delete this device later when the device will not have any states anymore."
+    "tooMuchStatesToDelete": "This device has {{count}} states in database. To prevent your Gladys instance to be slow while deleting them, we've started a delete of those states slowly in background. You can come back to delete this device later when the device will not have any states anymore. To follow the delete job, <a href=\"/dashboard/settings/jobs\">click here</a>."
   },
   "login": {
     "title": "Gladys Assistant",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -44,7 +44,7 @@
   },
   "device": {
     "noFeatures": "Aucune fonctionnalité",
-    "tooMuchStatesToDelete": "Cet appareil a {{count}} états dans la base de donnée. Afin d'éviter que Gladys soit bloquée pendant la suppression de cet appareil, nous avons lancé une suppression lente en arrière-plan de tous les états de cet appareil. D'ici quelques minutes/heures ( selon la rapidité de votre disque ), nous vous invitons à revenir sur cet onglet pour re-tenter une suppression de cet appareil. Pour suivre la suppression, <a href=\"/dashboard/settings/jobs\">c'est ici</a>."
+    "tooMuchStatesToDelete": "Cet appareil a {{count}} états dans la base de données. Afin d'éviter que Gladys soit bloquée pendant la suppression de cet appareil, nous avons lancé une suppression lente en arrière-plan de tous les états de cet appareil. D'ici quelques minutes/heures ( selon la rapidité de votre disque ), nous vous invitons à revenir sur cet onglet pour re-tenter une suppression de cet appareil. Pour suivre la suppression, <a href=\"/dashboard/settings/jobs\">c'est ici</a>."
   },
   "login": {
     "title": "Gladys Assistant",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -43,7 +43,8 @@
     "noCalendarsConnected": "Vous n'avez connecté aucun calendrier. Pour connecter un calendrier, vous pouvez vous rendre dans l'onglet intégrations, ou demander à ce qu'un autre membre de cette instance Gladys partage un de ses calendriers."
   },
   "device": {
-    "noFeatures": "Aucune fonctionnalité"
+    "noFeatures": "Aucune fonctionnalité",
+    "tooMuchStatesToDelete": "Cet appareil a {{count}} états dans la base de donnée. Afin d'éviter que Gladys soit bloquée pendant la suppression de cet appareil, nous avons lancé une suppression lente en arrière-plan de tous les états de cet appareil. D'ici quelques minutes/heures ( selon la rapidité de votre disque ), nous vous invitons à revenir sur cet onglet pour re-tenter une suppression de cet appareil."
   },
   "login": {
     "title": "Gladys Assistant",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -44,7 +44,7 @@
   },
   "device": {
     "noFeatures": "Aucune fonctionnalité",
-    "tooMuchStatesToDelete": "Cet appareil a {{count}} états dans la base de donnée. Afin d'éviter que Gladys soit bloquée pendant la suppression de cet appareil, nous avons lancé une suppression lente en arrière-plan de tous les états de cet appareil. D'ici quelques minutes/heures ( selon la rapidité de votre disque ), nous vous invitons à revenir sur cet onglet pour re-tenter une suppression de cet appareil."
+    "tooMuchStatesToDelete": "Cet appareil a {{count}} états dans la base de donnée. Afin d'éviter que Gladys soit bloquée pendant la suppression de cet appareil, nous avons lancé une suppression lente en arrière-plan de tous les états de cet appareil. D'ici quelques minutes/heures ( selon la rapidité de votre disque ), nous vous invitons à revenir sur cet onglet pour re-tenter une suppression de cet appareil. Pour suivre la suppression, <a href=\"/dashboard/settings/jobs\">c'est ici</a>."
   },
   "login": {
     "title": "Gladys Assistant",

--- a/front/src/routes/integration/all/bluetooth/device-page/BluetoothDevice.jsx
+++ b/front/src/routes/integration/all/bluetooth/device-page/BluetoothDevice.jsx
@@ -1,4 +1,4 @@
-import { Text, Localizer } from 'preact-i18n';
+import { Text, Localizer, MarkupText } from 'preact-i18n';
 import { Component } from 'preact';
 import cx from 'classnames';
 import get from 'get-value';
@@ -32,11 +32,18 @@ class BluetoothDevice extends Component {
     this.setState({ loading: false });
   };
   deleteDevice = async () => {
-    this.setState({ loading: true });
+    this.setState({ loading: true, tooMuchStatesError: false, statesNumber: undefined });
     try {
       await this.props.deleteDevice(this.props.device, this.props.deviceIndex);
     } catch (e) {
-      this.setState({ error: RequestStatus.Error });
+      const status = get(e, 'response.status');
+      const dataMessage = get(e, 'response.data.message');
+      if (status === 400 && dataMessage && dataMessage.includes('Too much states')) {
+        const statesNumber = new Intl.NumberFormat().format(dataMessage.split(' ')[0]);
+        this.setState({ tooMuchStatesError: true, statesNumber });
+      } else {
+        this.setState({ error: RequestStatus.Error });
+      }
     }
     this.setState({ loading: false });
   };
@@ -54,7 +61,7 @@ class BluetoothDevice extends Component {
     this.refreshDeviceProperty();
   }
 
-  render({ device, houses }, { batteryLevel, loading }) {
+  render({ device, houses }, { batteryLevel, loading, tooMuchStatesError, statesNumber }) {
     return (
       <div class="col-md-6">
         <div class="card">
@@ -74,6 +81,11 @@ class BluetoothDevice extends Component {
             <div class="loader" />
             <div class="dimmer-content">
               <div class="card-body">
+                {tooMuchStatesError && (
+                  <div class="alert alert-warning">
+                    <MarkupText id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
+                  </div>
+                )}
                 <div class="form-group">
                   <label>
                     <Text id="integration.bluetooth.device.nameLabel" />

--- a/front/src/routes/integration/all/broadlink/device-page/DeviceBox.jsx
+++ b/front/src/routes/integration/all/broadlink/device-page/DeviceBox.jsx
@@ -2,6 +2,7 @@ import { Text, Localizer } from 'preact-i18n';
 import { Component } from 'preact';
 import cx from 'classnames';
 import { Link } from 'preact-router/match';
+import get from 'get-value';
 
 import DeviceFeatures from '../../../../../components/device/view/DeviceFeatures';
 import { RequestStatus } from '../../../../../utils/consts';
@@ -28,7 +29,9 @@ class DeviceBox extends Component {
 
   deleteDevice = async () => {
     this.setState({
-      loading: true
+      loading: true,
+      tooMuchStatesError: false,
+      statesNumber: undefined
     });
     try {
       await this.props.deleteDevice(this.props.device, this.props.deviceIndex);
@@ -37,9 +40,14 @@ class DeviceBox extends Component {
         saveError: undefined
       });
     } catch (e) {
-      this.setState({
-        error: RequestStatus.Error
-      });
+      const status = get(e, 'response.status');
+      const dataMessage = get(e, 'response.data.message');
+      if (status === 400 && dataMessage && dataMessage.includes('Too much states')) {
+        const statesNumber = new Intl.NumberFormat().format(dataMessage.split(' ')[0]);
+        this.setState({ tooMuchStatesError: true, statesNumber });
+      } else {
+        this.setState({ error: RequestStatus.Error });
+      }
     }
     this.setState({
       loading: false
@@ -54,7 +62,7 @@ class DeviceBox extends Component {
     this.props.updateDeviceProperty(this.props.deviceIndex, 'room_id', e.target.value);
   };
 
-  render({ deviceIndex, device, housesWithRooms = [] }, { loading, saveError }) {
+  render({ deviceIndex, device, housesWithRooms = [] }, { loading, saveError, tooMuchStatesError, statesNumber }) {
     return (
       <div class="col-md-6">
         <div class="card" data-cy="device-card">
@@ -70,6 +78,11 @@ class DeviceBox extends Component {
                 {saveError && (
                   <div class="alert alert-danger">
                     <Text id="integration.broadlink.device.saveError" />
+                  </div>
+                )}
+                {tooMuchStatesError && (
+                  <div class="alert alert-warning">
+                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
                   </div>
                 )}
                 <div class="form-group">

--- a/front/src/routes/integration/all/broadlink/device-page/DeviceBox.jsx
+++ b/front/src/routes/integration/all/broadlink/device-page/DeviceBox.jsx
@@ -1,4 +1,4 @@
-import { Text, Localizer } from 'preact-i18n';
+import { Text, Localizer, MarkupText } from 'preact-i18n';
 import { Component } from 'preact';
 import cx from 'classnames';
 import { Link } from 'preact-router/match';
@@ -82,7 +82,7 @@ class DeviceBox extends Component {
                 )}
                 {tooMuchStatesError && (
                   <div class="alert alert-warning">
-                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
+                    <MarkupText id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
                   </div>
                 )}
                 <div class="form-group">

--- a/front/src/routes/integration/all/ewelink/EweLinkDeviceBox.jsx
+++ b/front/src/routes/integration/all/ewelink/EweLinkDeviceBox.jsx
@@ -2,6 +2,7 @@ import { Component } from 'preact';
 import { Text, Localizer } from 'preact-i18n';
 import cx from 'classnames';
 import { Link } from 'preact-router';
+import get from 'get-value';
 
 import { DEVICE_FIRMWARE, DEVICE_ONLINE } from '../../../../../../server/services/ewelink/lib/utils/constants';
 import DeviceFeatures from '../../../../components/device/view/DeviceFeatures';
@@ -39,21 +40,33 @@ class EweLinkDeviceBox extends Component {
   deleteDevice = async () => {
     this.setState({
       loading: true,
-      errorMessage: null
+      errorMessage: null,
+      tooMuchStatesError: false,
+      statesNumber: undefined
     });
     try {
       await this.props.deleteDevice(this.props.deviceIndex);
     } catch (e) {
-      this.setState({
-        errorMessage: 'integration.eWeLink.error.defaultDeletionError'
-      });
+      const status = get(e, 'response.status');
+      const dataMessage = get(e, 'response.data.message');
+      if (status === 400 && dataMessage && dataMessage.includes('Too much states')) {
+        const statesNumber = new Intl.NumberFormat().format(dataMessage.split(' ')[0]);
+        this.setState({ tooMuchStatesError: true, statesNumber });
+      } else {
+        this.setState({
+          errorMessage: 'integration.eWeLink.error.defaultDeletionError'
+        });
+      }
     }
     this.setState({
       loading: false
     });
   };
 
-  render({ deviceIndex, device, housesWithRooms, editable, ...props }, { loading, errorMessage }) {
+  render(
+    { deviceIndex, device, housesWithRooms, editable, ...props },
+    { loading, errorMessage, tooMuchStatesError, statesNumber }
+  ) {
     const validModel = device.features && device.features.length > 0;
     const online = device.params.find(param => param.name === DEVICE_ONLINE).value === '1';
     const firmware = device.params.find(param => param.name === DEVICE_FIRMWARE).value;
@@ -85,6 +98,11 @@ class EweLinkDeviceBox extends Component {
                 {errorMessage && (
                   <div class="alert alert-danger">
                     <Text id={errorMessage} />
+                  </div>
+                )}
+                {tooMuchStatesError && (
+                  <div class="alert alert-warning">
+                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
                   </div>
                 )}
                 <div class="form-group">

--- a/front/src/routes/integration/all/ewelink/EweLinkDeviceBox.jsx
+++ b/front/src/routes/integration/all/ewelink/EweLinkDeviceBox.jsx
@@ -1,5 +1,5 @@
 import { Component } from 'preact';
-import { Text, Localizer } from 'preact-i18n';
+import { Text, Localizer, MarkupText } from 'preact-i18n';
 import cx from 'classnames';
 import { Link } from 'preact-router';
 import get from 'get-value';
@@ -102,7 +102,7 @@ class EweLinkDeviceBox extends Component {
                 )}
                 {tooMuchStatesError && (
                   <div class="alert alert-warning">
-                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
+                    <MarkupText id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
                   </div>
                 )}
                 <div class="form-group">

--- a/front/src/routes/integration/all/mqtt/device-page/Device.jsx
+++ b/front/src/routes/integration/all/mqtt/device-page/Device.jsx
@@ -21,11 +21,18 @@ class MqttDeviceBox extends Component {
   };
 
   deleteDevice = async () => {
-    this.setState({ loading: true });
+    this.setState({ loading: true, tooMuchStatesError: false, statesNumber: undefined });
     try {
       await this.props.deleteDevice(this.props.device, this.props.deviceIndex);
     } catch (e) {
-      this.setState({ error: RequestStatus.Error });
+      const status = get(e, 'response.status');
+      const dataMessage = get(e, 'response.data.message');
+      if (status === 400 && dataMessage && dataMessage.includes('Too much states')) {
+        const statesNumber = new Intl.NumberFormat().format(dataMessage.split(' ')[0]);
+        this.setState({ tooMuchStatesError: true, statesNumber });
+      } else {
+        this.setState({ error: RequestStatus.Error });
+      }
     }
     this.setState({ loading: false });
   };
@@ -50,7 +57,7 @@ class MqttDeviceBox extends Component {
     };
   };
 
-  render(props, { loading }) {
+  render(props, { loading, tooMuchStatesError, statesNumber }) {
     const { batteryLevel, mostRecentValueAt } = this.getDeviceProperty();
     return (
       <div class="col-md-6">
@@ -71,6 +78,12 @@ class MqttDeviceBox extends Component {
             <div class="loader" />
             <div class="dimmer-content">
               <div class="card-body">
+                {tooMuchStatesError && (
+                  <div class="alert alert-warning">
+                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
+                  </div>
+                )}
+
                 <MqttDeviceForm {...props} mostRecentValueAt={mostRecentValueAt} />
 
                 <div class="form-group">

--- a/front/src/routes/integration/all/mqtt/device-page/Device.jsx
+++ b/front/src/routes/integration/all/mqtt/device-page/Device.jsx
@@ -1,4 +1,4 @@
-import { Text } from 'preact-i18n';
+import { Text, MarkupText } from 'preact-i18n';
 import { Component } from 'preact';
 import { Link } from 'preact-router/match';
 import cx from 'classnames';
@@ -80,7 +80,7 @@ class MqttDeviceBox extends Component {
               <div class="card-body">
                 {tooMuchStatesError && (
                   <div class="alert alert-warning">
-                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
+                    <MarkupText id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
                   </div>
                 )}
 

--- a/front/src/routes/integration/all/philips-hue/device-page/Device.jsx
+++ b/front/src/routes/integration/all/philips-hue/device-page/Device.jsx
@@ -1,4 +1,4 @@
-import { Text } from 'preact-i18n';
+import { Text, MarkupText } from 'preact-i18n';
 import { Component } from 'preact';
 import cx from 'classnames';
 import { RequestStatus } from '../../../../../utils/consts';
@@ -48,7 +48,7 @@ class PhilipsHueDeviceBox extends Component {
               <div class="card-body">
                 {tooMuchStatesError && (
                   <div class="alert alert-warning">
-                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
+                    <MarkupText id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
                   </div>
                 )}
                 <DeviceForm {...props} />

--- a/front/src/routes/integration/all/philips-hue/device-page/Device.jsx
+++ b/front/src/routes/integration/all/philips-hue/device-page/Device.jsx
@@ -3,6 +3,7 @@ import { Component } from 'preact';
 import cx from 'classnames';
 import { RequestStatus } from '../../../../../utils/consts';
 import DeviceForm from './DeviceForm';
+import get from 'get-value';
 
 class PhilipsHueDeviceBox extends Component {
   saveDevice = async () => {
@@ -16,16 +17,23 @@ class PhilipsHueDeviceBox extends Component {
   };
 
   deleteDevice = async () => {
-    this.setState({ loading: true });
+    this.setState({ loading: true, tooMuchStatesError: false, statesNumber: undefined });
     try {
       await this.props.deleteDevice(this.props.device, this.props.deviceIndex);
     } catch (e) {
-      this.setState({ error: RequestStatus.Error });
+      const status = get(e, 'response.status');
+      const dataMessage = get(e, 'response.data.message');
+      if (status === 400 && dataMessage && dataMessage.includes('Too much states')) {
+        const statesNumber = new Intl.NumberFormat().format(dataMessage.split(' ')[0]);
+        this.setState({ tooMuchStatesError: true, statesNumber });
+      } else {
+        this.setState({ error: RequestStatus.Error });
+      }
     }
     this.setState({ loading: false });
   };
 
-  render(props, { loading }) {
+  render(props, { loading, tooMuchStatesError, statesNumber }) {
     return (
       <div class="col-md-6">
         <div class="card">
@@ -38,6 +46,11 @@ class PhilipsHueDeviceBox extends Component {
             <div class="loader" />
             <div class="dimmer-content">
               <div class="card-body">
+                {tooMuchStatesError && (
+                  <div class="alert alert-warning">
+                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
+                  </div>
+                )}
                 <DeviceForm {...props} />
 
                 <div class="form-group">

--- a/front/src/routes/integration/all/tasmota/TasmotaDeviceBox.jsx
+++ b/front/src/routes/integration/all/tasmota/TasmotaDeviceBox.jsx
@@ -1,5 +1,5 @@
 import { Component } from 'preact';
-import { Text, Localizer } from 'preact-i18n';
+import { Text, Localizer, MarkupText } from 'preact-i18n';
 import cx from 'classnames';
 import { Link } from 'preact-router';
 import get from 'get-value';
@@ -186,7 +186,7 @@ class TasmotaDeviceBox extends Component {
                 )}
                 {tooMuchStatesError && (
                   <div class="alert alert-warning">
-                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
+                    <MarkupText id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
                   </div>
                 )}
                 <div class="form-group">

--- a/front/src/routes/integration/all/tasmota/TasmotaDeviceBox.jsx
+++ b/front/src/routes/integration/all/tasmota/TasmotaDeviceBox.jsx
@@ -2,6 +2,7 @@ import { Component } from 'preact';
 import { Text, Localizer } from 'preact-i18n';
 import cx from 'classnames';
 import { Link } from 'preact-router';
+import get from 'get-value';
 
 import DeviceFeatures from '../../../../components/device/view/DeviceFeatures';
 
@@ -46,14 +47,23 @@ class TasmotaDeviceBox extends Component {
   deleteDevice = async () => {
     this.setState({
       loading: true,
-      errorMessage: null
+      errorMessage: null,
+      tooMuchStatesError: false,
+      statesNumber: undefined
     });
     try {
       await this.props.deleteDevice(this.props.deviceIndex);
     } catch (e) {
-      this.setState({
-        errorMessage: 'integration.tasmota.error.defaultDeletionError'
-      });
+      const status = get(e, 'response.status');
+      const dataMessage = get(e, 'response.data.message');
+      if (status === 400 && dataMessage && dataMessage.includes('Too much states')) {
+        const statesNumber = new Intl.NumberFormat().format(dataMessage.split(' ')[0]);
+        this.setState({ tooMuchStatesError: true, statesNumber });
+      } else {
+        this.setState({
+          errorMessage: 'integration.tasmota.error.defaultDeletionError'
+        });
+      }
     }
     this.setState({
       loading: false
@@ -97,7 +107,10 @@ class TasmotaDeviceBox extends Component {
     });
   };
 
-  render({ deviceIndex, device, housesWithRooms, editable, ...props }, { loading, errorMessage, authErrorMessage }) {
+  render(
+    { deviceIndex, device, housesWithRooms, editable, ...props },
+    { loading, errorMessage, authErrorMessage, tooMuchStatesError, statesNumber }
+  ) {
     const validModel = device.features.length > 0 || device.needAuthentication;
     // default value is 'mqtt'
     const deviceProtocol = ((device.params || []).find(p => p.name === 'protocol') || { value: 'mqtt' }).value;
@@ -169,6 +182,11 @@ class TasmotaDeviceBox extends Component {
                 {errorMessage && (
                   <div class="alert alert-danger">
                     <Text id={errorMessage} />
+                  </div>
+                )}
+                {tooMuchStatesError && (
+                  <div class="alert alert-warning">
+                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
                   </div>
                 )}
                 <div class="form-group">

--- a/front/src/routes/integration/all/tp-link/device-page/Device.jsx
+++ b/front/src/routes/integration/all/tp-link/device-page/Device.jsx
@@ -1,4 +1,4 @@
-import { Text } from 'preact-i18n';
+import { Text, MarkupText } from 'preact-i18n';
 import { Component } from 'preact';
 import cx from 'classnames';
 import get from 'get-value';
@@ -55,7 +55,7 @@ class TpLinkDeviceBox extends Component {
               <div class="card-body">
                 {tooMuchStatesError && (
                   <div class="alert alert-warning">
-                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
+                    <MarkupText id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
                   </div>
                 )}
 

--- a/front/src/routes/integration/all/tp-link/device-page/Device.jsx
+++ b/front/src/routes/integration/all/tp-link/device-page/Device.jsx
@@ -1,6 +1,8 @@
 import { Text } from 'preact-i18n';
 import { Component } from 'preact';
 import cx from 'classnames';
+import get from 'get-value';
+
 import { RequestStatus } from '../../../../../utils/consts';
 import DeviceForm from './DeviceForm';
 
@@ -16,16 +18,29 @@ class TpLinkDeviceBox extends Component {
   };
 
   deleteDevice = async () => {
-    this.setState({ loading: true, saveError: null, deleteError: null });
+    this.setState({
+      loading: true,
+      saveError: null,
+      deleteError: null,
+      tooMuchStatesError: false,
+      statesNumber: undefined
+    });
     try {
       await this.props.deleteDevice(this.props.device, this.props.deviceIndex);
     } catch (e) {
-      this.setState({ deleteError: RequestStatus.Error });
+      const status = get(e, 'response.status');
+      const dataMessage = get(e, 'response.data.message');
+      if (status === 400 && dataMessage && dataMessage.includes('Too much states')) {
+        const statesNumber = new Intl.NumberFormat().format(dataMessage.split(' ')[0]);
+        this.setState({ tooMuchStatesError: true, statesNumber });
+      } else {
+        this.setState({ deleteError: RequestStatus.Error });
+      }
     }
     this.setState({ loading: false });
   };
 
-  render(props, { loading, saveError, deleteError }) {
+  render(props, { loading, saveError, deleteError, tooMuchStatesError, statesNumber }) {
     return (
       <div class="col-md-6">
         <div class="card">
@@ -38,6 +53,12 @@ class TpLinkDeviceBox extends Component {
             <div class="loader" />
             <div class="dimmer-content">
               <div class="card-body">
+                {tooMuchStatesError && (
+                  <div class="alert alert-warning">
+                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
+                  </div>
+                )}
+
                 <DeviceForm {...props} />
 
                 <div class="form-group">

--- a/front/src/routes/integration/all/xiaomi/Device.jsx
+++ b/front/src/routes/integration/all/xiaomi/Device.jsx
@@ -1,4 +1,4 @@
-import { Text } from 'preact-i18n';
+import { Text, MarkupText } from 'preact-i18n';
 import { Component } from 'preact';
 import { Link } from 'preact-router/match';
 import cx from 'classnames';
@@ -93,7 +93,7 @@ class XiaomiDeviceBox extends Component {
               <div class="card-body">
                 {tooMuchStatesError && (
                   <div class="alert alert-warning">
-                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
+                    <MarkupText id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
                   </div>
                 )}
                 <div class="form-group">

--- a/front/src/routes/integration/all/xiaomi/Device.jsx
+++ b/front/src/routes/integration/all/xiaomi/Device.jsx
@@ -42,11 +42,18 @@ class XiaomiDeviceBox extends Component {
     this.setState({ loading: false });
   };
   deleteDevice = async () => {
-    this.setState({ loading: true });
+    this.setState({ loading: true, tooMuchStatesError: false, statesNumber: undefined });
     try {
       await this.props.deleteDevice(this.props.device, this.props.deviceIndex);
     } catch (e) {
-      this.setState({ error: RequestStatus.Error });
+      const status = get(e, 'response.status');
+      const dataMessage = get(e, 'response.data.message');
+      if (status === 400 && dataMessage && dataMessage.includes('Too much states')) {
+        const statesNumber = new Intl.NumberFormat().format(dataMessage.split(' ')[0]);
+        this.setState({ tooMuchStatesError: true, statesNumber });
+      } else {
+        this.setState({ error: RequestStatus.Error });
+      }
     }
     this.setState({ loading: false });
   };
@@ -64,7 +71,7 @@ class XiaomiDeviceBox extends Component {
     this.refreshDeviceProperty();
   }
 
-  render(props, { batteryLevel, loading }) {
+  render(props, { batteryLevel, loading, tooMuchStatesError, statesNumber }) {
     return (
       <div class="col-md-4">
         <div class="card">
@@ -84,6 +91,11 @@ class XiaomiDeviceBox extends Component {
             <div class="loader" />
             <div class="dimmer-content">
               <div class="card-body">
+                {tooMuchStatesError && (
+                  <div class="alert alert-warning">
+                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
+                  </div>
+                )}
                 <div class="form-group">
                   <label>
                     <Text id="integration.xiaomi.device.sidLabel" />

--- a/front/src/routes/integration/all/zigbee2mqtt/device-page/Zigbee2mqttBox.jsx
+++ b/front/src/routes/integration/all/zigbee2mqtt/device-page/Zigbee2mqttBox.jsx
@@ -2,6 +2,7 @@ import { Text, Localizer } from 'preact-i18n';
 import { Component } from 'preact';
 import cx from 'classnames';
 import { Link } from 'preact-router/match';
+import get from 'get-value';
 
 import { RequestStatus } from '../../../../../utils/consts';
 import DeviceFeatures from '../../../../../components/device/view/DeviceFeatures';
@@ -55,21 +56,30 @@ class Zigbee2mqttBox extends Component {
 
   deleteDevice = async () => {
     this.setState({
-      loading: true
+      loading: true,
+      tooMuchStatesError: false,
+      statesNumber: undefined
     });
     try {
       await this.props.deleteDevice(this.props.deviceIndex);
     } catch (e) {
-      this.setState({
-        deleteError: RequestStatus.Error
-      });
+      const status = get(e, 'response.status');
+      const dataMessage = get(e, 'response.data.message');
+      if (status === 400 && dataMessage && dataMessage.includes('Too much states')) {
+        const statesNumber = new Intl.NumberFormat().format(dataMessage.split(' ')[0]);
+        this.setState({ tooMuchStatesError: true, statesNumber });
+      } else {
+        this.setState({
+          deleteError: RequestStatus.Error
+        });
+      }
     }
     this.setState({
       loading: false
     });
   };
 
-  render(props, { loading, saveError }) {
+  render(props, { loading, saveError, tooMuchStatesError, statesNumber }) {
     return (
       <div class="col-md-6">
         <div class="card">
@@ -84,6 +94,11 @@ class Zigbee2mqttBox extends Component {
                 {saveError && (
                   <div class="alert alert-danger">
                     <Text id="integration.zigbee2mqtt.saveError" />
+                  </div>
+                )}
+                {tooMuchStatesError && (
+                  <div class="alert alert-warning">
+                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
                   </div>
                 )}
                 <div class="form-group">

--- a/front/src/routes/integration/all/zigbee2mqtt/device-page/Zigbee2mqttBox.jsx
+++ b/front/src/routes/integration/all/zigbee2mqtt/device-page/Zigbee2mqttBox.jsx
@@ -1,4 +1,4 @@
-import { Text, Localizer } from 'preact-i18n';
+import { Text, Localizer, MarkupText } from 'preact-i18n';
 import { Component } from 'preact';
 import cx from 'classnames';
 import { Link } from 'preact-router/match';
@@ -98,7 +98,7 @@ class Zigbee2mqttBox extends Component {
                 )}
                 {tooMuchStatesError && (
                   <div class="alert alert-warning">
-                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
+                    <MarkupText id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
                   </div>
                 )}
                 <div class="form-group">

--- a/front/src/routes/integration/all/zwave/node-page/Device.jsx
+++ b/front/src/routes/integration/all/zwave/node-page/Device.jsx
@@ -1,4 +1,4 @@
-import { Text, Localizer } from 'preact-i18n';
+import { Text, Localizer, MarkupText } from 'preact-i18n';
 import { Component } from 'preact';
 import cx from 'classnames';
 import get from 'get-value';
@@ -104,7 +104,7 @@ class ZWaveDeviceBox extends Component {
               <div class="card-body">
                 {tooMuchStatesError && (
                   <div class="alert alert-warning">
-                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
+                    <MarkupText id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
                   </div>
                 )}
                 <div class="form-group">

--- a/front/src/routes/integration/all/zwave/node-page/Device.jsx
+++ b/front/src/routes/integration/all/zwave/node-page/Device.jsx
@@ -43,11 +43,18 @@ class ZWaveDeviceBox extends Component {
     this.setState({ loading: false });
   };
   deleteDevice = async () => {
-    this.setState({ loading: true });
+    this.setState({ loading: true, tooMuchStatesError: false, statesNumber: undefined });
     try {
       await this.props.deleteDevice(this.props.device, this.props.deviceIndex);
     } catch (e) {
-      this.setState({ error: RequestStatus.Error });
+      const status = get(e, 'response.status');
+      const dataMessage = get(e, 'response.data.message');
+      if (status === 400 && dataMessage && dataMessage.includes('Too much states')) {
+        const statesNumber = new Intl.NumberFormat().format(dataMessage.split(' ')[0]);
+        this.setState({ tooMuchStatesError: true, statesNumber });
+      } else {
+        this.setState({ error: RequestStatus.Error });
+      }
     }
     this.setState({ loading: false });
   };
@@ -75,7 +82,7 @@ class ZWaveDeviceBox extends Component {
     this.refreshDeviceProperty();
   }
 
-  render(props, { batteryLevel, mostRecentValueAt, loading }) {
+  render(props, { batteryLevel, mostRecentValueAt, loading, tooMuchStatesError, statesNumber }) {
     return (
       <div class="col-md-6">
         <div class="card">
@@ -95,6 +102,11 @@ class ZWaveDeviceBox extends Component {
             <div class="loader" />
             <div class="dimmer-content">
               <div class="card-body">
+                {tooMuchStatesError && (
+                  <div class="alert alert-warning">
+                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
+                  </div>
+                )}
                 <div class="form-group">
                   <label>
                     <Text id="integration.zwave.device.nameLabel" />

--- a/server/lib/device/index.js
+++ b/server/lib/device/index.js
@@ -52,6 +52,7 @@ const DeviceManager = function DeviceManager(
 
   this.STATES_TO_PURGE_PER_DEVICE_FEATURE_CLEAN_BATCH = 1000;
   this.WAIT_TIME_BETWEEN_DEVICE_FEATURE_CLEAN_BATCH = 100;
+  this.MAX_NUMBER_OF_STATES_ALLOWED_TO_DELETE_DEVICE = 5000;
 
   // initialize all types of device feature categories
   this.camera = new CameraManager(this.stateManager, messageManager, eventManager, this);

--- a/server/test/lib/device/device.destroy.test.js
+++ b/server/test/lib/device/device.destroy.test.js
@@ -1,9 +1,12 @@
 const EventEmitter = require('events');
 const { assert } = require('chai');
+const { fake, assert: sinonAssert } = require('sinon');
 const Device = require('../../../lib/device');
 const StateManager = require('../../../lib/state');
 const ServiceManager = require('../../../lib/service');
 const Job = require('../../../lib/job');
+const db = require('../../../models');
+const { EVENTS } = require('../../../utils/constants');
 
 const event = new EventEmitter();
 const job = new Job(event);
@@ -19,6 +22,61 @@ describe('Device.destroy', () => {
       },
     ];
     await device.destroy('test-device');
+  });
+  it('should destroy device that has too much states', async () => {
+    const eventFake = {
+      emit: fake.returns(0),
+      on: fake.returns(0),
+    };
+    const stateManager = new StateManager(event);
+    const serviceManager = new ServiceManager({}, stateManager);
+    const device = new Device(eventFake, {}, stateManager, serviceManager, {}, {}, job);
+    device.MAX_NUMBER_OF_STATES_ALLOWED_TO_DELETE_DEVICE = 2;
+    device.devicesByPollFrequency[60000] = [
+      {
+        selector: 'test-device',
+      },
+    ];
+    await db.DeviceFeatureState.create({
+      value: 10,
+      device_feature_id: 'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4',
+    });
+    await db.DeviceFeatureState.create({
+      value: 10,
+      device_feature_id: 'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4',
+    });
+    await db.DeviceFeatureStateAggregate.create({
+      value: 10,
+      type: 'daily',
+      device_feature_id: 'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4',
+    });
+    const promise = device.destroy('test-device');
+    await assert.isRejected(promise, '3 states in DB. Too much states!');
+    sinonAssert.calledWith(
+      eventFake.emit,
+      EVENTS.DEVICE.PURGE_STATES_SINGLE_FEATURE,
+      'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4',
+    );
+    sinonAssert.calledWith(
+      eventFake.emit,
+      EVENTS.DEVICE.PURGE_STATES_SINGLE_FEATURE,
+      'ce9dc798-b09f-4e51-8c16-311cdebf97cd',
+    );
+    sinonAssert.calledWith(
+      eventFake.emit,
+      EVENTS.DEVICE.PURGE_STATES_SINGLE_FEATURE,
+      'bb1af3b9-f87d-4d9c-b5be-958cd9d28900',
+    );
+    sinonAssert.calledWith(
+      eventFake.emit,
+      EVENTS.DEVICE.PURGE_STATES_SINGLE_FEATURE,
+      'f07c5b27-9301-4482-a059-9f91329d30e7',
+    );
+    sinonAssert.calledWith(
+      eventFake.emit,
+      EVENTS.DEVICE.PURGE_STATES_SINGLE_FEATURE,
+      '3b5b4870-145d-4584-bf0e-d97fdcf908b5',
+    );
   });
   it('should return device not found', async () => {
     const stateManager = new StateManager(event);


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.
- [x] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [x] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

<img width="1512" alt="Screenshot 2022-10-14 at 11 57 50" src="https://user-images.githubusercontent.com/7365207/195765766-7e075905-14a3-48e9-99a0-69eb73917388.png">

