### PR TITLE
Use in stateManager data for homekit read

### DIFF
--- a/server/services/homekit/lib/buildService.js
+++ b/server/services/homekit/lib/buildService.js
@@ -44,8 +44,7 @@ function buildService(device, features, categoryMapping, subtype) {
 
         if (characteristic.props.perms.includes(Perms.PAIRED_READ)) {
           characteristic.on(CharacteristicEventTypes.GET, async (callback) => {
-            const { features: updatedFeatures } = await this.gladys.device.getBySelector(device.selector);
-            callback(undefined, updatedFeatures.find((feat) => feat.id === feature.id).last_value);
+            callback(undefined, this.gladys.stateManager.get('deviceFeature', feature.selector).last_value);
           });
         }
 
@@ -68,8 +67,7 @@ function buildService(device, features, categoryMapping, subtype) {
         const contactCharacteristic = service.getCharacteristic(Characteristic.ContactSensorState);
 
         contactCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
-          const { features: updatedFeatures } = await this.gladys.device.getBySelector(device.selector);
-          callback(undefined, +!updatedFeatures.find((feat) => feat.id === feature.id).last_value);
+          callback(undefined, +!this.gladys.stateManager.get('deviceFeature', feature.selector).last_value);
         });
         break;
       }
@@ -83,11 +81,10 @@ function buildService(device, features, categoryMapping, subtype) {
           const characteristic = service.getCharacteristic(Characteristic[c]);
           if (characteristic.props.perms.includes(Perms.PAIRED_READ)) {
             characteristic.on(CharacteristicEventTypes.GET, async (callback) => {
-              const { features: updatedFeatures } = await this.gladys.device.getBySelector(device.selector);
               callback(
                 undefined,
                 normalize(
-                  updatedFeatures.find((feat) => feat.id === feature.id).last_value,
+                  this.gladys.stateManager.get('deviceFeature', feature.selector).last_value,
                   feature.min,
                   feature.max,
                   characteristic.props.minValue,
@@ -125,15 +122,13 @@ function buildService(device, features, categoryMapping, subtype) {
         const hueCharacteristic = service.getCharacteristic(Characteristic.Hue);
 
         hueCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
-          const { features: updatedFeatures } = await this.gladys.device.getBySelector(device.selector);
-          const rgb = intToRgb(updatedFeatures.find((feat) => feat.id === feature.id).last_value);
+          const rgb = intToRgb(this.gladys.stateManager.get('deviceFeature', feature.selector).last_value);
           const [h] = rgbToHsb(rgb);
           callback(undefined, h);
         });
         hueCharacteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
           await sleep(50);
-          const { features: updatedFeatures } = await this.gladys.device.getBySelector(device.selector);
-          let rgb = intToRgb(updatedFeatures.find((feat) => feat.id === feature.id).last_value);
+          let rgb = intToRgb(this.gladys.stateManager.get('deviceFeature', feature.selector).last_value);
           const [, s, b] = rgbToHsb(rgb);
           rgb = hsbToRgb([value, s, b]);
           const action = {
@@ -150,14 +145,12 @@ function buildService(device, features, categoryMapping, subtype) {
         const saturationCharacteristic = service.getCharacteristic(Characteristic.Saturation);
 
         saturationCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
-          const { features: updatedFeatures } = await this.gladys.device.getBySelector(device.selector);
-          const rgb = intToRgb(updatedFeatures.find((feat) => feat.id === feature.id).last_value);
+          const rgb = intToRgb(this.gladys.stateManager.get('deviceFeature', feature.selector).last_value);
           const [, s] = rgbToHsb(rgb);
           callback(undefined, s);
         });
         saturationCharacteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
-          const { features: updatedFeatures } = await this.gladys.device.getBySelector(device.selector);
-          let rgb = intToRgb(updatedFeatures.find((feat) => feat.id === feature.id).last_value);
+          let rgb = intToRgb(this.gladys.stateManager.get('deviceFeature', feature.selector).last_value);
           const [h, , b] = rgbToHsb(rgb);
           rgb = hsbToRgb([h, value, b]);
           const action = {
@@ -176,8 +169,7 @@ function buildService(device, features, categoryMapping, subtype) {
         const currentTemperatureCharacteristic = service.getCharacteristic(Characteristic.CurrentTemperature);
 
         currentTemperatureCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
-          const { features: updatedFeatures } = await this.gladys.device.getBySelector(device.selector);
-          let currentTemp = updatedFeatures.find((feat) => feat.id === feature.id).last_value;
+          let currentTemp = this.gladys.stateManager.get('deviceFeature', feature.selector).last_value;
 
           if (feature.unit === DEVICE_FEATURE_UNITS.KELVIN) {
             currentTemp -= 273.15;
@@ -196,8 +188,10 @@ function buildService(device, features, categoryMapping, subtype) {
         );
 
         characteristic.on(CharacteristicEventTypes.GET, async (callback) => {
-          const { features: updatedFeatures } = await this.gladys.device.getBySelector(device.selector);
-          callback(undefined, coverStateMapping[updatedFeatures.find((feat) => feat.id === feature.id).last_value]);
+          callback(
+            undefined,
+            coverStateMapping[this.gladys.stateManager.get('deviceFeature', feature.selector).last_value],
+          );
         });
 
         if (

--- a/server/test/services/homekit/lib/buildService.test.js
+++ b/server/test/services/homekit/lib/buildService.test.js
@@ -17,35 +17,35 @@ describe('Build service', () => {
     gladys: {
       device: {},
       event: {},
+      stateManager: {
+        get: stub(),
+      },
     },
   };
 
   it('should build light service', async () => {
-    homekitHandler.gladys.device.getBySelector = stub().resolves({
-      features: [
-        {
-          id: '31c6a4a7-9710-4951-bf34-04eeae5b9ff7',
-          name: 'Luminosité',
-          category: DEVICE_FEATURE_CATEGORIES.LIGHT,
-          type: DEVICE_FEATURE_TYPES.LIGHT.BRIGHTNESS,
-          last_value: 50,
-        },
-        {
-          id: '81d2dc15-cb98-4235-96f4-5c12007b6ccd',
-          name: 'Couleur',
-          category: DEVICE_FEATURE_CATEGORIES.LIGHT,
-          type: DEVICE_FEATURE_TYPES.LIGHT.COLOR,
-          last_value: 3500000,
-        },
-        {
-          id: '77f26d98-49a5-4338-97c8-ab51fb5d2164',
-          name: 'Température',
-          category: DEVICE_FEATURE_CATEGORIES.LIGHT,
-          type: DEVICE_FEATURE_TYPES.LIGHT.TEMPERATURE,
-          last_value: 255,
-        },
-      ],
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'lampe-brightness').returns({
+      id: '31c6a4a7-9710-4951-bf34-04eeae5b9ff7',
+      name: 'Luminosité',
+      category: DEVICE_FEATURE_CATEGORIES.LIGHT,
+      type: DEVICE_FEATURE_TYPES.LIGHT.BRIGHTNESS,
+      last_value: 50,
     });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'lampe-color').returns({
+      id: '81d2dc15-cb98-4235-96f4-5c12007b6ccd',
+      name: 'Couleur',
+      category: DEVICE_FEATURE_CATEGORIES.LIGHT,
+      type: DEVICE_FEATURE_TYPES.LIGHT.COLOR,
+      last_value: 3500000,
+    });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'lampe-temperature').returns({
+      id: '77f26d98-49a5-4338-97c8-ab51fb5d2164',
+      name: 'Température',
+      category: DEVICE_FEATURE_CATEGORIES.LIGHT,
+      type: DEVICE_FEATURE_TYPES.LIGHT.TEMPERATURE,
+      last_value: 255,
+    });
+
     homekitHandler.gladys.event.emit = stub();
     const on = stub();
     const getCharacteristic = stub()
@@ -200,14 +200,10 @@ describe('Build service', () => {
   });
 
   it('should build switch service', async () => {
-    homekitHandler.gladys.device.getBySelector = stub().resolves({
-      features: [
-        {
-          name: 'onoff',
-          device_feature: 'lampe-onoff',
-          last_value: 1,
-        },
-      ],
+    homekitHandler.gladys.stateManager.get = stub().returns({
+      name: 'onoff',
+      device_feature: 'lampe-onoff',
+      last_value: 1,
     });
     homekitHandler.gladys.event.emit = stub();
     const on = stub();
@@ -267,33 +263,29 @@ describe('Build service', () => {
   });
 
   it('should build current temperature service', async () => {
-    homekitHandler.gladys.device.getBySelector = stub().resolves({
-      features: [
-        {
-          id: '26df6983-5127-4122-874a-b6ed0590badc',
-          name: 'Température Celsius',
-          category: DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
-          type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
-          unit: DEVICE_FEATURE_UNITS.CELSIUS,
-          last_value: 15,
-        },
-        {
-          id: '91ee488c-068b-4328-8563-e1e15678c5a1',
-          name: 'Température Kelvin',
-          category: DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
-          type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
-          unit: DEVICE_FEATURE_UNITS.KELVIN,
-          last_value: 293.15,
-        },
-        {
-          id: '110eb9f0-a84d-40df-b0c6-05791fb2ec15',
-          name: 'Température Fahrenheit',
-          category: DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
-          type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
-          unit: DEVICE_FEATURE_UNITS.FAHRENHEIT,
-          last_value: 77,
-        },
-      ],
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'temp-celsius').returns({
+      id: '26df6983-5127-4122-874a-b6ed0590badc',
+      name: 'Température Celsius',
+      category: DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
+      type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+      unit: DEVICE_FEATURE_UNITS.CELSIUS,
+      last_value: 15,
+    });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'temp-kelvin').returns({
+      id: '91ee488c-068b-4328-8563-e1e15678c5a1',
+      name: 'Température Kelvin',
+      category: DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
+      type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+      unit: DEVICE_FEATURE_UNITS.KELVIN,
+      last_value: 293.15,
+    });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'temp-fahrenheit').returns({
+      id: '110eb9f0-a84d-40df-b0c6-05791fb2ec15',
+      name: 'Température Fahrenheit',
+      category: DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
+      type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+      unit: DEVICE_FEATURE_UNITS.FAHRENHEIT,
+      last_value: 77,
     });
     const on = stub();
     const getCharacteristic = stub().returns({
@@ -319,6 +311,7 @@ describe('Build service', () => {
       {
         id: '26df6983-5127-4122-874a-b6ed0590badc',
         name: 'Température Celsius',
+        selector: 'temp-celsius',
         category: DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
         type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
         unit: DEVICE_FEATURE_UNITS.CELSIUS,
@@ -326,6 +319,7 @@ describe('Build service', () => {
       {
         id: '91ee488c-068b-4328-8563-e1e15678c5a1',
         name: 'Température Kelvin',
+        selector: 'temp-kelvin',
         category: DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
         type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
         unit: DEVICE_FEATURE_UNITS.KELVIN,
@@ -333,6 +327,7 @@ describe('Build service', () => {
       {
         id: '110eb9f0-a84d-40df-b0c6-05791fb2ec15',
         name: 'Température Fahrenheit',
+        selector: 'temp-fahrenheit',
         category: DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
         type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
         unit: DEVICE_FEATURE_UNITS.FAHRENHEIT,
@@ -354,16 +349,12 @@ describe('Build service', () => {
   });
 
   it('should build motion sensor service', async () => {
-    homekitHandler.gladys.device.getBySelector = stub().resolves({
-      features: [
-        {
-          id: '31c6a4a7-9710-4951-bf34-04eeae5b9ff7',
-          name: 'Motion Detection',
-          category: DEVICE_FEATURE_CATEGORIES.MOTION_SENSOR,
-          type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
-          last_value: 0,
-        },
-      ],
+    homekitHandler.gladys.stateManager.get = stub().returns({
+      id: '31c6a4a7-9710-4951-bf34-04eeae5b9ff7',
+      name: 'Motion Detection',
+      category: DEVICE_FEATURE_CATEGORIES.MOTION_SENSOR,
+      type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
+      last_value: 0,
     });
     const on = stub();
     const getCharacteristic = stub().returns({
@@ -413,16 +404,12 @@ describe('Build service', () => {
   });
 
   it('should build contact sensor service', async () => {
-    homekitHandler.gladys.device.getBySelector = stub().resolves({
-      features: [
-        {
-          id: '31c6a4a7-9710-4951-bf34-04eeae5b9ff7',
-          name: "Porte d'entrée",
-          category: DEVICE_FEATURE_CATEGORIES.OPENING_SENSOR,
-          type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
-          last_value: 0,
-        },
-      ],
+    homekitHandler.gladys.stateManager.get = stub().returns({
+      id: '31c6a4a7-9710-4951-bf34-04eeae5b9ff7',
+      name: "Porte d'entrée",
+      category: DEVICE_FEATURE_CATEGORIES.OPENING_SENSOR,
+      type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
+      last_value: 0,
     });
     const on = stub();
     const getCharacteristic = stub().returns({
@@ -465,23 +452,19 @@ describe('Build service', () => {
   });
 
   it('should build shutter/curtain service', async () => {
-    homekitHandler.gladys.device.getBySelector = stub().resolves({
-      features: [
-        {
-          id: '31c6a4a7-9710-4951-bf34-04eeae5b9ff7',
-          name: 'Shutter State',
-          category: DEVICE_FEATURE_CATEGORIES.SHUTTER,
-          type: DEVICE_FEATURE_TYPES.SHUTTER.STATE,
-          last_value: 0,
-        },
-        {
-          id: '81d2dc15-cb98-4235-96f4-5c12007b6ccd',
-          name: 'Shutter position',
-          category: DEVICE_FEATURE_CATEGORIES.SHUTTER,
-          type: DEVICE_FEATURE_TYPES.SHUTTER.POSITION,
-          last_value: 80,
-        },
-      ],
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'shutter-state').returns({
+      id: '31c6a4a7-9710-4951-bf34-04eeae5b9ff7',
+      name: 'Shutter State',
+      category: DEVICE_FEATURE_CATEGORIES.SHUTTER,
+      type: DEVICE_FEATURE_TYPES.SHUTTER.STATE,
+      last_value: 0,
+    });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'shutter-position').returns({
+      id: '81d2dc15-cb98-4235-96f4-5c12007b6ccd',
+      name: 'Shutter position',
+      category: DEVICE_FEATURE_CATEGORIES.SHUTTER,
+      type: DEVICE_FEATURE_TYPES.SHUTTER.POSITION,
+      last_value: 80,
     });
     homekitHandler.gladys.event.emit = stub();
     const on = stub();
@@ -577,17 +560,13 @@ describe('Build service', () => {
   });
 
   it('should build shutter/curtain service without real position', async () => {
-    homekitHandler.gladys.device.getBySelector = stub().resolves({
-      features: [
-        {
-          id: '31c6a4a7-9710-4951-bf34-04eeae5b9ff7',
-          name: 'Shutter State',
-          selector: 'shutter-state',
-          category: DEVICE_FEATURE_CATEGORIES.SHUTTER,
-          type: DEVICE_FEATURE_TYPES.SHUTTER.STATE,
-          last_value: 0,
-        },
-      ],
+    homekitHandler.gladys.stateManager.get = stub().returns({
+      id: '31c6a4a7-9710-4951-bf34-04eeae5b9ff7',
+      name: 'Shutter State',
+      selector: 'shutter-state',
+      category: DEVICE_FEATURE_CATEGORIES.SHUTTER,
+      type: DEVICE_FEATURE_TYPES.SHUTTER.STATE,
+      last_value: 0,
     });
     homekitHandler.gladys.event.emit = stub();
     const on = stub();


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

I optimize code in Homekit integration. I changed how `last_values` are retrieved by using in RAM data instead of database requests. I also reduce loops (`.find` methods)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized HomeKit feature state retrieval for improved performance across various device types including sensors, lights, and curtains.

* **Tests**
  * Updated HomeKit integration tests to align with the new state retrieval implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->