### PR TITLE
Do not hide password anymore with MQTT

### DIFF
--- a/front/src/routes/integration/all/mqtt/setup-page/SetupForm.jsx
+++ b/front/src/routes/integration/all/mqtt/setup-page/SetupForm.jsx
@@ -3,6 +3,8 @@ import { Text, Localizer } from 'preact-i18n';
 import cx from 'classnames';
 
 class SetupForm extends Component {
+  showPasswordTimer = null;
+
   updateUrl = e => {
     this.props.updateConfiguration({ mqttUrl: e.target.value });
   };
@@ -15,10 +17,27 @@ class SetupForm extends Component {
     this.props.updateConfiguration({ mqttPassword: e.target.value, passwordChanges: true });
   };
 
-  showPassword = () => {
-    this.setState({ showPassword: true });
-    setTimeout(() => this.setState({ showPassword: false }), 5000);
+  togglePassword = () => {
+    const { showPassword } = this.state;
+
+    if (this.showPasswordTimer) {
+      clearTimeout(this.showPasswordTimer);
+      this.showPasswordTimer = null;
+    }
+
+    this.setState({ showPassword: !showPassword });
+
+    if (!showPassword) {
+      this.showPasswordTimer = setTimeout(() => this.setState({ showPassword: false }), 5000);
+    }
   };
+
+  componentWillUnmount() {
+    if (this.showPasswordTimer) {
+      clearTimeout(this.showPasswordTimer);
+      this.showPasswordTimer = null;
+    }
+  }
 
   render(props, { showPassword }) {
     return (
@@ -66,7 +85,7 @@ class SetupForm extends Component {
               <input
                 id="mqttPassword"
                 name="mqttPassword"
-                type={props.useEmbeddedBroker && showPassword ? 'text' : 'password'}
+                type={showPassword ? 'text' : 'password'}
                 placeholder={<Text id="integration.mqtt.setup.passwordPlaceholder" />}
                 value={props.mqttPassword}
                 class="form-control"
@@ -74,16 +93,14 @@ class SetupForm extends Component {
                 autoComplete="new-password"
               />
             </Localizer>
-            {props.useEmbeddedBroker && (
-              <span class="input-icon-addon cursor-pointer" onClick={this.showPassword}>
-                <i
-                  class={cx('fe', {
-                    'fe-eye': !showPassword,
-                    'fe-eye-off': showPassword
-                  })}
-                />
-              </span>
-            )}
+            <span class="input-icon-addon cursor-pointer" onClick={this.togglePassword}>
+              <i
+                class={cx('fe', {
+                  'fe-eye': !showPassword,
+                  'fe-eye-off': showPassword
+                })}
+              />
+            </span>
           </div>
         </div>
 

--- a/server/services/mqtt/api/mqtt.controller.js
+++ b/server/services/mqtt/api/mqtt.controller.js
@@ -31,9 +31,6 @@ module.exports = function MqttController(mqttManager) {
    */
   async function getConfiguration(req, res) {
     const configuration = await mqttManager.getConfiguration();
-    if (!configuration.useEmbeddedBroker && configuration.mqttPassword) {
-      configuration.mqttPassword = DEFAULT.HIDDEN_PASSWORD; // Hide password from external broker
-    }
     res.json(configuration);
   }
 

--- a/server/services/mqtt/lib/constants.js
+++ b/server/services/mqtt/lib/constants.js
@@ -10,7 +10,6 @@ const DEFAULT = {
   TOPICS: [
     'gladys/master/#', // Default gladys topic
   ],
-  HIDDEN_PASSWORD: '*********',
   INSTALLATION_STATUS: {
     DONE: 'DONE',
     IN_PROGRESS: 'IN_PROGRESS',

--- a/server/test/services/mqtt/api/mqtt.controler.test.js
+++ b/server/test/services/mqtt/api/mqtt.controler.test.js
@@ -88,7 +88,7 @@ describe('GET /api/v1/service/mqtt/config', () => {
     assert.calledOnce(mqttHandler.getConfiguration);
     assert.calledWith(res.json, {
       useEmbeddedBroker: false,
-      mqttPassword: '*********',
+      mqttPassword: 'my_password',
     });
   });
 


### PR DESCRIPTION
Fixes #1724

### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- ~~[ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)~~
- [X] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.
- ~~[ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~~
- ~~[ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).~~
- ~~[ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).~~

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Allows to display stored password in any case, instead of just in embedded mode.

Fixes #1724 
