### PR TITLE
fix some typo/trad mistakes on Gladys App

### DIFF
--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -1083,7 +1083,7 @@
         "discoveringError": "An error occurred, check scanner configuration, or check logs."
       },
       "setup": {
-        "title": "LANManager settings",
+        "title": "LAN Settings",
         "errorLabel": "An error occurred while loading configuration.",
         "noConfigLabel": "Configuration not loaded, please retry.",
         "presenceScannerDescription": "The presence scanner feature is doing a network scan at a defined interval. When a device is detected, the device will be flagged as \"seen\" in Gladys. In scene, you can create a trigger on this state change to set you home when a device is detected at home for example.",
@@ -2034,7 +2034,7 @@
     "ppb": "Parts per billion (ppb)",
     "watt": "Watt (W)",
     "kilowatt": "Kilowatt (kW)",
-    "watt-hour": "Watt heure (Wh)",
+    "watt-hour": "Watt hour (Wh)",
     "kilowatt-hour": "Kilowatt hour (kWh)",
     "megawatt-hour": "Megawatt hour (MWh)",
     "ampere": "Ampere (A)",
@@ -2393,7 +2393,7 @@
     },
     "formaldehyd-sensor": {
       "shortCategoryName": "Formaldehyd sensor",
-      "decimal": "Formaldehyd(decimal)"
+      "decimal": "Formaldehyd (decimal)"
     },
     "vibration-sensor": {
       "shortCategoryName": "Vibration sensor",
@@ -2498,7 +2498,7 @@
     "curtain": {
       "shortCategoryName": "Curtain",
       "state": "Curtain state",
-      "position": "curtain position"
+      "position": "Curtain position"
     },
     "data": {
       "shortCategoryName": "Data",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -681,7 +681,7 @@
         "zigbee2mqttUsbDriverPathPlaceholder": "Port USB",
         "zigbee2mqttUsbDongleNameLabel": "Sélectionner le modèle du dongle Zigbee utilisé",
         "zigbee2mqttUsbDongleNamePlaceholder": "Modèle du dongle Zigbee",
-        "saveButton": "Sauvegarde",
+        "saveButton": "Sauvegarder",
         "refreshButton": "Rafraîchir la liste des appareils USB",
         "notAttached": "Aucun dongle USB Zigbee2mqtt n'est attaché à Gladys.",
         "attached": "Le dongle USB Zigbee2mqtt est configuré.",
@@ -1712,7 +1712,7 @@
     "unknownError": "Une erreur inconnue s'est produite. Veuillez réessayer ou contacter Gladys community."
   },
   "settings": {
-    "title": "Réglages",
+    "title": "Paramètres",
     "housesTab": "Maisons",
     "usersTab": "Utilisateurs",
     "sessionsTab": "Sessions",
@@ -2394,8 +2394,8 @@
       "decimal": "PM2.5 (Décimale)"
     },
     "formaldehyd-sensor": {
-      "shortCategoryName": "Formaldehyd sensor",
-      "decimal": "Formaldehyd (Décimale)"
+      "shortCategoryName": "Capteur Formaldéhyde",
+      "decimal": "Formaldéhyde (Décimale)"
     },
     "vibration-sensor": {
       "shortCategoryName": "Capteur de vibration",


### PR DESCRIPTION
I've fixed some typos/trad mistakes on Gladys overall :
- Trad mistake "Watt heure" on z2m integration (English language)
- Lan manager title more clearer than others
- In French langague, when you click on "Paramètres", the title of the window is "Réglages": it's not very coherent: I've fixed it.
- A save button was misspelled if you take the other buttons as an example.
- A few typing/translation errors have also been fixed in the MQTT integration.  