### PR TITLE
Temperature in room: Should exclude crazy temperature values

### DIFF
--- a/server/lib/device/temperature-sensor/temperature-sensor.getTemperatureInRoom.js
+++ b/server/lib/device/temperature-sensor/temperature-sensor.getTemperatureInRoom.js
@@ -41,9 +41,23 @@ async function getTemperatureInRoom(roomId, options) {
       },
       last_value: {
         [Op.not]: null,
-        [Op.gt]: -273.15,
-        [Op.lt]: 200,
       },
+      [Op.or]: [
+        {
+          unit: DEVICE_FEATURE_UNITS.CELSIUS,
+          last_value: {
+            [Op.gt]: -273.15,
+            [Op.lt]: 200,
+          },
+        },
+        {
+          unit: DEVICE_FEATURE_UNITS.FAHRENHEIT,
+          last_value: {
+            [Op.gt]: -459.67,
+            [Op.lt]: 392,
+          },
+        },
+      ],
       last_value_changed: {
         // we want fresh value, less than 1h
         [Op.gt]: oneHourAgo,

--- a/server/lib/device/temperature-sensor/temperature-sensor.getTemperatureInRoom.js
+++ b/server/lib/device/temperature-sensor/temperature-sensor.getTemperatureInRoom.js
@@ -41,6 +41,8 @@ async function getTemperatureInRoom(roomId, options) {
       },
       last_value: {
         [Op.not]: null,
+        [Op.gt]: -273.15,
+        [Op.lt]: 200,
       },
       last_value_changed: {
         // we want fresh value, less than 1h

--- a/server/test/lib/device/temperature-sensor/temperature-sensor.test.js
+++ b/server/test/lib/device/temperature-sensor/temperature-sensor.test.js
@@ -4,6 +4,7 @@ const { assert, fake } = require('sinon');
 const Device = require('../../../../lib/device');
 const StateManager = require('../../../../lib/state');
 const Job = require('../../../../lib/job');
+const db = require('../../../../models');
 
 const event = new EventEmitter();
 const job = new Job(event);
@@ -54,6 +55,57 @@ describe('TemperatureSensor.getTemperatureInRoom', () => {
       temperature: null,
       unit: 'fahrenheit',
     });
+  });
+  it('should exclude crazy values (below -273.15 or above 200) from average calculation', async () => {
+    const stateManager = new StateManager(event);
+    const deviceManager = new Device(event, messageManager, stateManager, {}, {}, {}, job);
+
+    // Create a temperature sensor with a crazy high value (500°C)
+    await db.DeviceFeature.create({
+      id: 'a5d22c4e-1b8f-4a3c-9f2d-6e7a8b9c0d1e',
+      name: 'Test temperature sensor crazy high value',
+      selector: 'test-temperature-sensor-crazy-high',
+      external_id: 'temperature-sensor:crazy-high',
+      category: 'temperature-sensor',
+      type: 'decimal',
+      unit: 'celsius',
+      read_only: false,
+      has_feedback: false,
+      min: 0,
+      max: 100,
+      last_value: 500,
+      last_value_changed: new Date(),
+      device_id: '7f85c2f8-86cc-4600-84db-6c074dadb4e8',
+    });
+
+    // Create a temperature sensor with a crazy low value (-999°C)
+    await db.DeviceFeature.create({
+      id: 'b6e33d5f-2c9a-5b4d-0a3e-7f8b9c0d2e3f',
+      name: 'Test temperature sensor crazy low value',
+      selector: 'test-temperature-sensor-crazy-low',
+      external_id: 'temperature-sensor:crazy-low',
+      category: 'temperature-sensor',
+      type: 'decimal',
+      unit: 'celsius',
+      read_only: false,
+      has_feedback: false,
+      min: 0,
+      max: 100,
+      last_value: -999,
+      last_value_changed: new Date(),
+      device_id: '7f85c2f8-86cc-4600-84db-6c074dadb4e8',
+    });
+    const result = await deviceManager.temperatureSensorManager.getTemperatureInRoom(
+      '2398c689-8b47-43cc-ad32-e98d9be098b5',
+      {
+        unit: 'celsius',
+      },
+    );
+    // The crazy value sensor (500°C) should be excluded from the calculation
+    // Only the valid sensors (20°C and 100°F = 37.78°C) should be included
+    // Average = (20 + 37.78) / 2 = 28.89°C
+    expect(result.temperature).to.be.closeTo(28.89, 0.01);
+    expect(result.unit).to.equal('celsius');
   });
 });
 

