### PR TITLE
fix documentKey for nextcloud doc

### DIFF
--- a/front/src/routes/integration/all/nextcloud-talk/NextcloudTalk.jsx
+++ b/front/src/routes/integration/all/nextcloud-talk/NextcloudTalk.jsx
@@ -18,7 +18,7 @@ const NextcloudTalkPage = ({ children, ...props }) => (
                   <DeviceConfigurationLink
                     user={props.user}
                     configurationKey="integrations"
-                    documentKey="nextcloudTalk"
+                    documentKey="nextcloud-talk"
                     linkClass="list-group-item list-group-item-action d-flex align-items-center"
                   >
                     <span class="icon mr-3">


### PR DESCRIPTION
The link to the nextcloud doc was dead because the documentKey was not correct : I've fix it.