### PR TITLE
fix(docker): Node as first process

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,4 +35,4 @@ ENV SERVER_PORT 80
 # Export listening port
 EXPOSE 80
 
-CMD ["npm" ,"run", "start:prod"]
+CMD ["node", "index.js"]

--- a/docker/Dockerfile.buildx
+++ b/docker/Dockerfile.buildx
@@ -45,4 +45,4 @@ ENV SERVER_PORT 80
 # Export listening port
 EXPOSE 80
 
-CMD ["npm" ,"run", "start:prod"]
+CMD ["node", "index.js"]


### PR DESCRIPTION
Fixes #1964

New list of processes
```
PID   USER     TIME  COMMAND
    1 root      0:42 node index.js
   58 root      0:00 /bin/sh
   67 root      0:00 ps aux
```

When I `docker stop`, I've got these 2 lines 🎉 
```
2023-12-04T21:45:17+0100 <info> index.js:25 (shutdown) SIGTERM received.
2023-12-04T21:45:17+0100 <info> index.js:31 (shutdown) Closing database connection.
```