### PR TITLE
Improve Gladys start : Fix performance bug on large DuckDB database + fix gladys check upgrade failing if one message not sent 

### DIFF
--- a/server/lib/device/device.getDuckDbMigrationState.js
+++ b/server/lib/device/device.getDuckDbMigrationState.js
@@ -1,5 +1,6 @@
 const db = require('../../models');
 const { SYSTEM_VARIABLE_NAMES } = require('../../utils/constants');
+const logger = require('../../utils/logger');
 
 /**
  * @description GetDuckDbMigrationState.
@@ -7,12 +8,17 @@ const { SYSTEM_VARIABLE_NAMES } = require('../../utils/constants');
  * @returns {Promise} Resolve with current migration state.
  */
 async function getDuckDbMigrationState() {
+  logger.info('Device : getDuckDbMigrationState');
   const isDuckDbMigrated = await this.variable.getValue(SYSTEM_VARIABLE_NAMES.DUCKDB_MIGRATED);
   // Use estimated_size from DuckDB metadata for fast approximate count
   const [{ estimated_size: duckDbDeviceStateCount }] = await db.duckDbReadConnectionAllAsync(`
     SELECT estimated_size FROM duckdb_tables() WHERE table_name = 't_device_feature_state';
   `);
   const sqliteDeviceStateCount = await db.DeviceFeatureState.count();
+
+  logger.info(`Device : getDuckDbMigrationState : isDuckDbMigrated: ${isDuckDbMigrated}`);
+  logger.info(`Device : getDuckDbMigrationState : duckDbDeviceStateCount: ${duckDbDeviceStateCount}`);
+  logger.info(`Device : getDuckDbMigrationState : sqliteDeviceStateCount: ${sqliteDeviceStateCount}`);
 
   return {
     is_duck_db_migrated: isDuckDbMigrated === 'true',

--- a/server/lib/device/device.getDuckDbMigrationState.js
+++ b/server/lib/device/device.getDuckDbMigrationState.js
@@ -8,8 +8,9 @@ const { SYSTEM_VARIABLE_NAMES } = require('../../utils/constants');
  */
 async function getDuckDbMigrationState() {
   const isDuckDbMigrated = await this.variable.getValue(SYSTEM_VARIABLE_NAMES.DUCKDB_MIGRATED);
-  const [{ count: duckDbDeviceStateCount }] = await db.duckDbReadConnectionAllAsync(`
-    SELECT COUNT(value) as count FROM t_device_feature_state;  
+  // Use estimated_size from DuckDB metadata for fast approximate count
+  const [{ estimated_size: duckDbDeviceStateCount }] = await db.duckDbReadConnectionAllAsync(`
+    SELECT estimated_size FROM duckdb_tables() WHERE table_name = 't_device_feature_state';
   `);
   const sqliteDeviceStateCount = await db.DeviceFeatureState.count();
 

--- a/server/lib/system/system.checkIfGladysUpgraded.js
+++ b/server/lib/system/system.checkIfGladysUpgraded.js
@@ -23,17 +23,26 @@ async function checkIfGladysUpgraded(gateway, waitTimeBetweenMessages = 300) {
           previousGladysVersion,
           gladysVersion: this.gladysVersion,
         });
-        await this.message.sendToUser(admin.selector, message);
+        try {
+          await this.message.sendToUser(admin.selector, message);
+        } catch (e) {
+          logger.error(e);
+        }
         await Promise.delay(waitTimeBetweenMessages);
         const gladysVersionInfos = await gateway.getLatestGladysVersion();
         if (gladysVersionInfos.name === this.gladysVersion) {
-          // If the user is french && there is a french release note link
-          if (admin.language === 'fr' && gladysVersionInfos.fr_release_note_link) {
-            // Send the release note to the user
-            await this.message.sendToUser(admin.selector, gladysVersionInfos.fr_release_note_link);
-          } else if (gladysVersionInfos.default_release_note_link) {
-            // If there is no release note in french / or the user is not french, send the default one (english)
-            await this.message.sendToUser(admin.selector, gladysVersionInfos.default_release_note_link);
+          try {
+            // If the user is french && there is a french release note link
+            if (admin.language === 'fr' && gladysVersionInfos.fr_release_note_link) {
+              // Send the release note to the user
+              await this.message.sendToUser(admin.selector, gladysVersionInfos.fr_release_note_link);
+            } else if (gladysVersionInfos.default_release_note_link) {
+              // If there is no release note in french / or the user is not french, send the default one (english)
+
+              await this.message.sendToUser(admin.selector, gladysVersionInfos.default_release_note_link);
+            }
+          } catch (e) {
+            logger.error(e);
           }
         }
       });

--- a/server/test/controllers/device/device.controller.test.js
+++ b/server/test/controllers/device/device.controller.test.js
@@ -218,11 +218,9 @@ describe('GET /api/v1/device/duckdb_migration_state', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((res) => {
-        expect(res.body).to.deep.equal({
-          duck_db_device_count: 0,
-          is_duck_db_migrated: false,
-          sqlite_db_device_state_count: 0,
-        });
+        expect(res.body).to.have.property('duck_db_device_count');
+        expect(res.body).to.have.property('is_duck_db_migrated', false);
+        expect(res.body).to.have.property('sqlite_db_device_state_count', 0);
       });
   });
 });

--- a/server/test/lib/device/device.getDuckDbMigrationState.test.js
+++ b/server/test/lib/device/device.getDuckDbMigrationState.test.js
@@ -16,11 +16,11 @@ describe('Device.getDuckDbMigrationState', () => {
     };
     const device = new Device(event, {}, stateManager, {}, {}, variable, job);
     const migrationState = await device.getDuckDbMigrationState();
-    expect(migrationState).to.deep.equal({
-      is_duck_db_migrated: false,
-      duck_db_device_count: 0,
-      sqlite_db_device_state_count: 0,
-    });
+    expect(migrationState).to.have.property('is_duck_db_migrated', false);
+    expect(migrationState)
+      .to.have.property('duck_db_device_count')
+      .that.is.a('number');
+    expect(migrationState).to.have.property('sqlite_db_device_state_count', 0);
   });
   it('should return migration done', async () => {
     const stateManager = new StateManager(event);
@@ -29,10 +29,10 @@ describe('Device.getDuckDbMigrationState', () => {
     };
     const device = new Device(event, {}, stateManager, {}, {}, variable, job);
     const migrationState = await device.getDuckDbMigrationState();
-    expect(migrationState).to.deep.equal({
-      is_duck_db_migrated: true,
-      duck_db_device_count: 0,
-      sqlite_db_device_state_count: 0,
-    });
+    expect(migrationState).to.have.property('is_duck_db_migrated', true);
+    expect(migrationState)
+      .to.have.property('duck_db_device_count')
+      .that.is.a('number');
+    expect(migrationState).to.have.property('sqlite_db_device_state_count', 0);
   });
 });


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

Improve startup performance on large DuckDB database