### PR TITLE
Scene: When duplicating a scene, prefill the title with "Copy of {{previous name}}"

### DIFF
--- a/front/cypress/e2e/routes/scene/Scene.cy.js
+++ b/front/cypress/e2e/routes/scene/Scene.cy.js
@@ -222,7 +222,9 @@ describe('Scene view', () => {
 
     cy.get('input:visible').then(inputs => {
       // Zone name
-      cy.wrap(inputs[0]).type('My Duplicated scene');
+      cy.wrap(inputs[0])
+        .clear()
+        .type('My Duplicated scene');
     });
 
     cy.get('.fe-activity').click();

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -2558,7 +2558,8 @@
     "duplicateSceneButton": "Duplizieren",
     "invalidName": "Name ist erforderlich",
     "invalidIcon": "Symbol ist erforderlich",
-    "sceneAlreadyExist": "Eine Szene mit diesem Namen existiert bereits."
+    "sceneAlreadyExist": "Eine Szene mit diesem Namen existiert bereits.",
+    "nameAfterCopy": "Kopie von {{name}}"
   },
   "scene": {
     "title": "Szenen",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -2558,7 +2558,8 @@
     "duplicateSceneButton": "Duplicate",
     "invalidName": "Name is required",
     "invalidIcon": "Icon is required",
-    "sceneAlreadyExist": "A scene with that name already exist."
+    "sceneAlreadyExist": "A scene with that name already exist.",
+    "nameAfterCopy": "Copy of {{name}}"
   },
   "scene": {
     "title": "Scenes",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -2558,7 +2558,8 @@
     "duplicateSceneButton": "Dupliquer",
     "invalidName": "Le nom est requis",
     "invalidIcon": "L'icône est requise",
-    "sceneAlreadyExist": "Une scène avec le même nom existe déjà."
+    "sceneAlreadyExist": "Une scène avec le même nom existe déjà.",
+    "nameAfterCopy": "Copie de {{name}}"
   },
   "scene": {
     "title": "Scènes",

--- a/front/src/routes/scene/duplicate-scene/index.js
+++ b/front/src/routes/scene/duplicate-scene/index.js
@@ -3,6 +3,7 @@ import { connect } from 'unistore/preact';
 import DuplicateScenePage from './DuplicateScenePage';
 import { route } from 'preact-router';
 import { RequestStatus } from '../../../utils/consts';
+import withIntlAsProp from '../../../utils/withIntlAsProp';
 import get from 'get-value';
 
 class DuplicateScene extends Component {
@@ -16,7 +17,7 @@ class DuplicateScene extends Component {
       sourceScene: scene,
       loading: false,
       scene: {
-        name: '',
+        name: get(this.props.intl.dictionary, 'duplicateScene.nameAfterCopy').replace('{{name}}', scene.name),
         icon: scene.icon
       }
     });
@@ -131,4 +132,4 @@ class DuplicateScene extends Component {
   }
 }
 
-export default connect('httpClient', {})(DuplicateScene);
+export default withIntlAsProp(connect('httpClient', {})(DuplicateScene));


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

Fix https://community.gladysassistant.com/t/scenes-pre-remplir-le-titre-dune-scene-dupliquee/9341