### PR TITLE
Fix #1714: When editing device in room box, select should not be hidden behind bottom bar

### DIFF
--- a/front/src/components/boxs/device-in-room/EditDeviceInRoom.jsx
+++ b/front/src/components/boxs/device-in-room/EditDeviceInRoom.jsx
@@ -120,12 +120,7 @@ class EditDeviceInRoom extends Component {
                   isMulti
                   onChange={this.updateDeviceFeatures}
                   options={deviceOptions}
-                  styles={{
-                    container: (base, state) => {
-                      base.zIndex = '1031'; // it needs to be more than the footer bar
-                      return base;
-                    }
-                  }}
+                  maxMenuHeight={220}
                 />
               </div>
             )}

--- a/front/src/components/boxs/device-in-room/EditDeviceInRoom.jsx
+++ b/front/src/components/boxs/device-in-room/EditDeviceInRoom.jsx
@@ -120,6 +120,12 @@ class EditDeviceInRoom extends Component {
                   isMulti
                   onChange={this.updateDeviceFeatures}
                   options={deviceOptions}
+                  styles={{
+                    container: (base, state) => {
+                      base.zIndex = '1031'; // it needs to be more than the footer bar
+                      return base;
+                    }
+                  }}
                 />
               </div>
             )}

--- a/front/src/components/house/RoomSelector.jsx
+++ b/front/src/components/house/RoomSelector.jsx
@@ -71,7 +71,7 @@ class RoomSelector extends Component {
   }
 
   render({}, { selectedRoom, houseOptions }) {
-    return <Select value={selectedRoom} options={houseOptions} onChange={this.updateSelection} />;
+    return <Select value={selectedRoom} options={houseOptions} onChange={this.updateSelection} maxMenuHeight={220} />;
   }
 }
 

--- a/front/src/routes/dashboard/style.css
+++ b/front/src/routes/dashboard/style.css
@@ -20,6 +20,7 @@
 
 .largeContainer {
   max-width: 1600px;
+  margin-bottom: 150px;
 }
 
 @media (min-width: 992px) {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.

### Description of change

Fix #1714

<img width="491" alt="Screenshot 2023-04-06 at 13 56 07" src="https://user-images.githubusercontent.com/7365207/230284632-8e7bfe87-8667-473d-a819-f24f2a59eebc.png">

