### PR TITLE
Fix autocomplete on trigger select

### DIFF
--- a/front/src/routes/scene/edit-scene/triggers/ChooseTriggerTypeCard.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/ChooseTriggerTypeCard.jsx
@@ -4,6 +4,8 @@ import { Text } from 'preact-i18n';
 import Select from 'react-select';
 
 import { EVENTS } from '../../../../../../server/utils/constants';
+import withIntlAsProp from '../../../../utils/withIntlAsProp';
+import get from 'get-value';
 
 const TRIGGER_LIST = [
   EVENTS.DEVICE.NEW_STATE,
@@ -21,9 +23,6 @@ const TRIGGER_LIST = [
 
 @connect('httpClient', {})
 class ChooseTriggerType extends Component {
-  state = {
-    currentTrigger: null
-  };
   handleChange = selectedOption => {
     if (selectedOption) {
       this.setState({
@@ -40,7 +39,24 @@ class ChooseTriggerType extends Component {
       this.props.updateTriggerProperty(this.props.index, 'type', this.state.currentTrigger.value);
     }
   };
-  render(props, { currentTrigger }) {
+
+  constructor(props) {
+    super(props);
+
+    const options = TRIGGER_LIST.map(trigger => {
+      return {
+        value: trigger,
+        label: get(props.intl.dictionary, `editScene.triggers.${trigger}`, { default: trigger })
+      };
+    });
+
+    this.state = {
+      options,
+      currentTrigger: null
+    };
+  }
+
+  render(props, { currentTrigger, options }) {
     return (
       <div>
         <div class="form-group">
@@ -50,10 +66,7 @@ class ChooseTriggerType extends Component {
           <Select
             class="choose-scene-trigger-type"
             value={currentTrigger}
-            options={TRIGGER_LIST.map(trigger => ({
-              value: trigger,
-              label: <Text id={`editScene.triggers.${trigger}`} />
-            }))}
+            options={options}
             onChange={this.handleChange}
           />
         </div>
@@ -67,4 +80,4 @@ class ChooseTriggerType extends Component {
   }
 }
 
-export default ChooseTriggerType;
+export default withIntlAsProp(ChooseTriggerType);


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- ~~[ ] If your changes affects code, did your write the tests?~~
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- ~~[ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)~~
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.
- ~~[ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~~
- ~~[ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).~~
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Fix autcomplete in select field (both languages).

I think we have to think about upgrading `react-select` dependency.

Fixes #1567 
