### PR TITLE
feat(gateway): Improve Gladys Plus login experience

### DIFF
--- a/front/src/actions/login/loginGateway.js
+++ b/front/src/actions/login/loginGateway.js
@@ -138,6 +138,10 @@ function createActions(store) {
       store.setState({
         gatewayLoginTwoFactorCode: e.target.value
       });
+      if (e.target.value.length === 6) {
+        const upToDateState = store.getState();
+        actions.loginTwoFactor(upToDateState, e);
+      }
     }
   };
   return actions;

--- a/front/src/components/gateway/GatewayLoginForm.jsx
+++ b/front/src/components/gateway/GatewayLoginForm.jsx
@@ -71,12 +71,6 @@ const GatewayLoginForm = ({ children, ...props }) => (
             <div class="form-group">
               <label class="form-label">
                 <Text id="gatewayLogin.passwordLabel" />
-                <a
-                  href={props.external_forgot_password ? EXTERNAL_FORGOT_PASSWORD_LINK : '/forgot-password'}
-                  class="float-right small"
-                >
-                  <Text id="gatewayLogin.forgotPasswordLabel" />
-                </a>
               </label>
               <Localizer>
                 <input
@@ -101,6 +95,7 @@ const GatewayLoginForm = ({ children, ...props }) => (
                   placeholder={<Text id="gatewayLogin.twoFactorCodePlaceholder" />}
                   value={props.gatewayLoginTwoFactorCode}
                   onInput={props.updateLoginTwoFactorCode}
+                  autofocus
                 />
               </Localizer>
               <div class="invalid-feedback">
@@ -129,6 +124,14 @@ const GatewayLoginForm = ({ children, ...props }) => (
               </button>
             )}
           </div>
+          {!props.gatewayLoginStep2 && (
+            <a
+              href={props.external_forgot_password ? EXTERNAL_FORGOT_PASSWORD_LINK : '/forgot-password'}
+              class="float-right small mt-2"
+            >
+              <Text id="gatewayLogin.forgotPasswordLabel" />
+            </a>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
I want to propose three improvements on Gladys Plus (gateway) login:
- Autofocus on code input for second step of the login
- Autosubmit form when the 6 digits are filled by User
- Move Forget password below `Connexion` button (like on local login)

For example, Github is proposing this way of working.

Tested and working locally