### PR TITLE
feat(scenes): Add does not contain for Calendar action

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -2223,6 +2223,7 @@
         "nameLabel": "Wenn der Name",
         "isExactly": "genau ist",
         "contains": "enthält",
+        "doesNotContain": "enthält nicht",
         "startsWith": "beginnt mit",
         "endsWith": "endet mit",
         "hasAnyName": "einen beliebigen Namen hat",

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -1968,7 +1968,8 @@
         "whenFoundLabel": "Wenn ein Ereignis gefunden wird",
         "whenNotFoundLabel": "Wenn kein Ereignis gefunden wird",
         "stopScene": "Szene stoppen",
-        "continueScene": "Szene fortsetzen"
+        "continueScene": "Szene fortsetzen",
+        "doesNotContainExplanation": "Wenn mindestens ein Ereignis gefunden wird, das den gesuchten Namen enthält, werden die anderen Ereignisse ignoriert."
       },
       "ecowattCondition": {
         "description": "Diese Bedingung ermöglicht es dir, den Status des französischen Stromnetzes zu überprüfen",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -1968,7 +1968,8 @@
         "whenFoundLabel": "If an event is found",
         "whenNotFoundLabel": "If no event is found",
         "stopScene": "Stop the scene",
-        "continueScene": "Continue the scene"
+        "continueScene": "Continue the scene",
+        "doesNotContainExplanation": "If at least one event containing the searched name is found, the other events will be ignored."
       },
       "ecowattCondition": {
         "description": "This conditions lets you check the status of the french electricity network",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -2223,6 +2223,7 @@
         "nameLabel": "If the name",
         "isExactly": "is exactly",
         "contains": "contains",
+        "doesNotContain": "does not contain",
         "startsWith": "starts with",
         "endsWith": "ends with",
         "hasAnyName": "has any name",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -2223,6 +2223,7 @@
         "nameLabel": "Si le nom",
         "isExactly": "est exactement",
         "contains": "contient",
+        "doesNotContain": "ne contient pas",
         "startsWith": "commence par",
         "endsWith": "finit par",
         "hasAnyName": "a n'importe quel nom",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -1968,7 +1968,8 @@
         "whenFoundLabel": "Si un évènement est trouvé",
         "whenNotFoundLabel": "Si aucun évènement n'est trouvé",
         "stopScene": "Arrêter la scène",
-        "continueScene": "Continuer la scène"
+        "continueScene": "Continuer la scène",
+        "doesNotContainExplanation": "Si au moins un évènement contenant le nom recherché est trouvé, les autres évènements seront ignorés."
       },
       "ecowattCondition": {
         "description": "Cette condition vous permet de vérifier l'état du réseau électrique français grâce à l'API Ecowatt.",

--- a/front/src/routes/scene/edit-scene/actions/CalendarIsEventRunning.jsx
+++ b/front/src/routes/scene/edit-scene/actions/CalendarIsEventRunning.jsx
@@ -245,6 +245,13 @@ class CheckTime extends Component {
               </Localizer>
             </div>
           )}
+          {action.calendar_event_name_comparator === 'does-not-contain' && (
+            <div className="col-md-12">
+              <p>
+                <Text id="editScene.actionsCard.calendarEventIsRunning.doesNotContainExplanation" />
+              </p>
+            </div>
+          )}
         </div>
         <div class={cx('row', style.calendarEventIsComingGroupMargin)}>
           <div class="col-sm-6">

