### PR TITLE
Scene: Handle device state change on text devices

### DIFF
--- a/front/src/routes/scene/edit-scene/EditScenePage.jsx
+++ b/front/src/routes/scene/edit-scene/EditScenePage.jsx
@@ -98,6 +98,11 @@ const EditScenePage = ({ children, ...props }) => (
             {props.error && (
               <div class="alert alert-danger">
                 <Text id="editScene.saveSceneError" />
+                {props.errorMessage && (
+                  <div class="mt-2">
+                    <small>{props.errorMessage}</small>
+                  </div>
+                )}
               </div>
             )}
             <div class="row">

--- a/front/src/routes/scene/edit-scene/triggers/device-states/DefaultDeviceState.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/device-states/DefaultDeviceState.jsx
@@ -1,6 +1,8 @@
 import { Component, Fragment } from 'preact';
 import { Text, Localizer } from 'preact-i18n';
 
+import { DEVICE_FEATURE_CATEGORIES } from '../../../../../../../server/utils/constants';
+
 class DefaultDeviceState extends Component {
   handleOperatorChange = e => {
     this.props.updateTriggerProperty(this.props.index, 'operator', e.target.value);
@@ -8,18 +10,27 @@ class DefaultDeviceState extends Component {
 
   handleValueChange = e => {
     let value = e.target.value;
-    if (value.includes(',')) {
-      value = value.replaceAll(',', '.');
-    }
-    const lastCharacter = value.length > 0 ? value[value.length - 1] : '';
-    if (!isNaN(parseFloat(e.target.value)) && lastCharacter !== '.') {
-      this.props.updateTriggerProperty(this.props.index, 'value', parseFloat(value));
-    } else {
+    const { selectedDeviceFeature } = this.props;
+    const isTextFeature = selectedDeviceFeature && selectedDeviceFeature.category === DEVICE_FEATURE_CATEGORIES.TEXT;
+
+    if (isTextFeature) {
       this.props.updateTriggerProperty(this.props.index, 'value', value);
+    } else {
+      if (value.includes(',')) {
+        value = value.replaceAll(',', '.');
+      }
+      const lastCharacter = value.length > 0 ? value[value.length - 1] : '';
+      if (!isNaN(parseFloat(e.target.value)) && lastCharacter !== '.') {
+        this.props.updateTriggerProperty(this.props.index, 'value', parseFloat(value));
+      } else {
+        this.props.updateTriggerProperty(this.props.index, 'value', value);
+      }
     }
   };
 
   render({ selectedDeviceFeature, trigger }) {
+    const isTextFeature = selectedDeviceFeature && selectedDeviceFeature.category === DEVICE_FEATURE_CATEGORIES.TEXT;
+
     return (
       <Fragment>
         <div class="col-md-3">
@@ -31,21 +42,29 @@ class DefaultDeviceState extends Component {
               <option value="=">
                 <Text id="editScene.triggersCard.newState.equal" />
               </option>
-              <option value=">=">
-                <Text id="editScene.triggersCard.newState.superiorOrEqual" />
-              </option>
-              <option value=">">
-                <Text id="editScene.triggersCard.newState.superior" />
-              </option>
+              {!isTextFeature && (
+                <option value=">=">
+                  <Text id="editScene.triggersCard.newState.superiorOrEqual" />
+                </option>
+              )}
+              {!isTextFeature && (
+                <option value=">">
+                  <Text id="editScene.triggersCard.newState.superior" />
+                </option>
+              )}
               <option value="!=">
                 <Text id="editScene.triggersCard.newState.different" />
               </option>
-              <option value="<=">
-                <Text id="editScene.triggersCard.newState.lessOrEqual" />
-              </option>
-              <option value="<">
-                <Text id="editScene.triggersCard.newState.less" />
-              </option>
+              {!isTextFeature && (
+                <option value="<=">
+                  <Text id="editScene.triggersCard.newState.lessOrEqual" />
+                </option>
+              )}
+              {!isTextFeature && (
+                <option value="<">
+                  <Text id="editScene.triggersCard.newState.less" />
+                </option>
+              )}
             </select>
           </div>
         </div>

--- a/server/lib/device/device.saveStringState.js
+++ b/server/lib/device/device.saveStringState.js
@@ -6,7 +6,7 @@ const { EVENTS, WEBSOCKET_MESSAGE_TYPES } = require('../../utils/constants');
  * @description Save new device feature string state in DB.
  * @param {object} device - A Device object.
  * @param {object} deviceFeature - A DeviceFeature object.
- * @param {number} newValue - The new value of the deviceFeature to save.
+ * @param {string} newValue - The new string value of the deviceFeature to save.
  * @example
  * saveState({
  *   id: 'fc235c88-b10d-4706-8b59-fef92a7119b2',
@@ -17,6 +17,8 @@ async function saveStringState(device, deviceFeature, newValue) {
   logger.debug(`device.saveStringState of deviceFeature ${deviceFeature.selector}`);
 
   const now = new Date();
+  const previousDeviceFeature = this.stateManager.get('deviceFeature', deviceFeature.selector);
+  const previousDeviceFeatureValue = previousDeviceFeature ? previousDeviceFeature.last_value_string : null;
 
   deviceFeature.last_value_string = newValue;
   deviceFeature.last_value_changed = now;
@@ -45,6 +47,15 @@ async function saveStringState(device, deviceFeature, newValue) {
       last_value_string: newValue,
       last_value_changed: now,
     },
+  });
+
+  // check if there is a trigger matching
+  this.eventManager.emit(EVENTS.TRIGGERS.CHECK, {
+    type: EVENTS.DEVICE.NEW_STATE,
+    device_feature: deviceFeature.selector,
+    previous_value: previousDeviceFeatureValue,
+    last_value: newValue,
+    last_value_changed: now,
   });
 }
 

--- a/server/models/scene.js
+++ b/server/models/scene.js
@@ -85,7 +85,7 @@ const triggersSchema = Joi.array().items(
     device: Joi.string(),
     device_feature: Joi.string(),
     operator: Joi.string().valid('=', '!=', '>', '>=', '<', '<='),
-    value: Joi.number(),
+    value: Joi.alternatives().try(Joi.number(), Joi.string()),
     user: Joi.string(),
     area: Joi.string(),
     scheduler_type: Joi.string().valid('every-month', 'every-week', 'every-day', 'interval', 'custom-time'),

--- a/server/test/lib/scene/triggers/scene.trigger.deviceNewState.test.js
+++ b/server/test/lib/scene/triggers/scene.trigger.deviceNewState.test.js
@@ -467,4 +467,156 @@ describe('scene.triggers.deviceNewState', () => {
       });
     });
   });
+  it('should execute scene with string value equality (text device feature like Shelly Button)', async () => {
+    sceneManager.addScene({
+      selector: 'my-scene',
+      active: true,
+      actions: [
+        [
+          {
+            type: ACTIONS.LIGHT.TURN_ON,
+            devices: ['light-1'],
+          },
+        ],
+      ],
+      triggers: [
+        {
+          type: EVENTS.DEVICE.NEW_STATE,
+          device_feature: 'shelly-button-1',
+          value: 'SS', // Double press event
+          operator: '=',
+        },
+      ],
+    });
+    sceneManager.checkTrigger({
+      type: EVENTS.DEVICE.NEW_STATE,
+      device_feature: 'shelly-button-1',
+      previous_value: 'S',
+      last_value: 'SS',
+    });
+    return new Promise((resolve, reject) => {
+      sceneManager.queue.start(() => {
+        try {
+          assert.calledOnce(device.setValue);
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  });
+  it('should not execute scene with string value equality when value does not match', async () => {
+    sceneManager.addScene({
+      selector: 'my-scene',
+      active: true,
+      actions: [
+        [
+          {
+            type: ACTIONS.LIGHT.TURN_ON,
+            devices: ['light-1'],
+          },
+        ],
+      ],
+      triggers: [
+        {
+          type: EVENTS.DEVICE.NEW_STATE,
+          device_feature: 'shelly-button-1',
+          value: 'SS', // Double press event
+          operator: '=',
+        },
+      ],
+    });
+    sceneManager.checkTrigger({
+      type: EVENTS.DEVICE.NEW_STATE,
+      device_feature: 'shelly-button-1',
+      previous_value: null,
+      last_value: 'S', // Single press, not double
+    });
+    return new Promise((resolve, reject) => {
+      sceneManager.queue.start(() => {
+        try {
+          assert.notCalled(device.setValue);
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  });
+  it('should execute scene with string value inequality', async () => {
+    sceneManager.addScene({
+      selector: 'my-scene',
+      active: true,
+      actions: [
+        [
+          {
+            type: ACTIONS.LIGHT.TURN_ON,
+            devices: ['light-1'],
+          },
+        ],
+      ],
+      triggers: [
+        {
+          type: EVENTS.DEVICE.NEW_STATE,
+          device_feature: 'shelly-button-1',
+          value: 'S', // Not single press
+          operator: '!=',
+        },
+      ],
+    });
+    sceneManager.checkTrigger({
+      type: EVENTS.DEVICE.NEW_STATE,
+      device_feature: 'shelly-button-1',
+      previous_value: 'S',
+      last_value: 'SS', // Double press, different from 'S'
+    });
+    return new Promise((resolve, reject) => {
+      sceneManager.queue.start(() => {
+        try {
+          assert.calledOnce(device.setValue);
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  });
+  it('should not execute scene with string value inequality when value matches', async () => {
+    sceneManager.addScene({
+      selector: 'my-scene',
+      active: true,
+      actions: [
+        [
+          {
+            type: ACTIONS.LIGHT.TURN_ON,
+            devices: ['light-1'],
+          },
+        ],
+      ],
+      triggers: [
+        {
+          type: EVENTS.DEVICE.NEW_STATE,
+          device_feature: 'shelly-button-1',
+          value: 'S',
+          operator: '!=',
+        },
+      ],
+    });
+    sceneManager.checkTrigger({
+      type: EVENTS.DEVICE.NEW_STATE,
+      device_feature: 'shelly-button-1',
+      previous_value: 'SS',
+      last_value: 'S', // Same as trigger value, should not execute
+    });
+    return new Promise((resolve, reject) => {
+      sceneManager.queue.start(() => {
+        try {
+          assert.notCalled(device.setValue);
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.
- [x] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [x] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Fix #2387: Handle device state change on text devices