### PR TITLE
Matterbridge: Should correctly save current version to upgrade only once

### DIFF
--- a/server/services/matterbridge/lib/init.js
+++ b/server/services/matterbridge/lib/init.js
@@ -28,11 +28,12 @@ async function init() {
   // Load stored configuration
   const configuration = await this.getConfiguration();
 
-  await this.saveConfiguration(configuration);
-
   logger.debug('Matterbridge: installing and starting required docker containers...');
   await this.checkForContainerUpdates(configuration);
   await this.installContainer(configuration);
+
+  // Save configuration after checkForContainerUpdates has updated the version
+  await this.saveConfiguration(configuration);
 }
 
 module.exports = {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.


### Description of change

Mattebridge is always restarting even if no upgrade is needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration persistence to properly save container updates and version changes after installation completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->