### PR TITLE
Energy monitoring: Add new refresh at 16:10 for Enedis late data

### DIFF
--- a/server/services/energy-monitoring/lib/energy-monitoring.init.js
+++ b/server/services/energy-monitoring/lib/energy-monitoring.init.js
@@ -36,7 +36,7 @@ async function init() {
     rule.hour = 11;
     rule.minute = 10;
     rule.tz = systemTimezone;
-    // Scheduling consumption and cost calculation every day at 9AM
+    // Scheduling consumption and cost calculation every day at 11:10
     this.calculateConsumptionAndCostEvery24HoursJob = this.gladys.scheduler.scheduleJob(rule, async () => {
       const yesterdayDate = dayjs
         .tz(dayjs(), systemTimezone)
@@ -49,13 +49,13 @@ async function init() {
     });
   }
 
-  // Re-calculate yesterday at 11 AM (useful for enedis)
+  // Re-calculate yesterday at 16:10 (useful for late enedis data)
   if (!this.calculateConsumptionAndCostEvery24HoursLastJob) {
     const rule = new schedule.RecurrenceRule();
     rule.hour = 16;
     rule.minute = 10;
     rule.tz = systemTimezone;
-    // Scheduling consumption and cost calculation every day at 9AM
+    // Scheduling consumption and cost calculation every day at 16:10
     this.calculateConsumptionAndCostEvery24HoursLastJob = this.gladys.scheduler.scheduleJob(rule, async () => {
       const yesterdayDate = dayjs
         .tz(dayjs(), systemTimezone)

--- a/server/services/energy-monitoring/lib/energy-monitoring.init.js
+++ b/server/services/energy-monitoring/lib/energy-monitoring.init.js
@@ -49,6 +49,25 @@ async function init() {
     });
   }
 
+  // Re-calculate yesterday at 11 AM (useful for enedis)
+  if (!this.calculateConsumptionAndCostEvery24HoursLastJob) {
+    const rule = new schedule.RecurrenceRule();
+    rule.hour = 16;
+    rule.minute = 10;
+    rule.tz = systemTimezone;
+    // Scheduling consumption and cost calculation every day at 9AM
+    this.calculateConsumptionAndCostEvery24HoursLastJob = this.gladys.scheduler.scheduleJob(rule, async () => {
+      const yesterdayDate = dayjs
+        .tz(dayjs(), systemTimezone)
+        .subtract(1, 'day')
+        .startOf('day')
+        .toDate();
+
+      // Add to queue
+      await this.calculateCostFromYesterday(yesterdayDate);
+    });
+  }
+
   return null;
 }
 

--- a/server/test/services/energy-monitoring/energy-monitoring.init.test.js
+++ b/server/test/services/energy-monitoring/energy-monitoring.init.test.js
@@ -281,5 +281,38 @@ describe('EnergyMonitoring.init', () => {
         clock.restore();
       }
     });
+    it('should execute calculateCostFromYesterday with yesterday at midnight when 16:10 daily job runs', async () => {
+      // Use sinon fake timers to mock a specific time
+      const clock = useFakeTimers(new Date('2023-10-15T09:00:00.000Z'));
+
+      try {
+        await energyMonitoring.init();
+
+        // Get the 16:10 daily job function (third call)
+        const dailyJobFunction = mockScheduler.scheduleJob.getCall(2).args[1];
+
+        // Execute the daily job
+        await dailyJobFunction();
+
+        // Verify calculateCostFromYesterday was called
+        assert.calledOnce(calculateCostFromYesterday);
+
+        const callArgs = calculateCostFromYesterday.getCall(0).args;
+        const yesterdayDate = callArgs[0];
+
+        // Should be yesterday at midnight in Europe/Paris timezone
+        expect(yesterdayDate).to.be.instanceOf(Date);
+        // October 14, 2023 at midnight in Europe/Paris (CEST = UTC+2)
+        // So midnight Paris = 22:00 UTC on Oct 13
+        expect(yesterdayDate.getUTCFullYear()).to.equal(2023);
+        expect(yesterdayDate.getUTCMonth()).to.equal(9); // October (0-indexed)
+        expect(yesterdayDate.getUTCDate()).to.equal(13);
+        expect(yesterdayDate.getUTCHours()).to.equal(22); // Midnight Paris = 22:00 UTC (CEST)
+        expect(yesterdayDate.getUTCMinutes()).to.equal(0);
+        expect(yesterdayDate.getUTCSeconds()).to.equal(0);
+      } finally {
+        clock.restore();
+      }
+    });
   });
 });

