### PR TITLE
Matter : Add Boolean & Switch clusters

### DIFF
--- a/server/services/matter/lib/matter.listenToStateChange.js
+++ b/server/services/matter/lib/matter.listenToStateChange.js
@@ -1,5 +1,7 @@
 const {
   OnOff,
+  BooleanState,
+  Switch,
   OccupancySensing,
   IlluminanceMeasurement,
   TemperatureMeasurement,
@@ -19,7 +21,7 @@ const {
 
 const logger = require('../../../utils/logger');
 const { hsbToRgb, rgbToInt } = require('../../../utils/colors');
-const { EVENTS, STATE } = require('../../../utils/constants');
+const { EVENTS, STATE, BUTTON_STATUS } = require('../../../utils/constants');
 
 /**
  * @description Listen to state changes of a device.
@@ -44,6 +46,61 @@ async function listenToStateChange(nodeId, devicePath, device) {
         state: value ? STATE.ON : STATE.OFF,
       });
     });
+  }
+
+  const booleanState = device.clusterClients.get(BooleanState.Complete.id);
+  if (booleanState && !this.stateChangeListeners.has(booleanState)) {
+    logger.debug(`Matter: Adding state change listener for BooleanState cluster ${booleanState.name}`);
+    this.stateChangeListeners.add(booleanState);
+    booleanState.addStateValueAttributeListener((value) => {
+      logger.debug(`Matter: BooleanState attribute changed to ${value}`);
+      this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
+        device_feature_external_id: `matter:${nodeId}:${devicePath}:${BooleanState.Complete.id}`,
+        state: value ? STATE.ON : STATE.OFF,
+      });
+    });
+  }
+
+  const switchCluster = device.clusterClients.get(Switch.Complete.id);
+  if (switchCluster && !this.stateChangeListeners.has(switchCluster)) {
+    logger.debug(`Matter: Adding state change listener for Switch cluster ${switchCluster.name}`);
+    this.stateChangeListeners.add(switchCluster);
+
+    if (switchCluster.addInitialPressEventListener) {
+      switchCluster.addInitialPressEventListener(() => {
+        this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
+          device_feature_external_id: `matter:${nodeId}:${devicePath}:${Switch.Complete.id}:click`,
+          state: BUTTON_STATUS.INITIAL_PRESS,
+        });
+      });
+    }
+
+    if (switchCluster.addShortReleaseEventListener) {
+      switchCluster.addShortReleaseEventListener(() => {
+        this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
+          device_feature_external_id: `matter:${nodeId}:${devicePath}:${Switch.Complete.id}:click`,
+          state: BUTTON_STATUS.SHORT_RELEASE,
+        });
+      });
+    }
+
+    if (switchCluster.addLongPressEventListener) {
+      switchCluster.addLongPressEventListener(() => {
+        this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
+          device_feature_external_id: `matter:${nodeId}:${devicePath}:${Switch.Complete.id}:click`,
+          state: BUTTON_STATUS.LONG_PRESS,
+        });
+      });
+    }
+
+    if (switchCluster.addLongReleaseEventListener) {
+      switchCluster.addLongReleaseEventListener(() => {
+        this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
+          device_feature_external_id: `matter:${nodeId}:${devicePath}:${Switch.Complete.id}:click`,
+          state: BUTTON_STATUS.LONG_RELEASE,
+        });
+      });
+    }
   }
 
   const occupancy = device.clusterClients.get(OccupancySensing.Complete.id);

--- a/server/services/matter/utils/convertToGladysDevice.js
+++ b/server/services/matter/utils/convertToGladysDevice.js
@@ -1,5 +1,7 @@
 const {
   OnOff,
+  BooleanState,
+  Switch,
   OccupancySensing,
   IlluminanceMeasurement,
   TemperatureMeasurement,
@@ -114,6 +116,29 @@ async function convertToGladysDevice(serviceId, nodeId, device, nodeDetailDevice
           external_id: `matter:${nodeId}:${devicePath}:${clusterIndex}`,
           min: 0,
           max: 1,
+        });
+      } else if (clusterIndex === BooleanState.Complete.id) {
+        gladysDevice.features.push({
+          ...commonNewFeature,
+          category: DEVICE_FEATURE_CATEGORIES.SWITCH,
+          type: DEVICE_FEATURE_TYPES.SWITCH.BINARY,
+          read_only: true,
+          has_feedback: true,
+          external_id: `matter:${nodeId}:${devicePath}:${clusterIndex}`,
+          min: 0,
+          max: 1,
+        });
+      } else if (clusterIndex === Switch.Complete.id) {
+        gladysDevice.features.push({
+          name: `${clusterClient.name} - ${clusterClient.endpointId} (Click)`,
+          selector: slugify(`matter-${device.name}-${clusterClient.name}-click`, true),
+          category: DEVICE_FEATURE_CATEGORIES.BUTTON,
+          type: DEVICE_FEATURE_TYPES.BUTTON.CLICK,
+          read_only: true,
+          has_feedback: true,
+          external_id: `matter:${nodeId}:${devicePath}:${clusterIndex}:click`,
+          min: 0,
+          max: 84,
         });
       } else if (clusterIndex === OccupancySensing.Complete.id) {
         gladysDevice.features.push({

--- a/server/test/services/matter/lib/convertToGladysDevice.test.js
+++ b/server/test/services/matter/lib/convertToGladysDevice.test.js
@@ -1,0 +1,74 @@
+const { expect } = require('chai');
+// eslint-disable-next-line import/no-unresolved
+const { BooleanState, Switch } = require('@matter/main/clusters');
+
+const { convertToGladysDevice } = require('../../../../services/matter/utils/convertToGladysDevice');
+
+describe('Matter.convertToGladysDevice', () => {
+  const serviceId = 'service-1';
+  const nodeId = 12345n;
+  const basicInformation = {
+    vendorName: 'Test Vendor',
+    productName: 'Test Product',
+  };
+
+  it('should create a read-only binary feature for BooleanState cluster', async () => {
+    const clusterClients = new Map();
+    clusterClients.set(BooleanState.Complete.id, {
+      id: BooleanState.Complete.id,
+      name: 'BooleanState',
+      endpointId: 1,
+    });
+
+    const device = {
+      name: 'Test Device',
+      number: 1,
+      clusterClients,
+    };
+
+    const gladysDevice = await convertToGladysDevice(serviceId, nodeId, device, basicInformation, '1');
+
+    expect(gladysDevice.features).to.have.lengthOf(1);
+    expect(gladysDevice.features[0]).to.deep.equal({
+      name: 'BooleanState - 1',
+      selector: gladysDevice.features[0].selector,
+      category: 'switch',
+      type: 'binary',
+      read_only: true,
+      has_feedback: true,
+      external_id: 'matter:12345:1:69',
+      min: 0,
+      max: 1,
+    });
+  });
+
+  it('should create a button click feature for Switch cluster', async () => {
+    const clusterClients = new Map();
+    clusterClients.set(Switch.Complete.id, {
+      id: Switch.Complete.id,
+      name: 'Switch',
+      endpointId: 2,
+    });
+
+    const device = {
+      name: 'Test Device',
+      number: 2,
+      clusterClients,
+    };
+
+    const gladysDevice = await convertToGladysDevice(serviceId, nodeId, device, basicInformation, '1:child_endpoint:2');
+
+    expect(gladysDevice.features).to.have.lengthOf(1);
+    expect(gladysDevice.features[0]).to.deep.equal({
+      name: 'Switch - 2 (Click)',
+      selector: gladysDevice.features[0].selector,
+      category: 'button',
+      type: 'click',
+      read_only: true,
+      has_feedback: true,
+      external_id: 'matter:12345:1:child_endpoint:2:59:click',
+      min: 0,
+      max: 84,
+    });
+  });
+});

--- a/server/test/services/matter/lib/listenToStateChange.test.js
+++ b/server/test/services/matter/lib/listenToStateChange.test.js
@@ -1,5 +1,7 @@
 const {
   OnOff,
+  BooleanState,
+  Switch,
   OccupancySensing,
   IlluminanceMeasurement,
   TemperatureMeasurement,
@@ -21,7 +23,7 @@ const sinon = require('sinon');
 
 const { fake, assert } = sinon;
 
-const { EVENTS, STATE } = require('../../../../utils/constants');
+const { EVENTS, STATE, BUTTON_STATUS } = require('../../../../utils/constants');
 
 const MatterHandler = require('../../../../services/matter/lib');
 
@@ -93,6 +95,61 @@ describe('Matter.listenToStateChange', () => {
     assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
       device_feature_external_id: 'matter:1234:1:child_endpoint:2:6',
       state: STATE.OFF,
+    });
+  });
+  it('should listen to state change (BooleanState = true)', async () => {
+    const clusterClients = new Map();
+    clusterClients.set(BooleanState.Complete.id, {
+      addStateValueAttributeListener: (callback) => {
+        callback(true);
+      },
+    });
+    const device = {
+      number: 1,
+      clusterClients,
+    };
+    await matterHandler.listenToStateChange(1234n, '1', device);
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'matter:1234:1:69',
+      state: STATE.ON,
+    });
+  });
+  it('should listen to switch events', async () => {
+    const clusterClients = new Map();
+    clusterClients.set(Switch.Complete.id, {
+      addInitialPressEventListener: (callback) => {
+        callback();
+      },
+      addShortReleaseEventListener: (callback) => {
+        callback();
+      },
+      addLongPressEventListener: (callback) => {
+        callback();
+      },
+      addLongReleaseEventListener: (callback) => {
+        callback();
+      },
+    });
+    const device = {
+      number: 1,
+      clusterClients,
+    };
+    await matterHandler.listenToStateChange(1234n, '1', device);
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'matter:1234:1:59:click',
+      state: BUTTON_STATUS.INITIAL_PRESS,
+    });
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'matter:1234:1:59:click',
+      state: BUTTON_STATUS.SHORT_RELEASE,
+    });
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'matter:1234:1:59:click',
+      state: BUTTON_STATUS.LONG_PRESS,
+    });
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'matter:1234:1:59:click',
+      state: BUTTON_STATUS.LONG_RELEASE,
     });
   });
   it('should listen to state change (Occupancy = true)', async () => {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.
- [x] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [x] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Fix https://community.gladysassistant.com/t/matter-ajout-cluster-boolean-pour-aqara-door-and-window-sensor-p2/10131/1 & https://community.gladysassistant.com/t/matter-ajout-cluster-switch-pour-ikea-bilresa-dual-button/10130/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Matter devices with BooleanState cluster now recognized and supported as read-only binary switches
  * Matter devices with Switch cluster now supported with button event detection for press and release actions

* **Tests**
  * Added test coverage for BooleanState and Switch cluster handling and state change listeners

<!-- end of auto-generated comment: release notes by coderabbit.ai -->