### PR TITLE
Add shutter/curtain in Homekit

### DIFF
--- a/server/services/homekit/lib/buildService.js
+++ b/server/services/homekit/lib/buildService.js
@@ -81,14 +81,16 @@ function buildService(device, features, categoryMapping, subtype) {
           if (characteristic.props.perms.includes(Perms.PAIRED_READ)) {
             characteristic.on(CharacteristicEventTypes.GET, async (callback) => {
               const { features: updatedFeatures } = await this.gladys.device.getBySelector(device.selector);
-              callback(undefined,
+              callback(
+                undefined,
                 normalize(
                   updatedFeatures.find((feat) => feat.id === feature.id).last_value,
                   feature.min,
                   feature.max,
                   characteristic.props.minValue,
                   characteristic.props.maxValue,
-                ),);
+                ),
+              );
             });
           }
 

--- a/server/services/homekit/lib/deviceMappings.js
+++ b/server/services/homekit/lib/deviceMappings.js
@@ -1,4 +1,4 @@
-const { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } = require('../../../utils/constants');
+const { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES, COVER_STATE } = require('../../../utils/constants');
 
 const mappings = {
   [DEVICE_FEATURE_CATEGORIES.LIGHT]: {
@@ -68,6 +68,34 @@ const mappings = {
       },
     },
   },
+  [DEVICE_FEATURE_CATEGORIES.SHUTTER]: {
+    service: 'WindowCovering',
+    capabilities: {
+      [DEVICE_FEATURE_TYPES.SHUTTER.POSITION]: {
+        characteristics: ['CurrentPosition', 'TargetPosition'],
+      },
+      [DEVICE_FEATURE_TYPES.SHUTTER.STATE]: {
+        characteristics: ['PositionState'],
+      },
+    },
+  },
+  [DEVICE_FEATURE_CATEGORIES.CURTAIN]: {
+    service: 'WindowCovering',
+    capabilities: {
+      [DEVICE_FEATURE_TYPES.CURTAIN.POSITION]: {
+        characteristics: ['CurrentPosition', 'TargetPosition'],
+      },
+      [DEVICE_FEATURE_TYPES.CURTAIN.STATE]: {
+        characteristics: ['PositionState'],
+      },
+    },
+  },
 };
 
-module.exports = { mappings };
+const coverStateMapping = {
+  [COVER_STATE.CLOSE]: 0,
+  [COVER_STATE.OPEN]: 1,
+  [COVER_STATE.STOP]: 2,
+};
+
+module.exports = { mappings, coverStateMapping };

--- a/server/services/homekit/lib/sendState.js
+++ b/server/services/homekit/lib/sendState.js
@@ -38,19 +38,21 @@ function sendState(hkAccessory, feature, event) {
     }
     case `${DEVICE_FEATURE_CATEGORIES.LIGHT}:${DEVICE_FEATURE_TYPES.LIGHT.BRIGHTNESS}`:
     case `${DEVICE_FEATURE_CATEGORIES.LIGHT}:${DEVICE_FEATURE_TYPES.LIGHT.TEMPERATURE}`:
