### PR TITLE
Dashboard: When websocket connection is restored, refresh widgets

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "gladys-front",
       "dependencies": {
-        "@gladysassistant/gladys-gateway-js": "4.15.0",
+        "@gladysassistant/gladys-gateway-js": "4.17.0",
         "@gladysassistant/theme-optimized": "^1.0.4",
         "@jaames/iro": "^5.5.2",
         "@yaireo/tagify": "4.5.0",
@@ -4085,9 +4085,9 @@
       "dev": true
     },
     "node_modules/@gladysassistant/gladys-gateway-js": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@gladysassistant/gladys-gateway-js/-/gladys-gateway-js-4.15.0.tgz",
-      "integrity": "sha512-vQlycZWF0sA3/KuIlPf0/DVFJ2lbf/R+SbCrkyeuT3P+NnD/EZ9QEFKI/Xu7x1uf4pS+H7CVUT0SudzOGMBoPw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@gladysassistant/gladys-gateway-js/-/gladys-gateway-js-4.17.0.tgz",
+      "integrity": "sha512-47/aT2n7JF0kFPtBkKxPoKGfizGwac5C7vzHuaFTGH4gq0AwOPPSiSOCInIwfr3DAxKeh+deSDDs9toK4Pginw==",
       "dependencies": {
         "@ctrlpanel/pbkdf2": "^1.0.0",
         "array-buffer-to-hex": "^1.0.0",
@@ -31250,9 +31250,9 @@
       "dev": true
     },
     "@gladysassistant/gladys-gateway-js": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@gladysassistant/gladys-gateway-js/-/gladys-gateway-js-4.15.0.tgz",
