### PR TITLE
Zigbee2mqtt: Add Philips Hue Dimmer Switch v2

### DIFF
--- a/server/services/zigbee2mqtt/exposes/enumType.js
+++ b/server/services/zigbee2mqtt/exposes/enumType.js
@@ -75,6 +75,17 @@ addMapping('action', BUTTON_STATUS.DOWN_HOLD, 'down-hold');
 addMapping('action', BUTTON_STATUS.OFF_PRESS, 'off-press');
 addMapping('action', BUTTON_STATUS.OFF_HOLD, 'off-hold');
 
+// For Philips Hue Dimmer Switch v2
+// https://www.zigbee2mqtt.io/devices/929002398602.html
+addMapping('action', BUTTON_STATUS.ON_PRESS, 'on_press');
+addMapping('action', BUTTON_STATUS.ON_HOLD, 'on_hold');
+addMapping('action', BUTTON_STATUS.UP_PRESS, 'up_press');
+addMapping('action', BUTTON_STATUS.UP_HOLD, 'up_hold');
+addMapping('action', BUTTON_STATUS.DOWN_PRESS, 'down_press');
+addMapping('action', BUTTON_STATUS.DOWN_HOLD, 'down_hold');
+addMapping('action', BUTTON_STATUS.OFF_PRESS, 'off_press');
+addMapping('action', BUTTON_STATUS.OFF_HOLD, 'off_hold');
+
 addMapping('action', BUTTON_STATUS.INITIAL_PRESS, 'initial_press');
 addMapping('action', BUTTON_STATUS.LONG_PRESS, 'long_press');
 addMapping('action', BUTTON_STATUS.SHORT_RELEASE, 'short_release');


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

Zigbee2mqtt: Add Philips Hue Dimmer Switch v2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed button action recognition for Philips Hue Dimmer Switch v2, ensuring all button press and hold events (ON, UP, DOWN, OFF) are properly mapped and translated.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GladysAssistant/Gladys/pull/2523)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->