--- a/server/test/lib/device/temperature-sensor/temperature-sensor.test.js
+++ b/server/test/lib/device/temperature-sensor/temperature-sensor.test.js
@@ -107,6 +107,58 @@ describe('TemperatureSensor.getTemperatureInRoom', () => {
     expect(result.temperature).to.be.closeTo(28.89, 0.01);
     expect(result.unit).to.equal('celsius');
   });
+  it('should exclude crazy fahrenheit values (below -459.67 or above 392) from average calculation', async () => {
+    const stateManager = new StateManager(event);
+    const deviceManager = new Device(event, messageManager, stateManager, {}, {}, {}, job);
+
+    // Create a temperature sensor with a crazy high fahrenheit value (1000°F)
+    await db.DeviceFeature.create({
+      id: 'c7f44e6a-3d0b-6c5e-1b4f-8a9c0d3e4f5a',
+      name: 'Test temperature sensor crazy high fahrenheit',
+      selector: 'test-temperature-sensor-crazy-high-f',
+      external_id: 'temperature-sensor:crazy-high-f',
+      category: 'temperature-sensor',
+      type: 'decimal',
+      unit: 'fahrenheit',
+      read_only: false,
+      has_feedback: false,
+      min: 0,
+      max: 100,
+      last_value: 1000,
+      last_value_changed: new Date(),
+      device_id: '7f85c2f8-86cc-4600-84db-6c074dadb4e8',
+    });
+
+    // Create a temperature sensor with a crazy low fahrenheit value (-1000°F)
+    await db.DeviceFeature.create({
+      id: 'd8a55f7b-4e1c-7d6f-2c5a-9b0d1e4f5a6b',
+      name: 'Test temperature sensor crazy low fahrenheit',
+      selector: 'test-temperature-sensor-crazy-low-f',
+      external_id: 'temperature-sensor:crazy-low-f',
+      category: 'temperature-sensor',
+      type: 'decimal',
+      unit: 'fahrenheit',
+      read_only: false,
+      has_feedback: false,
+      min: 0,
+      max: 100,
+      last_value: -1000,
+      last_value_changed: new Date(),
+      device_id: '7f85c2f8-86cc-4600-84db-6c074dadb4e8',
+    });
+
+    const result = await deviceManager.temperatureSensorManager.getTemperatureInRoom(
+      '2398c689-8b47-43cc-ad32-e98d9be098b5',
+      {
+        unit: 'celsius',
+      },
+    );
+    // The crazy fahrenheit values should be excluded from the calculation
+    // Only the valid sensors (20°C and 100°F = 37.78°C) should be included
+    // Average = (20 + 37.78) / 2 = 28.89°C
+    expect(result.temperature).to.be.closeTo(28.89, 0.01);
+    expect(result.unit).to.equal('celsius');
+  });
 });
 
 describe('TemperatureSensor.command', () => {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.
- [x] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [x] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Exclude values below -273°C and above 200°C


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temperature sensors now automatically exclude out-of-range or physically impossible readings when calculating room temperatures, improving accuracy
  * Added validation to filter unrealistic values (below absolute zero or above feasible limits) for both Celsius and Fahrenheit units
  * Invalid sensor readings no longer skew room temperature averages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->