### PR TITLE
Zigbee2mqtt : Remove containers when disabling integration

### DIFF
--- a/server/services/zigbee2mqtt/lib/disconnect.js
+++ b/server/services/zigbee2mqtt/lib/disconnect.js
@@ -28,7 +28,7 @@ async function disconnect() {
   this.gladysConnected = false;
   this.emitStatusEvent();
 
-  // Stop MQTT container
+  // Stop & remove MQTT container
   let dockerContainer = await this.gladys.system.getContainers({
     all: true,
     filters: { name: [mqttContainerDescriptor.name] },
@@ -36,11 +36,12 @@ async function disconnect() {
   if (dockerContainer.length > 0) {
     [container] = dockerContainer;
     await this.gladys.system.stopContainer(container.id);
+    await this.gladys.system.removeContainer(container.id);
   }
   this.mqttRunning = false;
   this.emitStatusEvent();
 
-  // Stop zigbee2mqtt container
+  // Stop & remove zigbee2mqtt container
   dockerContainer = await this.gladys.system.getContainers({
     all: true,
     filters: { name: [zigbee2mqttContainerDescriptor.name] },
@@ -48,6 +49,7 @@ async function disconnect() {
   if (dockerContainer.length > 0) {
     [container] = dockerContainer;
     await this.gladys.system.stopContainer(container.id);
+    await this.gladys.system.removeContainer(container.id);
   }
   this.zigbee2mqttRunning = false;
   this.zigbee2mqttConnected = false;

--- a/server/test/services/zigbee2mqtt/lib/disconnect.test.js
+++ b/server/test/services/zigbee2mqtt/lib/disconnect.test.js
@@ -38,6 +38,7 @@ describe('zigbee2mqtt disconnect', () => {
       system: {
         getContainers: fake.resolves([container]),
         stopContainer: fake.resolves(true),
+        removeContainer: fake.resolves(true),
       },
     };
 
@@ -71,6 +72,7 @@ describe('zigbee2mqtt disconnect', () => {
       },
     });
     assert.calledTwice(gladys.system.stopContainer);
+    assert.calledTwice(gladys.system.removeContainer);
   });
 
   it('mqtt connected', async () => {
@@ -96,6 +98,7 @@ describe('zigbee2mqtt disconnect', () => {
       },
     });
     assert.calledTwice(gladys.system.stopContainer);
+    assert.calledTwice(gladys.system.removeContainer);
     assert.calledOnce(mqtt.end);
     assert.calledOnce(mqtt.removeAllListeners);
 


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

Fix #2108 - Remove containers when disabling the integration. It fixes a bug when the user disable then re-enable containers, the new credentials are not taken into account