### PR TITLE
Nuki: Should not process all homeassistant discovery messages

### DIFF
--- a/server/services/nuki/lib/mqtt/index.js
+++ b/server/services/nuki/lib/mqtt/index.js
@@ -19,6 +19,10 @@ const NukiMQTTHandler = function NukiMQTTHandler(nukiHandler) {
   this.mqttService = this.nukiHandler.gladys.service.getService('mqtt');
   // Found devices
   this.discoveredDevices = {};
+  // Scan timeout handle
+  this.scanTimeout = null;
+  // Discovery window duration in ms (can be overridden in tests)
+  this.scanTimeoutMs = 60 * 1000; // 1 minute
 };
 
 // Commons

--- a/server/services/nuki/lib/mqtt/nuki.mqtt.connect.js
+++ b/server/services/nuki/lib/mqtt/nuki.mqtt.connect.js
@@ -1,5 +1,4 @@
 const logger = require('../../../../utils/logger');
-const { DISCOVERY_TOPIC } = require('../utils/nuki.constants');
 
 /**
  * @description Initialize service with dependencies and connect to devices.
@@ -9,10 +8,9 @@ const { DISCOVERY_TOPIC } = require('../utils/nuki.constants');
 async function connect() {
   logger.debug('MQTT Connect');
 
-  // Subscribe to Nuki topics
-  // discover topic
-  this.mqttService.device.subscribe(DISCOVERY_TOPIC, this.handleMessage.bind(this));
-  // Devices topics
+  // Subscribe to existing Nuki device topics only
+  // Discovery topic (homeassistant/#) is only subscribed during scan() to avoid
+  // processing all Home Assistant MQTT messages when not actively discovering
   const devices = await this.nukiHandler.gladys.device.get({ service_id: this.nukiHandler.serviceId });
   devices.forEach((device) => {
     this.subscribeDeviceTopic(device);

--- a/server/services/nuki/lib/mqtt/nuki.mqtt.connect.js
+++ b/server/services/nuki/lib/mqtt/nuki.mqtt.connect.js
@@ -11,7 +11,7 @@ async function connect() {
   // Subscribe to existing Nuki device topics only
   // Discovery topic (homeassistant/#) is only subscribed during scan() to avoid
   // processing all Home Assistant MQTT messages when not actively discovering
-  const devices = await this.nukiHandler.gladys.device.get({ service_id: this.nukiHandler.serviceId });
+  const devices = await this.nukiHandler.gladys.device.get({ service: 'nuki' });
   devices.forEach((device) => {
     this.subscribeDeviceTopic(device);
   });

--- a/server/services/nuki/lib/mqtt/nuki.mqtt.disconnect.js
+++ b/server/services/nuki/lib/mqtt/nuki.mqtt.disconnect.js
@@ -18,7 +18,7 @@ async function disconnect() {
   // Unsubscribe to Nuki topics
   this.mqttService.device.unsubscribe(DISCOVERY_TOPIC);
   // Unsubscribe devices topics
-  const devices = await this.nukiHandler.gladys.device.get({ service_id: this.nukiHandler.serviceId });
+  const devices = await this.nukiHandler.gladys.device.get({ service: 'nuki' });
   devices.forEach((device) => {
     const topic = `nuki/${device.external_id.split(':')[1]}/#`;
     this.mqttService.device.unsubscribe(topic);

--- a/server/services/nuki/lib/mqtt/nuki.mqtt.disconnect.js
+++ b/server/services/nuki/lib/mqtt/nuki.mqtt.disconnect.js
@@ -8,6 +8,13 @@ const { DISCOVERY_TOPIC } = require('../utils/nuki.constants');
  */
 async function disconnect() {
   logger.debug(`Call MQTT disconnect`);
+
+  // Clear scan timeout if active
+  if (this.scanTimeout) {
+    clearTimeout(this.scanTimeout);
+    this.scanTimeout = null;
+  }
+
   // Unsubscribe to Nuki topics
   this.mqttService.device.unsubscribe(DISCOVERY_TOPIC);
   // Unsubscribe devices topics

--- a/server/services/nuki/lib/mqtt/nuki.mqtt.handleMessage.js
+++ b/server/services/nuki/lib/mqtt/nuki.mqtt.handleMessage.js
@@ -21,19 +21,18 @@ function handleMessage(topic, message) {
   let device;
   if (main === 'homeassistant') {
     // Only process Nuki devices from Home Assistant discovery
-    // Check if message contains Nuki manufacturer identifier before processing
-    if (!message || !message.includes('"mf":"Nuki"')) {
+    if (!message || !message.includes('"Nuki"')) {
       return;
     }
     logger.debug(topic, deviceType);
     try {
       device = this.convertToDevice(message);
-      this.discoveredDevices[device.external_id] = device;
-      this.nukiHandler.notifyNewDevice(device, WEBSOCKET_MESSAGE_TYPES.NUKI.NEW_MQTT_DEVICE);
     } catch (e) {
       logger.debug(`MQTT : Unable to parse Nuki discovery message: ${e.message}`);
       return;
     }
+    this.discoveredDevices[device.external_id] = device;
+    this.nukiHandler.notifyNewDevice(device, WEBSOCKET_MESSAGE_TYPES.NUKI.NEW_MQTT_DEVICE);
   } else if (main === 'nuki') {
     let externalId;
     const { gladys } = this.nukiHandler;

--- a/server/services/nuki/lib/mqtt/nuki.mqtt.handleMessage.js
+++ b/server/services/nuki/lib/mqtt/nuki.mqtt.handleMessage.js
@@ -20,10 +20,20 @@ function handleMessage(topic, message) {
 
   let device;
   if (main === 'homeassistant') {
+    // Only process Nuki devices from Home Assistant discovery
+    // Check if message contains Nuki manufacturer identifier before processing
+    if (!message || !message.includes('"mf":"Nuki"')) {
+      return;
+    }
     logger.debug(topic, deviceType);
-    device = this.convertToDevice(message);
-    this.discoveredDevices[device.external_id] = device;
-    this.nukiHandler.notifyNewDevice(device, WEBSOCKET_MESSAGE_TYPES.NUKI.NEW_MQTT_DEVICE);
+    try {
+      device = this.convertToDevice(message);
+      this.discoveredDevices[device.external_id] = device;
+      this.nukiHandler.notifyNewDevice(device, WEBSOCKET_MESSAGE_TYPES.NUKI.NEW_MQTT_DEVICE);
+    } catch (e) {
+      logger.debug(`MQTT : Unable to parse Nuki discovery message: ${e.message}`);
+      return;
+    }
   } else if (main === 'nuki') {
     let externalId;
     const { gladys } = this.nukiHandler;

--- a/server/services/nuki/lib/mqtt/nuki.mqtt.scan.js
+++ b/server/services/nuki/lib/mqtt/nuki.mqtt.scan.js
@@ -1,3 +1,4 @@
+const logger = require('../../../../utils/logger');
 const { DISCOVERY_TOPIC } = require('../utils/nuki.constants');
 const { ServiceNotConfiguredError } = require('../../../../utils/coreErrors');
 
@@ -11,9 +12,23 @@ async function scan() {
   if (!mqttOk) {
     throw new ServiceNotConfiguredError('Unable to discover Nuki devices until MQTT service is configured');
   }
-  // Subscribe to Nuki
+
+  // Clear any existing scan timeout
+  if (this.scanTimeout) {
+    clearTimeout(this.scanTimeout);
+  }
+
+  // Subscribe to discovery topic
   this.mqttService.device.unsubscribe(DISCOVERY_TOPIC);
   this.mqttService.device.subscribe(DISCOVERY_TOPIC, this.handleMessage.bind(this));
+  logger.debug(`Nuki: Subscribed to ${DISCOVERY_TOPIC} for discovery`);
+
+  // Automatically unsubscribe after scan timeout to avoid processing all homeassistant messages
+  this.scanTimeout = setTimeout(() => {
+    this.mqttService.device.unsubscribe(DISCOVERY_TOPIC);
+    logger.debug(`Nuki: Unsubscribed from ${DISCOVERY_TOPIC} after scan timeout`);
+    this.scanTimeout = null;
+  }, this.scanTimeoutMs);
 }
 
 module.exports = {

--- a/server/test/services/nuki/lib/mqtt/nuki.mqtt.connect.test.js
+++ b/server/test/services/nuki/lib/mqtt/nuki.mqtt.connect.test.js
@@ -36,8 +36,10 @@ describe('nuki.mqtt.connect command', () => {
   it('should connect to search mqtt topic and subscribe to specific device mqtt topic', async () => {
     await nukiHandler.connect();
     assert.calledWith(gladys.service.getService, 'mqtt');
-    assert.callCount(mqttService.device.subscribe, 2);
-    mqttService.device.subscribe.firstCall.calledWith('stat/+/+', nukiHandler.handleMessage.bind(nukiHandler));
+    // Only subscribes to device topics, not discovery topic (homeassistant/#)
+    // Discovery topic is only subscribed during scan()
+    assert.callCount(mqttService.device.subscribe, 1);
+    assert.calledWith(mqttService.device.subscribe, 'nuki/398172F4/#', sinon.match.func);
     assert.calledOnce(nukiHandler.subscribeDeviceTopic);
   });
 });

--- a/server/test/services/nuki/lib/mqtt/nuki.mqtt.connect.test.js
+++ b/server/test/services/nuki/lib/mqtt/nuki.mqtt.connect.test.js
@@ -36,6 +36,9 @@ describe('nuki.mqtt.connect command', () => {
   it('should subscribe to existing device topics only (not discovery topic)', async () => {
     await nukiHandler.connect();
     assert.calledWith(gladys.service.getService, 'mqtt');
+    // Verify device.get is called with correct service filter
+    assert.calledOnce(gladys.device.get);
+    assert.calledWith(gladys.device.get, { service: 'nuki' });
     // Only subscribes to device topics, not discovery topic (homeassistant/#)
     // Discovery topic is only subscribed during scan()
     assert.callCount(mqttService.device.subscribe, 1);

--- a/server/test/services/nuki/lib/mqtt/nuki.mqtt.connect.test.js
+++ b/server/test/services/nuki/lib/mqtt/nuki.mqtt.connect.test.js
@@ -33,7 +33,7 @@ describe('nuki.mqtt.connect command', () => {
     sinon.reset();
   });
 
-  it('should connect to search mqtt topic and subscribe to specific device mqtt topic', async () => {
+  it('should subscribe to existing device topics only (not discovery topic)', async () => {
     await nukiHandler.connect();
     assert.calledWith(gladys.service.getService, 'mqtt');
     // Only subscribes to device topics, not discovery topic (homeassistant/#)

--- a/server/test/services/nuki/lib/mqtt/nuki.mqtt.disconnect.test.js
+++ b/server/test/services/nuki/lib/mqtt/nuki.mqtt.disconnect.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 
-const { fake } = sinon;
+const { assert, fake } = sinon;
 const { serviceId } = require('../../mocks/consts.test');
 const { mqttService } = require('../../mocks/mqtt.mock.test');
 const NukiHandler = require('../../../../../services/nuki/lib');
@@ -30,8 +30,11 @@ describe('Nuki - MQTT - disconnect', () => {
     sinon.reset();
   });
 
-  it('should disconnect with unsubscription of all devices topics', () => {
-    nukiHandler.disconnect();
+  it('should disconnect with unsubscription of all devices topics', async () => {
+    await nukiHandler.disconnect();
+    // Verify device.get is called with correct service filter
+    assert.calledOnce(gladys.device.get);
+    assert.calledWith(gladys.device.get, { service: 'nuki' });
     nukiHandler.mqttService.device.unsubscribe.firstCall.calledWith('homeassistant/#');
     // nukiHandler.mqttService.device.unsubscribe.secondCall.calledWith('nuki/4242/#');
     // nukiHandler.mqttService.device.unsubscribe.thirdCall.calledWith('nuki/4343/#');

--- a/server/test/services/nuki/lib/mqtt/nuki.mqtt.disconnect.test.js
+++ b/server/test/services/nuki/lib/mqtt/nuki.mqtt.disconnect.test.js
@@ -1,3 +1,4 @@
+const { expect } = require('chai');
 const sinon = require('sinon');
 
 const { fake } = sinon;
@@ -34,5 +35,25 @@ describe('Nuki - MQTT - disconnect', () => {
     nukiHandler.mqttService.device.unsubscribe.firstCall.calledWith('homeassistant/#');
     // nukiHandler.mqttService.device.unsubscribe.secondCall.calledWith('nuki/4242/#');
     // nukiHandler.mqttService.device.unsubscribe.thirdCall.calledWith('nuki/4343/#');
+  });
+
+  it('should clear scan timeout on disconnect', async () => {
+    // Simulate an active scan timeout
+    const fakeTimeout = setTimeout(() => {}, 10000);
+    nukiHandler.scanTimeout = fakeTimeout;
+
+    await nukiHandler.disconnect();
+
+    expect(nukiHandler.scanTimeout).to.equal(null);
+  });
+
+  it('should handle disconnect when no scan timeout is active', async () => {
+    // Ensure scanTimeout is null
+    nukiHandler.scanTimeout = null;
+
+    // Should not throw
+    await nukiHandler.disconnect();
+
+    expect(nukiHandler.scanTimeout).to.equal(null);
   });
 });

--- a/server/test/services/nuki/lib/mqtt/nuki.mqtt.handleMessage.test.js
+++ b/server/test/services/nuki/lib/mqtt/nuki.mqtt.handleMessage.test.js
@@ -141,4 +141,27 @@ describe('Nuki - MQTT - Handle message', () => {
     assert.notCalled(mqttService.device.publish);
     assert.notCalled(gladys.event.emit);
   });
+
+  it('should handle malformed Nuki discovery message (contains "Nuki" but invalid JSON)', () => {
+    // This message contains "Nuki" so it passes the filter, but is not valid JSON
+    nukiHandler.handleMessage('homeassistant/lock/nuki_test/config', 'invalid json with "Nuki" in it');
+    assert.notCalled(mqttService.device.publish);
+    assert.notCalled(gladys.event.emit);
+    expect(nukiHandler.discoveredDevices).to.deep.equal({});
+  });
+
+  it('should handle Nuki message with missing required fields', () => {
+    // Valid JSON with "Nuki" but missing dev.ids field
+    const invalidNukiMessage = JSON.stringify({
+      name: 'Test',
+      dev: {
+        mf: 'Nuki',
+        name: 'Test Lock',
+      },
+    });
+    nukiHandler.handleMessage('homeassistant/lock/nuki_test/config', invalidNukiMessage);
+    assert.notCalled(mqttService.device.publish);
+    assert.notCalled(gladys.event.emit);
+    expect(nukiHandler.discoveredDevices).to.deep.equal({});
+  });
 });

--- a/server/test/services/nuki/lib/mqtt/nuki.mqtt.handleMessage.test.js
+++ b/server/test/services/nuki/lib/mqtt/nuki.mqtt.handleMessage.test.js
@@ -85,4 +85,60 @@ describe('Nuki - MQTT - Handle message', () => {
     assert.notCalled(mqttService.device.publish);
     assert.calledOnce(gladys.event.emit);
   });
+
+  it('should ignore non-Nuki homeassistant discovery messages (Zigbee2MQTT)', () => {
+    const zigbee2mqttMessage = JSON.stringify({
+      availability: [{ topic: 'zigbee2mqtt/bridge/state' }],
+      device: {
+        identifiers: ['zigbee2mqtt_0x00158d0001234567'],
+        manufacturer: 'Xiaomi',
+        model: 'Aqara temperature sensor',
+        name: 'Temperature Sensor',
+      },
+      name: 'Temperature',
+      state_topic: 'zigbee2mqtt/Temperature Sensor',
+      unique_id: '0x00158d0001234567_temperature_zigbee2mqtt',
+    });
+    nukiHandler.handleMessage('homeassistant/sensor/0x00158d0001234567/temperature/config', zigbee2mqttMessage);
+    assert.notCalled(mqttService.device.publish);
+    assert.notCalled(gladys.event.emit);
+    expect(nukiHandler.discoveredDevices).to.deep.equal({});
+  });
+
+  it('should ignore non-Nuki homeassistant discovery messages (Tasmota)', () => {
+    const tasmotaMessage = JSON.stringify({
+      name: 'Tasmota Switch',
+      stat_t: 'tele/tasmota_switch/STATE',
+      avty_t: 'tele/tasmota_switch/LWT',
+      pl_avail: 'Online',
+      pl_not_avail: 'Offline',
+      cmd_t: 'cmnd/tasmota_switch/POWER',
+      val_tpl: '{{value_json.POWER}}',
+      pl_off: 'OFF',
+      pl_on: 'ON',
+      uniq_id: 'tasmota_switch_RL_1',
+      dev: {
+        ids: ['tasmota_switch'],
+        name: 'Tasmota Switch',
+        mdl: 'Sonoff Basic',
+        mf: 'Tasmota',
+      },
+    });
+    nukiHandler.handleMessage('homeassistant/switch/tasmota_switch/config', tasmotaMessage);
+    assert.notCalled(mqttService.device.publish);
+    assert.notCalled(gladys.event.emit);
+    expect(nukiHandler.discoveredDevices).to.deep.equal({});
+  });
+
+  it('should ignore empty homeassistant messages', () => {
+    nukiHandler.handleMessage('homeassistant/sensor/test/config', '');
+    assert.notCalled(mqttService.device.publish);
+    assert.notCalled(gladys.event.emit);
+  });
+
+  it('should ignore malformed homeassistant messages', () => {
+    nukiHandler.handleMessage('homeassistant/sensor/test/config', 'not valid json');
+    assert.notCalled(mqttService.device.publish);
+    assert.notCalled(gladys.event.emit);
+  });
 });

--- a/server/test/services/nuki/lib/mqtt/nuki.mqtt.scan.test.js
+++ b/server/test/services/nuki/lib/mqtt/nuki.mqtt.scan.test.js
@@ -18,13 +18,21 @@ const gladys = {
 
 describe('nuki.mqtt.scan command', () => {
   let nukiHandler;
+  let clock;
 
   beforeEach(() => {
     sinon.reset();
+    clock = sinon.useFakeTimers();
     const nuki = new NukiHandler(gladys, serviceId);
     nukiHandler = new NukiMQTTHandler(nuki);
     nukiHandler.mqttService = mqttService;
+    // Use short timeout for tests
+    nukiHandler.scanTimeoutMs = 100;
     sinon.spy(nukiHandler, 'handleMessage');
+  });
+
+  afterEach(() => {
+    clock.restore();
   });
 
   it('should subscribe to mqtt topic', async () => {
@@ -44,5 +52,45 @@ describe('nuki.mqtt.scan command', () => {
     await expect(nukiHandler.scan()).to.be.rejectedWith(Error);
     assert.notCalled(nukiHandler.mqttService.device.unsubscribe);
     assert.notCalled(nukiHandler.mqttService.device.subscribe);
+  });
+
+  it('should unsubscribe from discovery topic after timeout', async () => {
+    mqttService.isUsed = fake.resolves(true);
+    await nukiHandler.scan();
+
+    // Verify initial subscription
+    assert.callCount(nukiHandler.mqttService.device.subscribe, 1);
+    assert.callCount(nukiHandler.mqttService.device.unsubscribe, 1);
+
+    // Fast-forward past the scan timeout
+    clock.tick(100);
+
+    // Should have unsubscribed from discovery topic
+    assert.callCount(nukiHandler.mqttService.device.unsubscribe, 2);
+    expect(nukiHandler.scanTimeout).to.equal(null);
+  });
+
+  it('should clear previous timeout when scanning again', async () => {
+    mqttService.isUsed = fake.resolves(true);
+
+    // First scan
+    await nukiHandler.scan();
+    const firstTimeout = nukiHandler.scanTimeout;
+    expect(firstTimeout).to.not.equal(null);
+
+    // Second scan before timeout expires
+    clock.tick(50);
+    await nukiHandler.scan();
+
+    // Should have a new timeout
+    expect(nukiHandler.scanTimeout).to.not.equal(null);
+
+    // Fast-forward past the new timeout
+    clock.tick(100);
+
+    // Should only have 2 unsubscribes from scan() calls + 1 from timeout
+    // (first timeout was cleared, only second one fired)
+    assert.callCount(nukiHandler.mqttService.device.unsubscribe, 3);
+    expect(nukiHandler.scanTimeout).to.equal(null);
   });
 });


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

Nuki: Should not process all homeassistant discovery messages (https://community.gladysassistant.com/t/titel-high-cpu-usage-60-with-v4-70-0-fixed-by-downgrading-to-v4-66-8/10126/19?u=pierre-gilles) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation and early-exit for Home Assistant discovery messages missing expected content.
  * Improved error handling so malformed or unparsable discovery payloads are logged and safely ignored.

* **Tests**
  * Expanded unit tests for discovery handling: non-Nuki payloads, empty/malformed messages, invalid JSON, and missing discovery fields.
  * Added tests for timed scan behavior and timeout clearing.

* **Chores**
  * Stopped subscribing to broad Home Assistant discovery topics during normal connection.
  * Implemented a bounded discovery scan with automatic unsubscribe and ensured scan timers are cleared on disconnect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->