### PR TITLE
Make the title optional in the device and scene widgets.

### DIFF
--- a/front/src/components/boxs/device-in-room/DeviceCard.jsx
+++ b/front/src/components/boxs/device-in-room/DeviceCard.jsx
@@ -23,7 +23,7 @@ const DeviceCard = ({ children, ...props }) => {
 
   return (
     <div class="card">
-      {(boxTitle || hasBinaryLightDeviceFeature) && (      
+      {boxTitle && (
         <div class="card-header">
           <h3 class="card-title">{boxTitle}</h3>
           {hasBinaryLightDeviceFeature && (

--- a/front/src/components/boxs/device-in-room/DeviceCard.jsx
+++ b/front/src/components/boxs/device-in-room/DeviceCard.jsx
@@ -23,24 +23,26 @@ const DeviceCard = ({ children, ...props }) => {
 
   return (
     <div class="card">
-      <div class="card-header">
-        <h3 class="card-title">{boxTitle}</h3>
-        {hasBinaryLightDeviceFeature && (
-          <div class="card-options">
-            <label class="custom-switch m-0">
-              <input
-                type="checkbox"
-                name={props.boxTitle}
-                value="1"
-                class="custom-switch-input"
-                checked={roomLightStatus === 1}
-                onClick={props.changeAllLightsStatusRoom}
-              />
-              <span class="custom-switch-indicator" />
-            </label>
-          </div>
-        )}
-      </div>
+      {(boxTitle || hasBinaryLightDeviceFeature) && (      
+        <div class="card-header">
+          <h3 class="card-title">{boxTitle}</h3>
+          {hasBinaryLightDeviceFeature && (
+            <div class="card-options">
+              <label class="custom-switch m-0">
+                <input
+                  type="checkbox"
+                  name={props.boxTitle}
+                  value="1"
+                  class="custom-switch-input"
+                  checked={roomLightStatus === 1}
+                  onClick={props.changeAllLightsStatusRoom}
+                />
+                <span class="custom-switch-indicator" />
+              </label>
+            </div>
+          )}
+        </div>
+      )}
       <div
         class={cx('dimmer', {
           active: loading

--- a/front/src/components/boxs/scene/SceneBox.jsx
+++ b/front/src/components/boxs/scene/SceneBox.jsx
@@ -42,10 +42,11 @@ class SceneBoxComponent extends Component {
 
     return (
       <div class="card">
-        <div class="card-header">
-          <h3 class="card-title">{boxTitle}</h3>
-        </div>
-
+        {boxTitle && (
+          <div class="card-header">
+            <h3 class="card-title">{boxTitle}</h3>
+          </div>
+        )}
         <div
           class={cx('dimmer', {
             active: loading

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -303,7 +303,7 @@
       },
       "devices": {
         "editDeviceFeaturesLabel": "Wähle die Geräte aus, die du anzeigen möchtest:",
-        "editNameLabel": "Widget-Name",
+        "editNameLabel": "Widget-Name (optional)",
         "editNamePlaceholder": "Gib den Namen des Widgets ein",
         "addADeviceLabel": "Füge ein Gerät hinzu:"
       },
@@ -414,7 +414,7 @@
         "no": "Nein"
       },
       "scene": {
-        "editNameLabel": "Gib den Namen dieser Box ein",
+        "editNameLabel": "Widget-Name (optional)",
         "editNamePlaceholder": "Name auf dem Dashboard angezeigt",
         "editSceneLabel": "Wähle die Szene aus, die hier angezeigt werden soll."
       },

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -303,7 +303,7 @@
       },
       "devices": {
         "editDeviceFeaturesLabel": "Select the devices you want to display:",
-        "editNameLabel": "Widget name",
+        "editNameLabel": "Widget Name (optional)",
         "editNamePlaceholder": "Enter the name of the widget",
         "addADeviceLabel": "Add a device:"
       },
@@ -414,7 +414,7 @@
         "no": "No"
       },
       "scene": {
-        "editNameLabel": "Enter the name of this box",
+        "editNameLabel": "Widget Name (optional)",
         "editNamePlaceholder": "Name displayed on the dashboard",
         "editSceneLabel": "Select the scene you want to display here."
       },

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -303,7 +303,7 @@
       },
       "devices": {
         "editDeviceFeaturesLabel": "Vous pouvez modifier le nom affiché ici :",
-        "editNameLabel": "Nom du widget",
+        "editNameLabel": "Nom du widget (optionnel)",
         "editNamePlaceholder": "Entrez le nom du widget",
         "addADeviceLabel": "Ajouter un appareil :"
       },
@@ -414,7 +414,7 @@
         "no": "Non"
       },
       "scene": {
-        "editNameLabel": "Entrez le nom de cette box",
+        "editNameLabel": "Nom du widget (optionnel)",
         "editNamePlaceholder": "Nom affiché sur le tableau de bord",
         "editSceneLabel": "Sélectionnez la scène que vous souhaitez afficher ici."
       },


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [ ] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

I have added the option to make the widget titles optional, as was already done for the alarm widget. If the title is not set, the box will not be displayed.

![image](https://github.com/user-attachments/assets/7c8ae4fe-4b9c-4c0e-87a6-8e1f18af0ce5)

![image](https://github.com/user-attachments/assets/35fc46a8-584e-4404-be9c-6470831ee2de)

https://community.gladysassistant.com/t/amelioration-ux-rendre-les-titres-optionnel-sur-widget-appareil-scene/9312/6