### PR TITLE
Dashboard: Chart should let the user select an aggregate function instead of the default (average)

### DIFF
--- a/front/src/components/boxs/chart/Chart.jsx
+++ b/front/src/components/boxs/chart/Chart.jsx
@@ -46,6 +46,23 @@ const notNullNotUndefined = value => {
 
 const average = arr => arr.reduce((p, c) => p + c, 0) / arr.length;
 
+const getDeviceValueByAggregateFunction = (value, aggregateFunction) => {
+  if (aggregateFunction === 'min') {
+    return value.min_value;
+  } else if (aggregateFunction === 'max') {
+    return value.max_value;
+  } else if (aggregateFunction === 'sum') {
+    return value.sum_value;
+  } else if (aggregateFunction === 'count') {
+    return value.count_value;
+  } else if (aggregateFunction === 'avg') {
+    return value.value;
+  }
+  // The default is the "avg", as before this feature
+  // we were not defining an aggregate function
+  return value.value;
+};
+
 const roundWith2DecimalIfNeeded = value => {
   if (!notNullNotUndefined(value)) {
     return null;
@@ -238,7 +255,10 @@ class Chartbox extends Component {
             name,
             data: values.map(value => {
               emptySeries = false;
-              return [Math.round(new Date(value.created_at).getTime() / 1000) * 1000, value.value];
+              return [
+                Math.round(new Date(value.created_at).getTime() / 1000) * 1000,
+                getDeviceValueByAggregateFunction(value, this.props.box.aggregate_function)
+              ];
             })
           };
         });

--- a/front/src/components/boxs/chart/EditChart.jsx
+++ b/front/src/components/boxs/chart/EditChart.jsx
@@ -125,8 +125,23 @@ class EditChart extends Component {
     }
   };
 
+  updateAggregateFunction = e => {
+    this.props.updateBoxConfig(this.props.x, this.props.y, { aggregate_function: e.target.value });
+  };
+
   updateBoxTitle = e => {
     this.props.updateBoxConfig(this.props.x, this.props.y, { title: e.target.value });
+  };
+
+  refreshAggregateFunction = (firstDeviceSelector = null) => {
+    if (firstDeviceSelector && !FEATURE_BINARY[firstDeviceSelector.type]) {
+      if (!this.props.box.aggregate_function) {
+        // set aggregate function to avg by default if not defined
+        this.props.updateBoxConfig(this.props.x, this.props.y, { aggregate_function: 'avg' });
+      }
+    } else {
+      this.props.updateBoxConfig(this.props.x, this.props.y, { aggregate_function: undefined });
+    }
   };
 
   addDeviceFeature = async selectedDeviceFeatureOption => {
@@ -191,6 +206,7 @@ class EditChart extends Component {
       this.setState({ chart_type: '' });
     }
     this.refreshChartTypeList(firstDeviceSelector);
+    this.refreshAggregateFunction(firstDeviceSelector);
     this.setState({ selectedDeviceFeaturesOptions });
   };
 
