### PR TITLE
fix(zigbee2mqtt): Filter unknown models

### DIFF
--- a/server/services/zigbee2mqtt/lib/getDiscoveredDevices.js
+++ b/server/services/zigbee2mqtt/lib/getDiscoveredDevices.js
@@ -10,6 +10,8 @@ const { convertDevice } = require('../utils/convertDevice');
  */
 function getDiscoveredDevices(filters = {}) {
   let devices = Object.values(this.discoveredDevices)
+    // Filter unknown models
+    .filter((d) => d.definition !== null)
     // Convert to Gladys device
     .map((d) => convertDevice(d, this.serviceId))
     .map((d) => {


### PR DESCRIPTION
New devices are in the discoverd devices list (like dongle) without model (due to release https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.35.0)

We need to filter them before converting them to Gladys devices.