### PR TITLE
Add a list of device feature categories that don't expires in time

### DIFF
--- a/front/src/components/boxs/device-in-room/device-features/sensor-value/SensorDeviceFeature.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/sensor-value/SensorDeviceFeature.jsx
@@ -26,6 +26,13 @@ const DISPLAY_BY_FEATURE_TYPE = {
   [DEVICE_FEATURE_TYPES.SENSOR.BINARY]: BinaryDeviceValue
 };
 
+const DEVICE_FEATURES_WITHOUT_EXPIRATION = [
+  DEVICE_FEATURE_CATEGORIES.SMOKE_SENSOR,
+  DEVICE_FEATURE_CATEGORIES.LEAK_SENSOR,
+  DEVICE_FEATURE_CATEGORIES.BUTTON,
+  DEVICE_FEATURE_CATEGORIES.TEXT
+];
+
 const SensorDeviceType = ({ children, ...props }) => {
   const { deviceFeature: feature } = props;
   const { category, type } = feature;
@@ -40,8 +47,9 @@ const SensorDeviceType = ({ children, ...props }) => {
     elementType = BadgeNumberDeviceValue;
   }
 
-  // If the device feature has no recent value, we display a message to the user
-  if (feature.last_value_is_too_old) {
+  // If the device feature has no recent value, and the feature is not in the blacklist
+  // we display a message to the user
+  if (feature.last_value_is_too_old && DEVICE_FEATURES_WITHOUT_EXPIRATION.indexOf(feature.category) === -1) {
     elementType = NoRecentValueBadge;
   }
 


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

Some feature categories should not expire