### PR TITLE
fix(2191): Migrate from ezsp to ember driver for Z2M

### DIFF
--- a/server/services/zigbee2mqtt/adapters/index.js
+++ b/server/services/zigbee2mqtt/adapters/index.js
@@ -1,12 +1,12 @@
 const CONFIG_KEYS = {
   DECONZ: 'deconz',
-  EZSP: 'ezsp',
+  EMBER: 'ember',
   NONE: 'none',
 };
 
 const ADAPTERS_BY_CONFIG_KEY = {
   [CONFIG_KEYS.DECONZ]: ['ConBee', 'ConBee II', 'RaspBee', 'RaspBee II'],
-  [CONFIG_KEYS.EZSP]: [
+  [CONFIG_KEYS.EMBER]: [
     'CoolKit ZB-GW04 USB dongle (a.k.a. easyiot stick)',
     'Elelabs ELU013 and Popp ZB-STICK',
     'Elelabs Zigbee Raspberry Pi Shield/Popp ZB-Shield',

--- a/server/services/zigbee2mqtt/lib/constants.js
+++ b/server/services/zigbee2mqtt/lib/constants.js
@@ -36,7 +36,7 @@ const DEFAULT = {
     'zigbee2mqtt/#', // Default zigbee2mqtt topic
   ],
   DOCKER_MQTT_VERSION: '4', // Last version of MQTT docker file
-  DOCKER_Z2M_VERSION: '4', // Last version of Z2M docker file,
+  DOCKER_Z2M_VERSION: '5', // Last version of Z2M docker file,
   CONFIGURATION_PATH: 'zigbee2mqtt/z2m/configuration.yaml',
   CONFIGURATION_CONTENT: {
     homeassistant: false,

--- a/server/test/services/zigbee2mqtt/lib/config/z2m_adapter-emberznet_config.yaml
+++ b/server/test/services/zigbee2mqtt/lib/config/z2m_adapter-emberznet_config.yaml
@@ -5,7 +5,7 @@ mqtt:
   server: mqtt://localhost:1884
 serial:
   port: /dev/ttyACM0
-  adapter: ezsp
+  adapter: ember
 map_options:
   graphviz:
     colors:

--- a/server/test/services/zigbee2mqtt/lib/configureContainer.test.js
+++ b/server/test/services/zigbee2mqtt/lib/configureContainer.test.js
@@ -27,7 +27,7 @@ const defaultConfigFilePath = path.join(configBasePath, 'z2m_default_config.yaml
 const mqttConfigFilePath = path.join(configBasePath, 'z2m_mqtt_config.yaml');
 const mqttOtherConfigFilePath = path.join(configBasePath, 'z2m_mqtt-other_config.yaml');
 const deconzConfigFilePath = path.join(configBasePath, 'z2m_adapter-deconz_config.yaml');
-const ezspConfigFilePath = path.join(configBasePath, 'z2m_adapter-ezsp_config.yaml');
+const emberznetConfigFilePath = path.join(configBasePath, 'z2m_adapter-emberznet_config.yaml');
 const portConfigFilePath = path.join(configBasePath, 'z2m_port_config.yaml');
 
 describe('zigbee2mqtt configureContainer', () => {
@@ -150,20 +150,20 @@ describe('zigbee2mqtt configureContainer', () => {
   it('it should only add serial adapter', async () => {
     // PREPARE
     const config = {
-      z2mDongleName: ADAPTERS_BY_CONFIG_KEY[CONFIG_KEYS.EZSP][0],
+      z2mDongleName: ADAPTERS_BY_CONFIG_KEY[CONFIG_KEYS.EMBER][0],
     };
     // EXECUTE
     const changed = await zigbee2mqttManager.configureContainer(basePathOnContainer, config);
     // ASSERT
     const resultContent = fs.readFileSync(configFilePath, 'utf8');
-    const expectedContent = fs.readFileSync(ezspConfigFilePath, 'utf8');
+    const expectedContent = fs.readFileSync(emberznetConfigFilePath, 'utf8');
     expect(resultContent).to.equal(expectedContent);
     expect(changed).to.be.eq(true);
   });
 
   it('it should remove serial adapter (adapter is not set)', async () => {
     // PREPARE
-    fs.copyFileSync(ezspConfigFilePath, configFilePath);
+    fs.copyFileSync(emberznetConfigFilePath, configFilePath);
     const config = {};
     // EXECUTE
     const changed = await zigbee2mqttManager.configureContainer(basePathOnContainer, config);
@@ -176,7 +176,7 @@ describe('zigbee2mqtt configureContainer', () => {
 
   it('it should remove serial adapter (adapter is expliclty none)', async () => {
     // PREPARE
-    fs.copyFileSync(ezspConfigFilePath, configFilePath);
+    fs.copyFileSync(emberznetConfigFilePath, configFilePath);
     const config = {
       z2mDongleName: ADAPTERS_BY_CONFIG_KEY[CONFIG_KEYS.NONE][0],
     };
@@ -191,22 +191,22 @@ describe('zigbee2mqtt configureContainer', () => {
 
   it('it should keep serial adapter', async () => {
     // PREPARE
-    fs.copyFileSync(ezspConfigFilePath, configFilePath);
+    fs.copyFileSync(emberznetConfigFilePath, configFilePath);
     const config = {
-      z2mDongleName: ADAPTERS_BY_CONFIG_KEY[CONFIG_KEYS.EZSP][0],
+      z2mDongleName: ADAPTERS_BY_CONFIG_KEY[CONFIG_KEYS.EMBER][0],
     };
     // EXECUTE
     const changed = await zigbee2mqttManager.configureContainer(basePathOnContainer, config);
     // ASSERT
     const resultContent = fs.readFileSync(configFilePath, 'utf8');
-    const expectedContent = fs.readFileSync(ezspConfigFilePath, 'utf8');
+    const expectedContent = fs.readFileSync(emberznetConfigFilePath, 'utf8');
     expect(resultContent).to.equal(expectedContent);
     expect(changed).to.be.eq(false);
   });
 
   it('it should override serial adapter', async () => {
     // PREPARE
-    fs.copyFileSync(ezspConfigFilePath, configFilePath);
+    fs.copyFileSync(emberznetConfigFilePath, configFilePath);
     const config = {
       z2mDongleName: ADAPTERS_BY_CONFIG_KEY[CONFIG_KEYS.DECONZ][0],
     };
@@ -221,7 +221,7 @@ describe('zigbee2mqtt configureContainer', () => {
 
   it('it should remove serial adapter (unknown adapter)', async () => {
     // PREPARE
-    fs.copyFileSync(ezspConfigFilePath, configFilePath);
+    fs.copyFileSync(emberznetConfigFilePath, configFilePath);
     const config = { z2mDongleName: 'this-is-not-a-real-adapter' };
     // EXECUTE
     const changed = await zigbee2mqttManager.configureContainer(basePathOnContainer, config);


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.
- [x] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [x] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

> Do you think this change could also impact Zigbee2mqtt backups? For instance, if someone is using the old driver and moves to a new Gladys installation with the new driver, would it break the restore process?

From this part, no issue
https://github.com/Koenkk/zigbee2mqtt/discussions/21462#discussioncomment-8510320

> Coordinator Backup & Restore
- If you have an ezsp v12 backup that you've used for testing before, this should restore it the same. ✅ 
- If you had been using v13 for previous ezsp tests (no backup available), and you keep your network settings in configuration.yaml the same (meaning they will match that of the adapter the last time it ran), after swapping for ember, it should simply take over where you left off (and this time you should get a backup file out of it as a bonus!).

⚠️ Do we need to check listed dongle between [here](https://github.com/Koenkk/zigbee2mqtt/discussions/21462#discussioncomment-8510320) and in [Gladys](https://github.com/GladysAssistant/Gladys/blob/master/server/services/zigbee2mqtt/adapters/index.js#L9) ?
