### PR TITLE
MCP: Fix schema build for device with no room

### DIFF
--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -18,7 +18,7 @@ async function getAllResources() {
 
   const sensorDevices = (await this.gladys.device.get())
     .filter((device) => {
-      return device.features.some((feature) => this.isSensorFeature(feature));
+      return device.room && device.features.some((feature) => this.isSensorFeature(feature));
     })
     .map((device) => ({
       ...device,
@@ -43,7 +43,7 @@ async function getAllResources() {
 
   const switchableDevices = (await this.gladys.device.get())
     .filter((device) => {
-      return device.features.some((feature) => this.isSwitchableFeature(feature));
+      return device.room && device.features.some((feature) => this.isSwitchableFeature(feature));
     })
     .map((device) => ({
       ...device,
@@ -104,7 +104,7 @@ async function getAllTools() {
   const scenes = (await this.gladys.scene.get()).map(({ id, name, selector }) => ({ id, name, selector }));
   const sensorDevices = (await this.gladys.device.get())
     .filter((device) => {
-      return device.features.some((feature) => this.isSensorFeature(feature));
+      return device.room && device.features.some((feature) => this.isSensorFeature(feature));
     })
     .map((device) => ({
       ...device,
@@ -123,7 +123,7 @@ async function getAllTools() {
 
   const switchableDevices = (await this.gladys.device.get())
     .filter((device) => {
-      return device.features.some((feature) => this.isSwitchableFeature(feature));
+      return device.room && device.features.some((feature) => this.isSwitchableFeature(feature));
     })
     .map((device) => ({
       ...device,


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([french forum](https://community.gladysassistant.com/)/[english forum](https://en-community.gladysassistant.com/)) for testing before merging.
- [x] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [x] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Fix error: 

```
2025-11-03T15:04:03+0100 <warn> service.start.js:44 (Service.start) Unable to start service mcp TypeError: Cannot read properties of null (reading 'selector')
    at /src/server/services/mcp/lib/buildSchemas.js:41:28
    at Array.forEach (<anonymous>)
    at MCPHandler.getAllResources (/src/server/services/mcp/lib/buildSchemas.js:28:17)
    at MCPHandler.createServer (/src/server/services/mcp/lib/createServer.js:26:4)
    at Object.start (/src/server/services/mcp/index.js:29:5)
    at Service.start (/src/server/lib/service/service.start.js:33:7)
```