### PR TITLE
MQTT : When unsuscribing a scene topic, check if device feature is not listening to it

### DIFF
--- a/server/services/mqtt/lib/unsubscribe.js
+++ b/server/services/mqtt/lib/unsubscribe.js
@@ -7,8 +7,11 @@ const logger = require('../../../utils/logger');
  * unsubscribe('topic/to/unsubscribe');
  */
 function unsubscribe(topic) {
-  logger.info(`Unsubscribing to MQTT topic ${topic}`);
-  if (this.mqttClient) {
+  // Check if any device feature is still listening to this topic
+  const deviceFeatureStillListening = this.deviceFeatureCustomMqttTopics.some((t) => t.topic === topic);
+  // Only unsubscribe from the MQTT broker if no device feature is listening to this topic
+  if (this.mqttClient && !deviceFeatureStillListening) {
+    logger.info(`Unsubscribing to MQTT topic ${topic}`);
     this.mqttClient.unsubscribe(topic);
   }
   delete this.topicBinds[topic];

--- a/server/test/services/mqtt/lib/unsubscribe.test.js
+++ b/server/test/services/mqtt/lib/unsubscribe.test.js
@@ -37,4 +37,44 @@ describe('Mqtt handle message', () => {
     assert.calledWith(mqttApi.unsubscribe, 'UNKNOWN_TOPIC');
     expect(Object.keys(mqttHandler.topicBinds)).deep.eq([]);
   });
+
+  it('should not unsubscribe from broker if device feature is still listening to topic', async () => {
+    await mqttHandler.connect({ mqttUrl: 'url' });
+    mqttHandler.subscribe('SHARED_TOPIC', () => {});
+    // Simulate a device feature listening to the same topic
+    mqttHandler.deviceFeatureCustomMqttTopics.push({
+      topic: 'SHARED_TOPIC',
+      device_feature_id: 'device-feature-id',
+    });
+
+    mqttHandler.unsubscribe('SHARED_TOPIC');
+
+    // Should NOT call mqttClient.unsubscribe because device feature is still listening
+    assert.notCalled(mqttApi.unsubscribe);
+    // But should still remove from topicBinds (only UNKNOWN_TOPIC from beforeEach remains)
+    expect(mqttHandler.topicBinds).to.not.have.property('SHARED_TOPIC');
+
+    // Cleanup
+    mqttHandler.deviceFeatureCustomMqttTopics = [];
+  });
+
+  it('should unsubscribe from broker if no device feature is listening to topic', async () => {
+    await mqttHandler.connect({ mqttUrl: 'url' });
+    mqttHandler.subscribe('UNIQUE_TOPIC', () => {});
+    // Simulate a device feature listening to a DIFFERENT topic
+    mqttHandler.deviceFeatureCustomMqttTopics.push({
+      topic: 'OTHER_TOPIC',
+      device_feature_id: 'device-feature-id',
+    });
+
+    mqttHandler.unsubscribe('UNIQUE_TOPIC');
+
+    // Should call mqttClient.unsubscribe because no device feature is listening to this topic
+    assert.calledWith(mqttApi.unsubscribe, 'UNIQUE_TOPIC');
+    // Should remove from topicBinds (only UNKNOWN_TOPIC from beforeEach remains)
+    expect(mqttHandler.topicBinds).to.not.have.property('UNIQUE_TOPIC');
+
+    // Cleanup
+    mqttHandler.deviceFeatureCustomMqttTopics = [];
+  });
 });


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

Fix https://github.com/GladysAssistant/Gladys/issues/2393