-      "integrity": "sha512-vQlycZWF0sA3/KuIlPf0/DVFJ2lbf/R+SbCrkyeuT3P+NnD/EZ9QEFKI/Xu7x1uf4pS+H7CVUT0SudzOGMBoPw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@gladysassistant/gladys-gateway-js/-/gladys-gateway-js-4.17.0.tgz",
+      "integrity": "sha512-47/aT2n7JF0kFPtBkKxPoKGfizGwac5C7vzHuaFTGH4gq0AwOPPSiSOCInIwfr3DAxKeh+deSDDs9toK4Pginw==",
       "requires": {
         "@ctrlpanel/pbkdf2": "^1.0.0",
         "array-buffer-to-hex": "^1.0.0",

--- a/front/package.json
+++ b/front/package.json
@@ -43,7 +43,7 @@
     "prettier": "^1.17.1"
   },
   "dependencies": {
-    "@gladysassistant/gladys-gateway-js": "4.15.0",
+    "@gladysassistant/gladys-gateway-js": "4.17.0",
     "@gladysassistant/theme-optimized": "^1.0.4",
     "@jaames/iro": "^5.5.2",
     "@yaireo/tagify": "4.5.0",

--- a/front/src/components/boxs/alarm/Alarm.jsx
+++ b/front/src/components/boxs/alarm/Alarm.jsx
@@ -30,6 +30,16 @@ class AlarmComponent extends Component {
     await this.setState({ loading: false });
   };
 
+  handleWebsocketConnected = ({ connected }) => {
+    // When the websocket is disconnected, we refresh the data when the websocket is reconnected
+    if (!connected) {
+      this.wasDisconnected = true;
+    } else if (this.wasDisconnected) {
+      this.getHouse();
+      this.wasDisconnected = false;
+    }
+  };
+
   callAlarmApi = async action => {
     await this.setState({ loading: true });
     try {
@@ -60,6 +70,7 @@ class AlarmComponent extends Component {
     this.props.session.dispatcher.addListener(WEBSOCKET_MESSAGE_TYPES.ALARM.DISARMED, this.getHouse);
     this.props.session.dispatcher.addListener(WEBSOCKET_MESSAGE_TYPES.ALARM.PARTIALLY_ARMED, this.getHouse);
     this.props.session.dispatcher.addListener(WEBSOCKET_MESSAGE_TYPES.ALARM.PANIC, this.getHouse);
+    this.props.session.dispatcher.addListener('websocket.connected', this.handleWebsocketConnected);
   }
 
   componentWillUnmount() {
@@ -68,6 +79,7 @@ class AlarmComponent extends Component {
     this.props.session.dispatcher.removeListener(WEBSOCKET_MESSAGE_TYPES.ALARM.DISARMED, this.getHouse);
     this.props.session.dispatcher.removeListener(WEBSOCKET_MESSAGE_TYPES.ALARM.PARTIALLY_ARMED, this.getHouse);
     this.props.session.dispatcher.removeListener(WEBSOCKET_MESSAGE_TYPES.ALARM.PANIC, this.getHouse);
+    this.props.session.dispatcher.removeListener('websocket.connected', this.handleWebsocketConnected);
   }
 
   componentDidUpdate(nextProps) {

--- a/front/src/components/boxs/camera/Camera.jsx
+++ b/front/src/components/boxs/camera/Camera.jsx
@@ -32,6 +32,16 @@ class CameraBoxComponent extends Component {
     }
   };
 
+  handleWebsocketConnected = ({ connected }) => {
+    // When the websocket is disconnected, we refresh the data when the websocket is reconnected
+    if (!connected) {
+      this.wasDisconnected = true;
+    } else if (this.wasDisconnected) {
+      this.refreshData();
+      this.wasDisconnected = false;
+    }
+  };
+
   updateDeviceStateWebsocket = payload => {
     if (this.props.box.camera === payload.device) {
       this.setState({
@@ -227,6 +237,7 @@ class CameraBoxComponent extends Component {
       WEBSOCKET_MESSAGE_TYPES.DEVICE.NEW_STRING_STATE,
       this.updateDeviceStateWebsocket
     );
+    this.props.session.dispatcher.addListener('websocket.connected', this.handleWebsocketConnected);
   }
 
   componentDidUpdate(previousProps) {
@@ -245,6 +256,7 @@ class CameraBoxComponent extends Component {
     if (this.state.streaming) {
       this.stopStreaming();
     }
+    this.props.session.dispatcher.removeListener('websocket.connected', this.handleWebsocketConnected);
   }
 
   render(

--- a/front/src/components/boxs/chart/Chart.jsx
+++ b/front/src/components/boxs/chart/Chart.jsx
@@ -124,6 +124,15 @@ class Chartbox extends Component {
     });
     this.getData();
   };
+  handleWebsocketConnected = ({ connected }) => {
+    // When the websocket is disconnected, we refresh the data when the websocket is reconnected
+    if (!connected) {
+      this.wasDisconnected = true;
+    } else if (this.wasDisconnected) {
+      this.getData();
+      this.wasDisconnected = false;
+    }
+  };
   getData = async () => {
     let deviceFeatures = this.props.box.device_features;
     let deviceFeatureNames = this.props.box.device_feature_names;
@@ -302,6 +311,7 @@ class Chartbox extends Component {
       WEBSOCKET_MESSAGE_TYPES.DEVICE.NEW_STATE,
       this.updateDeviceStateWebsocket
     );
+    this.props.session.dispatcher.addListener('websocket.connected', this.handleWebsocketConnected);
   }
   async componentDidUpdate(previousProps) {
     const intervalChanged = get(previousProps, 'box.interval') !== get(this.props, 'box.interval');
@@ -321,6 +331,7 @@ class Chartbox extends Component {
       WEBSOCKET_MESSAGE_TYPES.DEVICE.NEW_STATE,
       this.updateDeviceStateWebsocket
     );
+    this.props.session.dispatcher.removeListener('websocket.connected', this.handleWebsocketConnected);
   }
   render(
     props,

--- a/front/src/components/boxs/device-in-room/DeviceCard.jsx
+++ b/front/src/components/boxs/device-in-room/DeviceCard.jsx
@@ -1,5 +1,6 @@
 import cx from 'classnames';
 import DeviceRow from './DeviceRow';
+import style from './style.css';
 import { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } from '../../../../../server/utils/constants';
 
 const hasSwitchFeature = (features, featureSelectors) => {
@@ -20,6 +21,9 @@ const DeviceCard = ({ children, ...props }) => {
   const { device_features: featureSelectors = [] } = box;
 
   const hasBinaryLightDeviceFeature = hasSwitchFeature(deviceFeatures, featureSelectors) !== undefined;
+
+  // Create placeholder rows based on the number of expected features
+  const placeholderRows = Array(featureSelectors.length).fill(0);
 
   return (
     <div class="card">
@@ -43,32 +47,38 @@ const DeviceCard = ({ children, ...props }) => {
           )}
         </div>
       )}
-      <div
-        class={cx('dimmer', {
-          active: loading
-        })}
-      >
+      <div>
         <div class="loader py-3" />
-        <div class="dimmer-content">
-          <div class="table-responsive">
-            <table class="table card-table table-vcenter">
-              <tbody>
-                {deviceFeatures.map((deviceFeature, deviceFeatureIndex) => (
-                  <DeviceRow
-                    user={props.user}
-                    x={props.x}
-                    y={props.y}
-                    device={deviceFeature.device}
-                    deviceFeature={deviceFeature}
-                    roomIndex={props.roomIndex}
-                    deviceFeatureIndex={deviceFeatureIndex}
-                    updateValue={props.updateValue}
-                    updateValueWithDebounce={props.updateValueWithDebounce}
-                  />
-                ))}
-              </tbody>
-            </table>
-          </div>
+        <div class="table-responsive">
+          <table class="table card-table table-vcenter">
+            <tbody>
+              {loading
+                ? placeholderRows.map((_, index) => (
+                    <tr key={`placeholder-${index}`}>
+                      <td class="w-50">
+                        <div class={style.loadingSkeleton}></div>
+                      </td>
+                      <td>
+                        <div class={style.loadingSkeleton}></div>
+                      </td>
+                    </tr>
+                  ))
+                : deviceFeatures.map((deviceFeature, deviceFeatureIndex) => (
+                    <DeviceRow
+                      key={deviceFeatureIndex}
+                      user={props.user}
+                      x={props.x}
+                      y={props.y}
+                      device={deviceFeature.device}
+                      deviceFeature={deviceFeature}
+                      roomIndex={props.roomIndex}
+                      deviceFeatureIndex={deviceFeatureIndex}
+                      updateValue={props.updateValue}
+                      updateValueWithDebounce={props.updateValueWithDebounce}
+                    />
+                  ))}
+            </tbody>
+          </table>
         </div>
       </div>
     </div>

--- a/front/src/components/boxs/device-in-room/DeviceCard.jsx
+++ b/front/src/components/boxs/device-in-room/DeviceCard.jsx
@@ -1,4 +1,3 @@
-import cx from 'classnames';
 import DeviceRow from './DeviceRow';
 import style from './style.css';
 import { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } from '../../../../../server/utils/constants';
@@ -56,10 +55,10 @@ const DeviceCard = ({ children, ...props }) => {
                 ? placeholderRows.map((_, index) => (
                     <tr key={`placeholder-${index}`}>
                       <td class="w-50">
-                        <div class={style.loadingSkeleton}></div>
+                        <div class={style.loadingSkeleton} />
                       </td>
                       <td>
-                        <div class={style.loadingSkeleton}></div>
+                        <div class={style.loadingSkeleton} />
                       </td>
                     </tr>
                   ))

--- a/front/src/components/boxs/device-in-room/DevicesBox.jsx
+++ b/front/src/components/boxs/device-in-room/DevicesBox.jsx
@@ -44,7 +44,18 @@ class DevicesComponent extends Component {
       deviceFeatures: [],
       status: RequestStatus.Getting
     };
+    this.wasDisconnected = false;
   }
+
+  handleWebsocketConnected = ({ connected }) => {
+    // When the websocket is disconnected, we refresh the data when the websocket is reconnected
+    if (!connected) {
+      this.wasDisconnected = true;
+    } else if (this.wasDisconnected) {
+      this.refreshData();
+      this.wasDisconnected = false;
+    }
+  };
 
   refreshData = () => {
     this.getDeviceFeatures();
@@ -180,6 +191,7 @@ class DevicesComponent extends Component {
       WEBSOCKET_MESSAGE_TYPES.DEVICE.NEW_STRING_STATE,
       this.updateDeviceTextWebsocket
     );
+    this.props.session.dispatcher.addListener('websocket.connected', this.handleWebsocketConnected);
   }
 
   componentDidUpdate(previousProps) {
@@ -198,11 +210,12 @@ class DevicesComponent extends Component {
       WEBSOCKET_MESSAGE_TYPES.DEVICE.NEW_STRING_STATE,
       this.updateDeviceTextWebsocket
     );
+    this.props.session.dispatcher.removeListener('websocket.connected', this.handleWebsocketConnected);
   }
 
   render(props, { deviceFeatures, status }) {
     const boxTitle = props.box.name;
-    const loading = status === RequestStatus.Getting && !status;
+    const loading = status === RequestStatus.Getting;
     const roomLightStatus = this.getLightStatus();
 
     return (

--- a/front/src/components/boxs/device-in-room/style.css
+++ b/front/src/components/boxs/device-in-room/style.css
@@ -1,0 +1,14 @@
+.loadingSkeleton {
+  height: 1.2em;
+  background: #eee;
+  background: linear-gradient(110deg, #ececec 8%, #f5f5f5 18%, #ececec 33%);
+  border-radius: 5px;
+  background-size: 200% 100%;
+  animation: 1.5s shine linear infinite;
+}
+
+@keyframes shine {
+  to {
+    background-position-x: -200%;
+  }
+}

--- a/front/src/components/boxs/music/MusicBox.jsx
+++ b/front/src/components/boxs/music/MusicBox.jsx
@@ -86,12 +86,23 @@ class MusicComponent extends Component {
     }
   };
 
+  handleWebsocketConnected = ({ connected }) => {
+    // When the websocket is disconnected, we refresh the data when the websocket is reconnected
+    if (!connected) {
+      this.wasDisconnected = true;
+    } else if (this.wasDisconnected) {
+      this.getDevice();
+      this.wasDisconnected = false;
+    }
+  };
+
   componentDidMount() {
     this.getDevice();
     this.props.session.dispatcher.addListener(
       WEBSOCKET_MESSAGE_TYPES.DEVICE.NEW_STATE,
       this.updateDeviceStateWebsocket
     );
+    this.props.session.dispatcher.addListener('websocket.connected', this.handleWebsocketConnected);
   }
 
   componentWillUnmount() {
@@ -99,6 +110,7 @@ class MusicComponent extends Component {
       WEBSOCKET_MESSAGE_TYPES.DEVICE.NEW_STATE,
       this.updateDeviceStateWebsocket
     );
+    this.props.session.dispatcher.removeListener('websocket.connected', this.handleWebsocketConnected);
   }
 
   render(props, { isPlaying, musicDevice, previousFeature, nextFeature, volumeFeature }) {

--- a/front/src/components/boxs/room-humidity/RoomHumidity.jsx
+++ b/front/src/components/boxs/room-humidity/RoomHumidity.jsx
@@ -56,6 +56,16 @@ class RoomHumidityBoxComponent extends Component {
     this.props.getHumidityInRoom(this.props.box, this.props.x, this.props.y);
   };
 
+  handleWebsocketConnected = ({ connected }) => {
+    // When the websocket is disconnected, we refresh the data when the websocket is reconnected
+    if (!connected) {
+      this.wasDisconnected = true;
+    } else if (this.wasDisconnected) {
+      this.refreshData();
+      this.wasDisconnected = false;
+    }
+  };
+
   updateRoomHumidity = payload => {
     this.props.deviceFeatureWebsocketEvent(this.props.box, this.props.x, this.props.y, payload);
   };
@@ -63,6 +73,7 @@ class RoomHumidityBoxComponent extends Component {
   componentDidMount() {
     this.refreshData();
     this.props.session.dispatcher.addListener(WEBSOCKET_MESSAGE_TYPES.DEVICE.NEW_STATE, this.updateRoomHumidity);
+    this.props.session.dispatcher.addListener('websocket.connected', this.handleWebsocketConnected);
   }
 
   componentDidUpdate(previousProps) {
@@ -74,6 +85,7 @@ class RoomHumidityBoxComponent extends Component {
 
   componentWillUnmount() {
     this.props.session.dispatcher.removeListener(WEBSOCKET_MESSAGE_TYPES.DEVICE.NEW_STATE, this.updateRoomHumidity);
+    this.props.session.dispatcher.removeListener('websocket.connected', this.handleWebsocketConnected);
   }
 
   render(props, {}) {

--- a/front/src/components/boxs/room-temperature/RoomTemperature.jsx
+++ b/front/src/components/boxs/room-temperature/RoomTemperature.jsx
@@ -63,6 +63,16 @@ class RoomTemperatureBoxComponent extends Component {
     this.props.getTemperatureInRoom(this.props.box, this.props.x, this.props.y);
   };
 
+  handleWebsocketConnected = ({ connected }) => {
+    // When the websocket is disconnected, we refresh the data when the websocket is reconnected
+    if (!connected) {
+      this.wasDisconnected = true;
+    } else if (this.wasDisconnected) {
+      this.refreshData();
+      this.wasDisconnected = false;
+    }
+  };
+
   updateRoomTemperature = payload => {
     this.props.deviceFeatureWebsocketEvent(this.props.box, this.props.x, this.props.y, payload);
   };
@@ -70,6 +80,7 @@ class RoomTemperatureBoxComponent extends Component {
   componentDidMount() {
     this.refreshData();
     this.props.session.dispatcher.addListener(WEBSOCKET_MESSAGE_TYPES.DEVICE.NEW_STATE, this.updateRoomTemperature);
+    this.props.session.dispatcher.addListener('websocket.connected', this.handleWebsocketConnected);
   }
 
   componentDidUpdate(previousProps) {
@@ -81,6 +92,7 @@ class RoomTemperatureBoxComponent extends Component {
 
   componentWillUnmount() {
     this.props.session.dispatcher.removeListener(WEBSOCKET_MESSAGE_TYPES.DEVICE.NEW_STATE, this.updateRoomTemperature);
+    this.props.session.dispatcher.removeListener('websocket.connected', this.handleWebsocketConnected);
   }
 
   render(props, {}) {

--- a/front/src/components/boxs/user-presence/UserPresence.jsx
+++ b/front/src/components/boxs/user-presence/UserPresence.jsx
@@ -140,6 +140,15 @@ class UserPresenceComponent extends Component {
       });
     }
   };
+  handleWebsocketConnected = ({ connected }) => {
+    // When the websocket is disconnected, we refresh the data when the websocket is reconnected
+    if (!connected) {
+      this.wasDisconnected = true;
+    } else if (this.wasDisconnected) {
+      this.getUsersWithPresence();
+      this.wasDisconnected = false;
+    }
+  };
   refreshRelativeTime = () => {
     if (this.state.usersWithPresence && this.state.usersWithPresence.length > 0) {
       const usersWithPresence = this.state.usersWithPresence.map(user => {
@@ -159,6 +168,7 @@ class UserPresenceComponent extends Component {
     }, 60 * 1000);
     this.props.session.dispatcher.addListener(WEBSOCKET_MESSAGE_TYPES.USER_PRESENCE.BACK_HOME, this.userChanged);
     this.props.session.dispatcher.addListener(WEBSOCKET_MESSAGE_TYPES.USER_PRESENCE.LEFT_HOME, this.userChanged);
+    this.props.session.dispatcher.addListener('websocket.connected', this.handleWebsocketConnected);
   }
 
   componentDidUpdate(previousProps) {
@@ -172,6 +182,7 @@ class UserPresenceComponent extends Component {
     clearInterval(this.interval);
     this.props.session.dispatcher.removeListener(WEBSOCKET_MESSAGE_TYPES.USER_PRESENCE.BACK_HOME, this.userChanged);
     this.props.session.dispatcher.removeListener(WEBSOCKET_MESSAGE_TYPES.USER_PRESENCE.LEFT_HOME, this.userChanged);
+    this.props.session.dispatcher.removeListener('websocket.connected', this.handleWebsocketConnected);
   }
 
   render(props, { usersWithPresence, dashboardUserPresenceGetUsersStatus }) {

--- a/front/src/utils/GatewayHttpClient.js
+++ b/front/src/utils/GatewayHttpClient.js
@@ -3,14 +3,20 @@ import pLimit from 'p-limit';
 export class GatewayHttpClient {
   constructor(session) {
     this.session = session;
-    this.session.dispatcher.addListener('GLADYS_GATEWAY_CONNECTED', this.emptyQueue.bind(this));
+    this.session.dispatcher.addListener('websocket.connected', this.onWebsocketConnected.bind(this));
     // Allow a maximum of 5 concurrent API calls
     this.limiter = pLimit(5);
     this.queue = [];
     this.pendingRequests = new Map(); // Cache for pending GET requests
   }
 
-  async emptyQueue() {
+  onWebsocketConnected({ connected }) {
+    if (connected) {
+      this.emptyQueue();
+    }
+  }
+
+  emptyQueue() {
     this.queue.forEach(func => {
       func();
     });

--- a/front/src/utils/GatewaySession.js
+++ b/front/src/utils/GatewaySession.js
@@ -56,10 +56,16 @@ class GatewaySession {
         if (type === 'message') {
           this.dispatcher.dispatch(message.event, message.data);
         }
+        if (type === 'websocket.connected' && message.connected) {
+          this.websocketConnected = true;
+          this.dispatcher.dispatch('websocket.connected', { connected: true });
+        }
+        if (type === 'websocket.connected' && !message.connected) {
+          this.websocketConnected = false;
+          this.dispatcher.dispatch('websocket.connected', { connected: false });
+        }
       });
       this.ready = true;
-      this.websocketConnected = true;
-      this.dispatcher.dispatch('GLADYS_GATEWAY_CONNECTED');
     }
   }
 

--- a/front/src/utils/Session.js
+++ b/front/src/utils/Session.js
@@ -42,6 +42,7 @@ class Session {
     this.ws = new WebSocket(websocketUrl);
     this.ws.onopen = () => {
       this.websocketConnected = true;
+      this.dispatcher.dispatch('websocket.connected', { connected: true });
       this.ws.send(
         JSON.stringify({
           type: 'authenticate.request',
@@ -61,6 +62,7 @@ class Session {
     };
     this.ws.onclose = e => {
       console.error(e);
+      this.dispatcher.dispatch('websocket.connected', { connected: false });
       this.websocketConnected = false;
       if (e.reason === ERROR_MESSAGES.INVALID_ACCESS_TOKEN) {
         delete this.user.access_token;


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

Fix https://community.gladysassistant.com/t/dashboard-gerer-la-mise-a-jour-quand-on-revient-sur-lapplication/9337