### PR TITLE
Increase beforeEach performance to reduce server tests execution time

### DIFF
--- a/server/test/helpers/db.test.js
+++ b/server/test/helpers/db.test.js
@@ -9,15 +9,21 @@ const files = readdirSync(SEEDERS_PATH);
 const seeds = files.map((file) => require(join(SEEDERS_PATH, file))); // eslint-disable-line
 const reversedSeed = seeds.slice().reverse();
 
-const callLater = () =>
-  new Promise((resolve) => {
-    setTimeout(resolve, 10);
+const seedDb = async () => {
+  const queryInterface = db.sequelize.getQueryInterface();
+  await Promise.each(seeds, async (seed) => {
+    await seed.up(queryInterface);
   });
-
-module.exports.seedDb = async () => {
-  await Promise.mapSeries(seeds, (seed) => callLater().then(() => seed.up(db.sequelize.getQueryInterface())));
 };
 
-module.exports.cleanDb = async () => {
-  await Promise.mapSeries(reversedSeed, (seed) => callLater().then(() => seed.down(db.sequelize.getQueryInterface())));
+const cleanDb = async () => {
+  const queryInterface = db.sequelize.getQueryInterface();
+  await Promise.each(reversedSeed, async (seed) => {
+    await seed.down(queryInterface);
+  });
+};
+
+module.exports = {
+  seedDb,
+  cleanDb,
 };


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)


### Description of change

Just realized a way to massively increase server test speed my reducing the time spent in beforeEach from 500ms to... 20ms! 