### PR TITLE
CI Fix - Use buildx v0.9.1

### DIFF
--- a/.github/workflows/docker-release-build.yml
+++ b/.github/workflows/docker-release-build.yml
@@ -138,7 +138,7 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
         with:
-          version: latest
+          version: v0.9.1
       - name: ↙️ Download build artifact
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Manifest format have changed.

This PR is a temp workaround. Tested on https://github.com/VonOx/gh-test-ci/actions/runs/3932286856/jobs/6724798626

Related to https://github.com/moby/moby/issues/43126
