### PR TITLE
Chart: Display Http error message in UI

### DIFF
--- a/front/src/components/boxs/chart/Chart.jsx
+++ b/front/src/components/boxs/chart/Chart.jsx
@@ -9,6 +9,7 @@ import get from 'get-value';
 import withIntlAsProp from '../../../utils/withIntlAsProp';
 import ApexChartComponent from './ApexChartComponent';
 import { getDeviceName } from '../../../utils/device';
+import { formatHttpError } from '../../../utils/formatErrors';
 
 const ONE_HOUR_IN_MINUTES = 60;
 const TWELVE_HOURS_IN_MINUTES = 12 * 60;
@@ -189,7 +190,7 @@ class Chartbox extends Component {
       });
       return;
     }
-    await this.setState({ loading: true });
+    await this.setState({ loading: true, error: null, errorDetail: null });
     try {
       const maxStates = 300;
 
@@ -326,6 +327,12 @@ class Chartbox extends Component {
       await this.setState(newState);
     } catch (e) {
       console.error(e);
+      const { errorString, errorDetailString } = formatHttpError(e);
+      this.setState({
+        loading: false,
+        error: errorString,
+        errorDetail: errorDetailString
+      });
     }
   };
   updateDeviceStateWebsocket = payload => {
@@ -396,7 +403,9 @@ class Chartbox extends Component {
       interval,
       emptySeries,
       unit,
-      nbFeaturesDisplayed
+      nbFeaturesDisplayed,
+      error,
+      errorDetail
     }
   ) {
     const { box } = this.props;
@@ -618,6 +627,15 @@ class Chartbox extends Component {
                 <div class={style.smallTextEmptyState}>
                   <Text id="dashboard.boxes.chart.noChartTypeWarning" />
                 </div>
+              </div>
+            )}
+            {error && (
+              <div class={cx('text-center', style.bigEmptyState)}>
+                <div>
+                  <i class="fe fe-alert-circle mr-2" />
+                  {error}
+                </div>
+                {errorDetail && <div>{errorDetail}</div>}
               </div>
             )}
             {props.box.chart_type && (

--- a/front/src/utils/formatErrors.js
+++ b/front/src/utils/formatErrors.js
@@ -1,0 +1,22 @@
+const formatHttpError = error => {
+  const errorString = error.toString();
+  let errorDetailString = '';
+  // If it's an standard Gladys http error
+  if (error.response && error.response.data) {
+    const responseData = error.response.data;
+    if (responseData.code) {
+      errorDetailString += responseData.code;
+    }
+    if (responseData.message) {
+      errorDetailString += ': ';
+      errorDetailString += responseData.message;
+    }
+    if (responseData.error && Object.keys(responseData.error).length > 0) {
+      errorDetailString += ': ';
+      errorDetailString += JSON.stringify(responseData.error);
+    }
+  }
+  return { errorString, errorDetailString };
+};
+
+export { formatHttpError };

--- a/server/test/middlewares/errorMiddleware.test.js
+++ b/server/test/middlewares/errorMiddleware.test.js
@@ -1,5 +1,6 @@
 const sinon = require('sinon');
 const { fake, assert } = require('sinon');
+const { expect } = require('chai');
 const MockExpressRequest = require('mock-express-request');
 
 const { ConflictError } = require('../../utils/coreErrors');
@@ -41,5 +42,10 @@ describe('errorMiddleware', () => {
     });
     assert.calledWith(res.status, 500);
     assert.calledOnce(send);
+    // check that call args deep equal error 500 status, code & message:
+    const errorSent = send.getCall(0).args[0];
+    expect(errorSent).to.have.property('status', 500);
+    expect(errorSent).to.have.property('code', 'SERVER_ERROR');
+    expect(errorSent).to.have.property('message', 'Error: UNKNOWN_ERROR');
   });
 });

--- a/server/utils/httpErrors.js
+++ b/server/utils/httpErrors.js
@@ -75,6 +75,9 @@ class Error500 extends HttpError {
     this.status = 500;
     this.code = 'SERVER_ERROR';
     this.error = error;
+    if (error instanceof Error) {
+      this.message = error.toString();
+    }
   }
 }
 


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

Display HTTP error in UI to make debugging easier

![Screenshot 2025-06-06 at 08 58 14](https://github.com/user-attachments/assets/63318fb9-49d0-475d-a95a-1d9eb9750113)

