### PR TITLE
Gladys Plus: Display error message when local user is not accepted

### DIFF
--- a/front/src/actions/gatewayLinkUser.js
+++ b/front/src/actions/gatewayLinkUser.js
@@ -31,11 +31,6 @@ function createActions(store) {
           });
         }
       }
-    },
-    async saveUser(state, userId) {
-      await state.session.gatewayClient.updateUserIdInGladys(userId);
-      // hard redirect, to reload websocket connection
-      window.location = '/dashboard';
     }
   };
   return actions;

--- a/front/src/routes/gateway-setup/index.js
+++ b/front/src/routes/gateway-setup/index.js
@@ -2,10 +2,8 @@ import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import LinkGatewayUserPage from './LinkGatewayUser';
 import actions from '../../actions/gatewayLinkUser';
-import { route } from 'preact-router';
 import { RequestStatus } from '../../utils/consts';
 
-@connect('users,usersGetStatus,session', actions)
 class LinkGatewayUser extends Component {
   getSetupState = async () => {
     await this.setState({ loading: true });
@@ -28,13 +26,15 @@ class LinkGatewayUser extends Component {
   saveUser = async () => {
     this.setState({ savingUserLoading: true });
     try {
-      await this.props.saveUser(this.state.selectedUser);
-      this.setState({ savingUserLoading: false });
-      route('/dashboard');
+      await this.props.session.gatewayClient.updateUserIdInGladys(this.state.selectedUser);
+      await this.props.httpClient.get('/api/v1/me');
+      // hard redirect, to reload websocket connection
+      window.location = '/dashboard';
     } catch (e) {
       console.error(e);
-      this.setState({ savingUserLoading: false, error: true });
+      this.setState({ error: true });
     }
+    this.setState({ savingUserLoading: false });
   };
   componentWillMount() {
     this.props.getUsers();
@@ -55,4 +55,4 @@ class LinkGatewayUser extends Component {
   }
 }
 
-export default LinkGatewayUser;
+export default connect('users,usersGetStatus,session,httpClient', actions)(LinkGatewayUser);


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.

### Description of change

Fix https://github.com/GladysAssistant/Gladys/issues/1699

<img width="972" alt="Screenshot 2023-03-31 at 15 05 14" src="https://user-images.githubusercontent.com/7365207/229048363-eb1625c9-bc46-4a96-9537-c9ac6515fa75.png">
