### PR TITLE
Fix: Enedis daily consumption device is in Watt-Hour

### DIFF
--- a/front/src/routes/integration/all/enedis-gateway/Welcome.jsx
+++ b/front/src/routes/integration/all/enedis-gateway/Welcome.jsx
@@ -123,7 +123,7 @@ class EnedisWelcomePageComponent extends Component {
           category: DEVICE_FEATURE_CATEGORIES.ENERGY_SENSOR,
           external_id: `enedis:${usagePointId}:daily-consumption`,
           type: DEVICE_FEATURE_TYPES.ENERGY_SENSOR.DAILY_CONSUMPTION,
-          unit: DEVICE_FEATURE_UNITS.KILOWATT_HOUR,
+          unit: DEVICE_FEATURE_UNITS.WATT_HOUR,
           read_only: true,
           has_feedback: false,
           keep_history: true

--- a/server/migrations/20230414020652-enedis-unit-is-watt-hour.js
+++ b/server/migrations/20230414020652-enedis-unit-is-watt-hour.js
@@ -1,0 +1,42 @@
+const Promise = require('bluebird');
+const db = require('../models');
+const logger = require('../utils/logger');
+const { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES, DEVICE_FEATURE_UNITS } = require('../utils/constants');
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const service = await db.Service.findOne({
+      where: {
+        name: 'enedis',
+      },
+    });
+    if (service === null) {
+      return;
+    }
+    logger.info(`Enedis migration: Found service enedis = ${service.id}`);
+    const enedisDevices = await db.Device.findAll({
+      where: {
+        service_id: service.id,
+      },
+    });
+    logger.info(`Enedis migration: Found ${enedisDevices.length} enedis devices`);
+    await Promise.each(enedisDevices, async (enedisDevice) => {
+      const deviceFeature = await db.DeviceFeature.findOne({
+        where: {
+          device_id: enedisDevice.id,
+          category: DEVICE_FEATURE_CATEGORIES.ENERGY_SENSOR,
+          type: DEVICE_FEATURE_TYPES.ENERGY_SENSOR.DAILY_CONSUMPTION,
+        },
+      });
+      if (deviceFeature === null) {
+        return;
+      }
+      logger.info(`Enedis migration: Updating device_feature ${deviceFeature.id} with new unit`);
+      deviceFeature.set({
+        unit: DEVICE_FEATURE_UNITS.WATT_HOUR,
+      });
+      await deviceFeature.save();
+    });
+  },
+  down: async (queryInterface, Sequelize) => {},
+};


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.

### Description of change

Device feature is in watt-hour, not kilowatt-hour