### PR TITLE
Fix: Rollback socket-io to old version to prevent Gladys Plus disconnect

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "gladys-front",
       "dependencies": {
-        "@gladysassistant/gladys-gateway-js": "4.16.2",
+        "@gladysassistant/gladys-gateway-js": "4.15.0",
         "@gladysassistant/theme-optimized": "^1.0.3",
         "@jaames/iro": "^5.5.2",
         "@yaireo/tagify": "4.5.0",
@@ -4085,9 +4085,9 @@
       "dev": true
     },
     "node_modules/@gladysassistant/gladys-gateway-js": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@gladysassistant/gladys-gateway-js/-/gladys-gateway-js-4.16.2.tgz",
-      "integrity": "sha512-ePkq3W1nYg5rRtNnI9s4A7SXFatSf1loKV6sHJkYzOk2b1uluHI0VrW7gmLrizvomfzpzmvKcC06PJJmKk894g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@gladysassistant/gladys-gateway-js/-/gladys-gateway-js-4.15.0.tgz",
+      "integrity": "sha512-vQlycZWF0sA3/KuIlPf0/DVFJ2lbf/R+SbCrkyeuT3P+NnD/EZ9QEFKI/Xu7x1uf4pS+H7CVUT0SudzOGMBoPw==",
       "dependencies": {
         "@ctrlpanel/pbkdf2": "^1.0.0",
         "array-buffer-to-hex": "^1.0.0",
@@ -4096,7 +4096,7 @@
         "encode-utf8": "^1.0.2",
         "hex-to-array-buffer": "^1.1.0",
         "secure-remote-password": "^0.3.1",
-        "socket.io-client": "^4.8.0"
+        "socket.io-client": "^4.5.3"
       }
     },
     "node_modules/@gladysassistant/theme-optimized": {
@@ -11328,15 +11328,15 @@
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.1.tgz",
-      "integrity": "sha512-aYuoak7I+R83M/BBPIOs2to51BmFIpC1wZe6zZzMrT2llVsHy5cvcmdsJgP2Qz6smHu+sD9oexiSUAVd8OfBPw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
+      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
         "ws": "~8.17.1",
-        "xmlhttprequest-ssl": "~2.1.1"
+        "xmlhttprequest-ssl": "~2.0.0"
       }
     },
     "node_modules/engine.io-client/node_modules/debug": {
@@ -23472,13 +23472,13 @@
       }
     },
     "node_modules/socket.io-client": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.0.tgz",
-      "integrity": "sha512-C0jdhD5yQahMws9alf/yvtsMGTaIDBnZ8Rb5HU56svyq0l5LIrGzIDZZD5pHQlmzxLuU91Gz+VpQMKgCTNYtkw==",
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
+      "integrity": "sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
-        "engine.io-client": "~6.6.1",
+        "engine.io-client": "~6.5.2",
         "socket.io-parser": "~4.2.4"
       },
       "engines": {
@@ -28137,9 +28137,9 @@
       "dev": true
     },
     "node_modules/xmlhttprequest-ssl": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.1.tgz",
-      "integrity": "sha512-ptjR8YSJIXoA3Mbv5po7RtSYHO6mZr8s7i5VGmEk7QY2pQWyT1o0N+W1gKbOyJPUCGXGnuw0wqe8f0L6Y0ny7g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -31250,9 +31250,9 @@
       "dev": true
     },
     "@gladysassistant/gladys-gateway-js": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@gladysassistant/gladys-gateway-js/-/gladys-gateway-js-4.16.2.tgz",
-      "integrity": "sha512-ePkq3W1nYg5rRtNnI9s4A7SXFatSf1loKV6sHJkYzOk2b1uluHI0VrW7gmLrizvomfzpzmvKcC06PJJmKk894g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@gladysassistant/gladys-gateway-js/-/gladys-gateway-js-4.15.0.tgz",
+      "integrity": "sha512-vQlycZWF0sA3/KuIlPf0/DVFJ2lbf/R+SbCrkyeuT3P+NnD/EZ9QEFKI/Xu7x1uf4pS+H7CVUT0SudzOGMBoPw==",
       "requires": {
         "@ctrlpanel/pbkdf2": "^1.0.0",
         "array-buffer-to-hex": "^1.0.0",
@@ -31261,7 +31261,7 @@
         "encode-utf8": "^1.0.2",
         "hex-to-array-buffer": "^1.1.0",
         "secure-remote-password": "^0.3.1",
-        "socket.io-client": "^4.8.0"
+        "socket.io-client": "^4.5.3"
       }
     },
     "@gladysassistant/theme-optimized": {
@@ -37015,15 +37015,15 @@
       }
     },
     "engine.io-client": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.1.tgz",
