### PR TITLE
fix(scene): Tag placeholder

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -1623,7 +1623,7 @@
     "iconLabel": "Symbol",
     "editDescriptionPlaceholder": "Gib eine Beschreibung für die Szene ein",
     "tagsTitle": "Tags",
-    "editTagsPlaceholder": "Gib Tags für die Szene ein",
+    "editTagsPlaceholder": "Geben Sie ein Tag für die Szene ein oder wählen Sie es aus",
     "createTag": "Tag erstellen: '{{tagName}}'",
     "startButton": "Start",
     "saveButton": "Sichern",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -1625,7 +1625,7 @@
     "iconLabel": "Icon",
     "editDescriptionPlaceholder": "Enter a scene description",
     "tagsTitle": "Tags",
-    "editTagsPlaceholder": "Enter a scene tags",
+    "editTagsPlaceholder": "Enter or choose a tag scene",
     "createTag": "Create tag: '{{tagName}}'",
     "startButton": "Start",
     "saveButton": "Save",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -1628,7 +1628,7 @@
     "editDescriptionPlaceholder": "Entrez une description pour la scène",
     "createTag": "Créer le tag : '{{tagName}}'",
     "tagsTitle": "Tags",
-    "editTagsPlaceholder": "Entrez un tag pour la scène",
+    "editTagsPlaceholder": "Entrez ou choisissez un tag pour la scène",
     "startButton": "Démarrer",
     "saveButton": "Sauvegarder",
     "deleteButton": "Supprimer",

--- a/front/src/routes/scene/edit-scene/Settings.jsx
+++ b/front/src/routes/scene/edit-scene/Settings.jsx
@@ -89,6 +89,7 @@ class Settings extends Component {
                         isMulti
                         options={props.tags && props.tags.map(tag => ({ value: tag.name, label: tag.name }))}
                         onChange={tags => props.setTags(tags.map(tag => tag.value))}
+                        placeholder={<Text id="editScene.editTagsPlaceholder" />}
                         formatCreateLabel={inputValue => (
                           <Text id="editScene.createTag" fields={{ tagName: inputValue }} />
                         )}


### PR DESCRIPTION
Following community feedbacks https://community.gladysassistant.com/t/changement-du-texte-pour-la-liste-des-tags-ambiguite/8716

Fixes done:
- correct display of the placeholder
- reword the text to express the fact that User "can creat or choose"

![image](https://github.com/GladysAssistant/Gladys/assets/1773153/93626b64-9209-468e-a250-2df782c50c11)

![image](https://github.com/GladysAssistant/Gladys/assets/1773153/e7efa7a8-77a4-4226-9522-47f006d845eb)