--- a/server/test/services/energy-monitoring/energy-monitoring.init.test.js
+++ b/server/test/services/energy-monitoring/energy-monitoring.init.test.js
@@ -61,7 +61,7 @@ describe('EnergyMonitoring.init', () => {
     await energyMonitoring.init();
 
     // Verify both jobs are scheduled (30 min job + 24h job)
-    assert.calledTwice(mockScheduler.scheduleJob);
+    assert.calledThrice(mockScheduler.scheduleJob);
 
     // Verify combined job (at 00:00 and 00:30)
     const jobCall = mockScheduler.scheduleJob.getCall(0);
@@ -77,6 +77,15 @@ describe('EnergyMonitoring.init', () => {
     expect(rule).to.have.property('tz', 'Europe/Paris');
     expect(typeof dailyJobCall.args[1]).to.equal('function');
 
+     // Verify 24h job uses RecurrenceRule with timezone
+    const lastDailyJobCall = mockScheduler.scheduleJob.getCall(2);
+    const rule2 = lastDailyJobCall.args[0];
+    expect(rule2).to.have.property('recurs', true);
+    expect(rule2).to.have.property('hour', 16);
+    expect(rule2).to.have.property('minute', 10);
+    expect(rule2).to.have.property('tz', 'Europe/Paris');
+    expect(typeof lastDailyJobCall.args[1]).to.equal('function');
+
     // Verify job IDs are stored
     expect(energyMonitoring.calculateConsumptionAndCostEvery30MinutesJob).to.equal('mock-job-id');
     expect(energyMonitoring.calculateConsumptionAndCostEvery24HoursJob).to.equal('mock-job-id');
@@ -86,6 +95,7 @@ describe('EnergyMonitoring.init', () => {
     // Set existing job IDs
     energyMonitoring.calculateConsumptionAndCostEvery30MinutesJob = 'existing-job';
     energyMonitoring.calculateConsumptionAndCostEvery24HoursJob = 'existing-daily-job';
+    energyMonitoring.calculateConsumptionAndCostEvery24HoursLastJob = 'existing-last-daily-job';
 
     await energyMonitoring.init();
 
@@ -95,6 +105,7 @@ describe('EnergyMonitoring.init', () => {
     // Verify existing job IDs are preserved
     expect(energyMonitoring.calculateConsumptionAndCostEvery30MinutesJob).to.equal('existing-job');
     expect(energyMonitoring.calculateConsumptionAndCostEvery24HoursJob).to.equal('existing-daily-job');
+    expect(energyMonitoring.calculateConsumptionAndCostEvery24HoursLastJob).to.equal('existing-last-daily-job');
   });
 
   it('should schedule job if not already scheduled', async () => {
@@ -104,8 +115,8 @@ describe('EnergyMonitoring.init', () => {
 
     await energyMonitoring.init();
 
-    // Verify both jobs are scheduled
-    assert.calledTwice(mockScheduler.scheduleJob);
+    // Verify all jobs are scheduled
+    assert.calledThrice(mockScheduler.scheduleJob);
 
     const jobCall = mockScheduler.scheduleJob.getCall(0);
     expect(jobCall.args[0]).to.equal('0 0,30 * * * *');

--- a/server/test/services/energy-monitoring/energy-monitoring.init.test.js
+++ b/server/test/services/energy-monitoring/energy-monitoring.init.test.js
@@ -77,7 +77,7 @@ describe('EnergyMonitoring.init', () => {
     expect(rule).to.have.property('tz', 'Europe/Paris');
     expect(typeof dailyJobCall.args[1]).to.equal('function');
 
-     // Verify 24h job uses RecurrenceRule with timezone
+    // Verify 24h job uses RecurrenceRule with timezone
     const lastDailyJobCall = mockScheduler.scheduleJob.getCall(2);
     const rule2 = lastDailyJobCall.args[0];
     expect(rule2).to.have.property('recurs', true);

--- a/server/test/services/energy-monitoring/index.test.js
+++ b/server/test/services/energy-monitoring/index.test.js
@@ -35,7 +35,7 @@ describe('EnergyMonitoring Service', () => {
     await energyMonitoringService.start();
 
     // Verify scheduler was called to schedule both jobs (30 min + 24h)
-    assert.calledTwice(mockScheduler.scheduleJob);
+    assert.calledThrice(mockScheduler.scheduleJob);
 
     // Verify that 30-minute job is scheduled
     const thirtyMinJobCall = mockScheduler.scheduleJob.getCall(0);
@@ -47,6 +47,13 @@ describe('EnergyMonitoring Service', () => {
     expect(rule).to.have.property('hour', 11);
     expect(rule).to.have.property('minute', 10);
     expect(rule).to.have.property('tz', 'Europe/Paris');
+
+    // Verify that 24h job is scheduled with RecurrenceRule
+    const dailyJobCall2 = mockScheduler.scheduleJob.getCall(2);
+    const rule2 = dailyJobCall2.args[0];
+    expect(rule2).to.have.property('hour', 16);
+    expect(rule2).to.have.property('minute', 10);
+    expect(rule2).to.have.property('tz', 'Europe/Paris');
   });
 
   it('should not throw error when starting service', async () => {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

Energy monitoring: Add new refresh at 16:10 for Enedis late data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a daily scheduled task that calculates the previous day's energy consumption and costs at 16:10 (system timezone).

* **Bug Fixes / Maintenance**
  * Clarified scheduling comment for an existing daily task; existing task behavior and scheduling remain unchanged.

* **Tests**
  * Updated tests to cover the new daily task and to confirm existing scheduling behavior is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->