### PR TITLE
feat(ecowatt): Add day in box display

### DIFF
--- a/front/src/components/boxs/ecowatt/Ecowatt.jsx
+++ b/front/src/components/boxs/ecowatt/Ecowatt.jsx
@@ -117,7 +117,7 @@ class Ecowatt extends Component {
         days.push({
           day: dayjs(day.jour)
             .locale(this.props.user.language)
-            .format('LL'),
+            .format('ddd LL'),
           data: day.dvalue
         });
       });


### PR DESCRIPTION
<img width="478" alt="CleanShot 2023-01-13 at 22 19 38@2x" src="https://user-images.githubusercontent.com/1773153/212421226-a1492964-dd78-4e34-a5ac-58c2d7e4905a.png">

DayJS proposes only 3 formats for day:
- d => day in number, not relevant
- dd => day on two letters
- ddd => day on three letters

With the available space, I thought that last format was the best