### PR TITLE
Clean eslint default parameter order warning

### DIFF
--- a/server/services/zigbee2mqtt/utils/features/buildFeatures.js
+++ b/server/services/zigbee2mqtt/utils/features/buildFeatures.js
@@ -10,7 +10,7 @@ const { completeFeature } = require('./completeFeature');
  *
  * @example buildByParentType({ switch: {}, light: {}}, 'light');
  */
-function buildByParentType(types = {}, parentType) {
+function buildByParentType(types, parentType) {
   return types[parentType];
 }
 
@@ -24,7 +24,7 @@ function buildByParentType(types = {}, parentType) {
  *
  * @example buildByName({ state: {}}, 'state', 'light');
  */
-function buildByName(names = {}, name, parentType) {
+function buildByName(names, name, parentType) {
   const { types = {}, feature } = names[name] || {};
   const byType = buildByParentType(types, parentType);
 
@@ -44,7 +44,7 @@ function buildByName(names = {}, name, parentType) {
  *
  * @example buildFeature('MyDevice', {}, 'light');
  */
-function buildFeatures(deviceName, expose = {}, parentType) {
+function buildFeatures(deviceName, expose, parentType) {
   const { type, name, property, access, value_min: minValue, value_max: maxValue, unit: deviceUnit, values } = expose;
   const { names = {}, feature, getFeatureIndexes = () => [''] } = exposesMap[type] || {};
   const byName = buildByName(names, name, parentType);

--- a/server/test/services/zigbee2mqtt/utils/feature/buildFeatures.test.js
+++ b/server/test/services/zigbee2mqtt/utils/feature/buildFeatures.test.js
@@ -8,7 +8,7 @@ const {
 
 describe('zigbee2mqtt buildByParentType', () => {
   it(`no type map`, () => {
-    const result = buildByParentType(undefined, undefined);
+    const result = buildByParentType({}, undefined);
     expect(result).eq(undefined);
   });
 
@@ -31,7 +31,7 @@ describe('zigbee2mqtt buildByParentType', () => {
 
 describe('zigbee2mqtt buildByName', () => {
   it(`all empty`, () => {
-    const result = buildByName(undefined, 'binary', 'light');
+    const result = buildByName({}, 'binary', 'light');
     expect(result).eq(undefined);
   });
 
@@ -71,7 +71,7 @@ describe('zigbee2mqtt buildByName', () => {
 
 describe('zigbee2mqtt buildFeature', () => {
   it(`no data`, () => {
-    const result = buildFeatures('deviceName', undefined, undefined);
+    const result = buildFeatures('deviceName', {}, undefined);
     expect(result).deep.eq([]);
   });
 


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- ~~[ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)~~
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.
- ~~[ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~~
- ~~[ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- ~~[ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).~~

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Clean warnings on build time.

```
/home/alex/Gladys/server/services/zigbee2mqtt/utils/features/buildFeatures.js
  13:28  warning  Default parameters should be last  default-param-last
  27:22  warning  Default parameters should be last  default-param-last
  47:36  warning  Default parameters should be last  default-param-last
```