### PR TITLE
fix: use numeric bitmap for ColorControl optionsMask

### DIFF
--- a/server/services/matter/lib/matter.setValue.js
+++ b/server/services/matter/lib/matter.setValue.js
@@ -160,11 +160,9 @@ async function setValue(gladysDevice, gladysFeature, value) {
     await colorControl.moveToHueAndSaturation({
       hue: matterHue,
       saturation: matterSaturation,
-      transitionTime: null,
-      optionsMask: {
-        executeIfOff: true,
-      },
-      optionsOverride: {},
+      transitionTime: 0,
+      optionsMask: 1, // bitmap: bit 0 = executeIfOff
+      optionsOverride: 1, // bitmap: bit 0 = executeIfOff
     });
     // If the user changes the color, we needs to turn on the light
     await onOff.on();

--- a/server/test/services/matter/lib/matter.setValue.test.js
+++ b/server/test/services/matter/lib/matter.setValue.test.js
@@ -328,11 +328,9 @@ describe('Matter.setValue', () => {
     assert.calledWith(clusterClient.moveToHueAndSaturation, {
       hue: 100,
       saturation: 41,
-      transitionTime: null,
-      optionsMask: {
-        executeIfOff: true,
-      },
-      optionsOverride: {},
+      transitionTime: 0,
+      optionsMask: 1,
+      optionsOverride: 1,
     });
     assert.calledOnce(onOff.on);
   });


### PR DESCRIPTION
## Description of Change

`ColorControl.moveToHueAndSaturation` expects `optionsMask` and `optionsOverride` as **uint8 numbers** (raw bitmap), unlike `LevelControl.moveToLevel` which accepts typed bitmap objects.

Passing `{ executeIfOff: true }` (object) causes a TLV validation crash:

```
ValidationDatatypeMismatchError/128: Expected number, got object.
  at TlvNumberSchema.validate
  at Object.ClusterClient.commands [as moveToHueAndSaturation]
  at MatterHandler.setValue (matter.setValue.js:160)
```

This breaks **all color changes** on Matter devices. On/off and brightness work fine since they use different clusters.

### Fix

| Parameter | Before (broken) | After (fixed) |
|---|---|---|
| `optionsMask` | `{ executeIfOff: true }` | `1` (bit 0 = executeIfOff) |
| `optionsOverride` | `{}` | `1` (executeIfOff = true) |
| `transitionTime` | `null` | `0` (instant) |

Test assertions updated accordingly.

### Tested with

- Matterbridge devices (Magic Home LED controllers exposed as Matter lights via [matterbridge-magic-home](https://github.com/david-digitis/matterbridge-magic-home))
- Gladys 4.58 on Docker (Synology NAS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved light color control parameter handling for internal optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->