### PR TITLE
MQTT : Custom topics should parse number if number

### DIFF
--- a/server/services/mqtt/lib/handler/handleDeviceCustomTopicMessage.js
+++ b/server/services/mqtt/lib/handler/handleDeviceCustomTopicMessage.js
@@ -3,6 +3,17 @@ const logger = require('../../../../utils/logger');
 const { EVENTS } = require('../../../../utils/constants');
 
 /**
+ * @description Convert a value to a Number if it's a valid number, otherwise return it as-is.
+ * @param {any} value - The value to convert.
+ * @returns {number|any} The converted number or the original value.
+ * @example parseNumber('42') // returns 42
+ */
+function parseNumber(value) {
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? value : parsed;
+}
+
+/**
  * @description When a new MQTT message is received on a custom topic.
  * @param {string} topic - The topic where the message was published.
  * @param {string} message - The content of the message.
@@ -24,13 +35,13 @@ function handleDeviceCustomTopicMessage(topic, message, deviceFeatureId, objectP
       const state = get(JSON.parse(message), objectPath);
       this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
         device_feature_external_id: deviceFeature.external_id,
-        state,
+        state: parseNumber(state),
       });
     } else {
       // else, it's supposed to be a normal string, send it raw
       this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
         device_feature_external_id: deviceFeature.external_id,
-        state: message,
+        state: parseNumber(message),
       });
     }
   } catch (e) {

--- a/server/test/services/mqtt/lib/handleNewMessage.test.js
+++ b/server/test/services/mqtt/lib/handleNewMessage.test.js
@@ -132,7 +132,39 @@ describe('Mqtt handle message', () => {
 
     assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
       device_feature_external_id: 'device_feature_external_id',
-      state: '12',
+      state: 12,
+    });
+  });
+  it('handle device with custom topic and numeric string value', () => {
+    mqttHandler.deviceFeatureCustomMqttTopics = [
+      {
+        device_feature_id: 'b42d3688-4403-479a-9376-9f5227ab543a',
+        regex_key: 'custom_mqtt_topic/test/test',
+        topic: 'custom_mqtt_topic/test/test',
+        object_path: null,
+      },
+    ];
+    mqttHandler.handleNewMessage('custom_mqtt_topic/test/test', '19.8');
+
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'device_feature_external_id',
+      state: 19.8,
+    });
+  });
+  it('handle device with custom topic and non-numeric string value', () => {
+    mqttHandler.deviceFeatureCustomMqttTopics = [
+      {
+        device_feature_id: 'b42d3688-4403-479a-9376-9f5227ab543a',
+        regex_key: 'custom_mqtt_topic/test/test',
+        topic: 'custom_mqtt_topic/test/test',
+        object_path: null,
+      },
+    ];
+    mqttHandler.handleNewMessage('custom_mqtt_topic/test/test', 'hello-world');
+
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'device_feature_external_id',
+      state: 'hello-world',
     });
   });
   it('handle device with custom topic and custom object path', () => {
@@ -156,6 +188,52 @@ describe('Mqtt handle message', () => {
     assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
       device_feature_external_id: 'device_feature_external_id',
       state: 18,
+    });
+  });
+  it('handle device with custom topic and custom object path with string number', () => {
+    mqttHandler.deviceFeatureCustomMqttTopics = [
+      {
+        device_feature_id: 'b42d3688-4403-479a-9376-9f5227ab543a',
+        regex_key: 'custom_mqtt_topic/test/test',
+        topic: 'custom_mqtt_topic/test/test',
+        object_path: 'test.temperature',
+      },
+    ];
+    mqttHandler.handleNewMessage(
+      'custom_mqtt_topic/test/test',
+      JSON.stringify({
+        test: {
+          temperature: '22.5',
+        },
+      }),
+    );
+
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'device_feature_external_id',
+      state: 22.5,
+    });
+  });
+  it('handle device with custom topic and custom object path with non-numeric string', () => {
+    mqttHandler.deviceFeatureCustomMqttTopics = [
+      {
+        device_feature_id: 'b42d3688-4403-479a-9376-9f5227ab543a',
+        regex_key: 'custom_mqtt_topic/test/test',
+        topic: 'custom_mqtt_topic/test/test',
+        object_path: 'test.status',
+      },
+    ];
+    mqttHandler.handleNewMessage(
+      'custom_mqtt_topic/test/test',
+      JSON.stringify({
+        test: {
+          status: 'online',
+        },
+      }),
+    );
+
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'device_feature_external_id',
+      state: 'online',
     });
   });
 


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

MQTT : Custom topics should parse number if number

Fix https://github.com/GladysAssistant/Gladys/issues/2373