### PR TITLE
TP-Link: Prefer await to then()/catch()/finally()

### DIFF
--- a/server/services/tp-link/lib/smart-device/index.js
+++ b/server/services/tp-link/lib/smart-device/index.js
@@ -28,6 +28,7 @@ const TPLinkSmartDeviceHandler = function TPLinkSmartDeviceHandler(gladys, tpLin
   this.client = tpLinkClient;
   this.serviceId = serviceId;
   this.tpLinkDevicesBySerialNumber = new Map();
+  this.discoverDevicesDelay = 2000;
 };
 
 TPLinkSmartDeviceHandler.prototype.getDevices = getDevices;

--- a/server/services/tp-link/lib/smart-device/smart-device.getDevices.js
+++ b/server/services/tp-link/lib/smart-device/smart-device.getDevices.js
@@ -25,26 +25,26 @@ async function getDevices() {
 
   const discovery = this.client.startDiscovery({ discoveryTimeout: 1900, discoveryInterval: 800 });
 
-  discovery.on('device-online', (device) => {
-    device.getSysInfo().then((deviceSysInfo) => {
-      const type = deviceSysInfo.type ? deviceSysInfo.type : deviceSysInfo.mic_type;
-      switch (type) {
-        case 'IOT.SMARTPLUGSWITCH':
-        case 'IOT.RANGEEXTENDER.SMARTPLUG':
-          devicesToReturn.push(getTpLinkPlug(device, deviceSysInfo, this.serviceId));
-          break;
-        case 'IOT.SMARTBULB':
-          devicesToReturn.push(getTpLinkBulb(device, deviceSysInfo, this.serviceId));
-          break;
-        default:
-          devicesToReturn.push(getTpLinkDevice(device, deviceSysInfo, this.serviceId));
-      }
-    });
+  discovery.on('device-online', async (device) => {
+    const deviceSysInfo = await device.getSysInfo();
+    const type = deviceSysInfo.type ? deviceSysInfo.type : deviceSysInfo.mic_type;
+    switch (type) {
+      case 'IOT.SMARTPLUGSWITCH':
+      case 'IOT.RANGEEXTENDER.SMARTPLUG':
+        devicesToReturn.push(getTpLinkPlug(device, deviceSysInfo, this.serviceId));
+        break;
+      case 'IOT.SMARTBULB':
+        devicesToReturn.push(getTpLinkBulb(device, deviceSysInfo, this.serviceId));
+        break;
+      default:
+        devicesToReturn.push(getTpLinkDevice(device, deviceSysInfo, this.serviceId));
+    }
   });
-  return Promise.delay(2000).then(() => {
-    discovery.removeAllListeners('device-online');
-    return uniqById(devicesToReturn);
-  });
+
+  await Promise.delay(this.discoverDevicesDelay);
+
+  discovery.removeAllListeners('device-online');
+  return uniqById(devicesToReturn);
 }
 
 module.exports = {


### PR DESCRIPTION
It removes 3 on 4 promise warnings:

```
/home/runner/work/Gladys/Gladys/server/services/tp-link/lib/smart-device/smart-device.getDevices.js
Warning:   29:25  warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then
Warning:   44:30  warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then

/home/runner/work/Gladys/Gladys/server/test/services/tp-link/smart-device/smart-device.getDevices.test.js
Warning:   65:20  warning  Prefer await to then()/catch()/finally()  promise/prefer-await-to-then
```