### PR TITLE
Fix binary state when the same deviceFeatures is displayed multiple times

### DIFF
--- a/front/src/components/boxs/device-in-room/DevicesInRoomsBox.jsx
+++ b/front/src/components/boxs/device-in-room/DevicesInRoomsBox.jsx
@@ -17,9 +17,9 @@ class DevicesInRoomComponent extends Component {
   componentDidMount() {
     this.getRoom();
   }
-  render({ box }, { room }) {
+  render({ box, x, y }, { room }) {
     const boxModified = { ...box, name: room && room.name };
-    return <DeviceBox box={boxModified} />;
+    return <DeviceBox box={boxModified} x={x} y={y} />;
   }
 }
 

--- a/front/src/components/boxs/device-in-room/device-features/BinaryDeviceFeature.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/BinaryDeviceFeature.jsx
@@ -13,7 +13,7 @@ const BinaryDeviceType = ({ children, ...props }) => {
         <label class="custom-switch">
           <input
             type="radio"
-            name={props.deviceFeature.id}
+            name={`box-${props.x}-${props.y}-${props.deviceFeature.id}`}
             value="1"
             class="custom-switch-input"
             checked={props.deviceFeature.last_value}


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.

### Description of change

Fix #1861 