### PR TITLE
Chart: Rollback smart rounding of values, only keep small number part

### DIFF
--- a/front/src/components/boxs/chart/yAxisFormatter.js
+++ b/front/src/components/boxs/chart/yAxisFormatter.js
@@ -17,10 +17,7 @@ const yAxisFormatter = value => {
   }
 
   // For normal values, format with up to 2 decimal places
-  return roundedValue.toLocaleString(undefined, {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2
-  });
+  return value.toFixed(2);
 };
 
 export { yAxisFormatter };


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

Smart rounding doesn't work: https://community.gladysassistant.com/t/arrondi-des-ordonnees-sur-les-graphiques/9289/16?u=pierre-gilles