### PR TITLE
Add capability to launch scene from chat

### DIFF
--- a/server/config/brain/scene/questions.en.json
+++ b/server/config/brain/scene/questions.en.json
@@ -1,0 +1,6 @@
+[
+  {
+    "label": "scene.start",
+    "questions": ["Run %scene%", "Launch %scene%"]
+  }
+]

--- a/server/config/brain/scene/questions.fr.json
+++ b/server/config/brain/scene/questions.fr.json
@@ -1,0 +1,7 @@
+[
+  {
+    "label": "scene.start",
+    "questions": ["Lance la scène %scene%", "Lance %scene%",
+      "Exécute la scène %scene%", "Exécute %scene%"]
+  }
+]

--- a/server/config/brain/scene/questions.fr.json
+++ b/server/config/brain/scene/questions.fr.json
@@ -1,7 +1,6 @@
 [
   {
     "label": "scene.start",
-    "questions": ["Lance la scène %scene%", "Lance %scene%",
-      "Exécute la scène %scene%", "Exécute %scene%"]
+    "questions": ["Lance la scène %scene%", "Lance %scene%", "Exécute la scène %scene%", "Exécute %scene%"]
   }
 ]


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

Add the capability to launch a scene from the chat with sentences : 
 - Launch [scene name]
 - Run [scene name]
 - Lance la scène [scene name]
 - Lance [scene name]


![bd8277f2be019560018e6413528a6989e919587a_2_690x425](https://github.com/GladysAssistant/Gladys/assets/11317212/5f7a7451-ef2c-4c2a-b3f2-ccd29d7d9d4d)
