### PR TITLE
User can define the threshold of the room temperature

### DIFF
--- a/front/src/components/boxs/room-humidity/RoomHumidity.jsx
+++ b/front/src/components/boxs/room-humidity/RoomHumidity.jsx
@@ -30,7 +30,7 @@ const RoomHumidityBox = ({ children, ...props }) => (
         </span>
       )}
       {!isNotNullOrUndefined(props.humidity) && (
-        <span class="stamp stamp-md bg-red-dark mr-3">
+        <span class="stamp stamp-md bg-warning mr-3">
           <i class="fe fe-droplet" />
         </span>
       )}

--- a/front/src/components/boxs/room-humidity/RoomHumidity.jsx
+++ b/front/src/components/boxs/room-humidity/RoomHumidity.jsx
@@ -30,7 +30,7 @@ const RoomHumidityBox = ({ children, ...props }) => (
         </span>
       )}
       {!isNotNullOrUndefined(props.humidity) && (
-        <span class="stamp stamp-md bg-red mr-3">
+        <span class="stamp stamp-md bg-red-dark mr-3">
           <i class="fe fe-droplet" />
         </span>
       )}

--- a/front/src/components/boxs/room-temperature/EditRoomTemperatureBox.jsx
+++ b/front/src/components/boxs/room-temperature/EditRoomTemperatureBox.jsx
@@ -46,10 +46,13 @@ const EditRoomTemperatureBox = ({ children, ...props }) => (
         renderThumb={(props, state) => (
           <div {...props}>
             <Text id="global.degreeValue" fields={{ value: state.valueNow }} />
+            <Text id="global.celsius" />
           </div>
         )}
         pearling
         minDistance={10}
+        max={50}
+        min={-20}
         onAfterChange={props.updateBoxValue}
         value={[props.temperatureMin, props.temperatureMax]}
         disabled={!(props.box.temperature_use_custom_value || false)}

--- a/front/src/components/boxs/room-temperature/EditRoomTemperatureBox.jsx
+++ b/front/src/components/boxs/room-temperature/EditRoomTemperatureBox.jsx
@@ -1,6 +1,6 @@
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
-import { Localizer, Text } from 'preact-i18n';
+import { Text } from 'preact-i18n';
 import BaseEditBox from '../baseEditBox';
 import ReactSlider from 'react-slider';
 

--- a/front/src/components/boxs/room-temperature/EditRoomTemperatureBox.jsx
+++ b/front/src/components/boxs/room-temperature/EditRoomTemperatureBox.jsx
@@ -1,9 +1,12 @@
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
-import { Text } from 'preact-i18n';
+import { Localizer, Text } from 'preact-i18n';
 import BaseEditBox from '../baseEditBox';
+import ReactSlider from 'react-slider';
 
+import { DEFAULT_VALUE_TEMPERATURE } from '../../../../../server/utils/constants';
 import RoomSelector from '../../house/RoomSelector';
+import cx from 'classnames';
 
 const updateBoxRoom = (updateBoxRoomFunc, x, y) => room => {
   updateBoxRoomFunc(x, y, room.selector);
@@ -20,6 +23,38 @@ const EditRoomTemperatureBox = ({ children, ...props }) => (
         updateRoomSelection={updateBoxRoom(props.updateBoxRoom, props.x, props.y)}
       />
     </div>
+    <div className="form-group form-check">
+      <label className="form-check-label">
+        <input
+          type="checkbox"
+          id="useCustomValue"
+          className="form-check-input"
+          checked={props.box.temperature_use_custom_value || false}
+          onChange={props.updateBoxUseCustomValue}
+        />
+        <Text id="dashboard.boxes.temperatureInRoom.thresholdsLabel" />
+      </label>
+    </div>
+    <div class="form-group">
+      <ReactSlider
+        className={cx('temperature-slider', {
+          'opacity-60': !(props.box.temperature_use_custom_value || false)
+        })}
+        thumbClassName="temperature-slider-thumb"
+        trackClassName="temperature-slider-track"
+        defaultValue={[props.temperatureMin, props.temperatureMax]}
+        renderThumb={(props, state) => (
+          <div {...props}>
+            <Text id="global.degreeValue" fields={{ value: state.valueNow }} />
+          </div>
+        )}
+        pearling
+        minDistance={10}
+        onAfterChange={props.updateBoxValue}
+        value={[props.temperatureMin, props.temperatureMax]}
+        disabled={!(props.box.temperature_use_custom_value || false)}
+      />
+    </div>
   </BaseEditBox>
 );
 
@@ -29,8 +64,46 @@ class EditRoomTemperatureBoxComponent extends Component {
       room
     });
   };
