### PR TITLE
Dashboard: Should display  light widget control only if there is more than 2 lights

### DIFF
--- a/front/src/components/boxs/device-in-room/DeviceCard.jsx
+++ b/front/src/components/boxs/device-in-room/DeviceCard.jsx
@@ -2,11 +2,11 @@ import DeviceRow from './DeviceRow';
 import style from './style.css';
 import { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } from '../../../../../server/utils/constants';
 
-const hasSwitchFeature = (features, featureSelectors) => {
-  return features.find(feature => isSwitchFeature(feature, featureSelectors));
+const countLightBinaryFeature = (features, featureSelectors) => {
+  return features.filter(feature => isLightBinaryFeature(feature, featureSelectors)).length;
 };
 
-const isSwitchFeature = (feature, featureSelectors) => {
+const isLightBinaryFeature = (feature, featureSelectors) => {
   return (
     feature.category === DEVICE_FEATURE_CATEGORIES.LIGHT &&
     feature.type === DEVICE_FEATURE_TYPES.LIGHT.BINARY &&
@@ -19,7 +19,7 @@ const DeviceCard = ({ children, ...props }) => {
   const { boxTitle, roomLightStatus, loading, deviceFeatures = [], box = {} } = props;
   const { device_features: featureSelectors = [] } = box;
 
-  const hasBinaryLightDeviceFeature = hasSwitchFeature(deviceFeatures, featureSelectors) !== undefined;
+  const hasAtLeastTwoLightBinaryFeature = countLightBinaryFeature(deviceFeatures, featureSelectors) >= 2;
 
   // Create placeholder rows based on the number of expected features
   const placeholderRows = Array(featureSelectors.length).fill(0);
@@ -29,7 +29,7 @@ const DeviceCard = ({ children, ...props }) => {
       {boxTitle && (
         <div class="card-header">
           <h3 class="card-title">{boxTitle}</h3>
-          {hasBinaryLightDeviceFeature && (
+          {hasAtLeastTwoLightBinaryFeature && (
             <div class="card-options">
               <label class="custom-switch m-0">
                 <input


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

https://community.gladysassistant.com/t/modification-du-widget-appareils/8560