### PR TITLE
Fix z-index issue in only-continue-if selector in scene action

### DIFF
--- a/front/src/routes/scene/edit-scene/actions/only-continue-if/Condition.css
+++ b/front/src/routes/scene/edit-scene/actions/only-continue-if/Condition.css
@@ -4,10 +4,6 @@
   align-items: center;
 }
 
-.deviceSelector {
-  z-index: 10;
-}
-
 .explanationText {
   font-size: 12px;
   margin-bottom: .375rem;

--- a/front/src/routes/scene/edit-scene/actions/only-continue-if/Condition.jsx
+++ b/front/src/routes/scene/edit-scene/actions/only-continue-if/Condition.jsx
@@ -76,7 +76,6 @@ class Condition extends Component {
               </label>
               <Select
                 defaultValue={''}
-                className={cx(style.deviceSelector)}
                 value={selectedOption}
                 onChange={this.handleChange}
                 options={props.variableOptions}

--- a/front/src/routes/scene/edit-scene/actions/only-continue-if/Condition.jsx
+++ b/front/src/routes/scene/edit-scene/actions/only-continue-if/Condition.jsx
@@ -2,7 +2,6 @@ import { Component } from 'preact';
 import { Text, Localizer } from 'preact-i18n';
 import Select from 'react-select';
 import update from 'immutability-helper';
-import cx from 'classnames';
 
 import TextWithVariablesInjected from '../../../../../components/scene/TextWithVariablesInjected';
 


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [ ] If your changes affects code, did your write the tests?
- [ ] Are tests passing? (`npm test` on both front/server)
- [ ] Is the linter passing? (`npm run eslint` on both front/server)
- [ ] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Fix z-index issue in only-continue-if selector in scene action
![image](https://github.com/GladysAssistant/Gladys/assets/11477113/e32c2346-dbf5-438c-b51b-69699d93f088)

