### PR TITLE
OpenWeather: Display next 8 slots of 3 hours instead of offsetting by 1

### DIFF
--- a/server/services/openweather/lib/formatResults.js
+++ b/server/services/openweather/lib/formatResults.js
@@ -51,7 +51,7 @@ function formatResults(options, result, forecast) {
 
   if (forecast) {
     dataToReturn.hours = [];
-    for (let i = 1; i < 9; i += 1) {
+    for (let i = 0; i < 8; i += 1) {
       dataToReturn.hours.push({
         temperature: Math.round(forecast.list[i].main.temp),
         humidity: forecast.list[i].main.humidity,

--- a/server/test/services/openweather/expected-result.json
+++ b/server/test/services/openweather/expected-result.json
@@ -10,6 +10,16 @@
   "hours": [
     {
       "temperature": 15,
+      "humidity": 78,
+      "pressure": 1018,
+      "datetime": "2023-05-01T12:00:00.000Z",
+      "units": "metric",
+      "wind_speed": 4.01,
+      "wind_direction": 298,
+      "weather": "rain"
+    },
+    {
+      "temperature": 15,
       "humidity": 77,
       "pressure": 1018,
       "datetime": "2023-05-01T15:00:00.000Z",
@@ -76,16 +86,6 @@
       "units": "metric",
       "wind_speed": 2.01,
       "wind_direction": 8,
-      "weather": "cloud"
-    },
-    {
-      "temperature": 17,
-      "humidity": 52,
-      "pressure": 1022,
-      "datetime": "2023-05-02T12:00:00.000Z",
-      "units": "metric",
-      "wind_speed": 2.92,
-      "wind_direction": 20,
       "weather": "cloud"
     }
   ],


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [ ] If your changes affects code, did your write the tests?
- [ ] Are tests passing? (`npm test` on both front/server)
- [ ] Is the linter passing? (`npm run eslint` on both front/server)
- [ ] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Please provide a description of the change here. It's always best with screenshots, so don't hesitate to add some!
