### PR TITLE
add function to mark integrations as favorites

### DIFF
--- a/front/src/components/app.jsx
+++ b/front/src/components/app.jsx
@@ -251,6 +251,7 @@ const AppRouter = connect(
         <NewDashboard path="/dashboard/create/new" />
         <SafeAsyncRoute path="/dashboard/integration" component={IntegrationPage} />
 
+        <IntegrationPage path="/dashboard/integration/favorites" category="favorites" />
         <IntegrationPage path="/dashboard/integration/device" category="device" />
         <IntegrationPage path="/dashboard/integration/communication" category="communication" />
         <IntegrationPage path="/dashboard/integration/calendar" category="calendar" />

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -512,6 +512,7 @@
       "noIntegrations": "Keine Integrationen gefunden",
       "menu": {
         "all": "Alle Integrationen",
+        "favorites": "Favoriten",
         "device": "Geräte",
         "communication": "Kommunikation",
         "calendar": "Kalender",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -508,17 +508,18 @@
     "root": {
       "title": "Integrations",
       "subtitle": "{{length}} of {{total}} integrations",
-      "searchPlaceholder": "Search integrations",
-      "noIntegrations": "No integrations found",
+      "searchPlaceholder": "Search an integration",
+      "noIntegrations": "No integration found",
       "menu": {
         "all": "All integrations",
+        "favorites": "Favorites",
         "device": "Devices",
         "communication": "Communication",
         "calendar": "Calendar",
         "music": "Music",
         "health": "Health",
         "weather": "Weather",
-        "navigation": "navigation"
+        "navigation": "Navigation"
       }
     },
     "telegram": {

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -512,6 +512,7 @@
       "noIntegrations": "Aucune intégration trouvée",
       "menu": {
         "all": "Toutes les intégrations",
+        "favorites": "Favoris",
         "device": "Appareils",
         "communication": "Communication",
         "calendar": "Calendrier",

--- a/front/src/routes/integration/IntegrationCategory.jsx
+++ b/front/src/routes/integration/IntegrationCategory.jsx
@@ -5,11 +5,11 @@ import ScrollToTopLink from '../../components/router/ScrollToTopLink';
  * Component to display an integration category.
  *
  * @param {Object} integration - The key of integration.
- * @param {string} integration.url - The URL of integration.
- * @param {string} integration.img - The URL of image for integration.
- * @param {boolean} integration.invertInDarkMode - If true, image will be
+ * @prop {string} integration.url - The URL of integration.
+ * @prop {string} integration.img - The URL of image for integration.
+ * @prop {boolean} integration.invertInDarkMode - If true, image will be
  *  inverted in dark mode.
- * @param {boolean} integration.whiteBackground - If true, image will have a
+ * @prop {boolean} integration.whiteBackground - If true, image will have a
  *  white background.
  * @param {Function} integration.toggleFavorite - Function to toggle favorite status.
  *
@@ -61,12 +61,12 @@ const IntegrationCategory = ({ integration, toggleFavorite }) => {
             onClick={onToggleFavorite}
           >
             <svg
-              width="32"
-              height="32"
+              width="26"
+              height="26"
               viewBox="0 0 24 24"
               fill={isFavorite ? '#FFD700' : 'none'}
               stroke={isFavorite ? '#FFD700' : '#9aa0a6'}
-              stroke-width="2"
+              stroke-width="1.5"
               stroke-linecap="round"
               stroke-linejoin="round"
             >

--- a/front/src/routes/integration/IntegrationCategory.jsx
+++ b/front/src/routes/integration/IntegrationCategory.jsx
@@ -4,7 +4,7 @@ import ScrollToTopLink from '../../components/router/ScrollToTopLink';
 /**
  * Component to display an integration category.
  *
- * @param {Object} integration - The key of integration.
+ * @param {Object} integration
  * @prop {string} integration.key - The key of the integration.
  * @prop {string} integration.url - The URL of the integration.
  * @prop {string} integration.img - The URL of the image for the integration.
@@ -12,14 +12,14 @@ import ScrollToTopLink from '../../components/router/ScrollToTopLink';
  *  inverted in dark mode.
  * @prop {boolean} integration.whiteBackground - If true, the image will have a
  *  white background.
- * @param {Function} integration.toggleFavorite - Function to toggle favorite status.
+ * @prop {Function} integration.toggleFavorite - Function to toggle favorite status.
  *
  * @returns {ReactElement} The integration category component.
  */
 const IntegrationCategory = ({ integration, toggleFavorite }) => {
   const isFavorite = !!integration.isFavorite;
 
-  const onToggleFavorite = (e) => {
+  const onToggleFavorite = e => {
     e.preventDefault();
     e.stopPropagation();
     if (toggleFavorite) {

--- a/front/src/routes/integration/IntegrationCategory.jsx
+++ b/front/src/routes/integration/IntegrationCategory.jsx
@@ -42,27 +42,27 @@ const IntegrationCategory = ({ integration, toggleFavorite }) => {
             </Localizer>
           </ScrollToTopLink>
         </div>
-        <button
-          type="button"
-          class={`favorite-star ${isFavorite ? 'favorite-star--active' : ''}`}
-          onClick={onToggleFavorite}
-        >
-          <svg
-            width="28"
-            height="28"
-            viewBox="0 0 24 24"
-            stroke-width="1.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-          </svg>
-        </button>
         <div class="card-body d-flex flex-column">
-          <h4>
-            <ScrollToTopLink href={integration.url}>
+          <h4 class="d-flex align-items-center">
+            <ScrollToTopLink href={integration.url} class="flex-fill">
               <Text id={`integration.${integration.key}.title`} />
             </ScrollToTopLink>
+            <button
+              type="button"
+              class={`favorite-star ${isFavorite ? 'favorite-star--active' : ''}`}
+              onClick={onToggleFavorite}
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+              </svg>
+            </button>
           </h4>
           <div class="text-muted">
             <Text id={`integration.${integration.key}.description`} />

--- a/front/src/routes/integration/IntegrationCategory.jsx
+++ b/front/src/routes/integration/IntegrationCategory.jsx
@@ -16,28 +16,14 @@ import ScrollToTopLink from '../../components/router/ScrollToTopLink';
  * @returns {ReactElement} The integration category component.
  */
 const IntegrationCategory = ({ integration, toggleFavorite }) => {
-  const favorites = JSON.parse(localStorage.getItem('integration_favorites') || '[]');
-  const isFavorite = integration.isFavorite !== undefined ? integration.isFavorite : favorites.includes(integration.key);
+  const isFavorite = !!integration.isFavorite;
 
   const onToggleFavorite = (e) => {
     e.preventDefault();
     e.stopPropagation();
-    // Debug: confirm click is triggered
-    // eslint-disable-next-line no-console
-    console.log('[integration] star clicked', integration.key);
-
     if (toggleFavorite) {
       toggleFavorite(integration.key);
-      return;
     }
-
-    // Fallback: if toggleFavorite is not provided, still persist in localStorage
-    const currentFavorites = JSON.parse(localStorage.getItem('integration_favorites') || '[]');
-    const newFavorites = currentFavorites.includes(integration.key)
-      ? currentFavorites.filter((key) => key !== integration.key)
-      : [...currentFavorites, integration.key];
-    localStorage.setItem('integration_favorites', JSON.stringify(newFavorites));
-    window.location.reload();
   };
 
   return (
@@ -55,25 +41,23 @@ const IntegrationCategory = ({ integration, toggleFavorite }) => {
               />
             </Localizer>
           </ScrollToTopLink>
-          <button
-            type="button"
-            class={`favorite-star ${isFavorite ? 'favorite-star--active' : ''}`}
-            onClick={onToggleFavorite}
-          >
-            <svg
-              width="26"
-              height="26"
-              viewBox="0 0 24 24"
-              fill={isFavorite ? '#FFD700' : 'none'}
-              stroke={isFavorite ? '#FFD700' : '#9aa0a6'}
-              stroke-width="1.5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-            </svg>
-          </button>
         </div>
+        <button
+          type="button"
+          class={`favorite-star ${isFavorite ? 'favorite-star--active' : ''}`}
+          onClick={onToggleFavorite}
+        >
+          <svg
+            width="28"
+            height="28"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+          </svg>
+        </button>
         <div class="card-body d-flex flex-column">
           <h4>
             <ScrollToTopLink href={integration.url}>

--- a/front/src/routes/integration/IntegrationCategory.jsx
+++ b/front/src/routes/integration/IntegrationCategory.jsx
@@ -5,11 +5,12 @@ import ScrollToTopLink from '../../components/router/ScrollToTopLink';
  * Component to display an integration category.
  *
  * @param {Object} integration - The key of integration.
- * @prop {string} integration.url - The URL of integration.
- * @prop {string} integration.img - The URL of image for integration.
- * @prop {boolean} integration.invertInDarkMode - If true, image will be
+ * @prop {string} integration.key - The key of the integration.
+ * @prop {string} integration.url - The URL of the integration.
+ * @prop {string} integration.img - The URL of the image for the integration.
+ * @prop {boolean} integration.invertInDarkMode - If true, the image will be
  *  inverted in dark mode.
- * @prop {boolean} integration.whiteBackground - If true, image will have a
+ * @prop {boolean} integration.whiteBackground - If true, the image will have a
  *  white background.
  * @param {Function} integration.toggleFavorite - Function to toggle favorite status.
  *

--- a/front/src/routes/integration/IntegrationCategory.jsx
+++ b/front/src/routes/integration/IntegrationCategory.jsx
@@ -4,32 +4,76 @@ import ScrollToTopLink from '../../components/router/ScrollToTopLink';
 /**
  * Component to display an integration category.
  *
- * @param {Object} integration
- * @prop {string} integration.key - The key of the integration.
- * @prop {string} integration.url - The URL of the integration.
- * @prop {string} integration.img - The URL of the image for the integration.
- * @prop {boolean} integration.invertInDarkMode - If true, the image will be
+ * @param {Object} integration - The key of integration.
+ * @param {string} integration.url - The URL of integration.
+ * @param {string} integration.img - The URL of image for integration.
+ * @param {boolean} integration.invertInDarkMode - If true, image will be
  *  inverted in dark mode.
- * @prop {boolean} integration.whiteBackground - If true, the image will have a
+ * @param {boolean} integration.whiteBackground - If true, image will have a
  *  white background.
+ * @param {Function} integration.toggleFavorite - Function to toggle favorite status.
  *
  * @returns {ReactElement} The integration category component.
  */
-const IntegrationCategory = ({ integration }) => {
+const IntegrationCategory = ({ integration, toggleFavorite }) => {
+  const favorites = JSON.parse(localStorage.getItem('integration_favorites') || '[]');
+  const isFavorite = integration.isFavorite !== undefined ? integration.isFavorite : favorites.includes(integration.key);
+
+  const onToggleFavorite = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    // Debug: confirm click is triggered
+    // eslint-disable-next-line no-console
+    console.log('[integration] star clicked', integration.key);
+
+    if (toggleFavorite) {
+      toggleFavorite(integration.key);
+      return;
+    }
+
+    // Fallback: if toggleFavorite is not provided, still persist in localStorage
+    const currentFavorites = JSON.parse(localStorage.getItem('integration_favorites') || '[]');
+    const newFavorites = currentFavorites.includes(integration.key)
+      ? currentFavorites.filter((key) => key !== integration.key)
+      : [...currentFavorites, integration.key];
+    localStorage.setItem('integration_favorites', JSON.stringify(newFavorites));
+    window.location.reload();
+  };
+
   return (
     <div class="col-sm-6 col-lg-4">
       <div class="card">
-        <ScrollToTopLink href={integration.url}>
-          <Localizer>
-            <img
-              class={`card-img-top ${integration.invertInDarkMode ? 'keep-dark' : ''} ${
-                integration.whiteBackground ? 'white-bg' : ''
-              }`}
-              src={integration.img}
-              alt={<Text id={`integration.${integration.key}.title`} />}
-            />
-          </Localizer>
-        </ScrollToTopLink>
+        <div class="card-img-container">
+          <ScrollToTopLink href={integration.url}>
+            <Localizer>
+              <img
+                class={`card-img-top ${integration.invertInDarkMode ? 'keep-dark' : ''} ${
+                  integration.whiteBackground ? 'white-bg' : ''
+                }`}
+                src={integration.img}
+                alt={<Text id={`integration.${integration.key}.title`} />}
+              />
+            </Localizer>
+          </ScrollToTopLink>
+          <button
+            type="button"
+            class={`favorite-star ${isFavorite ? 'favorite-star--active' : ''}`}
+            onClick={onToggleFavorite}
+          >
+            <svg
+              width="32"
+              height="32"
+              viewBox="0 0 24 24"
+              fill={isFavorite ? '#FFD700' : 'none'}
+              stroke={isFavorite ? '#FFD700' : '#9aa0a6'}
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+            </svg>
+          </button>
+        </div>
         <div class="card-body d-flex flex-column">
           <h4>
             <ScrollToTopLink href={integration.url}>

--- a/front/src/routes/integration/IntegrationMenu.jsx
+++ b/front/src/routes/integration/IntegrationMenu.jsx
@@ -14,6 +14,16 @@ const IntegrationMenu = ({ integrationCategories }) => {
         </span>
         <Text id="integration.root.menu.all" />
       </Link>
+      <Link
+        activeClassName="active"
+        href="/dashboard/integration/favorites"
+        class="list-group-item list-group-item-action d-flex align-items-center"
+      >
+        <span class="icon mr-3">
+          <i class="fe fe-star" />
+        </span>
+        <Text id="integration.root.menu.favorites" />
+      </Link>
       {integrationCategories.map(category => (
         <Link
           activeClassName="active"

--- a/front/src/routes/integration/IntegrationPage.jsx
+++ b/front/src/routes/integration/IntegrationPage.jsx
@@ -47,9 +47,9 @@ const IntegrationPage = ({
               <div class="col-lg-9">
                 <div class="row row-cards">
                   {integrations.map(integration => (
-                    <IntegrationCategory 
-                      currentUrl={currentUrl} 
-                      integration={integration} 
+                    <IntegrationCategory
+                      currentUrl={currentUrl}
+                      integration={integration}
                       category={category}
                       toggleFavorite={toggleFavorite}
                     />

--- a/front/src/routes/integration/IntegrationPage.jsx
+++ b/front/src/routes/integration/IntegrationPage.jsx
@@ -13,7 +13,8 @@ const IntegrationPage = ({
   orderDir,
   changeOrderDir,
   search,
-  integrationCategories
+  integrationCategories,
+  toggleFavorite
 }) => (
   <div class="page">
     <div class="page-main">
@@ -46,7 +47,12 @@ const IntegrationPage = ({
               <div class="col-lg-9">
                 <div class="row row-cards">
                   {integrations.map(integration => (
-                    <IntegrationCategory currentUrl={currentUrl} integration={integration} category={category} />
+                    <IntegrationCategory 
+                      currentUrl={currentUrl} 
+                      integration={integration} 
+                      category={category}
+                      toggleFavorite={toggleFavorite}
+                    />
                   ))}
                   {integrations.length === 0 && (
                     <div class="col-12">

--- a/front/src/routes/integration/index.js
+++ b/front/src/routes/integration/index.js
@@ -25,6 +25,21 @@ class Integration extends Component {
   }
 
   componentWillMount() {
+    this.loadFavorites();
+  }
+
+  async loadFavorites() {
+    try {
+      const { httpClient } = this.props;
+      if (httpClient) {
+        const result = await httpClient.get('/api/v1/user/variable/INTEGRATION_FAVORITES');
+        const favorites = JSON.parse(result.value);
+        await this.setState({ favorites });
+      }
+    } catch (e) {
+      // Variable not found = no favorites yet
+      await this.setState({ favorites: [] });
+    }
     this.getIntegrations();
   }
 
@@ -64,8 +79,8 @@ class Integration extends Component {
       totalSize = integrations.filter(i => HIDDEN_CATEGORIES_FOR_NON_ADMIN_USERS.indexOf(i.type) === -1).length;
     }
 
-    // Get favorites from localStorage
-    const favorites = JSON.parse(localStorage.getItem('integration_favorites') || '[]');
+    // Get favorites (use cached state if available, otherwise empty)
+    const favorites = this.state.favorites || [];
 
     // Add favorite status to integrations
     selectedIntegrations = selectedIntegrations.map(integration => ({
@@ -119,17 +134,24 @@ class Integration extends Component {
     });
   }
 
-  toggleFavorite = (integrationKey) => {
-    const favorites = JSON.parse(localStorage.getItem('integration_favorites') || '[]');
+  toggleFavorite = async (integrationKey) => {
+    const favorites = this.state.favorites || [];
     const newFavorites = favorites.includes(integrationKey)
       ? favorites.filter(key => key !== integrationKey)
       : [...favorites, integrationKey];
-    
-    localStorage.setItem('integration_favorites', JSON.stringify(newFavorites));
-    // Debug: verify favorite toggle is triggered and persisted
-    // eslint-disable-next-line no-console
-    console.log('[integration] toggleFavorite', integrationKey, newFavorites);
+
+    // Update state immediately for responsive UI
+    await this.setState({ favorites: newFavorites });
     this.getIntegrations();
+
+    // Persist to backend
+    try {
+      await this.props.httpClient.post('/api/v1/user/variable/INTEGRATION_FAVORITES', {
+        value: JSON.stringify(newFavorites)
+      });
+    } catch (e) {
+      console.error('[integration] Failed to save favorites', e);
+    }
   };
 
   search = async e => {
@@ -160,4 +182,4 @@ class Integration extends Component {
   }
 }
 
-export default connect('user', {})(withIntlAsProp(Integration));
+export default connect('user,httpClient', {})(withIntlAsProp(Integration));

--- a/front/src/routes/integration/index.js
+++ b/front/src/routes/integration/index.js
@@ -134,7 +134,7 @@ class Integration extends Component {
     });
   }
 
-  toggleFavorite = async (integrationKey) => {
+  toggleFavorite = async integrationKey => {
     const favorites = this.state.favorites || [];
     const newFavorites = favorites.includes(integrationKey)
       ? favorites.filter(key => key !== integrationKey)

--- a/front/src/style/dark-mode.css
+++ b/front/src/style/dark-mode.css
@@ -168,6 +168,11 @@ body.dark-mode {
   filter: none;
 }
 
+/* Preserve favorite star colors in dark mode */
+.dark-mode .favorite-star {
+  filter: invert(100%) hue-rotate(180deg);
+}
+
 /* Dark mode toggle button */
 .mode-toggle {
   padding: 0.5rem;

--- a/front/src/style/index.css
+++ b/front/src/style/index.css
@@ -420,20 +420,35 @@ body {
   padding: 0;
   line-height: 1;
   position: absolute;
-  /*top: 1px;*/
-  right: 1px !important;
-  /*left: auto !important;*/
+  top: 8px;
+  right: 8px;
   width: 48px;
   height: 48px;
   display: flex;
   align-items: center;
   justify-content: center;
-  /*font-size: 32px;*/
-  color: #9aa0a6;
   cursor: pointer;
-  transition: color 0.2s ease, transform 0.2s ease;
-  z-index: 2;
+  transition: transform 0.2s ease;
+  z-index: 10;
   pointer-events: auto;
   box-shadow: none;
   outline: none;
+}
+
+.favorite-star:focus,
+.favorite-star:active,
+.favorite-star:focus-visible {
+  outline: none;
+  box-shadow: none;
+  border: none;
+}
+
+.favorite-star svg {
+  fill: none;
+  stroke: #9aa0a6;
+}
+
+.favorite-star--active svg {
+  fill: #FFA000;
+  stroke: #FFA000;
 }

--- a/front/src/style/index.css
+++ b/front/src/style/index.css
@@ -402,3 +402,39 @@ body {
 .rti--tag button:focus {
   outline: none !important;
 }
+
+.favorite-star {
+  -webkit-appearance: none;
+  appearance: none;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  line-height: 1;
+  position: absolute;
+  /*top: 1px;*/
+  right: 1px !important;
+  /*left: auto !important;*/
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /*font-size: 32px;*/
+  color: #9aa0a6;
+  cursor: pointer;
+  transition: color 0.2s ease, transform 0.2s ease;
+  z-index: 2;
+  pointer-events: auto;
+  box-shadow: none;
+  outline: none;
+}
+
+.card-img-container {
+  position: relative;
+}
+
+.card-img-container > a {
+  display: block;
+  position: relative;
+  z-index: 1;
+}

--- a/front/src/style/index.css
+++ b/front/src/style/index.css
@@ -417,20 +417,14 @@ body {
   appearance: none;
   border: 0;
   background: transparent;
-  padding: 0;
+  padding: 4px;
   line-height: 1;
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  width: 48px;
-  height: 48px;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   transition: transform 0.2s ease;
-  z-index: 10;
-  pointer-events: auto;
+  flex-shrink: 0;
   box-shadow: none;
   outline: none;
 }

--- a/front/src/style/index.css
+++ b/front/src/style/index.css
@@ -403,6 +403,15 @@ body {
   outline: none !important;
 }
 
+.row-cards > [class*="col"] {
+  display: flex;
+}
+
+.row-cards > [class*="col"] > .card {
+  width: 100%;
+  flex: 1;
+}
+
 .favorite-star {
   -webkit-appearance: none;
   appearance: none;
@@ -427,14 +436,4 @@ body {
   pointer-events: auto;
   box-shadow: none;
   outline: none;
-}
-
-.card-img-container {
-  position: relative;
-}
-
-.card-img-container > a {
-  display: block;
-  position: relative;
-  z-index: 1;
 }

--- a/server/api/controllers/variable.controller.js
+++ b/server/api/controllers/variable.controller.js
@@ -44,6 +44,30 @@ module.exports = function VariableController(gladys) {
   }
 
   /**
+   * @api {post} /api/user/variable/:variable_key Save user variable
+   * @apiName SaveUserVariable
+   * @apiGroup Variable
+   * @apiParam {string} value value to save
+   */
+  async function setForUser(req, res) {
+    const variable = await gladys.variable.setValue(req.params.variable_key, req.body.value, null, req.user.id);
+    res.json(variable);
+  }
+
+  /**
+   * @api {get} /api/user/variable/:variable_key Get user variable
+   * @apiName GetUserVariable
+   * @apiGroup Variable
+   */
+  async function getForUser(req, res) {
+    const value = await gladys.variable.getValue(req.params.variable_key, null, req.user.id);
+    if (!value) {
+      throw new NotFoundError('VARIABLE_NOT_FOUND');
+    }
+    res.json({ value });
+  }
+
+  /**
    * @api {get} /api/variable/:variable_key Get variable
    * @apiName getVariable
    * @apiGroup Variable
@@ -62,5 +86,7 @@ module.exports = function VariableController(gladys) {
     setValue: asyncMiddleware(setValue),
     getValue: asyncMiddleware(getValue),
     getByLocalService: asyncMiddleware(getByLocalService),
+    setForUser: asyncMiddleware(setForUser),
+    getForUser: asyncMiddleware(getForUser),
   });
 };

--- a/server/api/routes.js
+++ b/server/api/routes.js
@@ -483,6 +483,14 @@ function getRoutes(gladys) {
       authenticated: true,
       controller: variableController.getValue,
     },
+    'post /api/v1/user/variable/:variable_key': {
+      authenticated: true,
+      controller: variableController.setForUser,
+    },
+    'get /api/v1/user/variable/:variable_key': {
+      authenticated: true,
+      controller: variableController.getForUser,
+    },
     // session
     'post /api/v1/session/:session_id/revoke': {
       authenticated: true,

--- a/server/test/controllers/variable/variable.test.js
+++ b/server/test/controllers/variable/variable.test.js
@@ -56,6 +56,70 @@ describe('POST /api/v1/service/:service_name/variable/:variable_name', () => {
   });
 });
 
+describe('POST /api/v1/user/variable/:variable_name', () => {
+  it('should create a user variable', async () => {
+    await authenticatedRequest
+      .post('/api/v1/user/variable/INTEGRATION_FAVORITES')
+      .send({
+        value: '["zigbee2mqtt","mqtt"]',
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then((res) => {
+        expect(res.body).to.have.property('value', '["zigbee2mqtt","mqtt"]');
+        expect(res.body).to.have.property('user_id', '0cd30aef-9c4e-4a23-88e3-3547971296e5');
+      });
+  });
+  it('should update an existing user variable', async () => {
+    // First create
+    await authenticatedRequest
+      .post('/api/v1/user/variable/INTEGRATION_FAVORITES')
+      .send({
+        value: '["zigbee2mqtt"]',
+      })
+      .expect(200);
+    // Then update
+    await authenticatedRequest
+      .post('/api/v1/user/variable/INTEGRATION_FAVORITES')
+      .send({
+        value: '["zigbee2mqtt","mqtt","philips-hue"]',
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then((res) => {
+        expect(res.body).to.have.property('value', '["zigbee2mqtt","mqtt","philips-hue"]');
+      });
+  });
+});
+
+describe('GET /api/v1/user/variable/:variable_name', () => {
+  it('should get a user variable', async () => {
+    // First create the variable
+    await authenticatedRequest
+      .post('/api/v1/user/variable/INTEGRATION_FAVORITES')
+      .send({
+        value: '["zigbee2mqtt"]',
+      })
+      .expect(200);
+    // Then read it back
+    await authenticatedRequest
+      .get('/api/v1/user/variable/INTEGRATION_FAVORITES')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then((res) => {
+        expect(res.body).to.deep.equal({
+          value: '["zigbee2mqtt"]',
+        });
+      });
+  });
+  it('should return 404 not found', async () => {
+    await authenticatedRequest
+      .get('/api/v1/user/variable/NOT_FOUND_USER_VAR')
+      .expect('Content-Type', /json/)
+      .expect(404);
+  });
+});
+
 describe('POST /api/v1/variable/:variable_name', () => {
   it('should create a variable', async () => {
     await authenticatedRequest


### PR DESCRIPTION
### Description of change

This PR adds the ability to mark integrations as favorites. Favorites are persisted in the database per user and accessible from any browser.

<img width="1298" height="746" alt="image" src="https://github.com/user-attachments/assets/5b546588-287d-4887-acb2-606734d2a839" />
<img width="1216" height="404" alt="image" src="https://github.com/user-attachments/assets/a66014bf-3919-47da-a5cd-5b2e1da7a8de" />
<img width="1242" height="313" alt="image" src="https://github.com/user-attachments/assets/72bbcddb-1e13-40b1-9082-07ea15e12110" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mark integrations as favorites using a new star button on each integration card
  * Access all favorited integrations from a dedicated "Favorites" section
  * Favorites persist across sessions

* **UI/UX Improvements**
  * Enhanced search placeholder and empty state messaging for integrations
  * New menu navigation item for quick access to favorites
  * Favorite buttons fully supported in dark mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->