### PR TITLE
fix(front): Increase chat height

### DIFF
--- a/front/src/routes/chat/style.css
+++ b/front/src/routes/chat/style.css
@@ -167,7 +167,7 @@
 }
 
 .msg_history {
-  height: 356px;
+  height: 60vh;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
I'm bad at CSS so trying this

<img width="1218" alt="CleanShot 2023-07-06 at 20 16 45@2x" src="https://github.com/GladysAssistant/Gladys/assets/1773153/150086cd-ce96-454d-862f-025c08502721">
