### PR TITLE
[Zwavejs-ui] add selector when converting zwave device to Gladys device

### DIFF
--- a/server/services/zwavejs-ui/utils/convertToGladysDevice.js
+++ b/server/services/zwavejs-ui/utils/convertToGladysDevice.js
@@ -40,6 +40,7 @@ const convertToGladysDevice = (serviceId, device) => {
         ...exposeFound,
         name: value.id,
         external_id: getDeviceFeatureId(device.id, commandClassName, endpoint, propertyName, propertyKeyName),
+        selector: getDeviceFeatureId(device.id, commandClassName, endpoint, propertyName, propertyKeyName),
         node_id: device.id,
         // These are custom properties only available on the object in memory (not in DB)
         command_class_version: commandClassVersion,
@@ -55,7 +56,7 @@ const convertToGladysDevice = (serviceId, device) => {
   return {
     name: device.name,
     external_id: `zwavejs-ui:${device.id}`,
-    selector: `zwavejs-ui:${device.id}:${device.name}`,
+    selector: `zwavejs-ui:${device.id}`,
     service_id: serviceId,
     should_poll: false,
     features,

--- a/server/services/zwavejs-ui/utils/convertToGladysDevice.js
+++ b/server/services/zwavejs-ui/utils/convertToGladysDevice.js
@@ -55,6 +55,7 @@ const convertToGladysDevice = (serviceId, device) => {
   return {
     name: device.name,
     external_id: `zwavejs-ui:${device.id}`,
+    selector: `zwavejs-ui:${device.id}:${device.name}`,
     service_id: serviceId,
     should_poll: false,
     features,

--- a/server/test/services/zwavejs-ui/lib/zwaveJSUI.onNewDeviceDiscover.test.js
+++ b/server/test/services/zwavejs-ui/lib/zwaveJSUI.onNewDeviceDiscover.test.js
@@ -34,6 +34,7 @@ describe('zwaveJSUIHandler.onNewDeviceDiscover.js', () => {
       {
         name: 'capteur-ouverture',
         external_id: 'zwavejs-ui:2',
+        selector: `zwavejs-ui:2:capteur-ouverture`,
         service_id: 'ffa13430-df93-488a-9733-5c540e9558e0',
         should_poll: false,
         features: [

--- a/server/test/services/zwavejs-ui/lib/zwaveJSUI.onNewDeviceDiscover.test.js
+++ b/server/test/services/zwavejs-ui/lib/zwaveJSUI.onNewDeviceDiscover.test.js
@@ -34,7 +34,7 @@ describe('zwaveJSUIHandler.onNewDeviceDiscover.js', () => {
       {
         name: 'capteur-ouverture',
         external_id: 'zwavejs-ui:2',
-        selector: `zwavejs-ui:2:capteur-ouverture`,
+        selector: `zwavejs-ui:2`,
         service_id: 'ffa13430-df93-488a-9733-5c540e9558e0',
         should_poll: false,
         features: [
@@ -52,6 +52,7 @@ describe('zwaveJSUIHandler.onNewDeviceDiscover.js', () => {
             command_class_version: 5,
             endpoint: 0,
             external_id: 'zwavejs-ui:2:0:notification:access_control:door_state_simple',
+            selector: 'zwavejs-ui:2:0:notification:access_control:door_state_simple',
             node_id: 2,
             property_name: 'Access Control',
             property_key_name: 'Door state (simple)',

--- a/server/test/services/zwavejs-ui/lib/zwaveJSUI.setValue.test.js
+++ b/server/test/services/zwavejs-ui/lib/zwaveJSUI.setValue.test.js
@@ -135,6 +135,7 @@ describe('zwaveJSUIHandler.setValue', () => {
       {
         name: 'prise01-wp',
         external_id: 'zwavejs-ui:3',
+        selector: 'zwavejs-ui:3:prise01-wp',
         service_id: 'ee03cc7e-8551-4774-bd47-ca7565f6665d',
         should_poll: false,
         features: [
@@ -186,6 +187,7 @@ describe('zwaveJSUIHandler.setValue', () => {
       {
         name: 'prise01-wp',
         external_id: 'zwavejs-ui:3',
+        selector: 'zwavejs-ui:3:prise01-wp',
         service_id: 'ee03cc7e-8551-4774-bd47-ca7565f6665d',
         should_poll: false,
         features: [

--- a/server/test/services/zwavejs-ui/lib/zwaveJSUI.setValue.test.js
+++ b/server/test/services/zwavejs-ui/lib/zwaveJSUI.setValue.test.js
@@ -135,7 +135,7 @@ describe('zwaveJSUIHandler.setValue', () => {
       {
         name: 'prise01-wp',
         external_id: 'zwavejs-ui:3',
-        selector: 'zwavejs-ui:3:prise01-wp',
+        selector: 'zwavejs-ui:3',
         service_id: 'ee03cc7e-8551-4774-bd47-ca7565f6665d',
         should_poll: false,
         features: [
@@ -149,6 +149,7 @@ describe('zwaveJSUIHandler.setValue', () => {
             has_feedback: true,
             name: '3-37-0-currentValue',
             external_id: 'zwavejs-ui:3:0:binary_switch:currentvalue',
+            selector: 'zwavejs-ui:3:0:binary_switch:currentvalue',
             node_id: 3,
             command_class_version: 1,
             command_class_name: 'Binary Switch',
@@ -187,7 +188,7 @@ describe('zwaveJSUIHandler.setValue', () => {
       {
         name: 'prise01-wp',
         external_id: 'zwavejs-ui:3',
-        selector: 'zwavejs-ui:3:prise01-wp',
+        selector: 'zwavejs-ui:3',
         service_id: 'ee03cc7e-8551-4774-bd47-ca7565f6665d',
         should_poll: false,
         features: [
@@ -201,6 +202,7 @@ describe('zwaveJSUIHandler.setValue', () => {
             has_feedback: true,
             name: '3-37-0-currentValue',
             external_id: 'zwavejs-ui:3:0:binary_switch:currentvalue',
+            selector: 'zwavejs-ui:3:0:binary_switch:currentvalue',
             node_id: 3,
             command_class_version: 1,
             command_class_name: 'Binary Switch',


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Without selector there is a conflict issue when adding zwave device to Gladys so I propose to add selector when converting Zwave device to Gladys device.

![image](https://github.com/GladysAssistant/Gladys/assets/11477113/3582369e-64cc-4056-a570-55907fa1d10d)
![image](https://github.com/GladysAssistant/Gladys/assets/11477113/bb69ca7d-b7c8-4b4e-80a9-3be3bc07ad6b)


With the selector
![image](https://github.com/GladysAssistant/Gladys/assets/11477113/2c583b22-2cfb-4780-95d5-1893fbac3035)


https://community.gladysassistant.com/t/evolution-du-service-z-wave-js-ui/8692/26