### PR TITLE
Camera: Increase get camera image timeout to 20 seconds

### DIFF
--- a/server/services/rtsp-camera/lib/getImage.js
+++ b/server/services/rtsp-camera/lib/getImage.js
@@ -72,7 +72,7 @@ async function getImage(device) {
       'ffmpeg',
       args,
       {
-        timeout: 10 * 1000, // 10 second max
+        timeout: 20 * 1000, // 20 second max
       },
       async (error, stdout, stderr) => {
         if (error) {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

Increase get camera image timeout to 20 seconds ( https://community.gladysassistant.com/t/camera-hs-aucune-image-dans-gladys-mais-image-dans-lappli-constructeur/9425/12?u=pierre-gilles ) 