### PR TITLE
Fix endtime for events with duration

### DIFF
--- a/server/services/caldav/lib/calendar/calendar.formaters.js
+++ b/server/services/caldav/lib/calendar/calendar.formaters.js
@@ -167,14 +167,15 @@ function formatEvents(caldavEvents, gladysCalendar) {
       } else if (caldavEvent.start && caldavEvent.duration) {
         newEvent.end = this.dayjs
           .tz(this.dayjs(caldavEvent.start).format('YYYY-MM-DDTHH:mm:ss'), caldavEvent.start.tz)
-          .add(this.dayjs.duration(caldavEvent.duration));
+          .add(this.dayjs.duration(caldavEvent.duration))
+          .format();
       }
 
       if (
         caldavEvent.start &&
         caldavEvent.start.tz === undefined &&
         (Number.isInteger(this.dayjs(caldavEvent.end).diff(this.dayjs(caldavEvent.start), 'days', true)) ||
-          !caldavEvent.end)
+          (!caldavEvent.end && !caldavEvent.duration))
       ) {
         newEvent.full_day = true;
       }

--- a/server/services/caldav/package-lock.json
+++ b/server/services/caldav/package-lock.json
@@ -18,7 +18,7 @@
       "dependencies": {
         "bluebird": "^3.7.0",
         "dav-request": "^1.8.0",
-        "dayjs": "^1.10.7",
+        "dayjs": "^1.11.10",
         "ical": "^0.8.0",
         "xmldom": "^0.6.0"
       }
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
-      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "node_modules/ical": {
       "version": "0.8.0",
@@ -170,9 +170,9 @@
       }
     },
     "dayjs": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
-      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "ical": {
       "version": "0.8.0",

--- a/server/services/caldav/package.json
+++ b/server/services/caldav/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "bluebird": "^3.7.0",
     "dav-request": "^1.8.0",
-    "dayjs": "^1.10.7",
+    "dayjs": "^1.11.10",
     "ical": "^0.8.0",
     "xmldom": "^0.6.0"
   }


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [ ] If your changes affects code, did your write the tests?
- [ ] Are tests passing? (`npm test` on both front/server)
- [ ] Is the linter passing? (`npm run eslint` on both front/server)
- [ ] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Please provide a description of the change here. It's always best with screenshots, so don't hesitate to add some!

When calendars used duration instead of end time, event on Gladys was badly setted and displayed as fullday event (wrong endtime).

Before
<img width="311" alt="image" src="https://github.com/GladysAssistant/Gladys/assets/18148265/fec84e86-cdf8-4a13-badd-08e1d94190b5">

Now
<img width="308" alt="image" src="https://github.com/GladysAssistant/Gladys/assets/18148265/3c80ec0a-f0e9-42ea-b837-dc61bc8fb731">
