### PR TITLE
Zigbee2mqtt: Fix bug at first start, mosquitto.passwd was not created

### DIFF
--- a/server/services/zigbee2mqtt/lib/installMqttContainer.js
+++ b/server/services/zigbee2mqtt/lib/installMqttContainer.js
@@ -37,6 +37,7 @@ async function installMqttContainer(config) {
 
       const mosquittoFolderPath = path.join(basePathOnContainer, '/zigbee2mqtt/mqtt');
       const mosquittoConfigFilePath = path.join(mosquittoFolderPath, 'mosquitto.conf');
+      const mosquittoPasswordFilePath = path.join(mosquittoFolderPath, 'mosquitto.passwd');
 
       logger.info(`Writing Mosquitto config file in ${mosquittoConfigFilePath}`);
 
@@ -44,6 +45,9 @@ async function installMqttContainer(config) {
       await fse.ensureDir(mosquittoFolderPath);
       const mosquittoConfContent = await fse.readFile(path.join(__dirname, '../docker/mosquitto.conf'));
       await fse.writeFile(mosquittoConfigFilePath, mosquittoConfContent, 'utf-8');
+      // create an empty password file so that the container can start
+      // it'll be filled later
+      await fse.writeFile(mosquittoPasswordFilePath, '', 'utf-8');
 
       await containerDescriptorToMutate.HostConfig.Binds.push(`${basePathOnHost}/zigbee2mqtt/mqtt:/mosquitto/config`);
 

--- a/server/test/services/zigbee2mqtt/lib/installMqttContainer.test.js
+++ b/server/test/services/zigbee2mqtt/lib/installMqttContainer.test.js
@@ -167,6 +167,9 @@ describe('zigbee2mqtt installMqttContainer', () => {
     expect(mosquittoConfContent).to.contain('password_file /mosquitto/config/mosquitto.passwd');
     expect(mosquittoConfContent).to.contain('persistence true');
     expect(mosquittoConfContent).to.contain('persistence_location /mosquitto/config/');
+    const mosquittoPwdPath = `${TEMP_GLADYS_FOLDER}/zigbee2mqtt/mqtt/mosquitto.passwd`;
+    const mosquittoPwdContent = await fs.readFile(mosquittoPwdPath, 'utf-8');
+    expect(mosquittoPwdContent).to.equal('');
   });
   it('should fail to configure MQTT container', async function Test() {
     // PREPARE


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.
- [x] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [x] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

mosquitto.passwd was not created 
