### PR TITLE
Display caldav error logs in service config

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -1867,6 +1867,7 @@
       "synchronizationNeeded": "Starte die Synchronisierung, um verfügbare Kalender aufzulisten.",
       "calendarChoiceSuccess": "Deine Auswahl wurde gesichert.",
       "calendarChoiceError": "Das Sichern ist fehlgeschlagen.",
+      "logTitle": "Protokoll",
       "buttonSave": "Sichern",
       "buttonCleanUp": "Aufräumen",
       "buttonSync": "Jetzt synchronisieren"

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -1867,6 +1867,7 @@
       "synchronizationNeeded": "A first synchronization is necessary to list your calendars.",
       "calendarChoiceSuccess": "Your choices have been saved.",
       "calendarChoiceError": "An error occurred while saving.",
+      "logTitle": "Log",
       "buttonSave": "Save",
       "buttonCleanUp": "Clean Up",
       "buttonSync": "Sync now"

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -696,6 +696,7 @@
       "synchronizationNeeded": "Une première synchronisation est nécessaire pour lister les calendriers.",
       "calendarChoiceSuccess": "Choix enregistrés avec succès.",
       "calendarChoiceError": "Une erreur est survenue lors de la sauvegarde.",
+      "logTitle": "Journal",
       "buttonSave": "Sauvegarder",
       "buttonCleanUp": "Remettre à zéro",
       "buttonSync": "Synchroniser"

