### PR TITLE
LAN Manager: Should save a 0 once if a device is not discovered

### DIFF
--- a/server/services/lan-manager/lib/lan-manager.scanPresence.js
+++ b/server/services/lan-manager/lib/lan-manager.scanPresence.js
@@ -39,6 +39,14 @@ async function scanPresence() {
           device_feature_external_id: externalId,
           state: 1,
         });
+      } else {
+        const deviceFeatureInCache = this.gladys.stateManager.get('deviceFeatureByExternalId', externalId);
+        if (deviceFeatureInCache.last_value !== 0) {
+          this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
+            device_feature_external_id: externalId,
+            state: 0,
+          });
+        }
       }
     });
   }

--- a/server/test/services/lan-manager/lib/lan-manager.scanPresence.test.js
+++ b/server/test/services/lan-manager/lib/lan-manager.scanPresence.test.js
@@ -7,7 +7,7 @@ const scanMock = stub();
 const LANManager = proxyquire('../../../../services/lan-manager/lib', {
   './lan-manager.scan': { scan: scanMock },
 });
-const { DEVICE_FEATURE_CATEGORIES } = require('../../../../utils/constants');
+const { EVENTS, DEVICE_FEATURE_CATEGORIES } = require('../../../../utils/constants');
 
 const gladys = {
   event: {
@@ -29,6 +29,10 @@ describe('LANManager scanPresence', () => {
         mac: 'AA:BB:CC:DD',
       },
     ];
+
+    gladys.stateManager = {
+      get: fake.returns({ last_value: 0 }),
+    };
 
     gladys.event = {
       emit: fake.returns(true),
@@ -66,7 +70,7 @@ describe('LANManager scanPresence', () => {
     assert.notCalled(gladys.event.emit);
   });
 
-  it('scanPresence presence device not discovered', async () => {
+  it('scanPresence presence device not discovered, should save value 0', async () => {
     gladys.device.get = fake.resolves([
       {
         features: [
@@ -77,6 +81,43 @@ describe('LANManager scanPresence', () => {
         ],
       },
     ]);
+
+    gladys.stateManager = {
+      get: fake.returns({
+        last_value: 1,
+      }),
+    };
+
+    scanMock.resolves([]);
+    await manager.scanPresence();
+
+    assert.calledOnceWithExactly(gladys.device.get, {
+      service: 'lan-manager',
+      device_feature_category: DEVICE_FEATURE_CATEGORIES.PRESENCE_SENSOR,
+    });
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'lan-manager:unknown-uuid',
+      state: 0,
+    });
+  });
+
+  it('scanPresence presence device not discovered, should not save value 0 as last value is 0', async () => {
+    gladys.device.get = fake.resolves([
+      {
+        features: [
+          {
+            external_id: 'lan-manager:unknown-uuid',
+            category: DEVICE_FEATURE_CATEGORIES.PRESENCE_SENSOR,
+          },
+        ],
+      },
+    ]);
+
+    gladys.stateManager = {
+      get: fake.returns({
+        last_value: 0,
+      }),
+    };
 
     scanMock.resolves([]);
     await manager.scanPresence();


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

When a device is not seen, should save a 0 but only once to avoid saving too much useless 0.