### PR TITLE
chore(eslint): Add no-console rule + clean

### DIFF
--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -26,7 +26,8 @@
         "selector": "CallExpression[callee.object.name='store'][callee.property.name='setState']",
         "message": "Usage of unistore is not recommended anymore, please use local states instead."
       } */
-    ]
+    ],
+    "no-console": ["error", { "allow": ["error"] }]
   },
   "env": {
     "browser": true

--- a/front/src/components/boxs/camera/Camera.jsx
+++ b/front/src/components/boxs/camera/Camera.jsx
@@ -137,9 +137,6 @@ class CameraBoxComponent extends Component {
         }
       });
       this.hls.on(Hls.Events.MEDIA_ATTACHED, () => {});
-      this.hls.on(Hls.Events.MANIFEST_PARSED, (event, data) => {
-        console.log(`manifest loaded, found ${data.levels.length} quality level`);
-      });
       this.hls.on(Hls.Events.ERROR, (event, data) => {
         console.error(event, data);
         const errorType = data.type;

--- a/front/src/components/boxs/camera/EditCamera.jsx
+++ b/front/src/components/boxs/camera/EditCamera.jsx
@@ -104,7 +104,6 @@ class EditCameraBoxComponent extends Component {
 
   updateCameraLiveAutoStart = e => {
     const newValue = e.target.checked;
-    console.log({ newValue });
     this.props.updateBoxConfig(this.props.x, this.props.y, {
       camera_live_auto_start: newValue
     });

--- a/front/src/components/boxs/room-temperature/RoomTemperature.jsx
+++ b/front/src/components/boxs/room-temperature/RoomTemperature.jsx
@@ -106,8 +106,6 @@ class RoomTemperatureBoxComponent extends Component {
       temperature_max = DEFAULT_VALUE_TEMPERATURE.MAXIMUM;
     }
 
-    console.log('unit', unit);
-
     if (unit === DEVICE_FEATURE_UNITS.FAHRENHEIT) {
       temperature_min = celsiusToFahrenheit(temperature_min);
       temperature_max = celsiusToFahrenheit(temperature_min);

--- a/front/src/routes/integration/all/zwavejs-ui/setup-page/index.js
+++ b/front/src/routes/integration/all/zwavejs-ui/setup-page/index.js
@@ -69,7 +69,6 @@ class DiscoverTab extends Component {
     await this.setState({ loading: true });
     await this.getStatus();
     await this.getConfiguration();
-    console.log('Finish init');
     await this.setState({ loading: false });
   };
 

--- a/front/src/routes/scene/edit-scene/index.js
+++ b/front/src/routes/scene/edit-scene/index.js
@@ -336,7 +336,6 @@ class EditScene extends Component {
   };
 
   updateSceneIcon = e => {
-    console.log('updateSceneIcon', e.target.value);
     this.setState(prevState => {
       const newState = update(prevState, {
         scene: {


### PR DESCRIPTION
Following discussion on French Community, we decide to add a rule to forbid `console.log()` in Frontend.

I decided to allow `console.error()` to help in case of error

- rule added
- existing errors cleaned