+
+  updateBoxUseCustomValue = e => {
+    this.props.updateBoxConfig(this.props.x, this.props.y, {
+      temperature_use_custom_value: e.target.checked
+    });
+  };
+
+  updateBoxValue = values => {
+    this.props.updateBoxConfig(this.props.x, this.props.y, {
+      temperature_min: values[0],
+      temperature_max: values[1]
+    });
+  };
+
   render(props, {}) {
-    return <EditRoomTemperatureBox {...props} updateBoxRoom={this.updateBoxRoom} />;
+    let temperature_min = this.props.box.temperature_min;
+    let temperature_max = this.props.box.temperature_max;
+
+    if (!this.props.box.temperature_use_custom_value) {
+      temperature_min = DEFAULT_VALUE_TEMPERATURE.MINIMUM;
+      temperature_max = DEFAULT_VALUE_TEMPERATURE.MAXIMUM;
+    }
+
+    if (isNaN(temperature_min)) {
+      temperature_min = DEFAULT_VALUE_TEMPERATURE.MINIMUM;
+    }
+    if (isNaN(temperature_max)) {
+      temperature_max = DEFAULT_VALUE_TEMPERATURE.MAXIMUM;
+    }
+
+    return (
+      <EditRoomTemperatureBox
+        {...props}
+        updateBoxRoom={this.updateBoxRoom}
+        updateBoxUseCustomValue={this.updateBoxUseCustomValue}
+        updateBoxValue={this.updateBoxValue}
+        temperatureMin={temperature_min}
+        temperatureMax={temperature_max}
+      />
+    );
   }
 }
 

--- a/front/src/components/boxs/room-temperature/RoomTemperature.jsx
+++ b/front/src/components/boxs/room-temperature/RoomTemperature.jsx
@@ -5,11 +5,7 @@ import get from 'get-value';
 
 import actions from '../../../actions/dashboard/boxes/temperatureInRoom';
 import { DASHBOARD_BOX_STATUS_KEY, DASHBOARD_BOX_DATA_KEY } from '../../../utils/consts';
-import {
-  DEFAULT_VALUE_HUMIDITY,
-  DEFAULT_VALUE_TEMPERATURE,
-  WEBSOCKET_MESSAGE_TYPES
-} from '../../../../../server/utils/constants';
+import { DEFAULT_VALUE_TEMPERATURE, WEBSOCKET_MESSAGE_TYPES } from '../../../../../server/utils/constants';
 
 const isNotNullOrUndefined = value => value !== undefined && value !== null;
 
@@ -34,7 +30,7 @@ const RoomTemperatureBox = ({ children, ...props }) => (
         </span>
       )}
       {!isNotNullOrUndefined(props.temperature) && (
-        <span class="stamp stamp-md bg-red-dark mr-3">
+        <span class="stamp stamp-md bg-warning mr-3">
           <i class="fe fe-thermometer" />
         </span>
       )}

--- a/front/src/components/boxs/room-temperature/RoomTemperature.jsx
+++ b/front/src/components/boxs/room-temperature/RoomTemperature.jsx
@@ -5,7 +5,12 @@ import get from 'get-value';
 
 import actions from '../../../actions/dashboard/boxes/temperatureInRoom';
 import { DASHBOARD_BOX_STATUS_KEY, DASHBOARD_BOX_DATA_KEY } from '../../../utils/consts';
-import { DEFAULT_VALUE_TEMPERATURE, WEBSOCKET_MESSAGE_TYPES } from '../../../../../server/utils/constants';
+import {
+  DEFAULT_VALUE_TEMPERATURE,
+  DEVICE_FEATURE_UNITS,
+  WEBSOCKET_MESSAGE_TYPES
+} from '../../../../../server/utils/constants';
+import { celsiusToFahrenheit } from '../../../../../server/utils/units';
 
 const isNotNullOrUndefined = value => value !== undefined && value !== null;
 
