### PR TITLE
Add userId to the where clause to prevent the exposure of sessions

### DIFF
--- a/server/api/routes.js
+++ b/server/api/routes.js
@@ -487,6 +487,7 @@ function getRoutes(gladys) {
     },
     'get /api/v1/session': {
       authenticated: true,
+      admin: true,
       controller: sessionController.get,
     },
     // light

--- a/server/api/routes.js
+++ b/server/api/routes.js
@@ -487,7 +487,6 @@ function getRoutes(gladys) {
     },
     'get /api/v1/session': {
       authenticated: true,
-      admin: true,
       controller: sessionController.get,
     },
     // light

--- a/server/lib/session/session.get.js
+++ b/server/lib/session/session.get.js
@@ -37,6 +37,7 @@ async function get(userId, options) {
     order: [[optionsWithDefault.order_by, optionsWithDefault.order_dir]],
     where: {
       revoked: false,
+      user_id: userId,
     },
   });
 


### PR DESCRIPTION
### Description

During the code review, I discovered a vulnerability in the session controller that allows access to other users' accounts. The following route can be called by any user:

```
'get /api/v1/session': {
  authenticated: true,
  controller: sessionController.get,
}
```

The get function is implemented as follows:
```
async function get(userId, options) {
  const optionsWithDefault = { ...DEFAULT_OPTIONS, ...options };

  const sessions = await db.Session.findAll({
    attributes: FIELDS,
    limit: optionsWithDefault.take,
    offset: optionsWithDefault.skip,
    order: [[optionsWithDefault.order_by, optionsWithDefault.order_dir]],
    where: {
      revoked: false,
    },
  });
}
```

The issue here is that the userId parameter passed to the get function is not used anywhere in the code. As a result, the query retrieves all session IDs from the database. This endpoint can be invoked by any user, regardless of their permission. Moreover, with access to other users' apiKey, it is possible to call other application endpoints. This is because the authMiddleware allows the use of apiKey for user authentication:

```
else if (authHeader || req.body.api_key || req.query.api_key) {
  const token = authHeader || req.body.api_key || req.query.api_key;
  // we validate the token
  userId = await gladys.session.validateApiKey(token, scope);
}
```

I think it would be better to check the user’s permissions for this endpoint. Alternatively, another solution is to return only the current sessions of the user making the request, rather than the sessions of other users.
