### PR TITLE
Gladys Plus : Change backup to 2-4 AM

### DIFF
--- a/server/lib/gateway/gateway.init.js
+++ b/server/lib/gateway/gateway.init.js
@@ -44,7 +44,7 @@ async function init() {
   // schedule backup at midnight
   const timezone = await this.variable.getValue(SYSTEM_VARIABLE_NAMES.TIMEZONE);
 
-  const rule = { tz: timezone, hour: 0, minute: 0, second: 0 };
+  const rule = { tz: timezone, hour: 2, minute: 0, second: 0 };
   this.backupSchedule = this.scheduler.scheduleJob(rule, this.checkIfBackupNeeded.bind(this));
 
   // Get latest Gladys version in 5 minutes

--- a/server/test/lib/gateway/gateway.init.test.js
+++ b/server/test/lib/gateway/gateway.init.test.js
@@ -84,7 +84,7 @@ describe('gateway.init', () => {
     expect(gateway.connected).to.equal(true);
     expect(gateway.usersKeys).to.deep.equal(userKeys);
     expect(gateway.backupSchedule).to.deep.contains({
-      rule: { tz: 'Europe/Paris', hour: 0, minute: 0, second: 0 },
+      rule: { tz: 'Europe/Paris', hour: 2, minute: 0, second: 0 },
     });
   });
 
@@ -101,7 +101,7 @@ describe('gateway.init', () => {
     expect(gateway.connected).to.equal(false);
     expect(gateway.usersKeys).to.deep.equal(userKeys);
     expect(gateway.backupSchedule).to.deep.contains({
-      rule: { tz: 'Europe/Paris', hour: 0, minute: 0, second: 0 },
+      rule: { tz: 'Europe/Paris', hour: 2, minute: 0, second: 0 },
     });
   });
 


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

Change Gladys Plus backups to 2:00 - 4:00 AM