@@ -99,6 +104,13 @@ class RoomTemperatureBoxComponent extends Component {
     }
     if (isNaN(temperature_max)) {
       temperature_max = DEFAULT_VALUE_TEMPERATURE.MAXIMUM;
+    }
+
+    console.log('unit', unit);
+
+    if (unit === DEVICE_FEATURE_UNITS.FAHRENHEIT) {
+      temperature_min = celsiusToFahrenheit(temperature_min);
+      temperature_max = celsiusToFahrenheit(temperature_min);
     }
 
     return (

--- a/front/src/components/boxs/room-temperature/RoomTemperature.jsx
+++ b/front/src/components/boxs/room-temperature/RoomTemperature.jsx
@@ -5,24 +5,48 @@ import get from 'get-value';
 
 import actions from '../../../actions/dashboard/boxes/temperatureInRoom';
 import { DASHBOARD_BOX_STATUS_KEY, DASHBOARD_BOX_DATA_KEY } from '../../../utils/consts';
-import { WEBSOCKET_MESSAGE_TYPES } from '../../../../../server/utils/constants';
+import {
+  DEFAULT_VALUE_HUMIDITY,
+  DEFAULT_VALUE_TEMPERATURE,
+  WEBSOCKET_MESSAGE_TYPES
+} from '../../../../../server/utils/constants';
 
 const isNotNullOrUndefined = value => value !== undefined && value !== null;
 
 const RoomTemperatureBox = ({ children, ...props }) => (
   <div class="card p-3">
     <div class="d-flex align-items-center">
-      <span class="stamp stamp-md bg-blue mr-3">
-        <i class="fe fe-thermometer" />
-      </span>
+      {isNotNullOrUndefined(props.temperature) &&
+        props.temperature >= props.temperatureMin &&
+        props.temperature <= props.temperatureMax && (
+          <span class="stamp stamp-md bg-green mr-3">
+            <i class="fe fe-thermometer" />
+          </span>
+        )}
+      {isNotNullOrUndefined(props.temperature) && props.temperature < props.temperatureMin && (
+        <span class="stamp stamp-md bg-blue mr-3">
+          <i class="fe fe-thermometer" />
+        </span>
+      )}
+      {isNotNullOrUndefined(props.temperature) && props.temperature > props.temperatureMax && (
+        <span class="stamp stamp-md bg-red mr-3">
+          <i class="fe fe-thermometer" />
+        </span>
+      )}
+      {!isNotNullOrUndefined(props.temperature) && (
+        <span class="stamp stamp-md bg-red-dark mr-3">
+          <i class="fe fe-thermometer" />
+        </span>
+      )}
+
       <div>
-        {props.valued && (
+        {isNotNullOrUndefined(props.temperature) && (
           <h4 class="m-0">
             <Text id="global.degreeValue" fields={{ value: Number(props.temperature).toFixed(1) }} />
             <Text id={`global.${props.unit}`} />
           </h4>
         )}
-        {!props.valued && (
+        {!isNotNullOrUndefined(props.temperature) && (
           <p class="m-0">
             <Text id="dashboard.boxes.temperatureInRoom.noTemperatureRecorded" />
           </p>
@@ -64,7 +88,22 @@ class RoomTemperatureBoxComponent extends Component {
     const temperature = get(boxData, 'room.temperature.temperature');
     const unit = get(boxData, 'room.temperature.unit');
     const roomName = get(boxData, 'room.name');
-    const valued = isNotNullOrUndefined(temperature);
+
+    const temperature_use_custom_value = get(props, 'box.temperature_use_custom_value');
+    let temperature_min = get(props, 'box.temperature_min');
+    let temperature_max = get(props, 'box.temperature_max');
+
+    if (!temperature_use_custom_value) {
+      temperature_min = DEFAULT_VALUE_TEMPERATURE.MINIMUM;
+      temperature_max = DEFAULT_VALUE_TEMPERATURE.MAXIMUM;
+    }
+
+    if (isNaN(temperature_min)) {
+      temperature_min = DEFAULT_VALUE_TEMPERATURE.MINIMUM;
+    }
+    if (isNaN(temperature_max)) {
+      temperature_max = DEFAULT_VALUE_TEMPERATURE.MAXIMUM;
+    }
 
     return (
       <RoomTemperatureBox
@@ -73,7 +112,9 @@ class RoomTemperatureBoxComponent extends Component {
         unit={unit}
         boxStatus={boxStatus}
         roomName={roomName}
-        valued={valued}
+        useCustomValue={temperature_use_custom_value}
+        temperatureMin={temperature_min}
+        temperatureMax={temperature_max}
       />
     );
   }

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -253,7 +253,8 @@
       },
       "temperatureInRoom": {
         "editRoomLabel": "Select the room you want to display here.",
-        "noTemperatureRecorded": "No temperature recorded recently."
+        "noTemperatureRecorded": "No temperature recorded recently.",
+        "thresholdsLabel": "Configure custom thresholds"
       },
       "humidityInRoom": {
         "editRoomLabel": "Select the room you want to display here.",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -253,7 +253,8 @@
       },
       "temperatureInRoom": {
         "editRoomLabel": "Sélectionnez la pièce que vous souhaitez afficher ici.",
-        "noTemperatureRecorded": "Aucune température enregistrée récemment."
+        "noTemperatureRecorded": "Aucune température enregistrée récemment.",
+        "thresholdsLabel": "Configurer des seuils personnalisés"
       },
       "humidityInRoom": {
         "editRoomLabel": "Sélectionnez la pièce que vous souhaitez afficher ici.",

--- a/front/src/style/index.css
+++ b/front/src/style/index.css
@@ -323,7 +323,6 @@ body {
   font-size: 0.9em;
   text-align: center;
   background-color: #fafafa;
-  #color: white;
   cursor: pointer;
   border: 1px solid gray;
   border-radius: 10px;
@@ -353,6 +352,52 @@ body {
 }
 
 .humidity-slider .humidity-slider-thumb {
+  top: 3px;
+  width: 41px;
+  height: 24px;
+  line-height: 22px;
+}
+
+
+.temperature-slider {
+  width: 100%;
+  max-width: 500px;
+  height: 30px;
+}
+
+.temperature-slider-thumb {
+  font-size: 0.9em;
+  text-align: center;
+  background-color: #fafafa;
+  cursor: pointer;
+  border: 1px solid gray;
+  border-radius: 10px;
+  box-sizing: border-box;
+}
+
+.temperature-slider-thumb.active {
+  border: 1px solid #467fcf;
+}
+
+.temperature-slider-track {
+  position: relative;
+  background: #467fcf;
+}
+
+.temperature-slider-track-1 {
+  background: #5eba00;
+}
+
+.temperature-slider-track-2 {
+  background: #cd201f;
+}
+
+.temperature-slider .temperature-slider-track {
+  top: 10px;
+  height: 10px;
+}
+
+.temperature-slider .temperature-slider-thumb {
   top: 3px;
   width: 41px;
   height: 24px;

--- a/server/models/dashboard.js
+++ b/server/models/dashboard.js
@@ -32,6 +32,9 @@ const boxesSchema = Joi.array().items(
       humidity_use_custom_value: Joi.boolean(),
       humidity_min: Joi.number(),
       humidity_max: Joi.number(),
+      temperature_use_custom_value: Joi.boolean(),
+      temperature_min: Joi.number(),
+      temperature_max: Joi.number(),
     }),
   ),
 );

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -949,6 +949,11 @@ const DEFAULT_VALUE_HUMIDITY = {
   MAXIMUM: 60,
 };
 
+const DEFAULT_VALUE_TEMPERATURE = {
+  MINIMUM: 17,
+  MAXIMUM: 24,
+};
+
 const createList = (obj) => {
   const list = [];
   Object.keys(obj).forEach((key) => {
@@ -1046,3 +1051,4 @@ module.exports.JOB_ERROR_TYPES = JOB_ERROR_TYPES;
 module.exports.JOB_ERROR_TYPES_LIST = JOB_ERROR_TYPES_LIST;
 
 module.exports.DEFAULT_VALUE_HUMIDITY = DEFAULT_VALUE_HUMIDITY;
+module.exports.DEFAULT_VALUE_TEMPERATURE = DEFAULT_VALUE_TEMPERATURE;


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Add a threshold for the room temperature widget

<img width="538" alt="Screenshot 2023-09-21 at 14 15 22" src="https://github.com/GladysAssistant/Gladys/assets/11317212/eb6d616a-72ec-48b1-93d1-4dc2bda6014c">
<img width="543" alt="Screenshot 2023-09-21 at 14 15 11" src="https://github.com/GladysAssistant/Gladys/assets/11317212/cf3a38ad-e184-4a06-b338-ae7504d1afb4">
<img width="546" alt="Screenshot 2023-09-21 at 14 14 49" src="https://github.com/GladysAssistant/Gladys/assets/11317212/d140adf1-1cf6-4742-a0c3-b56ead8d5736">
<img width="539" alt="Screenshot 2023-09-21 at 14 14 26" src="https://github.com/GladysAssistant/Gladys/assets/11317212/bd6d124f-3ce6-4055-8696-6d2b3905cda0">
<img width="675" alt="Screenshot 2023-09-21 at 14 14 18" src="https://github.com/GladysAssistant/Gladys/assets/11317212/6cd8489c-aa63-4f9b-bfb7-8f6d34287a8b">
