### PR TITLE
Smartly restart z2m container

### DIFF
--- a/server/services/zigbee2mqtt/lib/configureContainer.js
+++ b/server/services/zigbee2mqtt/lib/configureContainer.js
@@ -11,6 +11,7 @@ const { DEFAULT_KEY, CONFIG_KEYS, ADAPTERS_BY_CONFIG_KEY } = require('../adapter
  * @description Configure Z2M container.
  * @param {string} basePathOnContainer - Zigbee2mqtt base path.
  * @param {object} config - Gladys Z2M stored configuration.
+ * @returns {Promise} Indicates if the configuration file has been creted or modified.
  * @example
  * await this.configureContainer({});
  */
@@ -22,6 +23,7 @@ async function configureContainer(basePathOnContainer, config) {
   await fs.mkdir(path.dirname(configFilepath), { recursive: true });
 
   // Check if config file not already exists
+  let configCreated = false;
   try {
     // eslint-disable-next-line no-bitwise
     await fs.access(configFilepath, constants.R_OK | constants.W_OK);
@@ -29,6 +31,7 @@ async function configureContainer(basePathOnContainer, config) {
   } catch (e) {
     logger.info('Writting default Z2M configuration...');
     await fs.writeFile(configFilepath, yaml.stringify(DEFAULT.CONFIGURATION_CONTENT));
+    configCreated = true;
   }
 
   // Check for changes
@@ -63,6 +66,8 @@ async function configureContainer(basePathOnContainer, config) {
     logger.info('Writting MQTT and USB adapter information to Z2M configuration...');
     await fs.writeFile(configFilepath, yaml.stringify(loadedConfig));
   }
+
+  return configCreated || configChanged;
 }
 
 module.exports = {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- ~~[ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)~~
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.
- ~~[ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~~
- ~~[ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).~~
- ~~[ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).~~

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Redo: smartly restart z2m container instead of "at each restart".
It checks if the config has changed (or created), or if the container is not running.