### PR TITLE
Scene: In device.set-value action, binary feature should default to 0

### DIFF
--- a/front/src/routes/scene/edit-scene/actions/DeviceSetValue.jsx
+++ b/front/src/routes/scene/edit-scene/actions/DeviceSetValue.jsx
@@ -33,8 +33,13 @@ class DeviceSetValue extends Component {
       this.props.updateActionProperty(columnIndex, index, 'device_feature', null);
     }
     if (deviceFeatureChanged) {
-      this.props.updateActionProperty(columnIndex, index, 'value', undefined);
-      this.props.updateActionProperty(columnIndex, index, 'evaluate_value', undefined);
+      if (deviceFeature.type === DEVICE_FEATURE_TYPES.SWITCH.BINARY) {
+        this.props.updateActionProperty(columnIndex, index, 'value', 0);
+        this.props.updateActionProperty(columnIndex, index, 'evaluate_value', undefined);
+      } else {
+        this.props.updateActionProperty(columnIndex, index, 'value', undefined);
+        this.props.updateActionProperty(columnIndex, index, 'evaluate_value', undefined);
+      }
     }
     this.setState({ deviceFeature, device });
   };


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

Fix #1892