### PR TITLE
Add promise/prefer-await-to-then eslint rule

### DIFF
--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -8,12 +8,13 @@
     "jest/expect-expect": "off",
     "jest/valid-expect": "off",
     "no-async-promise-executor": "off",
-    "react/jsx-key": "off"
+    "react/jsx-key": "off",
+    "promise/prefer-await-to-then": "warn"
   },
   "env": {
     "browser": true
   },
-  "plugins": ["json", "cypress"],
+  "plugins": ["json", "cypress", "promise"],
   "parserOptions": {
     "ecmaFeatures": {
       "jsx": true

--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -22,5 +22,13 @@
   },
   "settings": {
     "targets": null
-  }
+  },
+  "overrides": [
+    {
+      "files": ["cypress/**/*.js"],
+      "rules": {
+        "promise/prefer-await-to-then": "off"
+      }
+    }
+  ]
 }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -46,6 +46,7 @@
         "eslint-plugin-compat": "^4.0.2",
         "eslint-plugin-cypress": "^2.12.1",
         "eslint-plugin-json": "^3.1.0",
+        "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-react": "^7.29.4",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^21.2.1",
@@ -13323,6 +13324,18 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "node_modules/eslint-plugin-promise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
+      "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.29.4",
@@ -44125,6 +44138,13 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-promise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
+      "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-react": {
       "version": "7.29.4",

--- a/front/package.json
+++ b/front/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-compat": "^4.0.2",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-json": "^3.1.0",
+    "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react": "^7.29.4",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^21.2.1",

--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["jsdoc", "require-jsdoc", "no-call", "mocha"],
+  "plugins": ["jsdoc", "require-jsdoc", "no-call", "mocha", "promise"],
   "extends": ["airbnb-base", "plugin:jsdoc/recommended", "prettier"],
   "parserOptions": {
     "ecmaVersion": 2018
@@ -130,7 +130,8 @@
     "max-classes-per-file": "off",
     "import/no-import-module-exports": "off",
     "import/no-relative-packages": "off",
-    "default-param-last": "warn"
+    "default-param-last": "warn",
+    "promise/prefer-await-to-then": "warn"
   },
   "overrides": [
     {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -58,6 +58,7 @@
         "eslint-plugin-jsdoc": "^4.1.0",
         "eslint-plugin-mocha": "^10.1.0",
         "eslint-plugin-no-call": "^1.2.5",
+        "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-require-jsdoc": "^1.0.4",
         "jsdoc": "^3.6.10",
         "mocha": "^8.3.2",
@@ -4548,6 +4549,18 @@
       },
       "engines": {
         "node": ">=6.12.2"
+      }
+    },
+    "node_modules/eslint-plugin-promise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
+      "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -15322,6 +15335,13 @@
       "requires": {
         "requireindex": "1.2.0"
       }
+    },
+    "eslint-plugin-promise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
+      "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-react": {
       "version": "7.31.11",

--- a/server/package.json
+++ b/server/package.json
@@ -58,6 +58,7 @@
     "eslint-plugin-jsdoc": "^4.1.0",
     "eslint-plugin-mocha": "^10.1.0",
     "eslint-plugin-no-call": "^1.2.5",
+    "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-require-jsdoc": "^1.0.4",
     "jsdoc": "^3.6.10",
     "mocha": "^8.3.2",


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)

### Description of change

The goal is to recommend using async/await, and stop doing chains of Promises like Promise.then().then().then(), expect in Cypress code.

https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/prefer-await-to-then.md