### PR TITLE
Zigbee2mqtt: Allow editing binary switches as light devices

### DIFF
--- a/front/src/routes/integration/all/zigbee2mqtt/edit-page/index.js
+++ b/front/src/routes/integration/all/zigbee2mqtt/edit-page/index.js
@@ -3,10 +3,7 @@ import { connect } from 'unistore/preact';
 // import actions from '../actions';
 import Zigbee2mqttPage from '../Zigbee2mqttPage.js';
 import UpdateDevice from '../../../../../components/device';
-import {
-  DEVICE_FEATURE_CATEGORIES,
-  DEVICE_FEATURE_TYPES
-} from '../../../../../../../server/utils/constants.js';
+import { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } from '../../../../../../../server/utils/constants.js';
 
 const ZIGBEE2MQTT_PAGE_PATH = '/dashboard/integration/device/zigbee2mqtt';
 

--- a/front/src/routes/integration/all/zigbee2mqtt/edit-page/index.js
+++ b/front/src/routes/integration/all/zigbee2mqtt/edit-page/index.js
@@ -3,12 +3,21 @@ import { connect } from 'unistore/preact';
 // import actions from '../actions';
 import Zigbee2mqttPage from '../Zigbee2mqttPage.js';
 import UpdateDevice from '../../../../../components/device';
-import { DEVICE_FEATURE_CATEGORIES } from '../../../../../../../server/utils/constants.js';
+import {
+  DEVICE_FEATURE_CATEGORIES,
+  DEVICE_FEATURE_TYPES
+} from '../../../../../../../server/utils/constants.js';
 
 const ZIGBEE2MQTT_PAGE_PATH = '/dashboard/integration/device/zigbee2mqtt';
 
 class EditZigbee2mqttDevice extends Component {
   canEditCategory = (device, feature) => {
+    // Allow editing category for:
+    // - Binary switches (to switch between SWITCH and LIGHT)
+    // - Shutters (existing behavior)
+    if (feature.type === DEVICE_FEATURE_TYPES.SWITCH.BINARY) {
+      return true;
+    }
     return feature.category === DEVICE_FEATURE_CATEGORIES.SHUTTER;
   };
 


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.

### Description of change

Fix https://community.gladysassistant.com/t/z2m-editer-les-categories-fonctionnalites/7472