### PR TITLE
MQTT/Zigbee2mqtt: Improve device page action buttons layout

### DIFF
--- a/front/src/routes/integration/all/mqtt/device-page/Device.jsx
+++ b/front/src/routes/integration/all/mqtt/device-page/Device.jsx
@@ -5,6 +5,7 @@ import cx from 'classnames';
 import get from 'get-value';
 
 import { RequestStatus } from '../../../../../utils/consts';
+import style from './style.css';
 import { DEVICE_FEATURE_CATEGORIES } from '../../../../../../../server/utils/constants';
 import MqttDeviceForm from './DeviceForm';
 import BatteryLevelFeature from '../../../../../components/device/view/BatteryLevelFeature';
@@ -86,16 +87,16 @@ class MqttDeviceBox extends Component {
 
                 <MqttDeviceForm {...props} mostRecentValueAt={mostRecentValueAt} />
 
-                <div class="form-group">
-                  <button onClick={this.saveDevice} class="btn btn-success mr-2">
+                <div class={style.mqttActionButtons}>
+                  <button onClick={this.saveDevice} class="btn btn-success flex-fill">
                     <Text id="integration.mqtt.device.saveButton" />
                   </button>
-                  <button onClick={this.deleteDevice} class="btn btn-danger mr-2">
+                  <button onClick={this.deleteDevice} class="btn btn-danger flex-fill">
                     <Text id="integration.mqtt.device.deleteButton" />
                   </button>
 
-                  <Link href={`/dashboard/integration/device/mqtt/edit/${props.device.selector}`}>
-                    <button class="btn btn-secondary float-right">
+                  <Link href={`/dashboard/integration/device/mqtt/edit/${props.device.selector}`} class="flex-fill">
+                    <button class="btn btn-primary w-100">
                       <Text id="integration.mqtt.device.editButton" />
                     </button>
                   </Link>

--- a/front/src/routes/integration/all/mqtt/device-page/style.css
+++ b/front/src/routes/integration/all/mqtt/device-page/style.css
@@ -1,3 +1,18 @@
 .emptyDiv {
   min-height: 200px;
 }
+
+.mqttActionButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mqttActionButtons > a {
+  display: flex; 
+  flex: 1 1 100%;
+}
+
+.mqttActionButtons > a button {
+  width: 100%;
+}

--- a/front/src/routes/integration/all/zigbee2mqtt/device-page/Zigbee2mqttBox.jsx
+++ b/front/src/routes/integration/all/zigbee2mqtt/device-page/Zigbee2mqttBox.jsx
@@ -5,6 +5,7 @@ import { Link } from 'preact-router/match';
 import get from 'get-value';
 
 import { RequestStatus } from '../../../../../utils/consts';
+import style from './style.css';
 import { DEVICE_FEATURE_CATEGORIES } from '../../../../../../../server/utils/constants';
 import DeviceFeatures from '../../../../../components/device/view/DeviceFeatures';
 import BatteryLevelFeature from '../../../../../components/device/view/BatteryLevelFeature';
@@ -170,15 +171,15 @@ class Zigbee2mqttBox extends Component {
                   <DeviceFeatures features={props.device.features} />
                 </div>
 
-                <div class="form-group">
-                  <button onClick={this.saveDevice} class="btn btn-success mr-2">
+                <div class={style.z2mActionButtons}>
+                  <button onClick={this.saveDevice} class="btn btn-success flex-fill">
                     <Text id="integration.zigbee2mqtt.saveButton" />
                   </button>
-                  <button onClick={this.deleteDevice} class="btn btn-danger">
+                  <button onClick={this.deleteDevice} class="btn btn-danger flex-fill">
                     <Text id="integration.zigbee2mqtt.deleteButton" />
                   </button>
-                  <Link href={`/dashboard/integration/device/zigbee2mqtt/edit/${props.device.selector}`}>
-                    <button class="btn btn-secondary float-right">
+                  <Link href={`/dashboard/integration/device/zigbee2mqtt/edit/${props.device.selector}`} class="flex-fill">
+                    <button class="btn btn-primary w-100">
                       <Text id="integration.zigbee2mqtt.device.editButton" />
                     </button>
                   </Link>

--- a/front/src/routes/integration/all/zigbee2mqtt/device-page/Zigbee2mqttBox.jsx
+++ b/front/src/routes/integration/all/zigbee2mqtt/device-page/Zigbee2mqttBox.jsx
@@ -178,7 +178,10 @@ class Zigbee2mqttBox extends Component {
                   <button onClick={this.deleteDevice} class="btn btn-danger flex-fill">
                     <Text id="integration.zigbee2mqtt.deleteButton" />
                   </button>
-                  <Link href={`/dashboard/integration/device/zigbee2mqtt/edit/${props.device.selector}`} class="flex-fill">
+                  <Link
+                    href={`/dashboard/integration/device/zigbee2mqtt/edit/${props.device.selector}`}
+                    class="flex-fill"
+                  >
                     <button class="btn btn-primary w-100">
                       <Text id="integration.zigbee2mqtt.device.editButton" />
                     </button>

--- a/front/src/routes/integration/all/zigbee2mqtt/device-page/style.css
+++ b/front/src/routes/integration/all/zigbee2mqtt/device-page/style.css
@@ -5,3 +5,18 @@
 .zigbee2mqttListBody {
   min-height: 200px
 }
+
+.z2mActionButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.z2mActionButtons > a {
+  display: flex; 
+  flex: 1 1 100%;
+}
+
+.z2mActionButtons > a button {
+  width: 100%;
+}


### PR DESCRIPTION
### Description of change

<img width="935" height="647" alt="image" src="https://github.com/user-attachments/assets/7ebebeea-f3b4-43d3-b880-c11e50423bbe" />
<img width="774" height="775" alt="image" src="https://github.com/user-attachments/assets/bfcb0faf-7c35-4a6d-9a84-80f45597c9db" />

<img width="931" height="654" alt="image" src="https://github.com/user-attachments/assets/a54d9c28-aa13-4c06-a544-530152ba4f63" />
<img width="351" height="559" alt="image" src="https://github.com/user-attachments/assets/55fcbc5c-634e-4030-b4f8-f8517133247f" />







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated action button layouts on MQTT and Zigbee2MQTT device pages for responsive, flex-based grouping.
  * Buttons now use flexible spacing, wrap responsively, and expand to full width on narrow layouts.
  * Edit action updated to primary, full-width presentation for clearer emphasis and consistent alignment with save/delete actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->