### PR TITLE
fix(front): Fix integrations search

### DIFF
--- a/front/src/actions/integration.js
+++ b/front/src/actions/integration.js
@@ -41,9 +41,13 @@ const actions = store => ({
 
     // Filter
     if (searchKeyword && searchKeyword.length > 0) {
+      const lowerCaseSearchKeyword = searchKeyword.toLowerCase();
       selectedIntegrations = selectedIntegrations.filter(integration => {
         const { name, description } = integration;
-        return name.toLowerCase().includes(searchKeyword) || description.toLowerCase().includes(searchKeyword);
+        return (
+          name.toLowerCase().includes(lowerCaseSearchKeyword) ||
+          description.toLowerCase().includes(lowerCaseSearchKeyword)
+        );
       });
     }
 


### PR DESCRIPTION
If User inputs a word with capital letter (by default on mobile), comparison with integrations names should take it in account and lowercase full input search

Fixes #1740