-      "integrity": "sha512-aYuoak7I+R83M/BBPIOs2to51BmFIpC1wZe6zZzMrT2llVsHy5cvcmdsJgP2Qz6smHu+sD9oexiSUAVd8OfBPw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
+      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
         "ws": "~8.17.1",
-        "xmlhttprequest-ssl": "~2.1.1"
+        "xmlhttprequest-ssl": "~2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -46379,13 +46379,13 @@
       }
     },
     "socket.io-client": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.0.tgz",
-      "integrity": "sha512-C0jdhD5yQahMws9alf/yvtsMGTaIDBnZ8Rb5HU56svyq0l5LIrGzIDZZD5pHQlmzxLuU91Gz+VpQMKgCTNYtkw==",
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
+      "integrity": "sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==",
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
-        "engine.io-client": "~6.6.1",
+        "engine.io-client": "~6.5.2",
         "socket.io-parser": "~4.2.4"
       },
       "dependencies": {
@@ -50107,9 +50107,9 @@
       "dev": true
     },
     "xmlhttprequest-ssl": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.1.tgz",
-      "integrity": "sha512-ptjR8YSJIXoA3Mbv5po7RtSYHO6mZr8s7i5VGmEk7QY2pQWyT1o0N+W1gKbOyJPUCGXGnuw0wqe8f0L6Y0ny7g=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/front/package.json
+++ b/front/package.json
@@ -43,7 +43,7 @@
     "prettier": "^1.17.1"
   },
   "dependencies": {
-    "@gladysassistant/gladys-gateway-js": "4.16.2",
+    "@gladysassistant/gladys-gateway-js": "4.15.0",
     "@gladysassistant/theme-optimized": "^1.0.3",
     "@jaames/iro": "^5.5.2",
     "@yaireo/tagify": "4.5.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@gladysassistant/gladys-gateway-js": "4.16.2",
+        "@gladysassistant/gladys-gateway-js": "4.15.0",
         "@hapi/joi": "^17.1.0",
         "@hapi/joi-date": "^2.0.1",
         "@nlpjs/similarity": "^4.26.1",
@@ -705,9 +705,9 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
     },
     "node_modules/@gladysassistant/gladys-gateway-js": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@gladysassistant/gladys-gateway-js/-/gladys-gateway-js-4.16.2.tgz",
-      "integrity": "sha512-ePkq3W1nYg5rRtNnI9s4A7SXFatSf1loKV6sHJkYzOk2b1uluHI0VrW7gmLrizvomfzpzmvKcC06PJJmKk894g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@gladysassistant/gladys-gateway-js/-/gladys-gateway-js-4.15.0.tgz",
+      "integrity": "sha512-vQlycZWF0sA3/KuIlPf0/DVFJ2lbf/R+SbCrkyeuT3P+NnD/EZ9QEFKI/Xu7x1uf4pS+H7CVUT0SudzOGMBoPw==",
       "dependencies": {
         "@ctrlpanel/pbkdf2": "^1.0.0",
         "array-buffer-to-hex": "^1.0.0",
@@ -716,7 +716,7 @@
         "encode-utf8": "^1.0.2",
         "hex-to-array-buffer": "^1.1.0",
         "secure-remote-password": "^0.3.1",
-        "socket.io-client": "^4.8.0"
+        "socket.io-client": "^4.5.3"
       }
     },
     "node_modules/@gladysassistant/gladys-gateway-js/node_modules/axios": {
@@ -4246,15 +4246,15 @@
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.1.tgz",
-      "integrity": "sha512-aYuoak7I+R83M/BBPIOs2to51BmFIpC1wZe6zZzMrT2llVsHy5cvcmdsJgP2Qz6smHu+sD9oexiSUAVd8OfBPw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
+      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
         "ws": "~8.17.1",
-        "xmlhttprequest-ssl": "~2.1.1"
+        "xmlhttprequest-ssl": "~2.0.0"
       }
     },
     "node_modules/engine.io-client/node_modules/debug": {
@@ -10373,13 +10373,13 @@
       }
     },
     "node_modules/socket.io-client": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.0.tgz",
