### PR TITLE
Clean eslint promise warnings -> bluetooth service

### DIFF
--- a/server/services/bluetooth/lib/commands/bluetooth.applyOnPeripheral.js
+++ b/server/services/bluetooth/lib/commands/bluetooth.applyOnPeripheral.js
@@ -15,22 +15,21 @@ const { connect } = require('../utils/peripheral/bluetooth.connect');
 async function applyOnPeripheral(peripheralUuid, applyFunc, keepConnected = false) {
   this.peripheralLookup = true;
 
-  return this.scan(true, peripheralUuid)
-    .then((peripheral) =>
-      connect(peripheral).then((connectedPerpheral) =>
-        new Promise((resolve) => {
-          return resolve(applyFunc(connectedPerpheral));
-        }).finally(() => {
-          if (!keepConnected) {
-            connectedPerpheral.disconnect();
-          }
-        }),
-      ),
-    )
-    .finally(() => {
-      this.peripheralLookup = false;
-      this.broadcastStatus();
-    });
+  try {
+    const peripheral = await this.scan(true, peripheralUuid);
+    const connectedPeripheral = await connect(peripheral);
+
+    try {
+      return applyFunc(connectedPeripheral);
+    } finally {
+      if (!keepConnected) {
+        connectedPeripheral.disconnect();
+      }
+    }
+  } finally {
+    this.peripheralLookup = false;
+    this.broadcastStatus();
+  }
 }
 
 module.exports = {

--- a/server/services/bluetooth/lib/commands/bluetooth.readDevice.js
+++ b/server/services/bluetooth/lib/commands/bluetooth.readDevice.js
@@ -10,9 +10,8 @@ const { read } = require('../utils/characteristic/bluetooth.read');
  * await bluetooth.readDevice({ external_id: 'bluetooth:uuid'});
  */
 async function readDevice(peripheral, serviceUuid, characteristicUuid) {
-  return this.getCharacteristic(peripheral, serviceUuid, characteristicUuid).then((characteristic) =>
-    read(characteristic),
-  );
+  const characteristic = await this.getCharacteristic(peripheral, serviceUuid, characteristicUuid);
+  return read(characteristic);
 }
 
 module.exports = {

--- a/server/services/bluetooth/lib/commands/bluetooth.scan.js
+++ b/server/services/bluetooth/lib/commands/bluetooth.scan.js
@@ -32,8 +32,9 @@ async function scan(state, peripheralUuid = undefined) {
 
     this.scanCounter += 1;
 
-    if (this.scanPromise && this.scanPromise.isPending()) {
-      this.scanPromise.cancel();
+    if (this.scanPromise) {
+      clearTimeout(this.scanPromise);
+      this.scanPromise = undefined;
     }
 
     return new Promise((resolve, reject) => {
@@ -71,12 +72,9 @@ async function scan(state, peripheralUuid = undefined) {
         this.bluetooth.startScanning([], true);
       }
 
-      this.scanPromise = new Promise(resolve, async () => {
-        await Promise.delay(TIMERS.SCAN);
+      this.scanPromise = setTimeout(() => {
         this.bluetooth.stopScanning();
-        resolve();
-      });
-      this.scanPromise();
+      }, TIMERS.SCAN);
     });
   }
 

--- a/server/services/bluetooth/lib/commands/bluetooth.scan.js
+++ b/server/services/bluetooth/lib/commands/bluetooth.scan.js
@@ -15,7 +15,7 @@ const { TIMERS } = require('../utils/bluetooth.constants');
  */
 async function scan(state, peripheralUuid = undefined) {
   if (!this.ready) {
-    return Promise.reject(new Error('Bluetooth is not ready to scan for peripherals, check BLE adapter.'));
+    throw new Error('Bluetooth is not ready to scan for peripherals, check BLE adapter.');
   }
 
   if (state) {
@@ -71,7 +71,12 @@ async function scan(state, peripheralUuid = undefined) {
         this.bluetooth.startScanning([], true);
       }
 
-      this.scanPromise = Promise.delay(TIMERS.SCAN).then(() => this.bluetooth.stopScanning());
+      this.scanPromise = new Promise(resolve, async () => {
+        await Promise.delay(TIMERS.SCAN);
+        this.bluetooth.stopScanning();
+        resolve();
+      });
+      this.scanPromise();
     });
   }
 

--- a/server/services/bluetooth/lib/commands/bluetooth.scan.js
+++ b/server/services/bluetooth/lib/commands/bluetooth.scan.js
@@ -32,9 +32,9 @@ async function scan(state, peripheralUuid = undefined) {
 
     this.scanCounter += 1;
 
-    if (this.scanPromise) {
-      clearTimeout(this.scanPromise);
-      this.scanPromise = undefined;
+    if (this.scanTimer) {
+      clearTimeout(this.scanTimer);
+      this.scanTimer = undefined;
     }
 
     return new Promise((resolve, reject) => {
@@ -72,7 +72,7 @@ async function scan(state, peripheralUuid = undefined) {
         this.bluetooth.startScanning([], true);
       }
 
-      this.scanPromise = setTimeout(() => {
+      this.scanTimer = setTimeout(() => {
         this.bluetooth.stopScanning();
       }, TIMERS.SCAN);
     });

--- a/server/services/bluetooth/lib/commands/bluetooth.stop.js
+++ b/server/services/bluetooth/lib/commands/bluetooth.stop.js
@@ -19,11 +19,11 @@ async function stop() {
   logger.debug(`Bluetooth: Reset service status`);
   this.bluetooth = undefined;
 
-  if (this.scanPromise) {
-    clearTimeout(this.scanPromise);
+  if (this.scanTimer) {
+    clearTimeout(this.scanTimer);
   }
 
-  this.scanPromise = undefined;
+  this.scanTimer = undefined;
   this.scanCounter = 0;
 }
 

--- a/server/services/bluetooth/lib/commands/bluetooth.stop.js
+++ b/server/services/bluetooth/lib/commands/bluetooth.stop.js
@@ -19,8 +19,8 @@ async function stop() {
   logger.debug(`Bluetooth: Reset service status`);
   this.bluetooth = undefined;
 
-  if (this.scanPromise && this.scanPromise.isPending()) {
-    this.scanPromise.cancel();
+  if (this.scanPromise) {
+    clearTimeout(this.scanPromise);
   }
 
   this.scanPromise = undefined;

--- a/server/services/bluetooth/lib/commands/bluetooth.subscribeDevice.js
+++ b/server/services/bluetooth/lib/commands/bluetooth.subscribeDevice.js
@@ -14,9 +14,11 @@ const { read } = require('../utils/characteristic/bluetooth.read');
  * await subscribeDevice({ uuid: 'peripheral' }, 'service1', 'char1', () => console.log('done'))
  */
 async function subscribeDevice(peripheral, serviceUuid, characteristicUuid, onNotify) {
-  return this.getCharacteristic(peripheral, serviceUuid, characteristicUuid).then((characteristic) =>
-    subscribe(characteristic, onNotify).then(() => read(characteristic).then((value) => onNotify(value))),
-  );
+  const characteristic = await this.getCharacteristic(peripheral, serviceUuid, characteristicUuid);
+  await subscribe(characteristic, onNotify);
+  const value = await read(characteristic);
+  await onNotify(value);
+  return value;
 }
 
 module.exports = {

--- a/server/services/bluetooth/lib/commands/bluetooth.unsubscribeDevice.js
+++ b/server/services/bluetooth/lib/commands/bluetooth.unsubscribeDevice.js
@@ -12,9 +12,8 @@ const { unsubscribe } = require('../utils/characteristic/bluetooth.unsubscribe')
  * await subscribeDevice({ uuid: 'peripheral' }, 'service1', 'char1')
  */
 async function unsubscribeDevice(peripheral, serviceUuid, characteristicUuid) {
-  return this.getCharacteristic(peripheral, serviceUuid, characteristicUuid).then((characteristic) =>
-    unsubscribe(characteristic),
-  );
+  const characteristic = await this.getCharacteristic(peripheral, serviceUuid, characteristicUuid);
+  return unsubscribe(characteristic);
 }
 
 module.exports = {

--- a/server/services/bluetooth/lib/commands/bluetooth.writeDevice.js
+++ b/server/services/bluetooth/lib/commands/bluetooth.writeDevice.js
@@ -12,9 +12,8 @@ const { write } = require('../utils/characteristic/bluetooth.write');
  * await writeDevice({ uuid: 'peripheral' }, 'service1', 'char1')
  */
 async function writeDevice(peripheral, serviceUuid, characteristicUuid, value, withoutResponse = false) {
-  return this.getCharacteristic(peripheral, serviceUuid, characteristicUuid).then((characteristic) =>
-    write(characteristic, value, withoutResponse),
-  );
+  const characteristic = await this.getCharacteristic(peripheral, serviceUuid, characteristicUuid);
+  return write(characteristic, value, withoutResponse);
 }
 
 module.exports = {

--- a/server/services/bluetooth/lib/events/bluetooth.scanStop.js
+++ b/server/services/bluetooth/lib/events/bluetooth.scanStop.js
@@ -6,8 +6,9 @@ const logger = require('../../../../utils/logger');
  * bluetooth.on('startStop', this.scanStop);
  */
 async function scanStop() {
-  if (this.scanPromise && this.scanPromise.isPending()) {
-    this.scanPromise.cancel();
+  if (this.scanPromise) {
+    clearTimeout(this.scanPromise);
+    this.scanPromise = undefined;
   }
   this.scanCounter = 0;
 

--- a/server/services/bluetooth/lib/events/bluetooth.scanStop.js
+++ b/server/services/bluetooth/lib/events/bluetooth.scanStop.js
@@ -6,9 +6,9 @@ const logger = require('../../../../utils/logger');
  * bluetooth.on('startStop', this.scanStop);
  */
 async function scanStop() {
-  if (this.scanPromise) {
-    clearTimeout(this.scanPromise);
-    this.scanPromise = undefined;
+  if (this.scanTimer) {
+    clearTimeout(this.scanTimer);
+    this.scanTimer = undefined;
   }
   this.scanCounter = 0;
 

--- a/server/services/bluetooth/lib/index.js
+++ b/server/services/bluetooth/lib/index.js
@@ -36,7 +36,7 @@ const BluetoothManager = function BluetoothManager(gladys, serviceId) {
   this.gladys = gladys;
   this.serviceId = serviceId;
 
-  this.scanPromise = undefined;
+  this.scanTimer = undefined;
   this.scanCounter = 0;
 
   this.ready = false;

--- a/server/test/services/bluetooth/lib/commands/bluetooth.readDevice.test.js
+++ b/server/test/services/bluetooth/lib/commands/bluetooth.readDevice.test.js
@@ -21,6 +21,8 @@ describe('bluetooth.readDevice', () => {
   let bluetooth;
   let bluetoothManager;
 
+  let clock;
+
   beforeEach(() => {
     throwError = false;
 
@@ -61,13 +63,12 @@ describe('bluetooth.readDevice', () => {
       bluetooth.emit('discover', peripheral);
       bluetooth.emit('scanStop');
     };
+
+    clock = sinon.useFakeTimers();
   });
 
   afterEach(() => {
-    if (bluetoothManager.scanPromise && bluetoothManager.scanPromise.isPending()) {
-      bluetoothManager.scanPromise.cancel();
-    }
-
+    clock.restore();
     sinon.reset();
   });
 

--- a/server/test/services/bluetooth/lib/commands/bluetooth.scan.test.js
+++ b/server/test/services/bluetooth/lib/commands/bluetooth.scan.test.js
@@ -13,36 +13,21 @@ describe('bluetooth.scan command', () => {
   let bluetooth;
   let bluetoothManager;
 
-  let stopScanning;
-  let stopScanningAsync;
+  let clock;
 
   beforeEach(() => {
-    stopScanning = fake.returns(null);
-    stopScanningAsync = fake.returns(null);
-
     bluetooth = new BluetoothMock();
-    bluetooth.stopScanning = () => {
-      if (bluetoothManager.scanPromise && bluetoothManager.scanPromise.isPending()) {
-        bluetoothManager.scanPromise.cancel();
-      }
-      stopScanning();
-    };
-    bluetooth.stopScanningAsync = () => {
-      if (bluetoothManager.scanPromise && bluetoothManager.scanPromise.isPending()) {
-        bluetoothManager.scanPromise.cancel();
-      }
-      stopScanningAsync();
-    };
+    bluetooth.stopScanning = fake.returns(null);
+    bluetooth.stopScanningAsync = fake.returns(null);
 
     bluetoothManager = new BluetoothManager(gladys, serviceId);
     bluetoothManager.bluetooth = bluetooth;
+
+    clock = sinon.useFakeTimers();
   });
 
   afterEach(() => {
-    if (bluetoothManager.scanPromise && bluetoothManager.scanPromise.isPending()) {
-      bluetoothManager.scanPromise.cancel();
-    }
-
+    clock.restore();
     sinon.reset();
   });
 
@@ -51,8 +36,8 @@ describe('bluetooth.scan command', () => {
     await bluetoothManager.scan();
 
     assert.notCalled(bluetooth.startScanning);
-    assert.notCalled(stopScanning);
-    assert.calledOnce(stopScanningAsync);
+    assert.notCalled(bluetooth.stopScanning);
+    assert.calledOnce(bluetooth.stopScanningAsync);
   });
 
   it('should not scan, not ready no args', async () => {
@@ -62,8 +47,8 @@ describe('bluetooth.scan command', () => {
       assert.fail('Should have fail');
     } catch (e) {
       assert.notCalled(bluetooth.startScanning);
-      assert.notCalled(stopScanning);
-      assert.notCalled(stopScanningAsync);
+      assert.notCalled(bluetooth.stopScanning);
+      assert.notCalled(bluetooth.stopScanningAsync);
     }
   });
 
@@ -72,8 +57,8 @@ describe('bluetooth.scan command', () => {
     await bluetoothManager.scan(false);
 
     assert.notCalled(bluetooth.startScanning);
-    assert.notCalled(stopScanning);
-    assert.calledOnce(stopScanningAsync);
+    assert.notCalled(bluetooth.stopScanning);
+    assert.calledOnce(bluetooth.stopScanningAsync);
   });
 
   it('should clear timeout, and discovered devices', async () => {
@@ -84,8 +69,8 @@ describe('bluetooth.scan command', () => {
     await bluetoothManager.scan(false);
 
     assert.calledOnce(bluetooth.startScanning);
-    assert.notCalled(stopScanning);
-    assert.calledOnce(stopScanningAsync);
+    assert.notCalled(bluetooth.stopScanning);
+    assert.calledOnce(bluetooth.stopScanningAsync);
 
     expect(bluetoothManager.discoveredDevices).deep.eq({});
   });
@@ -98,8 +83,8 @@ describe('bluetooth.scan command', () => {
     await bluetoothManager.scan(false);
 
     assert.calledOnce(bluetooth.startScanning);
-    assert.notCalled(stopScanning);
-    assert.calledOnce(stopScanningAsync);
+    assert.notCalled(bluetooth.stopScanning);
+    assert.calledOnce(bluetooth.stopScanningAsync);
 
     expect(bluetoothManager.discoveredDevices).deep.eq({ one: {}, two: {} });
   });
@@ -113,9 +98,29 @@ describe('bluetooth.scan command', () => {
     const peripheral = await bluetoothManager.scan(true, 'any');
 
     assert.notCalled(bluetooth.startScanning);
-    assert.notCalled(stopScanning);
-    assert.notCalled(stopScanningAsync);
+    assert.notCalled(bluetooth.stopScanning);
+    assert.notCalled(bluetooth.stopScanningAsync);
 
     expect(peripheral).deep.eq({ uuid: 'any' });
+  });
+
+  it('should stop discover if device is not found', async () => {
+    bluetoothManager.ready = true;
+
+    const scanPromise = bluetoothManager.scan(true);
+
+    assert.calledOnce(bluetooth.startScanning);
+    assert.notCalled(bluetooth.stopScanning);
+    assert.notCalled(bluetooth.stopScanningAsync);
+    expect(bluetoothManager.scanPromise).to.be.not.equal(undefined);
+
+    // wait for timeout
+    clock.tick(150000);
+    // check that scan is stopped after timeout
+    assert.calledOnce(bluetooth.stopScanning);
+
+    bluetooth.emit('scanStop');
+    const result = await scanPromise;
+    expect(result).to.be.deep.equal({});
   });
 });

--- a/server/test/services/bluetooth/lib/commands/bluetooth.scan.test.js
+++ b/server/test/services/bluetooth/lib/commands/bluetooth.scan.test.js
@@ -4,6 +4,7 @@ const sinon = require('sinon');
 const { fake, assert } = sinon;
 
 const BluetoothManager = require('../../../../../services/bluetooth/lib');
+const { NotFoundError } = require('../../../../../utils/coreErrors');
 const BluetoothMock = require('../../BluetoothMock.test');
 
 const gladys = {};
@@ -107,12 +108,12 @@ describe('bluetooth.scan command', () => {
   it('should stop discover if device is not found', async () => {
     bluetoothManager.ready = true;
 
-    const scanPromise = bluetoothManager.scan(true);
+    const scanTimer = bluetoothManager.scan(true);
 
     assert.calledOnce(bluetooth.startScanning);
     assert.notCalled(bluetooth.stopScanning);
     assert.notCalled(bluetooth.stopScanningAsync);
-    expect(bluetoothManager.scanPromise).to.be.not.equal(undefined);
+    expect(bluetoothManager.scanTimer).to.be.not.equal(undefined);
 
     // wait for timeout
     clock.tick(150000);
@@ -120,7 +121,33 @@ describe('bluetooth.scan command', () => {
     assert.calledOnce(bluetooth.stopScanning);
 
     bluetooth.emit('scanStop');
-    const result = await scanPromise;
+    const result = await scanTimer;
     expect(result).to.be.deep.equal({});
+  });
+
+  it('should stop discover and reject if specific device is not found', async () => {
+    bluetoothManager.ready = true;
+    bluetoothManager.scanTimer = 'any-timer';
+
+    const scanTimer = bluetoothManager.scan(true, 'device-uuid');
+
+    assert.calledOnce(bluetooth.startScanning);
+    assert.notCalled(bluetooth.stopScanning);
+    assert.notCalled(bluetooth.stopScanningAsync);
+    expect(bluetoothManager.scanTimer).to.be.not.equal(undefined);
+
+    // wait for timeout
+    clock.tick(150000);
+    // check that scan is stopped after timeout
+    assert.calledOnce(bluetooth.stopScanning);
+
+    bluetooth.emit('scanStop');
+    try {
+      await scanTimer;
+      assert.fail();
+    } catch (e) {
+      expect(e).to.be.instanceOf(NotFoundError);
+      expect(e.message).to.be.equal('Bluetooth: peripheral device-uuid not found');
+    }
   });
 });

--- a/server/test/services/bluetooth/lib/commands/bluetooth.scanDevice.test.js
+++ b/server/test/services/bluetooth/lib/commands/bluetooth.scanDevice.test.js
@@ -37,6 +37,8 @@ describe('bluetooth.scanDevice', () => {
   let bluetoothManager;
   let bluetooth;
 
+  let clock;
+
   beforeEach(() => {
     services = [];
 
@@ -71,13 +73,12 @@ describe('bluetooth.scanDevice', () => {
     bluetooth.stopScanning = () => {
       bluetooth.emit('scanStop');
     };
+
+    clock = sinon.useFakeTimers();
   });
 
   afterEach(() => {
-    if (bluetoothManager.scanPromise && bluetoothManager.scanPromise.isPending()) {
-      bluetoothManager.scanPromise.cancel();
-    }
-
+    clock.restore();
     sinon.reset();
   });
 

--- a/server/test/services/bluetooth/lib/commands/bluetooth.stop.test.js
+++ b/server/test/services/bluetooth/lib/commands/bluetooth.stop.test.js
@@ -32,7 +32,7 @@ describe('bluetooth.stop command', () => {
 
     expect(bluetoothManager.bluetooth).eq(undefined);
     expect(bluetoothManager.discoveredDevices).deep.eq({});
-    expect(bluetoothManager.scanPromise).eq(undefined);
+    expect(bluetoothManager.scanTimer).eq(undefined);
     expect(bluetoothManager.scanCounter).eq(0);
 
     // No more listener
@@ -42,11 +42,11 @@ describe('bluetooth.stop command', () => {
   });
 
   it('check timers are well removed', async () => {
-    bluetoothManager.scanPromise = 'any-timeout';
+    bluetoothManager.scanTimer = 'any-timeout';
 
     await bluetoothManager.stop();
 
     assert.calledOnce(bluetooth.stopScanning);
-    expect(bluetoothManager.scanPromise).to.be.equal(undefined);
+    expect(bluetoothManager.scanTimer).to.be.equal(undefined);
   });
 });

--- a/server/test/services/bluetooth/lib/commands/bluetooth.stop.test.js
+++ b/server/test/services/bluetooth/lib/commands/bluetooth.stop.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 
-const { assert, fake } = sinon;
+const { assert } = sinon;
 
 const BluetoothManager = require('../../../../../services/bluetooth/lib');
 const BluetoothMock = require('../../BluetoothMock.test');
@@ -41,29 +41,12 @@ describe('bluetooth.stop command', () => {
     assert.calledOnce(bluetooth.stopScanning);
   });
 
-  it('check only pending timers are well removed', async () => {
-    const scanPromise = {
-      isPending: () => false,
-      cancel: fake.returns(false),
-    };
-    bluetoothManager.scanPromise = scanPromise;
-
-    await bluetoothManager.stop();
-
-    assert.calledOnce(bluetooth.stopScanning);
-    assert.notCalled(scanPromise.cancel);
-  });
-
   it('check timers are well removed', async () => {
-    const scanPromise = {
-      isPending: () => true,
-      cancel: fake.returns(false),
-    };
-    bluetoothManager.scanPromise = scanPromise;
+    bluetoothManager.scanPromise = 'any-timeout';
 
     await bluetoothManager.stop();
 
     assert.calledOnce(bluetooth.stopScanning);
-    assert.calledOnce(scanPromise.cancel);
+    expect(bluetoothManager.scanPromise).to.be.equal(undefined);
   });
 });

--- a/server/test/services/bluetooth/lib/commands/bluetooth.subscribeDevice.test.js
+++ b/server/test/services/bluetooth/lib/commands/bluetooth.subscribeDevice.test.js
@@ -22,6 +22,8 @@ describe('bluetooth.subscribeDevice', () => {
   let bluetooth;
   let bluetoothManager;
 
+  let clock;
+
   beforeEach(() => {
     throwError = false;
 
@@ -70,13 +72,12 @@ describe('bluetooth.subscribeDevice', () => {
       bluetooth.emit('discover', peripheral);
       bluetooth.emit('scanStop');
     };
+
+    clock = sinon.useFakeTimers();
   });
 
   afterEach(() => {
-    if (bluetoothManager.scanPromise && bluetoothManager.scanPromise.isPending()) {
-      bluetoothManager.scanPromise.cancel();
-    }
-
+    clock.restore();
     sinon.reset();
   });
 

--- a/server/test/services/bluetooth/lib/commands/bluetooth.unsubscribeDevice.test.js
+++ b/server/test/services/bluetooth/lib/commands/bluetooth.unsubscribeDevice.test.js
@@ -21,6 +21,8 @@ describe('bluetooth.unsubscribeDevice', () => {
   let bluetooth;
   let bluetoothManager;
 
+  let clock;
+
   beforeEach(() => {
     throwError = false;
 
@@ -61,13 +63,12 @@ describe('bluetooth.unsubscribeDevice', () => {
       bluetooth.emit('discover', peripheral);
       bluetooth.emit('scanStop');
     };
+
+    clock = sinon.useFakeTimers();
   });
 
   afterEach(() => {
-    if (bluetoothManager.scanPromise && bluetoothManager.scanPromise.isPending()) {
-      bluetoothManager.scanPromise.cancel();
-    }
-
+    clock.restore();
     sinon.reset();
   });
 

--- a/server/test/services/bluetooth/lib/commands/bluetooth.writeDevice.test.js
+++ b/server/test/services/bluetooth/lib/commands/bluetooth.writeDevice.test.js
@@ -17,6 +17,7 @@ describe('bluetooth.writeDevice', () => {
   let peripheral;
 
   let bluetooth;
+  let clock;
 
   beforeEach(() => {
     throwError = false;
@@ -52,13 +53,12 @@ describe('bluetooth.writeDevice', () => {
     };
 
     bluetooth = new BluetoothManager(gladys, serviceId);
+
+    clock = sinon.useFakeTimers();
   });
 
   afterEach(() => {
-    if (bluetooth.scanPromise && bluetooth.scanPromise.isPending()) {
-      bluetooth.scanPromise.cancel();
-    }
-
+    clock.restore();
     sinon.reset();
   });
 

--- a/server/test/services/bluetooth/lib/events/bluetooth.scanStop.test.js
+++ b/server/test/services/bluetooth/lib/events/bluetooth.scanStop.test.js
@@ -39,7 +39,21 @@ describe('bluetooth.scanStop event', () => {
     bluetoothManager.ready = true;
     bluetoothManager.scanStop();
 
-    expect(false).eq(bluetoothManager.scanning);
+    expect(bluetoothManager.scanning).to.be.equal(false);
+
+    assert.calledWith(eventWS, {
+      payload: { peripheralLookup: false, ready: true, scanning: false },
+      type: 'bluetooth.status',
+    });
+  });
+
+  it('should handle stop scanning and cancel scan timer', () => {
+    bluetoothManager.ready = true;
+    bluetoothManager.scanTimer = 'anyTimer';
+    bluetoothManager.scanStop();
+
+    expect(bluetoothManager.scanning).to.be.equal(false);
+    expect(bluetoothManager.scanTimer).to.be.equal(undefined);
 
     assert.calledWith(eventWS, {
       payload: { peripheralLookup: false, ready: true, scanning: false },


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- ~~[ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)~~
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.
- ~~[ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~~
- ~~[ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).~~
- ~~[ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).~~

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Clean 16 warnings on 20 on server side about `Prefer await to then()/catch()/finally()`.

```
/home/alex/Gladys/server/services/bluetooth/lib/commands/bluetooth.applyOnPeripheral.js
  19:6   warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then
  20:27  warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then
  23:12  warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then
  30:6   warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then

/home/alex/Gladys/server/services/bluetooth/lib/commands/bluetooth.readDevice.js
  13:78  warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then

/home/alex/Gladys/server/services/bluetooth/lib/commands/bluetooth.scan.js
  74:53  warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then

/home/alex/Gladys/server/services/bluetooth/lib/commands/bluetooth.scanDevice.js
  37:16  warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then
  45:47  warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then
  50:16  warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then
  62:6   warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then
  63:6   warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then

/home/alex/Gladys/server/services/bluetooth/lib/commands/bluetooth.subscribeDevice.js
  17:78  warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then
  18:41  warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then
  18:73  warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then

/home/alex/Gladys/server/services/bluetooth/lib/commands/bluetooth.unsubscribeDevice.js
  15:78  warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then

/home/alex/Gladys/server/services/bluetooth/lib/commands/bluetooth.writeDevice.js
  15:78  warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then
```

I tested it locally, device presence detection still works.

Test image: `atrovato/gladys:bluetooth`