### PR TITLE
Devices in room widget should correctly refresh list of device features

### DIFF
--- a/front/src/components/boxs/device-in-room/EditDeviceInRoom.jsx
+++ b/front/src/components/boxs/device-in-room/EditDeviceInRoom.jsx
@@ -74,8 +74,12 @@ class EditDeviceInRoom extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.box.room !== this.props.box.room && this.props.box.room) {
-      this.getDeviceFeatures();
+    if (prevProps.box && this.props.box && this.props.box.room) {
+      const deviceFeaturesChanged = prevProps.box.device_features !== this.props.box.device_features;
+      const roomChanged = prevProps.box.room !== this.props.box.room;
+      if (deviceFeaturesChanged || roomChanged) {
+        this.getDeviceFeatures();
+      }
     }
   }
 


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to [the community](https://community.gladysassistant.com/) for testing before merging.

### Description of change

Fix refresh of device in rooms edition widget