### PR TITLE
fix typo mistake on openweather integration description (EN)

### DIFF
--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -720,7 +720,7 @@
     },
     "openWeather": {
       "title": "OpenWeather API",
-      "description": "Display the weather in your town on your dasboard.",
+      "description": "Display the weather in your town on your dashboard.",
       "introduction": "This integration helps you integrate with OpenWeather API to get the weather in Gladys.",
       "instructions": "You first need to create an account on OpenWeather API website: <a href=\"https://openweathermap.org/api\">https://openweathermap.org/api</a>.",
       "apiKeyLabel": "Then, enter your API key here:",


### PR DESCRIPTION
I have fixed a typo mistake on openweather integration description (EN language only)
