### PR TITLE
added configurationKey missing from sonos docs

### DIFF
--- a/front/src/routes/integration/all/sonos/SonosPage.jsx
+++ b/front/src/routes/integration/all/sonos/SonosPage.jsx
@@ -38,6 +38,7 @@ const SonosPage = ({ children, user }) => (
 
                   <DeviceConfigurationLink
                     user={user}
+                    configurationKey="integrations"
                     documentKey="sonos"
                     linkClass="list-group-item list-group-item-action d-flex align-items-center"
                   >


### PR DESCRIPTION
The link to the sonos doc was dead because the configurationKey was missing: I've added it.