-    case `${DEVICE_FEATURE_CATEGORIES.HUMIDITY_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.DECIMAL}`: {
-      const characteristic = hkAccessory
-        .getService(Service[mappings[feature.category].service])
-        .getCharacteristic(Characteristic[mappings[feature.category].capabilities[feature.type].characteristics[0]]);
-      characteristic.updateValue(
-        normalize(
-          event.last_value,
-          feature.min,
-          feature.max,
-          characteristic.props.minValue,
-          characteristic.props.maxValue,
-        ),
-      );
+    case `${DEVICE_FEATURE_CATEGORIES.HUMIDITY_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.DECIMAL}`:
+    case `${DEVICE_FEATURE_CATEGORIES.CURTAIN}:${DEVICE_FEATURE_TYPES.CURTAIN.POSITION}`:
+    case `${DEVICE_FEATURE_CATEGORIES.SHUTTER}:${DEVICE_FEATURE_TYPES.SHUTTER.POSITION}`: {
+      const { characteristics } = mappings[feature.category].capabilities[feature.type];
+      characteristics.forEach((c) => {
+        hkAccessory
+          .getService(Service[mappings[feature.category].service])
+          .updateCharacteristic(Characteristic[c], normalize(
+            event.last_value,
+            feature.min,
+            feature.max,
+            Characteristic[c].props.minValue,
+            Characteristic[c].props.maxValue,
+          ));
+      });
       break;
     }
     case `${DEVICE_FEATURE_CATEGORIES.LIGHT}:${DEVICE_FEATURE_TYPES.LIGHT.COLOR}`: {
@@ -86,16 +88,6 @@ function sendState(hkAccessory, feature, event) {
       hkAccessory
         .getService(Service[mappings[feature.category].service])
         .updateCharacteristic(Characteristic.PositionState, coverStateMapping[event.last_value]);
-      break;
-    }
-    case `${DEVICE_FEATURE_CATEGORIES.CURTAIN}:${DEVICE_FEATURE_TYPES.CURTAIN.POSITION}`:
-    case `${DEVICE_FEATURE_CATEGORIES.SHUTTER}:${DEVICE_FEATURE_TYPES.SHUTTER.POSITION}`: {
-      const { characteristics } = mappings[feature.category].capabilities[feature.type];
-      characteristics.forEach((c) => {
-        hkAccessory
-          .getService(Service[mappings[feature.category].service])
-          .updateCharacteristic(Characteristic[c], event.last_value);
-      });
       break;
     }
     default:

--- a/server/services/homekit/lib/sendState.js
+++ b/server/services/homekit/lib/sendState.js
@@ -45,13 +45,16 @@ function sendState(hkAccessory, feature, event) {
       characteristics.forEach((c) => {
         hkAccessory
           .getService(Service[mappings[feature.category].service])
-          .updateCharacteristic(Characteristic[c], normalize(
-            event.last_value,
-            feature.min,
-            feature.max,
-            Characteristic[c].props.minValue,
-            Characteristic[c].props.maxValue,
-          ));
+          .updateCharacteristic(
+            Characteristic[c],
+            normalize(
+              event.last_value,
+              feature.min,
+              feature.max,
+              Characteristic[c].props.minValue,
+              Characteristic[c].props.maxValue,
+            ),
+          );
       });
       break;
     }

--- a/server/test/services/homekit/lib/buildService.test.js
+++ b/server/test/services/homekit/lib/buildService.test.js
@@ -463,4 +463,119 @@ describe('Build service', () => {
     expect(getCharacteristic.args[0][0]).to.equal('CONTACTSENSORSTATE');
     expect(cb.args[0][1]).to.equal(1);
   });
+
+  it('should build shutter/curtain service', async () => {
+    homekitHandler.gladys.device.getBySelector = stub().resolves({
+      features: [
+        {
+          id: '31c6a4a7-9710-4951-bf34-04eeae5b9ff7',
+          name: 'Shutter State',
+          category: DEVICE_FEATURE_CATEGORIES.SHUTTER,
+          type: DEVICE_FEATURE_TYPES.SHUTTER.STATE,
+          last_value: 0,
+        },
+        {
+          id: '81d2dc15-cb98-4235-96f4-5c12007b6ccd',
+          name: 'Shutter position',
+          category: DEVICE_FEATURE_CATEGORIES.SHUTTER,
+          type: DEVICE_FEATURE_TYPES.SHUTTER.POSITION,
+          last_value: 80,
+        },
+      ],
+    });
+    homekitHandler.gladys.event.emit = stub();
+    const on = stub();
+    const getCharacteristic = stub()
+      .onCall(0)
+      .returns({
+        on,
+        props: {
+          perms: ['PAIRED_READ'],
+        },
+      })
+      .onCall(1)
+      .returns({
+        on,
+        props: {
+          perms: ['PAIRED_READ', 'PAIRED_WRITE'],
+        },
+      })
+      .onCall(2)
+      .returns({
+        on,
+        props: {
+          perms: ['PAIRED_READ', 'PAIRED_WRITE'],
+        },
+      });
+    const WindowCovering = stub().returns({
+      getCharacteristic,
+    });
+
+    homekitHandler.hap = {
+      Characteristic: {
+        CurrentPosition: 'CURRENTPOSITION',
+        PositionState: 'POSITIONSTATE',
+        TargetPosition: 'TARGETPOSITION',
+      },
+      CharacteristicEventTypes: stub(),
+      Perms: {
+        PAIRED_READ: 'PAIRED_READ',
+        PAIRED_WRITE: 'PAIRED_WRITE',
+      },
+      Service: {
+        WindowCovering,
+      },
+    };
+    const device = {
+      name: 'Shutter',
+    };
+    const features = [
+      {
+        id: '31c6a4a7-9710-4951-bf34-04eeae5b9ff7',
+        selector: 'shutter-state',
+        name: 'Shutter State',
+        category: DEVICE_FEATURE_CATEGORIES.SHUTTER,
+        type: DEVICE_FEATURE_TYPES.SHUTTER.STATE,
+      },
+      {
+        id: '81d2dc15-cb98-4235-96f4-5c12007b6ccd',
+        selector: 'shutter-position',
+        name: 'Shutter Position',
+        category: DEVICE_FEATURE_CATEGORIES.SHUTTER,
+        type: DEVICE_FEATURE_TYPES.SHUTTER.POSITION,
+      },
+    ];
+
+    const cb = stub();
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.SHUTTER]);
+    await on.args[0][1](cb);
+    await on.args[1][1](cb);
+    await on.args[2][1](30, cb);
+    await on.args[3][1](cb);
+    await on.args[4][1](70, cb);
+
+    expect(WindowCovering.args[0][0]).to.equal('Shutter');
+    expect(on.callCount).to.equal(5);
+    expect(getCharacteristic.args[0][0]).to.equal('POSITIONSTATE');
+    expect(getCharacteristic.args[1][0]).to.equal('CURRENTPOSITION');
+    expect(getCharacteristic.args[2][0]).to.equal('TARGETPOSITION');
+    expect(cb.args[0][1]).to.equal(2);
+    expect(cb.args[1][1]).to.equal(80);
+    expect(homekitHandler.gladys.event.emit.args[0][1]).to.eql({
+      type: ACTIONS.DEVICE.SET_VALUE,
+      status: ACTIONS_STATUS.PENDING,
+      value: 30,
+      device: device.selector,
+      device_feature: features[1].selector,
+    });
+    expect(cb.args[3][1]).to.equal(80);
+    expect(homekitHandler.gladys.event.emit.args[1][1]).to.eql({
+      type: ACTIONS.DEVICE.SET_VALUE,
+      status: ACTIONS_STATUS.PENDING,
+      value: 70,
+      device: device.selector,
+      device_feature: features[1].selector,
+    });
+  });
 });

