### PR TITLE
Add RangeValidator for take paramater

### DIFF
--- a/server/lib/user/user.get.js
+++ b/server/lib/user/user.get.js
@@ -1,11 +1,13 @@
 const { Op } = require('sequelize');
 const Sequelize = require('sequelize');
+const { RangeError } = require('../../utils/coreErrors');
 const db = require('../../models');
 
 const DEFAULT_OPTIONS = {
   fields: ['id', 'firstname', 'lastname', 'selector', 'email'],
   expand: [],
   skip: 0,
+  limit: 20,
   order_dir: 'ASC',
   order_by: 'firstname',
 };
@@ -40,6 +42,9 @@ async function get(options) {
   };
 
   if (optionsWithDefault.take) {
+    if (optionsWithDefault.take > DEFAULT_OPTIONS.limit) {
+      throw new RangeError('The value of the limit parameter is out of range');
+    }
     queryParams.limit = optionsWithDefault.take;
   }
 

--- a/server/test/controllers/user/user.get.test.js
+++ b/server/test/controllers/user/user.get.test.js
@@ -70,4 +70,18 @@ describe('GET /api/v1/user', () => {
       .expect('Content-Type', /json/)
       .expect(401);
   });
+
+  it('should return 500 for an out-of-range limit value', async () => {
+    await authenticatedRequest
+      .get('/api/v1/user?take=30')
+      .expect('Content-Type', /json/)
+      .expect(500);
+  });
+
+  it('should return 200 for a limit value within the valid range.', async () => {
+    await authenticatedRequest
+      .get('/api/v1/user?take=15')
+      .expect('Content-Type', /json/)
+      .expect(200);
+  });
 });

--- a/server/utils/coreErrors.js
+++ b/server/utils/coreErrors.js
@@ -12,6 +12,13 @@ class NotFoundError extends Error {
   }
 }
 
+class RangeError extends Error {
+  constructor(message) {
+    super();
+    this.message = message;
+  }
+}
+
 class NoValuesFoundError extends Error {
   constructor(message) {
     super();
@@ -80,4 +87,5 @@ module.exports = {
   ConflictError,
   ForbiddenError,
   TooManyRequests,
+  RangeError,
 };


### PR DESCRIPTION
### Description

In the `user.get.js ` file, no validator has been implemented for the take field. A client could send a request to the following endpoint and set takes to a large value, which could lead to reduced performance and a potential DoS attack on the application. I have added a new validator called RangeError.

In all controllers, it’s better to check that the value provided by the client does not exceed a certain range before passing this parameter to the database. For this purpose, I wrote two different tests: one for when the takes value is out of range, and another for when it is within the valid range.

```
if (optionsWithDefault.take) {
    if (optionsWithDefault.take > DEFAULT_OPTIONS.limit) {
      throw new RangeError('The value of the limit parameter is out of range');
    }
    queryParams.limit = optionsWithDefault.take;
  }
```