### PR TITLE
Privilege Escalation Fix

### DIFF
--- a/server/api/controllers/user.controller.js
+++ b/server/api/controllers/user.controller.js
@@ -131,6 +131,7 @@ module.exports = function UserController(gladys) {
    * @apiGroup User
    */
   async function updateMySelf(req, res, next) {
+    delete req.body.role;
     const newUser = await gladys.user.update(req.user.id, req.body);
     res.json(newUser);
   }

--- a/server/lib/user/user.update.js
+++ b/server/lib/user/user.update.js
@@ -27,7 +27,6 @@ async function update(userId, newUser) {
     newUser.password = await passwordUtils.hash(newUser.password);
   }
 
-  delete newUser.role;
   await user.update(newUser);
 
   const plainUser = user.get({ plain: true });

--- a/server/lib/user/user.update.js
+++ b/server/lib/user/user.update.js
@@ -27,6 +27,7 @@ async function update(userId, newUser) {
     newUser.password = await passwordUtils.hash(newUser.password);
   }
 
+  delete newUser.role;
   await user.update(newUser);
 
   const plainUser = user.get({ plain: true });


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [ ] If your changes affects code, did your write the tests?
- [ x] Are tests passing? (`npm test` on both front/server)
- [ x] Is the linter passing? (`npm run eslint` on both front/server)
- [ x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

This is a quick fix for a privilege escalation vulnerability reported privately through the security.md process. 
The /api/v1/me endpoint is called when updating/saving a users profile. This endpoints route handling is vulnerable to mass assignment which means, changing the role parameter from “user” to “admin” while submitting a save profile request will change your role to admin. This lets you have full control to the Gladys and could even kick out the original administrator.  This fix is to delete the role parameter before passing it to the update function. A more robust solution in the future will be to use options.fields from here https://sequelize.org/api/v6/class/src/model.js~model#static-method-update to allowlist what fields can be updated. 