--- a/server/test/services/homekit/lib/buildService.test.js
+++ b/server/test/services/homekit/lib/buildService.test.js
@@ -497,7 +497,9 @@ describe('Build service', () => {
       .returns({
         on,
         props: {
-          perms: ['PAIRED_READ', 'PAIRED_WRITE'],
+          perms: ['PAIRED_READ'],
+          minValue: 0,
+          maxValue: 100,
         },
       })
       .onCall(2)
@@ -505,6 +507,8 @@ describe('Build service', () => {
         on,
         props: {
           perms: ['PAIRED_READ', 'PAIRED_WRITE'],
+          minValue: 0,
+          maxValue: 100,
         },
       });
     const WindowCovering = stub().returns({
@@ -543,6 +547,8 @@ describe('Build service', () => {
         name: 'Shutter Position',
         category: DEVICE_FEATURE_CATEGORIES.SHUTTER,
         type: DEVICE_FEATURE_TYPES.SHUTTER.POSITION,
+        min: 0,
+        max: 100,
       },
     ];
 
@@ -551,26 +557,17 @@ describe('Build service', () => {
     await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.SHUTTER]);
     await on.args[0][1](cb);
     await on.args[1][1](cb);
-    await on.args[2][1](30, cb);
-    await on.args[3][1](cb);
-    await on.args[4][1](70, cb);
+    await on.args[2][1](cb);
+    await on.args[3][1](70, cb);
 
     expect(WindowCovering.args[0][0]).to.equal('Shutter');
-    expect(on.callCount).to.equal(5);
+    expect(on.callCount).to.equal(4);
     expect(getCharacteristic.args[0][0]).to.equal('POSITIONSTATE');
     expect(getCharacteristic.args[1][0]).to.equal('CURRENTPOSITION');
     expect(getCharacteristic.args[2][0]).to.equal('TARGETPOSITION');
     expect(cb.args[0][1]).to.equal(2);
     expect(cb.args[1][1]).to.equal(80);
     expect(homekitHandler.gladys.event.emit.args[0][1]).to.eql({
-      type: ACTIONS.DEVICE.SET_VALUE,
-      status: ACTIONS_STATUS.PENDING,
-      value: 30,
-      device: device.selector,
-      device_feature: features[1].selector,
-    });
-    expect(cb.args[3][1]).to.equal(80);
-    expect(homekitHandler.gladys.event.emit.args[1][1]).to.eql({
       type: ACTIONS.DEVICE.SET_VALUE,
       status: ACTIONS_STATUS.PENDING,
       value: 70,

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -19,34 +19,38 @@ describe('Send state to HomeKit', () => {
       Characteristic: {
         On: 'ON',
         Brightness: {
-          name: 'BRIGHTNESS', props: {
+          name: 'BRIGHTNESS',
+          props: {
             minValue: 0,
             maxValue: 100,
-          }
+          },
         },
         Hue: 'HUE',
         Saturation: 'SATURATION',
         ColorTemperature: {
-          name: 'COLORTEMPERATURE', props: {
+          name: 'COLORTEMPERATURE',
+          props: {
             minValue: 140,
             maxValue: 500,
-          }
+          },
         },
         ContactSensorState: 'CONTACTSENSORSTATE',
         MotionDetected: 'MOTIONDETECTED',
         CurrentTemperature: 'CURRENTTEMPERATURE',
         CurrentPosition: {
-          name: 'CURRENTPOSITION', props: {
+          name: 'CURRENTPOSITION',
+          props: {
             minValue: 0,
             maxValue: 100,
-          }
+          },
         },
         PositionState: 'POSITIONSTATE',
         TargetPosition: {
-          name: 'TARGETPOSITION', props: {
+          name: 'TARGETPOSITION',
+          props: {
             minValue: 0,
             maxValue: 100,
-          }
+          },
         },
       },
       Service: {

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -18,16 +18,36 @@ describe('Send state to HomeKit', () => {
     hap: {
       Characteristic: {
         On: 'ON',
-        Brightness: 'BRIGHTNESS',
+        Brightness: {
+          name: 'BRIGHTNESS', props: {
+            minValue: 0,
+            maxValue: 100,
+          }
+        },
         Hue: 'HUE',
         Saturation: 'SATURATION',
-        ColorTemperature: 'COLORTEMPERATURE',
+        ColorTemperature: {
+          name: 'COLORTEMPERATURE', props: {
+            minValue: 140,
+            maxValue: 500,
+          }
+        },
         ContactSensorState: 'CONTACTSENSORSTATE',
         MotionDetected: 'MOTIONDETECTED',
         CurrentTemperature: 'CURRENTTEMPERATURE',
-        CurrentPosition: 'CURRENTPOSITION',
+        CurrentPosition: {
+          name: 'CURRENTPOSITION', props: {
+            minValue: 0,
+            maxValue: 100,
+          }
+        },
         PositionState: 'POSITIONSTATE',
-        TargetPosition: 'TARGETPOSITION',
+        TargetPosition: {
+          name: 'TARGETPOSITION', props: {
+            minValue: 0,
+            maxValue: 100,
+          }
+        },
       },
       Service: {
         ContactSensor: 'CONTACTSENSOR',
@@ -114,17 +134,11 @@ describe('Send state to HomeKit', () => {
   });
 
   it('should notify light brightness', async () => {
-    const updateValue = stub().returns();
+    const updateCharacteristic = stub().returns();
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
       getService: stub().returns({
-        getCharacteristic: stub().returns({
-          props: {
-            minValue: 0,
-            maxValue: 100,
-          },
-          updateValue,
-        }),
+        updateCharacteristic,
       }),
     };
 
@@ -145,7 +159,8 @@ describe('Send state to HomeKit', () => {
 
     await homekitHandler.sendState(accessory, feature, event);
 
-    expect(updateValue.args[0]).eql([50]);
+    expect(updateCharacteristic.args[0][0].name).eql('BRIGHTNESS');
+    expect(updateCharacteristic.args[0][1]).eql(50);
   });
 
   it('should notify light color', async () => {
@@ -178,17 +193,11 @@ describe('Send state to HomeKit', () => {
   });
 
   it('should notify light temperature', async () => {
-    const updateValue = stub().returns();
+    const updateCharacteristic = stub().returns();
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
       getService: stub().returns({
-        getCharacteristic: stub().returns({
-          props: {
-            minValue: 140,
-            maxValue: 500,
-          },
-          updateValue,
-        }),
+        updateCharacteristic,
       }),
     };
 
@@ -209,7 +218,8 @@ describe('Send state to HomeKit', () => {
 
     await homekitHandler.sendState(accessory, feature, event);
 
-    expect(updateValue.args[0]).eql([320]);
+    expect(updateCharacteristic.args[0][0].name).eql('COLORTEMPERATURE');
+    expect(updateCharacteristic.args[0][1]).eql(320);
   });
 
   it('should notify sensor temperature Kelvin', async () => {
@@ -309,13 +319,17 @@ describe('Send state to HomeKit', () => {
       name: 'Shutter position',
       category: DEVICE_FEATURE_CATEGORIES.SHUTTER,
       type: DEVICE_FEATURE_TYPES.SHUTTER.POSITION,
+      min: 0,
+      max: 100,
     };
 
     await homekitHandler.sendState(accessory, feature, event);
 
     expect(updateCharacteristic.callCount).eq(2);
-    expect(updateCharacteristic.args[0]).eql(['CURRENTPOSITION', 60]);
-    expect(updateCharacteristic.args[1]).eql(['TARGETPOSITION', 60]);
+    expect(updateCharacteristic.args[0][0].name).eql('CURRENTPOSITION');
+    expect(updateCharacteristic.args[0][1]).eql(60);
+    expect(updateCharacteristic.args[1][0].name).eql('TARGETPOSITION');
+    expect(updateCharacteristic.args[1][1]).eql(60);
   });
 
   it('should do nothing wrong device category & type', async () => {

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -25,10 +25,14 @@ describe('Send state to HomeKit', () => {
         ContactSensorState: 'CONTACTSENSORSTATE',
         MotionDetected: 'MOTIONDETECTED',
         CurrentTemperature: 'CURRENTTEMPERATURE',
+        CurrentPosition: 'CURRENTPOSITION',
+        PositionState: 'POSITIONSTATE',
+        TargetPosition: 'TARGETPOSITION',
       },
       Service: {
         ContactSensor: 'CONTACTSENSOR',
         MotionSensor: 'MOTIONSENSOR',
+        WindowCovering: 'WINDOWCOVERING',
       },
     },
     notifyTimeouts: {},
@@ -258,6 +262,60 @@ describe('Send state to HomeKit', () => {
     await homekitHandler.sendState(accessory, feature, event);
 
     expect(updateCharacteristic.args[0]).eql(['CURRENTTEMPERATURE', 20]);
+  });
+
+  it('should notify shutter state', async () => {
+    const updateCharacteristic = stub().returns();
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns({ updateCharacteristic }),
+    };
+
+    const event = {
+      type: EVENTS.DEVICE.NEW_STATE,
+      last_value: 0,
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Shutter state',
+      category: DEVICE_FEATURE_CATEGORIES.SHUTTER,
+      type: DEVICE_FEATURE_TYPES.SHUTTER.STATE,
+    };
+
+    await homekitHandler.sendState(accessory, feature, event);
+
+    expect(updateCharacteristic.args[0]).eql(['POSITIONSTATE', 2]);
+  });
+
+  it('should notify shutter current/target position', async () => {
+    const updateCharacteristic = stub();
+    updateCharacteristic.returns({ updateCharacteristic });
+
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns({ updateCharacteristic }),
+    };
+
+    const event = {
+      type: EVENTS.DEVICE.NEW_STATE,
+      last_value: 60,
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Shutter position',
+      category: DEVICE_FEATURE_CATEGORIES.SHUTTER,
+      type: DEVICE_FEATURE_TYPES.SHUTTER.POSITION,
+    };
+
+    await homekitHandler.sendState(accessory, feature, event);
+
+    expect(updateCharacteristic.callCount).eq(2);
+    expect(updateCharacteristic.args[0]).eql(['CURRENTPOSITION', 60]);
+    expect(updateCharacteristic.args[1]).eql(['TARGETPOSITION', 60]);
   });
 
   it('should do nothing wrong device category & type', async () => {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Please provide a description of the change here. It's always best with screenshots, so don't hesitate to add some!

Handle Gladys shutter/curtain devices in Homekit. In homekit it's one service for both device types (known as `Window covering`)

https://community.gladysassistant.com/t/ajout-de-volets-roulants-a-homekit/9375