### PR TITLE
Align sensor display name (LANManager feedbacks)

### DIFF
--- a/front/src/components/boxs/device-in-room/DeviceRow.jsx
+++ b/front/src/components/boxs/device-in-room/DeviceRow.jsx
@@ -31,7 +31,7 @@ const ROW_TYPE_BY_FEATURE_TYPE = {
 const DeviceRow = ({ children, ...props }) => {
   // if device is a sensor, we display the sensor deviceFeature
   if (props.deviceFeature.read_only) {
-    return <SensorDeviceFeature user={props.user} deviceFeature={props.deviceFeature} />;
+    return <SensorDeviceFeature user={props.user} device={props.device} deviceFeature={props.deviceFeature} />;
   }
 
   const elementType = ROW_TYPE_BY_FEATURE_TYPE[props.deviceFeature.type];

--- a/front/src/components/boxs/device-in-room/device-features/sensor-value/SensorDeviceFeature.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/sensor-value/SensorDeviceFeature.jsx
@@ -10,6 +10,7 @@ import BadgeNumberDeviceValue from './BadgeNumberDeviceValue';
 import IconBinaryDeviceValue from './IconBinaryDeviceValue';
 import SignalQualityDeviceValue from './SignalQualityDeviceValue';
 import ButtonClickDeviceValue from './ButtonClickDeviceValue';
+import { getDeviceName } from '../../../../../utils/device';
 
 const DISPLAY_BY_FEATURE_CATEGORY = {
   [DEVICE_FEATURE_CATEGORIES.MOTION_SENSOR]: LastSeenDeviceValue,
@@ -24,7 +25,7 @@ const DISPLAY_BY_FEATURE_TYPE = {
 };
 
 const SensorDeviceType = ({ children, ...props }) => {
-  const { deviceFeature: feature } = props;
+  const { deviceFeature: feature, device } = props;
   const { category, type } = feature;
 
   let elementType = DISPLAY_BY_FEATURE_CATEGORY[category];
@@ -40,14 +41,9 @@ const SensorDeviceType = ({ children, ...props }) => {
   return (
     <tr>
       <td>
-        <i
-          class={`mr-2 fe fe-${get(
-            DeviceFeatureCategoriesIcon,
-            `${props.deviceFeature.category}.${props.deviceFeature.type}`
-          )}`}
-        />
+        <i class={`mr-2 fe fe-${get(DeviceFeatureCategoriesIcon, `${category}.${type}`)}`} />
       </td>
-      <td>{props.deviceFeature.name}</td>
+      <td>{getDeviceName(device, feature)}</td>
       <td class="text-right">{createElement(elementType, props)}</td>
     </tr>
   );


### PR DESCRIPTION
Use `device name method` for sensors on dashboard boxes.

https://community.gladysassistant.com/t/detection-de-presence-via-le-reseau-local/6131/93?u=alextrovato

Test URL: https://dashboard-display-label.gladys.pages.dev/ 