### PR TITLE
Stabilize Netatmo tests by isolating timers and fixtures

### DIFF
--- a/server/test/services/netatmo/lib/netatmo.init.test.js
+++ b/server/test/services/netatmo/lib/netatmo.init.test.js
@@ -41,6 +41,7 @@ describe('Netatmo Init', () => {
     sinon.reset();
 
     netatmoHandler.status = 'not_initialized';
+    netatmoHandler.refreshNetatmoValues = fake.resolves(null);
     netatmoHandler.gladys.variable.getValue = sinon.fake((variableName, serviceId) => {
       if (variableName === 'NETATMO_CLIENT_ID') {
         return Promise.resolve('valid_client_id');

--- a/server/test/services/netatmo/lib/netatmo.loadThermostatDetails.test.js
+++ b/server/test/services/netatmo/lib/netatmo.loadThermostatDetails.test.js
@@ -65,14 +65,15 @@ describe('Netatmo Load Thermostat Details', () => {
 
   it('should load thermostat details successfully with API configured', async () => {
     netatmoHandler.configuration.energyApi = true;
-    thermostatsDetailsMock.plugs.forEach((plug) => {
+    const expectedDetails = JSON.parse(JSON.stringify(thermostatsDetailsMock));
+    expectedDetails.plugs.forEach((plug) => {
       plug.apiNotConfigured = false;
       plug.modules.forEach((module) => {
         module.apiNotConfigured = false;
         module.plug.apiNotConfigured = false;
       });
     });
-    thermostatsDetailsMock.thermostats.forEach((thermostat) => {
+    expectedDetails.thermostats.forEach((thermostat) => {
       thermostat.apiNotConfigured = false;
       thermostat.plug.apiNotConfigured = false;
     });
@@ -89,8 +90,8 @@ describe('Netatmo Load Thermostat Details', () => {
       });
 
     const { plugs, thermostats } = await netatmoHandler.loadThermostatDetails();
-    expect(plugs).to.deep.eq(thermostatsDetailsMock.plugs);
-    expect(thermostats).to.deep.eq(thermostatsDetailsMock.thermostats);
+    expect(plugs).to.deep.eq(expectedDetails.plugs);
+    expect(thermostats).to.deep.eq(expectedDetails.thermostats);
     expect(plugs).to.be.an('array');
     expect(thermostats).to.be.an('array');
   });

--- a/server/test/services/netatmo/lib/netatmo.loadWeatherStationDetails.test.js
+++ b/server/test/services/netatmo/lib/netatmo.loadWeatherStationDetails.test.js
@@ -66,14 +66,15 @@ describe('Netatmo Load Weather Station Details', () => {
 
   it('should load weather station details successfully with API configured', async () => {
     netatmoHandler.configuration.weatherApi = true;
-    weatherStationsDetailsMock.weatherStations.forEach((weatherStation) => {
+    const expectedDetails = JSON.parse(JSON.stringify(weatherStationsDetailsMock));
+    expectedDetails.weatherStations.forEach((weatherStation) => {
       weatherStation.apiNotConfigured = false;
       weatherStation.modules.forEach((module) => {
         module.apiNotConfigured = false;
         module.plug.apiNotConfigured = false;
       });
     });
-    weatherStationsDetailsMock.modulesWeatherStations.forEach((moduleWeatherStations) => {
+    expectedDetails.modulesWeatherStations.forEach((moduleWeatherStations) => {
       moduleWeatherStations.apiNotConfigured = false;
       moduleWeatherStations.plug.apiNotConfigured = false;
     });
@@ -90,8 +91,8 @@ describe('Netatmo Load Weather Station Details', () => {
       });
 
     const { weatherStations, modulesWeatherStations } = await netatmoHandler.loadWeatherStationDetails();
-    expect(weatherStations).to.deep.eq(weatherStationsDetailsMock.weatherStations);
-    expect(modulesWeatherStations).to.deep.eq(weatherStationsDetailsMock.modulesWeatherStations);
+    expect(weatherStations).to.deep.eq(expectedDetails.weatherStations);
+    expect(modulesWeatherStations).to.deep.eq(expectedDetails.modulesWeatherStations);
     expect(weatherStations).to.be.an('array');
     expect(modulesWeatherStations).to.be.an('array');
   });

--- a/server/test/services/netatmo/lib/netatmo.pollRefreshingTokens.test.js
+++ b/server/test/services/netatmo/lib/netatmo.pollRefreshingTokens.test.js
@@ -28,6 +28,12 @@ describe('Netatmo pollRefreshingToken', () => {
   let mockAgent;
   let netatmoMock;
   let originalDispatcher;
+  const restoreClock = () => {
+    if (clock) {
+      clock.restore();
+      clock = null;
+    }
+  };
 
   beforeEach(() => {
     sinon.reset();
@@ -59,7 +65,7 @@ describe('Netatmo pollRefreshingToken', () => {
   });
 
   afterEach(() => {
-    clock.restore();
+    restoreClock();
     sinon.reset();
     // Clean up the mock agent
     mockAgent.close();
@@ -87,7 +93,7 @@ describe('Netatmo pollRefreshingToken', () => {
       .reply(200, tokens);
 
     clock.tick(3600 * 1000);
-    clock.restore();
+    restoreClock();
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(netatmoHandler.accessToken).to.equal('new-access-token');
     expect(netatmoHandler.refreshToken).to.equal('new-refresh-token2');

--- a/server/test/services/netatmo/lib/netatmo.pollRefreshingValues.test.js
+++ b/server/test/services/netatmo/lib/netatmo.pollRefreshingValues.test.js
@@ -22,6 +22,12 @@ const serviceId = 'serviceId';
 describe('Netatmo pollRefreshingValues', () => {
   let clock;
   let netatmoHandler;
+  const restoreClock = () => {
+    if (clock) {
+      clock.restore();
+      clock = null;
+    }
+  };
 
   beforeEach(() => {
     sinon.reset();
@@ -34,7 +40,7 @@ describe('Netatmo pollRefreshingValues', () => {
   });
 
   afterEach(() => {
-    clock.restore();
+    restoreClock();
     sinon.reset();
   });
 
@@ -46,7 +52,7 @@ describe('Netatmo pollRefreshingValues', () => {
     netatmoHandler.pollRefreshingValues();
 
     clock.tick(120 * 1000);
-    clock.restore();
+    restoreClock();
     await new Promise((resolve) => setTimeout(resolve, 50));
     sinon.assert.calledOnce(netatmoHandler.refreshNetatmoValues);
   });
@@ -58,7 +64,7 @@ describe('Netatmo pollRefreshingValues', () => {
     netatmoHandler.pollRefreshingValues();
 
     clock.tick(120 * 1000);
-    clock.restore();
+    restoreClock();
     await new Promise((resolve) => setTimeout(resolve, 50));
     sinon.assert.called(netatmoHandler.refreshNetatmoValues);
     sinon.assert.calledOnce(logger.error);
@@ -74,7 +80,7 @@ describe('Netatmo pollRefreshingValues', () => {
 
     netatmoHandler.refreshNetatmoValues();
 
-    clock.restore();
+    restoreClock();
     await new Promise((resolve) => setTimeout(resolve, 50));
     sinon.assert.calledOnce(netatmoHandler.loadDevices);
     sinon.assert.called(netatmoHandler.updateValues);
@@ -86,7 +92,7 @@ describe('Netatmo pollRefreshingValues', () => {
 
     await netatmoHandler.refreshNetatmoValues();
 
-    clock.restore();
+    restoreClock();
     await new Promise((resolve) => setTimeout(resolve, 50));
     sinon.assert.called(netatmoHandler.loadDevices);
     expect(netatmoHandler.configured).to.equal(true);
@@ -103,7 +109,7 @@ describe('Netatmo pollRefreshingValues', () => {
 
     await netatmoHandler.refreshNetatmoValues();
 
-    clock.restore();
+    restoreClock();
     await new Promise((resolve) => setTimeout(resolve, 50));
     sinon.assert.called(netatmoHandler.loadDevices);
     expect(netatmoHandler.configured).to.equal(true);


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

This PR stabilizes Netatmo tests by preventing network side effects in the init test and tightening test isolation elsewhere. We stub the refresh path in the init test to avoid real HTTP calls that can intermittently time out in CI. We also make timer cleanup idempotent in polling tests and avoid mutating shared fixtures in thermostat/weather tests to prevent cross‑test leakage. This keeps test intent intact while improving long‑term reliability.
