### PR TITLE
Fix Gladys Plus link gateway user at first login

### DIFF
--- a/front/src/routes/gateway-setup/index.js
+++ b/front/src/routes/gateway-setup/index.js
@@ -28,8 +28,12 @@ class LinkGatewayUser extends Component {
     this.setState({ savingUserLoading: true });
     try {
       await this.props.session.gatewayClient.updateUserIdInGladys(this.state.selectedUser);
-      await this.props.httpClient.get('/api/v1/me');
-      // hard redirect, to reload websocket connection
+      // Hard redirect to /dashboard to force a fresh websocket session against the
+      // gateway. The previous session was opened at login time with no local_user_id
+      // (or a stale one), so any call to a local Gladys API right now would fail with
+      // GATEWAY_USER_NOT_LINKED. If the user has not been accepted locally yet,
+      // checkSession / checkIfGladysUserIsLinkedToExistingUser will detect it after
+      // the reload and show the proper "errorNotAcceptedLocally" message.
       window.location = '/dashboard';
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

Fix Gladys Plus link gateway user at first login

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced gateway setup completion flow to ensure proper error handling and status messaging for users not yet linked to the gateway service.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GladysAssistant/Gladys/pull/2527?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->