### PR TITLE
Dashboard: Not controllable MQTT devices should be displayed as sensor + fix MQTT placeholder in scenes

### DIFF
--- a/front/src/components/boxs/device-in-room/DeviceRow.jsx
+++ b/front/src/components/boxs/device-in-room/DeviceRow.jsx
@@ -50,8 +50,8 @@ const DeviceRow = ({ children, ...props }) => {
   const elementType = ROW_TYPE_BY_FEATURE_TYPE[props.deviceFeature.type];
 
   if (!elementType) {
-    // if no related components, we return nothing
-    return null;
+    // if no related components, we display the device as a sensor
+    return <SensorDeviceFeature user={props.user} device={device} deviceFeature={deviceFeature} rowName={rowName} />;
   }
 
   return createElement(elementType, { ...props, rowName });

--- a/front/src/components/boxs/device-in-room/EditDevices.jsx
+++ b/front/src/components/boxs/device-in-room/EditDevices.jsx
@@ -7,7 +7,6 @@ import BaseEditBox from '../baseEditBox';
 import { getDeviceFeatureName } from '../../../utils/device';
 import { DeviceListWithDragAndDrop } from '../../drag-and-drop/DeviceListWithDragAndDrop';
 import withIntlAsProp from '../../../utils/withIntlAsProp';
-import SUPPORTED_FEATURE_TYPES from './SupportedFeatureTypes';
 
 class EditDevices extends Component {
   addDeviceFeature = async selectedDeviceFeatureOption => {

--- a/front/src/components/boxs/device-in-room/EditDevices.jsx
+++ b/front/src/components/boxs/device-in-room/EditDevices.jsx
@@ -79,9 +79,7 @@ class EditDevices extends Component {
           value: feature.selector,
           label: getDeviceFeatureName(this.props.intl.dictionary, device, feature)
         };
-        if (feature.read_only || SUPPORTED_FEATURE_TYPES.includes(feature.type)) {
-          deviceFeatures.push(featureOption);
-        }
+        deviceFeatures.push(featureOption);
         // If the feature is already selected
         if (this.props.box.device_features) {
           const featureIndex = this.props.box.device_features.indexOf(feature.selector);

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -2037,14 +2037,14 @@
       },
       "mqttMessage": {
         "topic": "Topic",
-        "topicPlaceholder": "/gladys/mein-topic",
+        "topicPlaceholder": "gladys/mein-topic",
         "messageLabel": "Message",
         "variablesExplanation": "Um eine Variable im Text einzufügen, gib \"{{\" ein. Um einen Variablenwert festzulegen, musst du vor diesem Feld das das Feld \"Gerätewert abrufen\" verwenden.",
         "messagePlaceholder": "Meine Message"
       },
       "zigbee2mqttMessage": {
         "topic": "Topic",
-        "topicPlaceholder": "/gladys/mein-topic",
+        "topicPlaceholder": "gladys/mein-topic",
         "messageLabel": "Message",
         "variablesExplanation": "Um eine Variable im Text einzufügen, gib \"{{\" ein. Um einen Variablenwert festzulegen, musst du vor diesem Feld das das Feld \"Gerätewert abrufen\" verwenden.",
         "messagePlaceholder": "Meine Message"

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -2037,14 +2037,14 @@
       },
       "mqttMessage": {
         "topic": "Topic",
-        "topicPlaceholder": "/gladys/my-topic",
+        "topicPlaceholder": "gladys/my-topic",
         "messageLabel": "Message",
         "variablesExplanation": "To inject a variable in the text, press '{{ '. To set a variable value, you need to use the 'Get device value' box before this one.",
         "messagePlaceholder": "My message"
       },
       "zigbee2mqttMessage": {
         "topic": "Topic",
-        "topicPlaceholder": "/gladys/my-topic",
+        "topicPlaceholder": "gladys/my-topic",
         "messageLabel": "Message",
         "variablesExplanation": "To inject a variable in the text, press '{{ '. To set a variable value, you need to use the 'Get device value' box before this one.",
         "messagePlaceholder": "My message"

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -2037,14 +2037,14 @@
       },
       "mqttMessage": {
         "topic": "Topic",
-        "topicPlaceholder": "/gladys/my-topic",
+        "topicPlaceholder": "gladys/my-topic",
         "messageLabel": "Message",
         "variablesExplanation": "Pour injecter une variable, tapez '{{ '. Attention, vous devez avoir défini une variable auparavant dans une action 'Récupérer le dernier état' placé avant ce bloc message.",
         "messagePlaceholder": "Mon message"
       },
       "zigbee2mqttMessage": {
         "topic": "Topic",
-        "topicPlaceholder": "/gladys/my-topic",
+        "topicPlaceholder": "gladys/my-topic",
         "messageLabel": "Message",
         "variablesExplanation": "Pour injecter une variable, tapez '{{ '. Attention, vous devez avoir défini une variable auparavant dans une action 'Récupérer le dernier état' placé avant ce bloc message.",
         "messagePlaceholder": "Mon message"


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

Fix https://community.gladysassistant.com/t/affichage-simple-sur-le-dashboard-des-topic-mqtt-nayant-pas-de-controleur/8587