--- a/front/src/routes/integration/all/caldav/account-page/AccountTab.jsx
+++ b/front/src/routes/integration/all/caldav/account-page/AccountTab.jsx
@@ -158,9 +158,11 @@ const AccountTab = ({ children, ...props }) => (
                   />
                   <Text id="integration.caldav.logTitle" />
                 </button>
-                <button type="button" class="btn p-0" onClick={() => navigator.clipboard.writeText(props.caldavLog)}>
-                  <i class="fe fe-copy me-1" />
-                </button>
+                {window.isSecureContext && (
+                  <button type="button" class="btn p-0" onClick={() => navigator.clipboard.writeText(props.caldavLog)}>
+                    <i class="fe fe-copy me-1" />
+                  </button>
+                )}
               </div>
               {!props.caldavLogVisibility && (
                 <pre id="caldav-log-content" class="mb-0 mt-2" style="white-space: pre-wrap; word-break: break-all;">

--- a/front/src/routes/integration/all/caldav/account-page/AccountTab.jsx
+++ b/front/src/routes/integration/all/caldav/account-page/AccountTab.jsx
@@ -156,7 +156,7 @@ const AccountTab = ({ children, ...props }) => (
                       'fe-chevron-down': !props.caldavLogVisibility
                     })}
                   />
-                  Log
+                  <Text id="integration.caldav.logTitle" />
                 </button>
               </div>
               {!props.caldavLogVisibility && (

--- a/front/src/routes/integration/all/caldav/account-page/AccountTab.jsx
+++ b/front/src/routes/integration/all/caldav/account-page/AccountTab.jsx
@@ -158,10 +158,12 @@ const AccountTab = ({ children, ...props }) => (
                   />
                   <Text id="integration.caldav.logTitle" />
                 </button>
+                <button type="button" class="btn p-0" onClick={() => navigator.clipboard.writeText(props.caldavLog)}>
+                  <i class="fe fe-copy me-1" />
+                </button>
               </div>
               {!props.caldavLogVisibility && (
                 <pre id="caldav-log-content" class="mb-0 mt-2" style="white-space: pre-wrap; word-break: break-all;">
-                  {' '}
                   {props.caldavLog}
                 </pre>
               )}

--- a/front/src/routes/integration/all/caldav/account-page/AccountTab.jsx
+++ b/front/src/routes/integration/all/caldav/account-page/AccountTab.jsx
@@ -140,6 +140,26 @@ const AccountTab = ({ children, ...props }) => (
               <Text id="integration.caldav.synchronizationSuccess" />
             </p>
           )}
+          {props.caldavLog && (
+            <div class="alert alert-secondary">
+              <div class="d-flex justify-content-between align-items-center">
+                <strong onClick={props.toggleCaldavLog}>
+                  <i
+                    class={cx('fe me-2', {
+                      'fe-chevron-right': props.caldavLogVisibility,
+                      'fe-chevron-down': !props.caldavLogVisibility
+                    })}
+                  />
+                  Log
+                </strong>
+              </div>
+              {!props.caldavLogVisibility && (
+                <pre class="mb-0 mt-2" style="white-space: pre-wrap; word-break: break-all;">
+                  {props.caldavLog}
+                </pre>
+              )}
+            </div>
+          )}
           <div class="form-group">
             <div className={style.successMessage}>
               <Text id={`integration.caldav.synchronizationInfo`} />

--- a/front/src/routes/integration/all/caldav/account-page/AccountTab.jsx
+++ b/front/src/routes/integration/all/caldav/account-page/AccountTab.jsx
@@ -143,7 +143,13 @@ const AccountTab = ({ children, ...props }) => (
           {props.caldavLog && (
             <div class="alert alert-secondary">
               <div class="d-flex justify-content-between align-items-center">
-                <strong onClick={props.toggleCaldavLog}>
+                <button
+                  type="button"
+                  class="btn btn-link p-0 text-start"
+                  onClick={props.toggleCaldavLog}
+                  aria-expanded={!props.caldavLogVisibility}
+                  aria-controls="caldav-log-content"
+                >
                   <i
                     class={cx('fe me-2', {
                       'fe-chevron-right': props.caldavLogVisibility,
@@ -151,10 +157,11 @@ const AccountTab = ({ children, ...props }) => (
                     })}
                   />
                   Log
-                </strong>
+                </button>
               </div>
               {!props.caldavLogVisibility && (
-                <pre class="mb-0 mt-2" style="white-space: pre-wrap; word-break: break-all;">
+                <pre id="caldav-log-content" class="mb-0 mt-2" style="white-space: pre-wrap; word-break: break-all;">
+                  {' '}
                   {props.caldavLog}
                 </pre>
               )}

--- a/front/src/routes/integration/all/caldav/account-page/actions.js
+++ b/front/src/routes/integration/all/caldav/account-page/actions.js
@@ -107,7 +107,8 @@ const actions = store => ({
     store.setState({
       caldavSaveSettingsStatus: CalDAVStatus.Getting,
       caldavCleanUpStatus: null,
-      caldavSyncStatus: null
+      caldavSyncStatus: null,
+      caldavLog: null
     });
     try {
       // save caldav host
@@ -143,26 +144,41 @@ const actions = store => ({
         caldavSaveSettingsStatus: CalDAVStatus.Success
       });
     } catch (e) {
-      const responseMessage = get(e, 'response.data.message');
+      let responseMessage = get(e, 'response.data.message');
+      let log;
+      if (typeof responseMessage === 'object') {
+        log = responseMessage.log;
+        responseMessage = responseMessage.message;
+      }
       if (responseMessage === 'CALDAV_BAD_USERNAME_PASSWORD') {
         store.setState({
-          caldavSaveSettingsStatus: CalDAVStatus.BadCredentialsError
+          caldavSaveSettingsStatus: CalDAVStatus.BadCredentialsError,
+          caldavLog: log || null,
+          caldavLogVisibility: !!log
         });
       } else if (responseMessage === 'CALDAV_BAD_URL') {
         store.setState({
-          caldavSaveSettingsStatus: CalDAVStatus.BadUrlError
+          caldavSaveSettingsStatus: CalDAVStatus.BadUrlError,
+          caldavLog: log || null,
+          caldavLogVisibility: !!log
         });
       } else if (responseMessage === 'CALDAV_BAD_SETTINGS_PRINCIPAL_URL') {
         store.setState({
-          caldavSaveSettingsStatus: CalDAVStatus.RetrievePrincipalUrlError
+          caldavSaveSettingsStatus: CalDAVStatus.RetrievePrincipalUrlError,
+          caldavLog: log || null,
+          caldavLogVisibility: !!log
         });
       } else if (responseMessage === 'CALDAV_BAD_SETTINGS_HOME_URL') {
         store.setState({
-          caldavSaveSettingsStatus: CalDAVStatus.RetrieveHomeUrlError
+          caldavSaveSettingsStatus: CalDAVStatus.RetrieveHomeUrlError,
+          caldavLog: log || null,
+          caldavLogVisibility: !!log
         });
       } else {
         store.setState({
-          caldavSaveSettingsStatus: CalDAVStatus.Error
+          caldavSaveSettingsStatus: CalDAVStatus.Error,
+          caldavLog: log || null,
+          caldavLogVisibility: !!log
         });
       }
     }
@@ -171,7 +187,8 @@ const actions = store => ({
     store.setState({
       caldavCleanUpStatus: CalDAVStatus.Getting,
       caldavSaveSettingsStatus: null,
-      caldavSyncStatus: null
+      caldavSyncStatus: null,
+      caldavLog: null
     });
 
     try {
@@ -189,7 +206,8 @@ const actions = store => ({
     store.setState({
       caldavSyncStatus: CalDAVStatus.Getting,
       caldavSaveSettingsStatus: null,
-      caldavCleanUpStatus: null
+      caldavCleanUpStatus: null,
+      caldavLog: null
     });
     try {
       await state.httpClient.get('/api/v1/service/caldav/sync');
@@ -197,29 +215,49 @@ const actions = store => ({
         caldavSyncStatus: CalDAVStatus.Success
       });
     } catch (e) {
-      const responseMessage = get(e, 'response.data.message');
+      let responseMessage = get(e, 'response.data.message');
+      let log;
+      if (typeof responseMessage === 'object') {
+        log = responseMessage.log;
+        responseMessage = responseMessage.message;
+      }
       if (responseMessage === 'SERVICE_NOT_CONFIGURED') {
         store.setState({
-          caldavSyncStatus: CalDAVStatus.BadCredentialsError
+          caldavSyncStatus: CalDAVStatus.BadCredentialsError,
+          caldavLog: log || null,
+          caldavLogVisibility: !!log
         });
       } else if (responseMessage === 'CALDAV_FAILED_REQUEST_CALENDARS') {
         store.setState({
-          caldavSyncStatus: CalDAVStatus.RequestCalendarsError
+          caldavSyncStatus: CalDAVStatus.RequestCalendarsError,
+          caldavLog: log || null,
+          caldavLogVisibility: !!log
         });
       } else if (responseMessage === 'CALDAV_FAILED_REQUEST_CHANGES') {
         store.setState({
-          caldavSyncStatus: CalDAVStatus.RequestChangesError
+          caldavSyncStatus: CalDAVStatus.RequestChangesError,
+          caldavLog: log || null,
+          caldavLogVisibility: !!log
         });
       } else if (responseMessage === 'CALDAV_FAILED_REQUEST_EVENTS') {
         store.setState({
-          caldavSyncStatus: CalDAVStatus.RequestEventsError
+          caldavSyncStatus: CalDAVStatus.RequestEventsError,
+          caldavLog: log || null,
+          caldavLogVisibility: !!log
         });
       } else {
         store.setState({
-          caldavSyncStatus: CalDAVStatus.Error
+          caldavSyncStatus: CalDAVStatus.Error,
+          caldavLog: log || null,
+          caldavLogVisibility: !!log
         });
       }
     }
+  },
+  toggleCaldavLog(state) {
+    store.setState({
+      caldavLogVisibility: !state.caldavLogVisibility
+    });
   }
 });
 

--- a/front/src/routes/integration/all/caldav/account-page/actions.js
+++ b/front/src/routes/integration/all/caldav/account-page/actions.js
@@ -146,7 +146,7 @@ const actions = store => ({
     } catch (e) {
       let responseMessage = get(e, 'response.data.message');
       let log;
-      if (typeof responseMessage === 'object') {
+      if (responseMessage && typeof responseMessage === 'object') {
         log = responseMessage.log;
         responseMessage = responseMessage.message;
       }
@@ -217,7 +217,7 @@ const actions = store => ({
     } catch (e) {
       let responseMessage = get(e, 'response.data.message');
       let log;
-      if (typeof responseMessage === 'object') {
+      if (responseMessage && typeof responseMessage === 'object') {
         log = responseMessage.log;
         responseMessage = responseMessage.message;
       }

--- a/front/src/routes/integration/all/caldav/account-page/index.js
+++ b/front/src/routes/integration/all/caldav/account-page/index.js
@@ -27,7 +27,7 @@ class AccountPage extends Component {
 
 export default withIntlAsProp(
   connect(
-    'user,caldavHost,caldavUrl,caldavCheckSSL,caldavUsername,caldavPassword,caldavSaveSettingsStatus,caldavGetSettingsStatus,caldavCleanUpStatus,caldavSyncStatus',
+    'user,caldavHost,caldavUrl,caldavCheckSSL,caldavUsername,caldavPassword,caldavSaveSettingsStatus,caldavGetSettingsStatus,caldavCleanUpStatus,caldavSyncStatus,caldavLog,caldavLogVisibility',
     actions
   )(AccountPage)
 );

--- a/server/services/caldav/lib/calendar/calendar.syncUserCalendars.js
+++ b/server/services/caldav/lib/calendar/calendar.syncUserCalendars.js
@@ -37,7 +37,7 @@ async function syncUserCalendars(userId) {
     davCalendars = await this.requestCalendars(xhr, CALDAV_HOME_URL);
   } catch (e) {
     logger.error(e);
-    throw new NotFoundError({ message: 'CALDAV_FAILED_REQUEST_CALENDARS', log: e.message });
+    throw new NotFoundError({ message: 'CALDAV_FAILED_REQUEST_CALENDARS', log: e.stack });
   }
 
   logger.info(`CalDAV : Found ${davCalendars.length} calendars.`);
@@ -76,7 +76,7 @@ async function syncUserCalendars(userId) {
         eventsToUpdate = await this.requestChanges(xhr, calendarToUpdate);
       } catch (e) {
         logger.error(e);
-        throw new NotFoundError({ message: 'CALDAV_FAILED_REQUEST_CHANGES', log: e.message });
+        throw new NotFoundError({ message: 'CALDAV_FAILED_REQUEST_CHANGES', log: e.stack });
       }
 
       await Promise.map(
@@ -110,7 +110,7 @@ async function syncUserCalendars(userId) {
         jsonEvents = await this.requestEventsData(xhr, calendarToUpdate.external_id, eventsToUpdate, CALDAV_HOST);
       } catch (e) {
         logger.error(e);
-        throw new NotFoundError({ message: 'CALDAV_FAILED_REQUEST_EVENTS', log: e.message });
+        throw new NotFoundError({ message: 'CALDAV_FAILED_REQUEST_EVENTS', log: e.stack });
       }
 
       await Promise.map(

--- a/server/services/caldav/lib/calendar/calendar.syncUserCalendars.js
+++ b/server/services/caldav/lib/calendar/calendar.syncUserCalendars.js
@@ -37,7 +37,7 @@ async function syncUserCalendars(userId) {
     davCalendars = await this.requestCalendars(xhr, CALDAV_HOME_URL);
   } catch (e) {
     logger.error(e);
-    throw new NotFoundError('CALDAV_FAILED_REQUEST_CALENDARS');
+    throw new NotFoundError({ message: 'CALDAV_FAILED_REQUEST_CALENDARS', log: e.message });
   }
 
   logger.info(`CalDAV : Found ${davCalendars.length} calendars.`);
@@ -76,7 +76,7 @@ async function syncUserCalendars(userId) {
         eventsToUpdate = await this.requestChanges(xhr, calendarToUpdate);
       } catch (e) {
         logger.error(e);
-        throw new NotFoundError('CALDAV_FAILED_REQUEST_CHANGES');
+        throw new NotFoundError({ message: 'CALDAV_FAILED_REQUEST_CHANGES', log: e.message });
       }
 
       await Promise.map(
@@ -110,7 +110,7 @@ async function syncUserCalendars(userId) {
         jsonEvents = await this.requestEventsData(xhr, calendarToUpdate.external_id, eventsToUpdate, CALDAV_HOST);
       } catch (e) {
         logger.error(e);
-        throw new NotFoundError('CALDAV_FAILED_REQUEST_EVENTS');
+        throw new NotFoundError({ message: 'CALDAV_FAILED_REQUEST_EVENTS', log: e.message });
       }
 
       await Promise.map(

--- a/server/services/caldav/lib/config/index.js
+++ b/server/services/caldav/lib/config/index.js
@@ -49,11 +49,11 @@ async function config(userId) {
     switch (e.message) {
       case 'Bad status: 401':
       case 'Bad status: 403':
-        throw new BadParameters('CALDAV_BAD_USERNAME_PASSWORD');
+        throw new BadParameters({ message: 'CALDAV_BAD_USERNAME_PASSWORD', log: e.message });
       case 'Bad status: 404':
-        throw new BadParameters('CALDAV_BAD_URL');
+        throw new BadParameters({ message: 'CALDAV_BAD_URL', log: e.message });
       default:
-        throw new Error400('CALDAV_BAD_SETTINGS_PRINCIPAL_URL');
+        throw new Error400({ message: 'CALDAV_BAD_SETTINGS_PRINCIPAL_URL', log: e.message });
     }
   }
 
@@ -75,7 +75,7 @@ async function config(userId) {
     CALDAV_HOME_URL = url.resolve(CALDAV_PRINCIPAL_URL, calendarHomeSet);
   } catch (e) {
     logger.error(e);
-    throw new Error400('CALDAV_BAD_SETTINGS_HOME_URL');
+    throw new Error400({ message: 'CALDAV_BAD_SETTINGS_HOME_URL', log: e.message });
   }
 
   logger.info(`CalDAV : Home URL found: ${CALDAV_HOME_URL}`);

--- a/server/services/caldav/lib/config/index.js
+++ b/server/services/caldav/lib/config/index.js
@@ -49,11 +49,11 @@ async function config(userId) {
     switch (e.message) {
       case 'Bad status: 401':
       case 'Bad status: 403':
-        throw new BadParameters({ message: 'CALDAV_BAD_USERNAME_PASSWORD', log: e.message });
+        throw new BadParameters({ message: 'CALDAV_BAD_USERNAME_PASSWORD', log: e.stack });
       case 'Bad status: 404':
-        throw new BadParameters({ message: 'CALDAV_BAD_URL', log: e.message });
+        throw new BadParameters({ message: 'CALDAV_BAD_URL', log: e.stack });
       default:
-        throw new Error400({ message: 'CALDAV_BAD_SETTINGS_PRINCIPAL_URL', log: e.message });
+        throw new Error400({ message: 'CALDAV_BAD_SETTINGS_PRINCIPAL_URL', log: e.stack });
     }
   }
 
@@ -75,7 +75,7 @@ async function config(userId) {
     CALDAV_HOME_URL = url.resolve(CALDAV_PRINCIPAL_URL, calendarHomeSet);
   } catch (e) {
     logger.error(e);
-    throw new Error400({ message: 'CALDAV_BAD_SETTINGS_HOME_URL', log: e.message });
+    throw new Error400({ message: 'CALDAV_BAD_SETTINGS_HOME_URL', log: e.stack });
   }
 
   logger.info(`CalDAV : Home URL found: ${CALDAV_HOME_URL}`);

--- a/server/test/services/caldav/lib/calendar/syncUserCalendars.test.js
+++ b/server/test/services/caldav/lib/calendar/syncUserCalendars.test.js
@@ -302,7 +302,9 @@ describe('CalDAV sync', () => {
 
     sync.requestCalendars.rejects();
 
-    await expect(sync.syncUserCalendars(userId)).to.be.rejectedWith(Error, 'CALDAV_FAILED_REQUEST_CALENDARS');
+    await expect(sync.syncUserCalendars(userId))
+      .to.be.rejectedWith(Error)
+      .and.eventually.have.nested.property('message.message', 'CALDAV_FAILED_REQUEST_CALENDARS');
   });
 
   it('should failed fetch changes', async () => {
@@ -354,7 +356,9 @@ describe('CalDAV sync', () => {
 
     sync.requestChanges.rejects();
 
-    await expect(sync.syncUserCalendars(userId)).to.be.rejectedWith(Error, 'CALDAV_FAILED_REQUEST_CHANGES');
+    await expect(sync.syncUserCalendars(userId))
+      .to.be.rejectedWith(Error)
+      .and.eventually.have.nested.property('message.message', 'CALDAV_FAILED_REQUEST_CHANGES');
   });
 
   it('should failed get events data', async () => {
@@ -421,6 +425,8 @@ describe('CalDAV sync', () => {
 
     sync.requestEventsData.rejects();
 
-    await expect(sync.syncUserCalendars(userId)).to.be.rejectedWith(Error, 'CALDAV_FAILED_REQUEST_EVENTS');
+    await expect(sync.syncUserCalendars(userId))
+      .to.be.rejectedWith(Error)
+      .and.eventually.have.nested.property('message.message', 'CALDAV_FAILED_REQUEST_EVENTS');
   });
 });

--- a/server/test/services/caldav/lib/config/index.test.js
+++ b/server/test/services/caldav/lib/config/index.test.js
@@ -127,7 +127,9 @@ describe('CalDAV config', () => {
       })
       .returns('request1');
 
-    await expect(configEnv.config(userId)).to.be.rejectedWith(Error, 'CALDAV_BAD_SETTINGS_PRINCIPAL_URL');
+    await expect(configEnv.config(userId))
+      .to.be.rejectedWith(Error)
+      .and.eventually.have.nested.property('message.message', 'CALDAV_BAD_SETTINGS_PRINCIPAL_URL');
   });
 
   it('should failed to get CALDAV_HOME_URL', async () => {
@@ -161,6 +163,8 @@ describe('CalDAV config', () => {
       })
       .returns('request2');
 
-    await expect(configEnv.config(userId)).to.be.rejectedWith(Error, 'CALDAV_BAD_SETTINGS_HOME_URL');
+    await expect(configEnv.config(userId))
+      .to.be.rejectedWith(Error)
+      .and.eventually.have.nested.property('message.message', 'CALDAV_BAD_SETTINGS_HOME_URL');
   });
 });

--- a/server/test/services/caldav/lib/config/index.test.js
+++ b/server/test/services/caldav/lib/config/index.test.js
@@ -106,7 +106,59 @@ describe('CalDAV config', () => {
     await expect(configEnv.config(userId)).to.be.rejectedWith(Error, 'MISSING_PARAMETERS');
   });
 
-  it('should failed to get CALDAV_PRINCIPAL_URL', async () => {
+  it('should failed with CALDAV_BAD_USERNAME_PASSWORD error', async () => {
+    configEnv.gladys.variable.getValue
+      .withArgs('CALDAV_URL', '5d6c666f-56be-4929-9104-718a78556844', userId)
+      .returns('https://caldav.host.com');
+    configEnv.gladys.variable.getValue
+      .withArgs('CALDAV_USERNAME', '5d6c666f-56be-4929-9104-718a78556844', userId)
+      .returns('tony');
+    configEnv.gladys.variable.getValue
+      .withArgs('CALDAV_PASSWORD', '5d6c666f-56be-4929-9104-718a78556844', userId)
+      .returns('12345');
+
+    send.withArgs('request1', 'https://caldav.host.com').rejects({ message: 'Bad status: 401' });
+
+    configEnv.dav.request.propfind
+      .withArgs({
+        props: [{ name: 'current-user-principal', namespace: namespace.DAV }],
+        depth: 0,
+        mergeResponses: true,
+      })
+      .returns('request1');
+
+    await expect(configEnv.config(userId))
+      .to.be.rejectedWith(Error)
+      .and.eventually.have.nested.property('message.message', 'CALDAV_BAD_USERNAME_PASSWORD');
+  });
+
+  it('should failed with CALDAV_BAD_URL error', async () => {
+    configEnv.gladys.variable.getValue
+      .withArgs('CALDAV_URL', '5d6c666f-56be-4929-9104-718a78556844', userId)
+      .returns('https://caldav.host.com');
+    configEnv.gladys.variable.getValue
+      .withArgs('CALDAV_USERNAME', '5d6c666f-56be-4929-9104-718a78556844', userId)
+      .returns('tony');
+    configEnv.gladys.variable.getValue
+      .withArgs('CALDAV_PASSWORD', '5d6c666f-56be-4929-9104-718a78556844', userId)
+      .returns('12345');
+
+    send.withArgs('request1', 'https://caldav.host.com').rejects({ message: 'Bad status: 404' });
+
+    configEnv.dav.request.propfind
+      .withArgs({
+        props: [{ name: 'current-user-principal', namespace: namespace.DAV }],
+        depth: 0,
+        mergeResponses: true,
+      })
+      .returns('request1');
+
+    await expect(configEnv.config(userId))
+      .to.be.rejectedWith(Error)
+      .and.eventually.have.nested.property('message.message', 'CALDAV_BAD_URL');
+  });
+
+  it('should failed with CALDAV_BAD_SETTINGS_PRINCIPAL_URL error', async () => {
     configEnv.gladys.variable.getValue
       .withArgs('CALDAV_URL', '5d6c666f-56be-4929-9104-718a78556844', userId)
       .returns('https://caldav.host.com');

--- a/server/test/services/caldav/lib/config/index.test.js
+++ b/server/test/services/caldav/lib/config/index.test.js
@@ -117,7 +117,7 @@ describe('CalDAV config', () => {
       .withArgs('CALDAV_PASSWORD', '5d6c666f-56be-4929-9104-718a78556844', userId)
       .returns('12345');
 
-    send.withArgs('request1', 'https://caldav.host.com').rejects({ message: 'Bad status: 401' });
+    send.withArgs('request1', 'https://caldav.host.com').rejects(new Error('Bad status: 401'));
 
     configEnv.dav.request.propfind
       .withArgs({
@@ -127,9 +127,16 @@ describe('CalDAV config', () => {
       })
       .returns('request1');
 
-    await expect(configEnv.config(userId))
-      .to.be.rejectedWith(Error)
-      .and.eventually.have.nested.property('message.message', 'CALDAV_BAD_USERNAME_PASSWORD');
+    try {
+      await configEnv.config(userId);
+      expect.fail('Expected config() to reject');
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+      expect(error).to.have.nested.property('message.message', 'CALDAV_BAD_USERNAME_PASSWORD');
+      expect(error)
+        .to.have.nested.property('message.log')
+        .that.is.a('string');
+    }
   });
 
   it('should failed with CALDAV_BAD_URL error', async () => {
@@ -143,7 +150,7 @@ describe('CalDAV config', () => {
       .withArgs('CALDAV_PASSWORD', '5d6c666f-56be-4929-9104-718a78556844', userId)
       .returns('12345');
 
-    send.withArgs('request1', 'https://caldav.host.com').rejects({ message: 'Bad status: 404' });
+    send.withArgs('request1', 'https://caldav.host.com').rejects(new Error('Bad status: 404'));
 
     configEnv.dav.request.propfind
       .withArgs({
@@ -153,9 +160,16 @@ describe('CalDAV config', () => {
       })
       .returns('request1');
 
-    await expect(configEnv.config(userId))
-      .to.be.rejectedWith(Error)
-      .and.eventually.have.nested.property('message.message', 'CALDAV_BAD_URL');
+    try {
+      await configEnv.config(userId);
+      expect.fail('Expected config() to reject');
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+      expect(error).to.have.nested.property('message.message', 'CALDAV_BAD_URL');
+      expect(error)
+        .to.have.nested.property('message.log')
+        .that.is.a('string');
+    }
   });
 
   it('should failed with CALDAV_BAD_SETTINGS_PRINCIPAL_URL error', async () => {
@@ -169,7 +183,7 @@ describe('CalDAV config', () => {
       .withArgs('CALDAV_PASSWORD', '5d6c666f-56be-4929-9104-718a78556844', userId)
       .returns('12345');
 
-    send.withArgs('request1', 'https://caldav.host.com').rejects();
+    send.withArgs('request1', 'https://caldav.host.com').rejects(new Error());
 
     configEnv.dav.request.propfind
       .withArgs({
@@ -179,9 +193,16 @@ describe('CalDAV config', () => {
       })
       .returns('request1');
 
-    await expect(configEnv.config(userId))
-      .to.be.rejectedWith(Error)
-      .and.eventually.have.nested.property('message.message', 'CALDAV_BAD_SETTINGS_PRINCIPAL_URL');
+    try {
+      await configEnv.config(userId);
+      expect.fail('Expected config() to reject');
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+      expect(error).to.have.nested.property('message.message', 'CALDAV_BAD_SETTINGS_PRINCIPAL_URL');
+      expect(error)
+        .to.have.nested.property('message.log')
+        .that.is.a('string');
+    }
   });
 
   it('should failed to get CALDAV_HOME_URL', async () => {
@@ -199,7 +220,7 @@ describe('CalDAV config', () => {
       .withArgs('request1', 'https://caldav.host.com')
       .returns({ props: { currentUserPrincipal: 'https://caldav.host.com/principal' } })
       .withArgs('request2', 'https://caldav.host.com/principal')
-      .rejects();
+      .rejects(new Error());
 
     configEnv.dav.request.propfind
       .withArgs({
@@ -215,8 +236,15 @@ describe('CalDAV config', () => {
       })
       .returns('request2');
 
-    await expect(configEnv.config(userId))
-      .to.be.rejectedWith(Error)
-      .and.eventually.have.nested.property('message.message', 'CALDAV_BAD_SETTINGS_HOME_URL');
+    try {
+      await configEnv.config(userId);
+      expect.fail('Expected config() to reject');
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+      expect(error).to.have.nested.property('message.message', 'CALDAV_BAD_SETTINGS_HOME_URL');
+      expect(error)
+        .to.have.nested.property('message.log')
+        .that.is.a('string');
+    }
   });
 });


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

I added caldav config/sync errors logs in service configuration

https://community.gladysassistant.com/t/pb-synchronisation-calendrier/10114/11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collapsible, toggleable CalDAV diagnostic log added to the account UI with localized labels ("Log"/"Protokoll"/"Journal").

* **Bug Fixes**
  * CalDAV errors now carry structured messages and logs; logs are displayed when present and cleared on save/sync/cleanup actions.

* **Tests**
  * CalDAV tests updated to validate the new structured error payload format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->