### PR TITLE
feat(dashboard edit): Add button -add- per column

### DIFF
--- a/front/src/routes/dashboard/edit-dashboard/EditBoxColumns.jsx
+++ b/front/src/routes/dashboard/edit-dashboard/EditBoxColumns.jsx
@@ -101,14 +101,15 @@ const EditBoxColumns = ({ children, ...props }) => (
               )}
 
               {column.length === 0 && <EmptyColumnDropZone moveCard={props.moveCard} x={x} />}
+
+              {props.isMobileReordering && <AutoScrollMobile position="bottom" box_type={DASHBOARD_EDIT_BOX_TYPE} />}
+              <div class="d-flex justify-content-center mb-4">
+                <button class="btn btn-primary" onClick={() => props.addBox(x)}>
+                  <Text id="dashboard.addBoxButton" /> <i class="fe fe-plus" />
+                </button>
+              </div>
             </div>
           ))}
-      </div>
-      {props.isMobileReordering && <AutoScrollMobile position="bottom" box_type={DASHBOARD_EDIT_BOX_TYPE} />}
-      <div class="d-flex justify-content-center">
-        <button class="btn btn-primary" onClick={props.addBox}>
-          <Text id="dashboard.addBoxButton" /> <i class="fe fe-plus" />
-        </button>
       </div>
     </DndProvider>
   </div>

--- a/front/src/routes/dashboard/edit-dashboard/index.js
+++ b/front/src/routes/dashboard/edit-dashboard/index.js
@@ -104,11 +104,11 @@ class EditDashboard extends Component {
     await this.setState(newState);
   };
 
-  addBox = () => {
+  addBox = x => {
     const newState = update(this.state, {
       currentDashboard: {
         boxes: {
-          0: {
+          [x]: {
             $push: [{}]
           }
         }


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [ ] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

[#1938] Add 3 buttons "Add" for every column in Dashboard edition mode.

Before:
<img width="719" alt="2023 12 07_PR_BEFORE_DESKTOP" src="https://github.com/GladysAssistant/Gladys/assets/138247436/3cf3e9fb-945e-442a-8960-ff760e1e2a15">
<img width="176" alt="2023 12 07_PR_BEFORE_MOBILE" src="https://github.com/GladysAssistant/Gladys/assets/138247436/c59cfd40-953a-4cea-85ff-62ffa93366c3">

After:
<img width="901" alt="2023 12 07_PR_AFTER_DESKTOP" src="https://github.com/GladysAssistant/Gladys/assets/138247436/f6d063fd-a50b-4f53-8e64-f0e1f1387416">
<img width="178" alt="2023 12 07_AFTER_MOBILE" src="https://github.com/GladysAssistant/Gladys/assets/138247436/f88339f6-fc1a-48cb-903b-fc456e0bb83b">
