### PR TITLE
Scene: Body is not mandatory in HTTP Request action

### DIFF
--- a/front/src/routes/scene/edit-scene/actions/HttpRequest.jsx
+++ b/front/src/routes/scene/edit-scene/actions/HttpRequest.jsx
@@ -101,7 +101,8 @@ class HttpRequestAction extends Component {
     this.props.updateActionProperty(this.props.columnIndex, this.props.index, 'url', e.target.value);
   };
   handleChangeBody = text => {
-    this.props.updateActionProperty(this.props.columnIndex, this.props.index, 'body', text);
+    const newBody = text && text.length > 0 ? text : undefined;
+    this.props.updateActionProperty(this.props.columnIndex, this.props.index, 'body', newBody);
   };
   addNewHeader = e => {
     e.preventDefault();
@@ -273,9 +274,6 @@ class HttpRequestAction extends Component {
                 <div class="form-group">
                   <label class="form-label">
                     <Text id="editScene.actionsCard.httpRequest.bodyLabel" />
-                    <span class="form-required">
-                      <Text id="global.requiredField" />
-                    </span>
                   </label>
                   <div style={helpTextStyle}>
                     <Text id="editScene.actionsCard.httpRequest.variablesExplanation" />


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.


### Description of change

Do not prevent user from saving if HTTP Request body is empty 

https://community.gladysassistant.com/t/probleme-pour-envoyer-une-requete-http/8136