### PR TITLE
fix(front): Fix NaN dates display in Tasks list

### DIFF
--- a/front/src/routes/settings/settings-background-jobs/index.js
+++ b/front/src/routes/settings/settings-background-jobs/index.js
@@ -8,10 +8,20 @@ import { WEBSOCKET_MESSAGE_TYPES } from '../../../../../server/utils/constants';
 const NUMBER_OF_JOBS_PER_PAGE = 15;
 
 class SettingsSystem extends Component {
+  /*
+   * Function to replace "2023-01-23 14:20:23.594 +00:00" by "2023-01-23T14:20:23.594+00:00"
+   * to be Firefox compatible (ISO8601)
+   */
+  convertGladysDateToISO8601 = gladysDate => {
+    return gladysDate.replace(' ', 'T').replace(' ', '');
+  };
+
   getJobs = async page => {
     try {
       const skip = page * NUMBER_OF_JOBS_PER_PAGE;
       const jobs = await this.props.httpClient.get(`/api/v1/job?take=${NUMBER_OF_JOBS_PER_PAGE}&skip=${skip}`);
+
+      jobs.forEach(job => (job.created_at = this.convertGladysDateToISO8601(job.created_at)));
 
       this.setState({
         jobs,
@@ -46,6 +56,7 @@ class SettingsSystem extends Component {
     const { jobs, currentPage } = this.state;
     // only add jobs to page if we are at the first page
     if (currentPage === 0) {
+      payload.created_at = this.convertGladysDateToISO8601(payload.created_at);
       jobs.unshift(payload);
       this.setState({
         jobs
@@ -57,6 +68,7 @@ class SettingsSystem extends Component {
     const { jobs } = this.state;
     const previousJobIndex = jobs.findIndex(j => j.id === payload.id);
     if (previousJobIndex !== -1) {
+      payload.created_at = this.convertGladysDateToISO8601(payload.created_at);
       jobs[previousJobIndex] = payload;
       this.setState({
         jobs


### PR DESCRIPTION
The idea is to transform created_at format to be in ISO8601 (compatible Firefox)

I took the `text` approach. To my opinion, better than using a Date library.
Seems not possible with Date object in Javascript 😞 

Still working on Chrome/Safari ✅ 

https://community.gladysassistant.com/t/affichage-en-nan-des-dates-dans-longlet-taches-en-arriere-plan/7784/12?u=cicoub13

![CleanShot 2023-01-23 at 15 38 36](https://user-images.githubusercontent.com/1773153/214066843-c68b3e39-cc1c-4b42-8c32-7634205cce2f.png)
