### PR TITLE
Gladys Plus: add confirm button before upgrading to yearly

### DIFF
--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -2334,6 +2334,8 @@
     "monthlyPlan": "You are currently using the monthly plan. If you want to switch to the annual plan (99.99€/year), you can click on the button below. The first payment will be prorated based on your current month.",
     "yearlyPlan": "You are currently on the annual plan.",
     "upgradeToYearly": "Switch to annual plan",
+    "confirmUpgradeToYearly": "Confirm switching to annual plan? Your payment method will be charged.",
+    "cancelUpgradeToYearly": "Cancel",
     "upgradeYearlyError": "An error occured while switching to the annual plan, please contact us by email.",
     "upgradeYearlySuccess": "Thanks for switching to the annual plan!"
   }

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -2334,6 +2334,8 @@
     "monthlyPlan": "Vous êtes actuellement en paiement mensuel. Si vous souhaitez passer au plan annuel ( 99.99€/an ), vous pouvez cliquer sur le bouton ci-dessous. Si vous êtes en cours d'un mois, le prix du premier paiement annuel sera fait au pro-rata pour vous éviter de payer plusieurs fois le mois en cours !",
     "yearlyPlan": "Vous êtes actuellement en paiement annuel.",
     "upgradeToYearly": "Passer au plan annuel",
+    "confirmUpgradeToYearly": "Confirmer le passage au plan annuel ? Votre moyen de paiement sera débité.",
+    "cancelUpgradeToYearly": "Annuler",
     "upgradeYearlyError": "Une erreur est survenue lors de la mise à jour vers le plan annuel, merci de nous contacter par email ou sur le forum.",
     "upgradeYearlySuccess": "Merci d'être passé au plan annuel !"
   }

--- a/front/src/routes/settings/settings-billing/GatewayBilling.jsx
+++ b/front/src/routes/settings/settings-billing/GatewayBilling.jsx
@@ -45,9 +45,23 @@ const Billing = ({ children, ...props }) => (
                   {props.plan === 'monthly' && <Text id="gatewayBilling.monthlyPlan" />}
                 </p>
                 {props.plan === 'monthly' && (
-                  <button class="btn btn-success mr-2" onClick={props.upgradeMonthlyToYearly}>
-                    <Text id="gatewayBilling.upgradeToYearly" />
-                  </button>
+                  <div>
+                    {!props.confirmUpgrade && (
+                      <button class="btn btn-success mr-2" onClick={props.wantYearlyUpgrade}>
+                        <Text id="gatewayBilling.upgradeToYearly" />
+                      </button>
+                    )}
+                    {props.confirmUpgrade && (
+                      <button class="btn btn-success mr-2" onClick={props.upgradeMonthlyToYearly}>
+                        <Text id="gatewayBilling.confirmUpgradeToYearly" />
+                      </button>
+                    )}
+                    {props.confirmUpgrade && (
+                      <button class="btn btn-danger mr-2" onClick={props.cancelYearlyUpgrade}>
+                        <Text id="gatewayBilling.cancelUpgradeToYearly" />
+                      </button>
+                    )}
+                  </div>
                 )}
               </div>
             </div>

--- a/front/src/routes/settings/settings-billing/index.js
+++ b/front/src/routes/settings/settings-billing/index.js
@@ -24,6 +24,16 @@ class SettingsBilling extends Component {
       console.error(e);
     }
   };
+  wantYearlyUpgrade = () => {
+    this.setState({
+      confirmUpgrade: true
+    });
+  };
+  cancelYearlyUpgrade = () => {
+    this.setState({
+      confirmUpgrade: false
+    });
+  };
   upgradeMonthlyToYearly = async () => {
     try {
       await this.setState({ upgradeYearlyError: false, loading: true });
@@ -34,7 +44,7 @@ class SettingsBilling extends Component {
       console.error(e);
     }
     await this.getCurrentPlan();
-    await this.setState({ loading: false });
+    await this.setState({ loading: false, confirmUpgrade: false });
   };
   openStripeBilling = async () => {
     window.open(
@@ -47,7 +57,7 @@ class SettingsBilling extends Component {
     this.getCurrentPlan();
   }
 
-  render(props, { loading, upgradeYearlyError, plan, upgradeYearlySuccess }) {
+  render(props, { loading, upgradeYearlyError, plan, upgradeYearlySuccess, confirmUpgrade }) {
     return (
       <SettingsLayout>
         <GatewayBilling
@@ -57,6 +67,9 @@ class SettingsBilling extends Component {
           loading={loading}
           upgradeYearlyError={upgradeYearlyError}
           upgradeYearlySuccess={upgradeYearlySuccess}
+          confirmUpgrade={confirmUpgrade}
+          wantYearlyUpgrade={this.wantYearlyUpgrade}
+          cancelYearlyUpgrade={this.cancelYearlyUpgrade}
           plan={plan}
         />
       </SettingsLayout>


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.

### Description of change

<img width="907" alt="Screenshot 2023-01-27 at 10 21 36" src="https://user-images.githubusercontent.com/7365207/215003301-440172dc-7e1d-41be-9575-e17e2ce4b450.png">
then: 
<img width="910" alt="Screenshot 2023-01-27 at 10 21 40" src="https://user-images.githubusercontent.com/7365207/215003309-338fa489-41a8-46d0-b582-ea846cdc7943.png">