--- a/front/src/routes/scene/edit-scene/actions/CalendarIsEventRunning.jsx
+++ b/front/src/routes/scene/edit-scene/actions/CalendarIsEventRunning.jsx
@@ -217,6 +217,9 @@ class CheckTime extends Component {
                 <option value="contains">
                   <Text id="editScene.triggersCard.calendarEventIsComing.contains" />
                 </option>
+                <option value="does-not-contain">
+                  <Text id="editScene.triggersCard.calendarEventIsComing.doesNotContain" />
+                </option>
                 <option value="starts-with">
                   <Text id="editScene.triggersCard.calendarEventIsComing.startsWith" />
                 </option>

--- a/server/lib/calendar/calendar.findCurrentlyRunningEvent.js
+++ b/server/lib/calendar/calendar.findCurrentlyRunningEvent.js
@@ -54,6 +54,12 @@ async function findCurrentlyRunningEvent(calendars, calendarEventNameComparator,
         [Op.like]: `%${calendarEventName}%`,
       };
       break;
+    case 'does-not-contain':
+      // @ts-ignore
+      queryParams.where.name = {
+        [Op.notLike]: `%${calendarEventName}%`,
+      };
+      break;
     case 'starts-with':
       // @ts-ignore
       queryParams.where.name = {

--- a/server/lib/scene/scene.actions.js
+++ b/server/lib/scene/scene.actions.js
@@ -449,8 +449,9 @@ const actionsFunc = {
         'contains',
         action.calendar_event_name,
       );
-      // if at least one event is found containing the word, we want to stop the scene (so events stays empty)
-      // otherwise we need to check if there is at least another event not containing the word from condition
+      /* if at least one event is found containing the word, events stays empty
+       and we will follow user choice to continue/stop the scene
+       otherwise we need to check if there is at least another event not containing the word from condition */
       if (eventThatContainsEventName.length === 0) {
         const eventThatDoesNotContainsEventName = await self.calendar.findCurrentlyRunningEvent(
           action.calendars,

--- a/server/models/scene.js
+++ b/server/models/scene.js
@@ -33,6 +33,7 @@ const actionSchema = Joi.array().items(
       calendar_event_name_comparator: Joi.string().valid(
         'is-exactly',
         'contains',
+        'does-not-contain',
         'starts-with',
         'ends-with',
         'has-any-name',

--- a/server/test/lib/calendar/calendar.event.test.js
+++ b/server/test/lib/calendar/calendar.event.test.js
@@ -302,6 +302,34 @@ describe('calendar.findCurrentlyRunningEvent', () => {
     const eventsId = events.map((e) => e.id);
     expect(eventsId).deep.equal(['a2b57b0a-7148-4961-8540-e493104bfd7c']);
   });
+  it('should find event in calendar - does-not-contain', async () => {
+    await calendar.createEvent('test-calendar', {
+      id: 'a2b57b0a-7148-4961-8540-e493104bfd7c',
+      name: 'my test event',
+      start: startDate,
+      end: endDate,
+    });
+    await calendar.createEvent('test-calendar', {
+      id: '3f148ad9-b189-4862-84c3-df26f9bf263a',
+      name: 'my red event',
+      start: startDate,
+      end: endDate,
+    });
+    const events = await calendar.findCurrentlyRunningEvent(['test-calendar'], 'does-not-contain', 'red');
+    const eventsId = events.map((e) => e.id);
+    expect(eventsId).deep.equal(['a2b57b0a-7148-4961-8540-e493104bfd7c']);
+  });
+  it('should find event in calendar - does not contain (rule is inside scene code)', async () => {
+    await calendar.createEvent('test-calendar', {
+      id: 'a2b57b0a-7148-4961-8540-e493104bfd7c',
+      name: 'my test event',
+      start: startDate,
+      end: endDate,
+    });
+    const events = await calendar.findCurrentlyRunningEvent(['test-calendar'], 'does-not-contain', 'random');
+    const eventsId = events.map((e) => e.id);
+    expect(eventsId).deep.equal(['a2b57b0a-7148-4961-8540-e493104bfd7c']);
+  });
   it('should find event in calendar - starts-with', async () => {
     await calendar.createEvent('test-calendar', {
       id: 'a2b57b0a-7148-4961-8540-e493104bfd7c',

--- a/server/test/lib/scene/actions/scene.action.isEventRunnning.test.js
+++ b/server/test/lib/scene/actions/scene.action.isEventRunnning.test.js
@@ -14,7 +14,7 @@ const Calendar = require('../../../../lib/calendar');
 const event = new EventEmitter();
 
 describe('scene.action.isEventRunning', () => {
-  const calendar = new Calendar();
+  let calendar = new Calendar();
   let clock;
   const now = new Date();
   const startDate = dayjs(now)
@@ -24,6 +24,7 @@ describe('scene.action.isEventRunning', () => {
     .add(45, 'minute')
     .toDate();
   beforeEach(async () => {
+    calendar = new Calendar();
     clock = useFakeTimers(now);
   });
   afterEach(() => {
@@ -221,6 +222,129 @@ describe('scene.action.isEventRunning', () => {
             calendar_event_name_comparator: 'contains',
             calendar_event_name: 'text-not-found',
             stop_scene_if_event_not_found: true,
+          },
+        ],
+        [
+          {
+            type: ACTIONS.MESSAGE.SEND,
+            user: 'pepper',
+            text: 'hello',
+          },
+        ],
+      ],
+      scope,
+    );
+    await chaiAssert.isRejected(promise, AbortScene);
+    assert.notCalled(message.sendToUser);
+  });
+  it('should execute condition is-event-running (does-not-contain), and send message because condition is true', async () => {
+    const stateManager = new StateManager(event);
+    const message = {
+      sendToUser: fake.resolves(null),
+    };
+    const scope = {};
+    await calendar.createEvent('test-calendar', {
+      id: 'a2b57b0a-7148-4961-8540-e493104bfd7c',
+      name: 'my test event',
+      description: 'my event description',
+      start: startDate,
+      end: endDate,
+    });
+    await executeActions(
+      { stateManager, event, message, calendar },
+      [
+        [
+          {
+            type: ACTIONS.CALENDAR.IS_EVENT_RUNNING,
+            calendars: ['test-calendar'],
+            calendar_event_name_comparator: 'does-not-contain',
+            calendar_event_name: 'red',
+            stop_scene_if_event_not_found: true,
+            stop_scene_if_event_found: false,
+          },
+        ],
+        [
+          {
+            type: ACTIONS.MESSAGE.SEND,
+            user: 'pepper',
+            text: 'hello',
+          },
+        ],
+      ],
+      scope,
+    );
+    assert.calledWith(message.sendToUser, 'pepper', 'hello');
+  });
+  it('should execute condition is-event-running (does-not-contain), and stop because condition is false', async () => {
+    const stateManager = new StateManager(event);
+    const message = {
+      sendToUser: fake.resolves(null),
+    };
+    const scope = {};
+    await calendar.createEvent('test-calendar', {
+      id: 'a2b57b0a-7148-4961-8540-e493104bfd7c',
+      name: 'my red event',
+      description: 'my event description',
+      start: startDate,
+      end: endDate,
+    });
+    const promise = executeActions(
+      { stateManager, event, message, calendar },
+      [
+        [
+          {
+            type: ACTIONS.CALENDAR.IS_EVENT_RUNNING,
+            calendars: ['test-calendar'],
+            calendar_event_name_comparator: 'does-not-contain',
+            calendar_event_name: 'red',
+            stop_scene_if_event_not_found: true,
+            stop_scene_if_event_found: false,
+          },
+        ],
+        [
+          {
+            type: ACTIONS.MESSAGE.SEND,
+            user: 'pepper',
+            text: 'hello',
+          },
+        ],
+      ],
+      scope,
+    );
+    await chaiAssert.isRejected(promise, AbortScene);
+    assert.notCalled(message.sendToUser);
+  });
+  it('should execute condition is-event-running (does-not-contain), and stop because condition is false', async () => {
+    const stateManager = new StateManager(event);
+    const message = {
+      sendToUser: fake.resolves(null),
+    };
+    const scope = {};
+    await calendar.createEvent('test-calendar', {
+      id: 'a2b57b0a-7148-4961-8540-e493104bfd7c',
+      name: 'my red event',
+      description: 'my event description',
+      start: startDate,
+      end: endDate,
+    });
+    await calendar.createEvent('test-calendar', {
+      id: '3cf3f147-96f6-484e-9655-e676fda4d578',
+      name: 'my second event',
+      description: 'my seconde event description',
+      start: startDate,
+      end: endDate,
+    });
+    const promise = executeActions(
+      { stateManager, event, message, calendar },
+      [
+        [
+          {
+            type: ACTIONS.CALENDAR.IS_EVENT_RUNNING,
+            calendars: ['test-calendar'],
+            calendar_event_name_comparator: 'does-not-contain',
+            calendar_event_name: 'red',
+            stop_scene_if_event_not_found: true,
+            stop_scene_if_event_found: false,
           },
         ],
         [


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [X] If your changes affects code, did your write the tests?
- [X] Are tests passing? (`npm test` on both front/server)
- [X] Is the linter passing? (`npm run eslint` on both front/server)
- [X] Did you run prettier? (`npm run prettier` on both front/server)
- [X] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [X] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

Provides a "does not contain" in "continue only if calendar event" action

![image](https://github.com/user-attachments/assets/95f71cd7-3fd8-4993-ae93-86a5b37a2ae4)

⚠️ If multiple events are happening now and at least one contains the word, scene will stop. 
