### PR TITLE
Scene: Fix variable bug when using more than 9 actions before injecting a variable

### DIFF
--- a/front/src/routes/scene/edit-scene/sceneUtils.js
+++ b/front/src/routes/scene/edit-scene/sceneUtils.js
@@ -5,7 +5,7 @@ import get from 'get-value';
 const isVariableAvailableAtThisPath = (variableSourcePath, targetPath) => {
   // if the targetPath is smaller than the sourcePath, it means that
   // the variable is not in the same branch
-  if (variableSourcePath.length > targetPath.length) {
+  if (variableSourcePath.split('.').length > targetPath.split('.').length) {
     return false;
   }
 


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

Fix https://community.gladysassistant.com/t/recuperer-un-etat-envoyer-message-mqtt-limitation-du-nb-de-variables/9525/3?u=pierre-gilles