### PR TITLE
Chart: Fix binary query, return first value

### DIFF
--- a/server/test/lib/device/device.getDeviceFeaturesAggregates.test.js
+++ b/server/test/lib/device/device.getDeviceFeaturesAggregates.test.js
@@ -244,6 +244,14 @@ describe('Device.getDeviceFeaturesAggregates binary feature', function Describe(
     expect(values).to.have.lengthOf(300);
     expect(device).to.have.property('name');
     expect(deviceFeature).to.have.property('name');
+
+    values.forEach((value) => {
+      expect(value).to.have.property('value');
+      // Check that both created_at and end_time are present
+      expect(value).to.have.property('created_at');
+      expect(value).to.have.property('end_time');
+    });
+
     // Check that the values are state changes
     for (let i = 1; i < values.length; i += 1) {
       expect(values[i].value).to.not.equal(values[i - 1].value);


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

Binary query was not returning the first value because it was not different from the previous value, fixing that