### PR TITLE
feat(boxs): Add Motion Sensor Device

### DIFF
--- a/front/src/components/boxs/device-in-room/device-features/sensor-value/MotionSensorDeviceValue.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/sensor-value/MotionSensorDeviceValue.jsx
@@ -1,0 +1,20 @@
+import { Text } from 'preact-i18n';
+
+import RelativeTime from '../../../../device/RelativeTime';
+
+const MotionSensorDeviceValue = ({ deviceFeature, user }) => {
+  const { last_value: lastValue, last_value_changed: lastValueChanged } = deviceFeature;
+  if (lastValue) {
+    return (
+      <span class="badge badge-info">
+        <Text id="dashboard.boxes.devicesInRoom.motionDetected" />
+      </span>
+    );
+  } else if (lastValueChanged) {
+    return <RelativeTime datetime={lastValueChanged} language={user ? user.language : null} futureDisabled />;
+  }
+
+  return <Text id="dashboard.boxes.devicesInRoom.noValue" />;
+};
+
+export default MotionSensorDeviceValue;

--- a/front/src/components/boxs/device-in-room/device-features/sensor-value/SensorDeviceFeature.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/sensor-value/SensorDeviceFeature.jsx
@@ -6,6 +6,7 @@ import { DeviceFeatureCategoriesIcon } from '../../../../../utils/consts';
 
 import BinaryDeviceValue from './BinaryDeviceValue';
 import LastSeenDeviceValue from './LastSeenDeviceValue';
+import MotionSensorDeviceValue from './MotionSensorDeviceValue';
 import BadgeNumberDeviceValue from './BadgeNumberDeviceValue';
 import IconBinaryDeviceValue from './IconBinaryDeviceValue';
 import SignalQualityDeviceValue from './SignalQualityDeviceValue';
@@ -14,7 +15,7 @@ import TextDeviceValue from './TextDeviceValue';
 import NoRecentValueBadge from './NoRecentValueBadge';
 
 const DISPLAY_BY_FEATURE_CATEGORY = {
-  [DEVICE_FEATURE_CATEGORIES.MOTION_SENSOR]: LastSeenDeviceValue,
+  [DEVICE_FEATURE_CATEGORIES.MOTION_SENSOR]: MotionSensorDeviceValue,
   [DEVICE_FEATURE_CATEGORIES.PRESENCE_SENSOR]: LastSeenDeviceValue,
   [DEVICE_FEATURE_CATEGORIES.OPENING_SENSOR]: IconBinaryDeviceValue,
   [DEVICE_FEATURE_CATEGORIES.SIGNAL]: SignalQualityDeviceValue,

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -280,7 +280,8 @@
         "noRecentValue": "Kein aktueller Wert",
         "deviceTitle": "{{name}} - {{type}}",
         "addButton": "+",
-        "substractButton": "-"
+        "substractButton": "-",
+        "motionDetected": "Bewegung erkannt"
       },
       "devices": {
         "editDeviceFeaturesLabel": "Wähle die Geräte aus, die du anzeigen möchtest:",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -280,7 +280,8 @@
         "noRecentValue": "No recent value",
         "deviceTitle": "{{name}} - {{type}}",
         "addButton": "+",
-        "substractButton": "-"
+        "substractButton": "-",
+        "motionDetected": "Motion detected"
       },
       "devices": {
         "editDeviceFeaturesLabel": "Select the devices you want to display:",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -280,7 +280,8 @@
         "noRecentValue": "Pas de valeur récente",
         "deviceTitle": "{{name}} - {{type}}",
         "addButton": "+",
-        "substractButton": "-"
+        "substractButton": "-",
+        "motionDetected": "Mouvement détecté"
       },
       "devices": {
         "editDeviceFeaturesLabel": "Vous pouvez modifier le nom affiché ici :",


### PR DESCRIPTION
This PR is adding a Motion Sensor Device row to display "Motion detected" when the device is sending a 1 value and the last time seen when it's not

<table>
<tr>
<th> Detection </th>
<th> No detection </th>
</tr>
<tr>
<td>

![image](https://github.com/GladysAssistant/Gladys/assets/1773153/9ac6483c-80a0-4d1c-8343-cc8f4885d677)

</td>
<td>

![image](https://github.com/GladysAssistant/Gladys/assets/1773153/ba38050e-bb0a-4f12-8131-1486c92c291e)

</td>
</tr>
</table>

You can follow discussion here in the community https://community.gladysassistant.com/t/dashboard-etat-detecteur-de-mouvement/8508/14?u=cicoub13

This could be extended later to Presence Sensor (with a different text like "Presence detected")