### PR TITLE
Zigbee2mqtt : Keep keep_history when updating feature + fix update from devices with duplicate features

### DIFF
--- a/server/services/zigbee2mqtt/lib/getDiscoveredDevices.js
+++ b/server/services/zigbee2mqtt/lib/getDiscoveredDevices.js
@@ -15,6 +15,19 @@ function getDiscoveredDevices(filters = {}) {
     // Convert to Gladys device
     .map((d) => convertDevice(d, this.serviceId))
     .map((d) => {
+      // Remove features with duplicate external_id
+      // This code is needed because AQARA motion sensor
+      // Returns 2 illuminance features and it doesn't work with Gladys
+      d.features = d.features.reduce((acc, current) => {
+        const isDuplicate = acc.some((feature) => feature.external_id === current.external_id);
+        if (!isDuplicate) {
+          acc.push(current);
+        }
+        return acc;
+      }, []);
+      return d;
+    })
+    .map((d) => {
       const existingDevice = this.gladys.stateManager.get('deviceByExternalId', d.external_id);
       // Merge with existing device.
       return mergeDevices(d, existingDevice);
@@ -24,19 +37,6 @@ function getDiscoveredDevices(filters = {}) {
   if (`${filterExisting}` === 'true') {
     devices = devices.filter((device) => device.id === undefined || device.updatable);
   }
-
-  devices.forEach((device) => {
-    // Remove features with duplicate external_id
-    // This code is needed because AQARA motion sensor
-    // Returns 2 illuminance features and it doesn't work with Gladys
-    device.features = device.features.reduce((acc, current) => {
-      const isDuplicate = acc.some((feature) => feature.external_id === current.external_id);
-      if (!isDuplicate) {
-        acc.push(current);
-      }
-      return acc;
-    }, []);
-  });
 
   return devices;
 }

--- a/server/test/utils/device.test.js
+++ b/server/test/utils/device.test.js
@@ -253,8 +253,48 @@ describe('mergeFeature', () => {
     const oldFeature = buildFeature('old');
     const mergedFeature = mergeFeatures(newFeature, oldFeature);
 
-    const expectedFeature = { ...newFeature, name: 'feature-old-name' };
+    const expectedFeature = { ...newFeature, name: 'feature-old-name', keep_history: 'feature-old-keep_history' };
     expect(mergedFeature).to.deep.equal(expectedFeature);
+  });
+  it('should keep keep_history from old feature', () => {
+    const newFeature = {
+      name: 'Temp sensor',
+      category: 'humidity-sensor',
+      type: 'decimal',
+      external_id: 'second-humidity',
+      selector: 'second-humidity',
+      read_only: true,
+      keep_history: true,
+      has_feedback: false,
+      min: -50,
+      max: 150,
+    };
+    const oldFeature = {
+      name: 'My custom name',
+      category: 'humidity-sensor',
+      type: 'decimal',
+      external_id: 'second-humidity',
+      selector: 'second-humidity',
+      read_only: true,
+      keep_history: false,
+      has_feedback: false,
+      min: -50,
+      max: 100,
+    };
+    const mergedFeature = mergeFeatures(newFeature, oldFeature);
+
+    expect(mergedFeature).to.deep.equal({
+      name: 'My custom name',
+      category: 'humidity-sensor',
+      type: 'decimal',
+      external_id: 'second-humidity',
+      selector: 'second-humidity',
+      read_only: true,
+      keep_history: false,
+      has_feedback: false,
+      min: -50,
+      max: 150,
+    });
   });
 });
 

--- a/server/test/utils/device.test.js
+++ b/server/test/utils/device.test.js
@@ -347,7 +347,7 @@ describe('mergeDevice', () => {
 
     const mergedDevice = mergeDevices(newDevice, oldDevice);
 
-    const expectedFeature = { ...newFeature, name: 'feature-old1-name' };
+    const expectedFeature = { ...newFeature, name: 'feature-old1-name', keep_history: 'feature-old1-keep_history' };
     const expectedDevice = { ...newDevice, features: [expectedFeature], updatable: true };
     expect(mergedDevice).to.deep.equal(expectedDevice);
   });

--- a/server/utils/device.js
+++ b/server/utils/device.js
@@ -135,7 +135,7 @@ function hasDeviceChanged(newDevice, existingDevice = {}) {
 
 /**
  * @description Merge feature attributes from existing with the new one.
- * It keeps 'name' attribute from existing.
+ * It keeps 'name' and 'keep_history' attribute from existing.
  * @param {object} newFeature - Newly created feature.
  * @param {object} existingFeature - Already existing feature.
  * @returns {object} A new feature merged with existing one.
@@ -143,13 +143,17 @@ function hasDeviceChanged(newDevice, existingDevice = {}) {
  * mergeFeatures({ name: 'Default name' }, { name: 'Overriden name' })
  */
 function mergeFeatures(newFeature, existingFeature = {}) {
-  const { name } = existingFeature || {};
+  const featureToReturn = { ...newFeature };
 
-  if (name) {
-    return { ...newFeature, name };
+  if (existingFeature && existingFeature.name) {
+    featureToReturn.name = existingFeature.name;
   }
 
-  return newFeature;
+  if (existingFeature && existingFeature.keep_history !== undefined) {
+    featureToReturn.keep_history = existingFeature.keep_history;
+  }
+
+  return featureToReturn;
 }
 
 /**


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.
- [x] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)

### Description of change

Fix https://github.com/GladysAssistant/Gladys/issues/2069 & https://github.com/GladysAssistant/Gladys/issues/2060