### PR TITLE
fix(chat): preserve spaces in messages by using pre-wrap

### DIFF
--- a/front/src/routes/chat/style.css
+++ b/front/src/routes/chat/style.css
@@ -177,5 +177,5 @@
 }
 
 .msg_txt_wrap {
-  white-space: pre-line;
+  white-space: pre-wrap;
 }


### PR DESCRIPTION
Hi,

This PR fixes the issue where multiple spaces in chat messages were being collapsed into a single space.
Previously, .msg_txt_wrap used white-space: pre-line, which removed extra spaces while keeping line breaks.

With this change, we replace it with white-space: pre-wrap to ensure that multiple consecutive spaces typed by the user are preserved in the chat.

This behavior is now consistent with Telegram, where users can use multiple spaces for formatting or notifications.

**_Before:_**
_Gladys Chat :_
<img width="329" height="305" alt="image" src="https://github.com/user-attachments/assets/fdf0e18f-5b7f-4b92-b8a3-2172e056b945" />
_Telegram notification :_ 
<img width="1028" height="925" alt="image" src="https://github.com/user-attachments/assets/cf5aeed6-ddaa-4712-9c0e-57bf715bc8d1" />

**_After:_**
_Gladys Chat :_
<img width="334" height="290" alt="image" src="https://github.com/user-attachments/assets/3c9c7ff4-902f-47b7-bc9b-c6570ed3517c" />
_Telegram notification :_ 
<img width="1028" height="925" alt="image" src="https://github.com/user-attachments/assets/e51a3a68-57b6-4575-ada3-899c4a192d69" />

This improves the chat UX, especially for notifications or formatting that rely on spacing.