### PR TITLE
Fix homekit live update for dynamic numeric value types

### DIFF
--- a/server/services/homekit/lib/sendState.js
+++ b/server/services/homekit/lib/sendState.js
@@ -41,18 +41,20 @@ function sendState(hkAccessory, feature, event) {
     case `${DEVICE_FEATURE_CATEGORIES.HUMIDITY_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.DECIMAL}`:
     case `${DEVICE_FEATURE_CATEGORIES.CURTAIN}:${DEVICE_FEATURE_TYPES.CURTAIN.POSITION}`:
     case `${DEVICE_FEATURE_CATEGORIES.SHUTTER}:${DEVICE_FEATURE_TYPES.SHUTTER.POSITION}`: {
+      const service = hkAccessory
+        .getService(Service[mappings[feature.category].service]);
       const { characteristics } = mappings[feature.category].capabilities[feature.type];
       characteristics.forEach((c) => {
-        hkAccessory
-          .getService(Service[mappings[feature.category].service])
+        const characteristic = service.getCharacteristic(Characteristic[c]);
+        service
           .updateCharacteristic(
             Characteristic[c],
             normalize(
               event.last_value,
               feature.min,
               feature.max,
-              Characteristic[c].props.minValue,
-              Characteristic[c].props.maxValue,
+              characteristic.props.minValue,
+              characteristic.props.maxValue,
             ),
           );
       });

--- a/server/services/homekit/lib/sendState.js
+++ b/server/services/homekit/lib/sendState.js
@@ -41,22 +41,20 @@ function sendState(hkAccessory, feature, event) {
     case `${DEVICE_FEATURE_CATEGORIES.HUMIDITY_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.DECIMAL}`:
     case `${DEVICE_FEATURE_CATEGORIES.CURTAIN}:${DEVICE_FEATURE_TYPES.CURTAIN.POSITION}`:
     case `${DEVICE_FEATURE_CATEGORIES.SHUTTER}:${DEVICE_FEATURE_TYPES.SHUTTER.POSITION}`: {
-      const service = hkAccessory
-        .getService(Service[mappings[feature.category].service]);
+      const service = hkAccessory.getService(Service[mappings[feature.category].service]);
       const { characteristics } = mappings[feature.category].capabilities[feature.type];
       characteristics.forEach((c) => {
         const characteristic = service.getCharacteristic(Characteristic[c]);
-        service
-          .updateCharacteristic(
-            Characteristic[c],
-            normalize(
-              event.last_value,
-              feature.min,
-              feature.max,
-              characteristic.props.minValue,
-              characteristic.props.maxValue,
-            ),
-          );
+        service.updateCharacteristic(
+          Characteristic[c],
+          normalize(
+            event.last_value,
+            feature.min,
+            feature.max,
+            characteristic.props.minValue,
+            characteristic.props.maxValue,
+          ),
+        );
       });
       break;
     }

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -119,7 +119,7 @@ describe('Send state to HomeKit', () => {
       props: {
         minValue: 0,
         maxValue: 100,
-      }
+      },
     });
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
@@ -185,7 +185,7 @@ describe('Send state to HomeKit', () => {
       props: {
         minValue: 140,
         maxValue: 500,
-      }
+      },
     });
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
@@ -300,7 +300,7 @@ describe('Send state to HomeKit', () => {
       props: {
         minValue: 0,
         maxValue: 100,
-      }
+      },
     });
 
     const accessory = {

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -18,40 +18,16 @@ describe('Send state to HomeKit', () => {
     hap: {
       Characteristic: {
         On: 'ON',
-        Brightness: {
-          name: 'BRIGHTNESS',
-          props: {
-            minValue: 0,
-            maxValue: 100,
-          },
-        },
+        Brightness: 'BRIGHTNESS',
         Hue: 'HUE',
         Saturation: 'SATURATION',
-        ColorTemperature: {
-          name: 'COLORTEMPERATURE',
-          props: {
-            minValue: 140,
-            maxValue: 500,
-          },
-        },
+        ColorTemperature: 'COLORTEMPERATURE',
         ContactSensorState: 'CONTACTSENSORSTATE',
         MotionDetected: 'MOTIONDETECTED',
         CurrentTemperature: 'CURRENTTEMPERATURE',
-        CurrentPosition: {
-          name: 'CURRENTPOSITION',
-          props: {
-            minValue: 0,
-            maxValue: 100,
-          },
-        },
+        CurrentPosition: 'CURRENTPOSITION',
         PositionState: 'POSITIONSTATE',
-        TargetPosition: {
-          name: 'TARGETPOSITION',
-          props: {
-            minValue: 0,
-            maxValue: 100,
-          },
-        },
+        TargetPosition: 'TARGETPOSITION',
       },
       Service: {
         ContactSensor: 'CONTACTSENSOR',
@@ -139,10 +115,17 @@ describe('Send state to HomeKit', () => {
 
   it('should notify light brightness', async () => {
     const updateCharacteristic = stub().returns();
+    const getCharacteristic = stub().returns({
+      props: {
+        minValue: 0,
+        maxValue: 100,
+      }
+    });
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
       getService: stub().returns({
         updateCharacteristic,
+        getCharacteristic,
       }),
     };
 
@@ -163,7 +146,7 @@ describe('Send state to HomeKit', () => {
 
     await homekitHandler.sendState(accessory, feature, event);
 
-    expect(updateCharacteristic.args[0][0].name).eql('BRIGHTNESS');
+    expect(updateCharacteristic.args[0][0]).eql('BRIGHTNESS');
     expect(updateCharacteristic.args[0][1]).eql(50);
   });
 
@@ -198,10 +181,17 @@ describe('Send state to HomeKit', () => {
 
   it('should notify light temperature', async () => {
     const updateCharacteristic = stub().returns();
+    const getCharacteristic = stub().returns({
+      props: {
+        minValue: 140,
+        maxValue: 500,
+      }
+    });
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
       getService: stub().returns({
         updateCharacteristic,
+        getCharacteristic,
       }),
     };
 
@@ -222,7 +212,7 @@ describe('Send state to HomeKit', () => {
 
     await homekitHandler.sendState(accessory, feature, event);
 
-    expect(updateCharacteristic.args[0][0].name).eql('COLORTEMPERATURE');
+    expect(updateCharacteristic.args[0][0]).eql('COLORTEMPERATURE');
     expect(updateCharacteristic.args[0][1]).eql(320);
   });
 
@@ -306,10 +296,16 @@ describe('Send state to HomeKit', () => {
   it('should notify shutter current/target position', async () => {
     const updateCharacteristic = stub();
     updateCharacteristic.returns({ updateCharacteristic });
+    const getCharacteristic = stub().returns({
+      props: {
+        minValue: 0,
+        maxValue: 100,
+      }
+    });
 
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
-      getService: stub().returns({ updateCharacteristic }),
+      getService: stub().returns({ updateCharacteristic, getCharacteristic }),
     };
 
     const event = {
@@ -330,9 +326,9 @@ describe('Send state to HomeKit', () => {
     await homekitHandler.sendState(accessory, feature, event);
 
     expect(updateCharacteristic.callCount).eq(2);
-    expect(updateCharacteristic.args[0][0].name).eql('CURRENTPOSITION');
+    expect(updateCharacteristic.args[0][0]).eql('CURRENTPOSITION');
     expect(updateCharacteristic.args[0][1]).eql(60);
-    expect(updateCharacteristic.args[1][0].name).eql('TARGETPOSITION');
+    expect(updateCharacteristic.args[1][0]).eql('TARGETPOSITION');
     expect(updateCharacteristic.args[1][1]).eql(60);
   });
 


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [ ] If your changes affects code, did your write the tests?
- [ ] Are tests passing? (`npm test` on both front/server)
- [ ] Is the linter passing? (`npm run eslint` on both front/server)
- [ ] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

In PR #2266, I made a mistake when I changed this part, now it throws error on live update for some features

Need someone with an Homekit concentrator to test that one of this device capability is live upadted in Home app
- light brigthness
- light temperature
- humidity value
- curtain position

If one works, all will work