@@ -546,6 +562,34 @@ class EditChart extends Component {
                 </option>
               </select>
             </div>
+            {props.box.chart_type !== 'timeline' && (
+              <div class="form-group">
+                <label>
+                  <Text id="dashboard.boxes.chart.aggregateFunction" />
+                </label>
+                <select
+                  onChange={this.updateAggregateFunction}
+                  className="form-control"
+                  value={props.box.aggregate_function}
+                >
+                  <option value="avg">
+                    <Text id="dashboard.boxes.chart.aggregateFunctions.avg" />
+                  </option>
+                  <option value="sum">
+                    <Text id="dashboard.boxes.chart.aggregateFunctions.sum" />
+                  </option>
+                  <option value="max">
+                    <Text id="dashboard.boxes.chart.aggregateFunctions.max" />
+                  </option>
+                  <option value="min">
+                    <Text id="dashboard.boxes.chart.aggregateFunctions.min" />
+                  </option>
+                  <option value="count">
+                    <Text id="dashboard.boxes.chart.aggregateFunctions.count" />
+                  </option>
+                </select>
+              </div>
+            )}
             {props.box.chart_type !== 'timeline' && (
               <div class="form-group">
                 <label>

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -380,7 +380,15 @@
         "on": "An",
         "off": "Aus",
         "start_date": "Startdatum: ",
-        "end_date": "Enddatum: "
+        "end_date": "Enddatum: ",
+        "aggregateFunction": "Aggregationsfunktion",
+        "aggregateFunctions": {
+          "sum": "Summe",
+          "avg": "Durchschnitt",
+          "max": "Max",
+          "min": "Min",
+          "count": "Count"
+        }
       },
       "ecowatt": {
         "title": "Ecowatt France",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -380,7 +380,15 @@
         "on": "On",
         "off": "Off",
         "start_date": "Start date: ",
-        "end_date": "End date: "
+        "end_date": "End date: ",
+        "aggregateFunction": "Aggregate function",
+        "aggregateFunctions": {
+          "sum": "Sum",
+          "avg": "Average",
+          "max": "Max",
+          "min": "Min",
+          "count": "Count"
+        }
       },
       "ecowatt": {
         "title": "Ecowatt France",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -380,7 +380,15 @@
         "on": "On",
         "off": "Off",
         "start_date": "Début le : ",
-        "end_date": "Fin le : "
+        "end_date": "Fin le : ",
+        "aggregateFunction": "Fonction d'agrégation",
+        "aggregateFunctions": {
+          "sum": "Somme",
+          "avg": "Moyenne",
+          "max": "Maximum",
+          "min": "Minimum",
+          "count": "Nombre"
+        }
       },
       "ecowatt": {
         "title": "Ecowatt France",

--- a/server/lib/device/device.getDeviceFeaturesAggregates.js
+++ b/server/lib/device/device.getDeviceFeaturesAggregates.js
@@ -14,7 +14,11 @@ const NON_BINARY_QUERY = `
     )
     SELECT
         MIN(created_at) AS created_at,
-        AVG(value) AS value
+        AVG(value) AS value,
+        MAX(value) AS max_value,
+        MIN(value) AS min_value,
+        SUM(value) AS sum_value,
+        COUNT(value) AS count_value
     FROM
         intervals
     GROUP BY
@@ -84,6 +88,11 @@ async function getDeviceFeaturesAggregates(selector, intervalInMinutes, maxState
     values = await db.duckDbReadConnectionAllAsync(BINARY_QUERY, deviceFeature.id, intervalDate, maxStates);
   } else {
     values = await db.duckDbReadConnectionAllAsync(NON_BINARY_QUERY, maxStates, deviceFeature.id, intervalDate);
+    // Convert BigInt count_value to regular JavaScript Number
+    values = values.map((value) => ({
+      ...value,
+      count_value: Number(value.count_value),
+    }));
   }
 
   return {

--- a/server/models/dashboard.js
+++ b/server/models/dashboard.js
@@ -21,6 +21,7 @@ const boxesSchema = Joi.array().items(
       units: Joi.array().items(Joi.string().allow(null)),
       title: Joi.string(),
       interval: Joi.string(),
+      aggregate_function: Joi.string().valid('avg', 'sum', 'max', 'min', 'count'),
       display_axes: Joi.boolean(),
       display_variation: Joi.boolean(),
       chart_type: Joi.string(),

--- a/server/test/lib/device/device.getDeviceFeaturesAggregates.test.js
+++ b/server/test/lib/device/device.getDeviceFeaturesAggregates.test.js
@@ -123,6 +123,11 @@ describe('Device.getDeviceFeaturesAggregates non binary feature', function Descr
     const deviceInstance = new Device(event, {}, stateManager, {}, {}, variable, job);
     const { values } = await deviceInstance.getDeviceFeaturesAggregates('test-device-feature', 60, 100);
     expect(values).to.have.lengthOf(1);
+    expect(values[0]).to.have.property('value');
+    expect(values[0]).to.have.property('max_value');
+    expect(values[0]).to.have.property('min_value');
+    expect(values[0]).to.have.property('sum_value');
+    expect(values[0]).to.have.property('count_value');
   });
   it('should return last day states', async () => {
     await insertStates(48 * 60);


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

https://community.gladysassistant.com/t/pouvoir-afficher-les-graphiques-en-max-ou-en-somme/7682