-      "integrity": "sha512-C0jdhD5yQahMws9alf/yvtsMGTaIDBnZ8Rb5HU56svyq0l5LIrGzIDZZD5pHQlmzxLuU91Gz+VpQMKgCTNYtkw==",
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
+      "integrity": "sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
-        "engine.io-client": "~6.6.1",
+        "engine.io-client": "~6.5.2",
         "socket.io-parser": "~4.2.4"
       },
       "engines": {
@@ -11996,9 +11996,9 @@
       "dev": true
     },
     "node_modules/xmlhttprequest-ssl": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.1.tgz",
-      "integrity": "sha512-ptjR8YSJIXoA3Mbv5po7RtSYHO6mZr8s7i5VGmEk7QY2pQWyT1o0N+W1gKbOyJPUCGXGnuw0wqe8f0L6Y0ny7g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -12576,9 +12576,9 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
     },
     "@gladysassistant/gladys-gateway-js": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@gladysassistant/gladys-gateway-js/-/gladys-gateway-js-4.16.2.tgz",
-      "integrity": "sha512-ePkq3W1nYg5rRtNnI9s4A7SXFatSf1loKV6sHJkYzOk2b1uluHI0VrW7gmLrizvomfzpzmvKcC06PJJmKk894g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@gladysassistant/gladys-gateway-js/-/gladys-gateway-js-4.15.0.tgz",
+      "integrity": "sha512-vQlycZWF0sA3/KuIlPf0/DVFJ2lbf/R+SbCrkyeuT3P+NnD/EZ9QEFKI/Xu7x1uf4pS+H7CVUT0SudzOGMBoPw==",
       "requires": {
         "@ctrlpanel/pbkdf2": "^1.0.0",
         "array-buffer-to-hex": "^1.0.0",
@@ -12587,7 +12587,7 @@
         "encode-utf8": "^1.0.2",
         "hex-to-array-buffer": "^1.1.0",
         "secure-remote-password": "^0.3.1",
-        "socket.io-client": "^4.8.0"
+        "socket.io-client": "^4.5.3"
       },
       "dependencies": {
         "axios": {
@@ -15488,15 +15488,15 @@
       }
     },
     "engine.io-client": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.1.tgz",
-      "integrity": "sha512-aYuoak7I+R83M/BBPIOs2to51BmFIpC1wZe6zZzMrT2llVsHy5cvcmdsJgP2Qz6smHu+sD9oexiSUAVd8OfBPw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
+      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
         "ws": "~8.17.1",
-        "xmlhttprequest-ssl": "~2.1.1"
+        "xmlhttprequest-ssl": "~2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -20101,13 +20101,13 @@
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
     },
     "socket.io-client": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.0.tgz",
-      "integrity": "sha512-C0jdhD5yQahMws9alf/yvtsMGTaIDBnZ8Rb5HU56svyq0l5LIrGzIDZZD5pHQlmzxLuU91Gz+VpQMKgCTNYtkw==",
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
+      "integrity": "sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==",
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
-        "engine.io-client": "~6.6.1",
+        "engine.io-client": "~6.5.2",
         "socket.io-parser": "~4.2.4"
       },
       "dependencies": {
@@ -21348,9 +21348,9 @@
       "dev": true
     },
     "xmlhttprequest-ssl": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.1.tgz",
-      "integrity": "sha512-ptjR8YSJIXoA3Mbv5po7RtSYHO6mZr8s7i5VGmEk7QY2pQWyT1o0N+W1gKbOyJPUCGXGnuw0wqe8f0L6Y0ny7g=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/server/package.json
+++ b/server/package.json
@@ -73,7 +73,7 @@
     "supertest": "^3.4.2"
   },
   "dependencies": {
-    "@gladysassistant/gladys-gateway-js": "4.16.2",
+    "@gladysassistant/gladys-gateway-js": "4.15.0",
     "@hapi/joi": "^17.1.0",
     "@hapi/joi-date": "^2.0.1",
     "@nlpjs/similarity": "^4.26.1",


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

Rollback to old socket-io version to fix Gladys Plus disconnect