### PR TITLE
feat(matter): add MediaPlayback, KeypadInput and LevelControl volume clusters support

### DIFF
--- a/front/src/components/boxs/television/EditTelevisionBox.jsx
+++ b/front/src/components/boxs/television/EditTelevisionBox.jsx
@@ -1,0 +1,71 @@
+import { Component } from 'preact';
+import { Text } from 'preact-i18n';
+import Select from 'react-select';
+import { connect } from 'unistore/preact';
+
+import BaseEditBox from '../baseEditBox';
+import { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } from '../../../../../server/utils/constants';
+
+class EditTelevisionBoxComponent extends Component {
+  updateDevice = option => {
+    this.props.updateBoxConfig(this.props.x, this.props.y, {
+      device: option ? option.value : null
+    });
+  };
+
+  getDevices = async () => {
+    try {
+      await this.setState({
+        error: false
+      });
+      let televisionDevices = await this.props.httpClient.get('/api/v1/device', {
+        device_feature_category: DEVICE_FEATURE_CATEGORIES.TELEVISION
+      });
+      televisionDevices = televisionDevices.filter(d =>
+        d.features.find(f => f.type === DEVICE_FEATURE_TYPES.TELEVISION.PLAY)
+      );
+      const televisionDevicesOptions = televisionDevices.map(d => ({
+        label: d.name,
+        value: d.selector
+      }));
+      this.setState({
+        televisionDevicesOptions
+      });
+    } catch (e) {
+      console.error(e);
+      this.setState({
+        error: true
+      });
+    }
+  };
+
+  componentDidMount() {
+    this.getDevices();
+  }
+
+  render(props, { televisionDevicesOptions }) {
+    let optionSelected = null;
+    if (televisionDevicesOptions && props.box.device) {
+      optionSelected = televisionDevicesOptions.find(o => o.value === props.box.device);
+    }
+    return (
+      <BaseEditBox {...props} titleKey="dashboard.boxTitle.television">
+        <div class="form-group">
+          <label>
+            <Text id="dashboard.boxes.television.selectDeviceLabel" />
+          </label>
+          <Select
+            defaultValue={null}
+            value={optionSelected}
+            onChange={this.updateDevice}
+            options={televisionDevicesOptions}
+            className="react-select-container"
+            classNamePrefix="react-select"
+          />
+        </div>
+      </BaseEditBox>
+    );
+  }
+}
+
+export default connect('httpClient', {})(EditTelevisionBoxComponent);

--- a/front/src/components/boxs/television/TelevisionBox.jsx
+++ b/front/src/components/boxs/television/TelevisionBox.jsx
@@ -1,0 +1,332 @@
+import { Component } from 'preact';
+import { Text } from 'preact-i18n';
+import { connect } from 'unistore/preact';
+
+import {
+  WEBSOCKET_MESSAGE_TYPES,
+  DEVICE_FEATURE_TYPES,
+  DEVICE_FEATURE_CATEGORIES
+} from '../../../../../server/utils/constants';
+
+const getVolumePercent = volumeFeature => {
+  if (!volumeFeature || volumeFeature.last_value === null || volumeFeature.last_value === undefined) {
+    return 0;
+  }
+  const min = volumeFeature.min ?? 0;
+  const max = volumeFeature.max ?? 100;
+  if (max === min) {
+    return 0;
+  }
+  return Math.round(((volumeFeature.last_value - min) / (max - min)) * 100);
+};
+
+class TelevisionBoxComponent extends Component {
+  state = {
+    isPlaying: false,
+    showRemote: false
+  };
+
+  getDevice = async () => {
+    try {
+      await this.setState({
+        error: false
+      });
+      const televisionDevice = await this.props.httpClient.get(`/api/v1/device/${this.props.box.device}`, {});
+      const features = televisionDevice.features;
+
+      this.setState({
+        televisionDevice,
+        playFeature: features.find(f => f.type === DEVICE_FEATURE_TYPES.TELEVISION.PLAY),
+        pauseFeature: features.find(f => f.type === DEVICE_FEATURE_TYPES.TELEVISION.PAUSE),
+        stopFeature: features.find(f => f.type === DEVICE_FEATURE_TYPES.TELEVISION.STOP),
+        previousFeature: features.find(f => f.type === DEVICE_FEATURE_TYPES.TELEVISION.PREVIOUS),
+        nextFeature: features.find(f => f.type === DEVICE_FEATURE_TYPES.TELEVISION.NEXT),
+        volumeFeature: features.find(f => f.type === DEVICE_FEATURE_TYPES.TELEVISION.VOLUME),
+        powerFeature: features.find(
+          f =>
+            f.category === DEVICE_FEATURE_CATEGORIES.SWITCH && f.type === DEVICE_FEATURE_TYPES.SWITCH.BINARY
+        ),
+        upFeature: features.find(f => f.type === DEVICE_FEATURE_TYPES.TELEVISION.UP),
+        downFeature: features.find(f => f.type === DEVICE_FEATURE_TYPES.TELEVISION.DOWN),
+        leftFeature: features.find(f => f.type === DEVICE_FEATURE_TYPES.TELEVISION.LEFT),
+        rightFeature: features.find(f => f.type === DEVICE_FEATURE_TYPES.TELEVISION.RIGHT),
+        enterFeature: features.find(f => f.type === DEVICE_FEATURE_TYPES.TELEVISION.ENTER),
+        returnFeature: features.find(f => f.type === DEVICE_FEATURE_TYPES.TELEVISION.RETURN)
+      });
+    } catch (e) {
+      console.error(e);
+      this.setState({
+        error: true
+      });
+    }
+  };
+
+  setValueDevice = async (deviceFeature, value) => {
+    if (!deviceFeature) {
+      return;
+    }
+    try {
+      await this.setState({ error: false });
+      await this.props.httpClient.post(`/api/v1/device_feature/${deviceFeature.selector}/value`, {
+        value
+      });
+    } catch (e) {
+      console.error(e);
+      this.setState({ error: true });
+    }
+  };
+
+  play = async () => {
+    await this.setState({ isPlaying: true });
+    await this.setValueDevice(this.state.playFeature, 1);
+  };
+
+  pause = async () => {
+    await this.setState({ isPlaying: false });
+    await this.setValueDevice(this.state.pauseFeature, 1);
+  };
+
+  stop = async () => {
+    await this.setState({ isPlaying: false });
+    await this.setValueDevice(this.state.stopFeature, 1);
+  };
+
+  previous = async () => {
+    await this.setValueDevice(this.state.previousFeature, 1);
+  };
+
+  next = async () => {
+    await this.setValueDevice(this.state.nextFeature, 1);
+  };
+
+  sendKey = async deviceFeature => {
+    await this.setValueDevice(deviceFeature, 1);
+  };
+
+  togglePower = async () => {
+    const { powerFeature } = this.state;
+    if (!powerFeature) {
+      return;
+    }
+    const newValue = powerFeature.last_value === 1 ? 0 : 1;
+    const newPowerFeature = { ...powerFeature, last_value: newValue };
+    await this.setState({ powerFeature: newPowerFeature });
+    await this.setValueDevice(powerFeature, newValue);
+  };
+
+  changeVolume = async e => {
+    const volume = parseInt(e.target.value, 10);
+    const newVolumeFeature = { ...this.state.volumeFeature, last_value: volume };
+    await this.setState({ volumeFeature: newVolumeFeature });
+    await this.setValueDevice(this.state.volumeFeature, volume);
+  };
+
+  toggleRemote = () => {
+    this.setState(prevState => ({ showRemote: !prevState.showRemote }));
+  };
+
+  updateDeviceStateWebsocket = payload => {
+    const { volumeFeature, powerFeature } = this.state;
+    if (volumeFeature && payload.device_feature_selector === volumeFeature.selector) {
+      const newVolumeFeature = { ...volumeFeature, last_value: payload.last_value };
+      this.setState({ volumeFeature: newVolumeFeature });
+    }
+    if (powerFeature && payload.device_feature_selector === powerFeature.selector) {
+      const newPowerFeature = { ...powerFeature, last_value: payload.last_value };
+      this.setState({ powerFeature: newPowerFeature });
+    }
+  };
+
+  handleWebsocketConnected = ({ connected }) => {
+    if (!connected) {
+      this.wasDisconnected = true;
+    } else if (this.wasDisconnected) {
+      this.getDevice();
+      this.wasDisconnected = false;
+    }
+  };
+
+  componentDidMount() {
+    this.getDevice();
+    this.props.session.dispatcher.addListener(
+      WEBSOCKET_MESSAGE_TYPES.DEVICE.NEW_STATE,
+      this.updateDeviceStateWebsocket
+    );
+    this.props.session.dispatcher.addListener('websocket.connected', this.handleWebsocketConnected);
+  }
+
+  componentWillUnmount() {
+    this.props.session.dispatcher.removeListener(
+      WEBSOCKET_MESSAGE_TYPES.DEVICE.NEW_STATE,
+      this.updateDeviceStateWebsocket
+    );
+    this.props.session.dispatcher.removeListener('websocket.connected', this.handleWebsocketConnected);
+  }
+
+  render(
+    props,
+    {
+      isPlaying,
+      showRemote,
+      televisionDevice,
+      playFeature,
+      pauseFeature,
+      stopFeature,
+      previousFeature,
+      nextFeature,
+      volumeFeature,
+      powerFeature,
+      upFeature,
+      downFeature,
+      leftFeature,
+      rightFeature,
+      enterFeature,
+      returnFeature
+    }
+  ) {
+    const hasPlayback = playFeature || pauseFeature || stopFeature;
+    const hasKeypad = upFeature || downFeature || leftFeature || rightFeature || enterFeature || returnFeature;
+    const volumePercent = getVolumePercent(volumeFeature);
+
+    return (
+      <div class="card">
+        <div class="card-header d-flex align-items-center justify-content-between">
+          <h3 class="card-title mb-0">{televisionDevice && televisionDevice.name}</h3>
+          {powerFeature && (
+            <button type="button" class="btn btn-sm btn-outline-secondary" onClick={this.togglePower}>
+              <i class={`fe fe-power${powerFeature.last_value === 1 ? '' : ' text-muted'}`} />
+            </button>
+          )}
+        </div>
+        <div class="card-body">
+          {hasPlayback && (
+            <div class="row">
+              {previousFeature && (
+                <div class="col">
+                  <button type="button" class="btn btn-block btn-secondary" onClick={this.previous}>
+                    <i class="fe fe-skip-back" />
+                  </button>
+                </div>
+              )}
+              {playFeature && !isPlaying && (
+                <div class="col">
+                  <button type="button" class="btn btn-block btn-secondary" onClick={this.play}>
+                    <i class="fe fe-play" />
+                  </button>
+                </div>
+              )}
+              {pauseFeature && isPlaying && (
+                <div class="col">
+                  <button type="button" class="btn btn-block btn-secondary" onClick={this.pause}>
+                    <i class="fe fe-pause" />
+                  </button>
+                </div>
+              )}
+              {stopFeature && (
+                <div class="col">
+                  <button type="button" class="btn btn-block btn-secondary" onClick={this.stop}>
+                    <i class="fe fe-square" />
+                  </button>
+                </div>
+              )}
+              {nextFeature && (
+                <div class="col">
+                  <button type="button" class="btn btn-block btn-secondary" onClick={this.next}>
+                    <i class="fe fe-skip-forward" />
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {volumeFeature && (
+            <div class="row mt-4 align-items-center">
+              <div class="col-auto">
+                <i class="fe fe-volume-2" />
+              </div>
+              <div class="col">
+                <input
+                  type="range"
+                  value={volumeFeature.last_value ?? volumeFeature.min ?? 0}
+                  onChange={this.changeVolume}
+                  class="form-control"
+                  step="1"
+                  min={volumeFeature.min ?? 0}
+                  max={volumeFeature.max ?? 100}
+                />
+              </div>
+              <div class="col-auto">
+                <span>{volumePercent}%</span>
+              </div>
+            </div>
+          )}
+
+          {hasKeypad && (
+            <div class="mt-4">
+              <button type="button" class="btn btn-sm btn-secondary btn-block" onClick={this.toggleRemote}>
+                <i class={`fe fe-chevron-${showRemote ? 'up' : 'down'}`} />{' '}
+                <Text id="dashboard.boxes.television.remoteToggle" />
+              </button>
+              {showRemote && (
+                <div class="mt-3">
+                  <div class="row">
+                    <div class="col-4 offset-4">
+                      {upFeature && (
+                        <button type="button" class="btn btn-block btn-secondary btn-sm" onClick={() => this.sendKey(upFeature)}>
+                          <i class="fe fe-chevron-up" />
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                  <div class="row mt-2">
+                    <div class="col-4">
+                      {leftFeature && (
+                        <button type="button" class="btn btn-block btn-secondary btn-sm" onClick={() => this.sendKey(leftFeature)}>
+                          <i class="fe fe-chevron-left" />
+                        </button>
+                      )}
+                    </div>
+                    <div class="col-4">
+                      {enterFeature && (
+                        <button type="button" class="btn btn-block btn-secondary btn-sm" onClick={() => this.sendKey(enterFeature)}>
+                          <i class="fe fe-corner-down-left" />
+                        </button>
+                      )}
+                    </div>
+                    <div class="col-4">
+                      {rightFeature && (
+                        <button type="button" class="btn btn-block btn-secondary btn-sm" onClick={() => this.sendKey(rightFeature)}>
+                          <i class="fe fe-chevron-right" />
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                  <div class="row mt-2">
+                    <div class="col-4 offset-4">
+                      {downFeature && (
+                        <button type="button" class="btn btn-block btn-secondary btn-sm" onClick={() => this.sendKey(downFeature)}>
+                          <i class="fe fe-chevron-down" />
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                  {returnFeature && (
+                    <div class="row mt-2">
+                      <div class="col-6 offset-3">
+                        <button type="button" class="btn btn-block btn-secondary btn-sm" onClick={() => this.sendKey(returnFeature)}>
+                          <i class="fe fe-rotate-ccw" /> <Text id="dashboard.boxes.television.returnButton" />
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default connect('httpClient,session', {})(TelevisionBoxComponent);

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -296,6 +296,7 @@
       "clock": "Uhr",
       "scene": "Szene",
       "music": "Musik",
+      "television": "Medienplayer",
       "gauge": "Messanzeige",
       "energy-consumption": "Energieverbrauch",
       "voice-assistant": "Sprachassistent",
@@ -516,6 +517,11 @@
       },
       "music": {
         "selectDeviceLabel": "Wähle das zu steuernde Gerät aus"
+      },
+      "television": {
+        "selectDeviceLabel": "Wähle das zu steuernde Gerät aus",
+        "remoteToggle": "Fernbedienung",
+        "returnButton": "Zurück"
       },
       "energyConsumption": {
         "editName": "Widget-Name (optional)",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -296,6 +296,7 @@
       "clock": "Clock",
       "scene": "Scene",
       "music": "Music",
+      "television": "Media player",
       "gauge": "Gauge",
       "energy-consumption": "Energy Consumption",
       "voice-assistant": "Voice assistant",
@@ -533,6 +534,11 @@
       },
       "music": {
         "selectDeviceLabel": "Select device to control"
+      },
+      "television": {
+        "selectDeviceLabel": "Select device to control",
+        "remoteToggle": "Remote control",
+        "returnButton": "Back"
       },
       "voice-assistant": {
         "speak": "Speak",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -296,6 +296,7 @@
       "clock": "Horloge",
       "scene": "Scène",
       "music": "Musique",
+      "television": "Lecteur média",
       "gauge": "Jauge",
       "energy-consumption": "Consommation Énergétique",
       "voice-assistant": "Assistant vocal",
@@ -501,6 +502,11 @@
       },
       "music": {
         "selectDeviceLabel": "Sélectionner l'appareil à contrôler"
+      },
+      "television": {
+        "selectDeviceLabel": "Sélectionner l'appareil à contrôler",
+        "remoteToggle": "Télécommande",
+        "returnButton": "Retour"
       },
       "gauge": {
         "description": "Ce widget affichera une jauge avec la valeur de la fonctionnalité sélectionnée entre sa valeur minimale et maximale.",

--- a/front/src/routes/dashboard/Box.jsx
+++ b/front/src/routes/dashboard/Box.jsx
@@ -11,6 +11,7 @@ import ClockBox from '../../components/boxs/clock/Clock';
 import SceneBox from '../../components/boxs/scene/SceneBox';
 import AlarmBox from '../../components/boxs/alarm/Alarm';
 import MusicBox from '../../components/boxs/music/MusicBox';
+import TelevisionBox from '../../components/boxs/television/TelevisionBox';
 import EdfTempoBox from '../../components/boxs/edf-tempo/EdfTempo';
 import GaugeBox from '../../components/boxs/gauge/GaugeBox';
 import EnergyConsumptionBox from '../../components/boxs/energy-consumption/EnergyConsumption';
@@ -45,6 +46,8 @@ const Box = ({ children, ...props }) => {
       return <AlarmBox {...props} />;
     case 'music':
       return <MusicBox {...props} />;
+    case 'television':
+      return <TelevisionBox {...props} />;
     case 'edf-tempo':
       return <EdfTempoBox {...props} />;
     case 'gauge':

--- a/front/src/routes/dashboard/edit-dashboard/EditBox.jsx
+++ b/front/src/routes/dashboard/edit-dashboard/EditBox.jsx
@@ -2,6 +2,7 @@ import EditWeatherBox from '../../../components/boxs/weather/EditWeatherBox';
 import EditRoomTemperatureBox from '../../../components/boxs/room-temperature/EditRoomTemperatureBox';
 import EditRoomHumidityBox from '../../../components/boxs/room-humidity/EditRoomHumidityBox';
 import EditMusicBox from '../../../components/boxs/music/EditMusicBox';
+import EditTelevisionBox from '../../../components/boxs/television/EditTelevisionBox';
 import EditCameraBox from '../../../components/boxs/camera/EditCamera';
 import EditAtHomeBox from '../../../components/boxs/user-presence/EditUserPresenceBox';
 import EditDevicesInRoom from '../../../components/boxs/device-in-room/EditDeviceInRoom';
@@ -48,6 +49,8 @@ const Box = ({ children, ...props }) => {
       return <EditAlarmBox {...props} />;
     case 'music':
       return <EditMusicBox {...props} />;
+    case 'television':
+      return <EditTelevisionBox {...props} />;
     case 'edf-tempo':
       return <EditEdfTempoBox {...props} />;
     case 'gauge':

--- a/server/services/matter/lib/matter.setValue.js
+++ b/server/services/matter/lib/matter.setValue.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unresolved
 const {
   OnOff,
   WindowCovering,
@@ -11,6 +10,7 @@ const {
   RvcCleanMode,
   MediaPlayback,
   KeypadInput,
+  // eslint-disable-next-line import/no-unresolved
 } = require('@matter/main/clusters');
 const { DEVICE_FEATURE_TYPES, DEVICE_FEATURE_CATEGORIES, COVER_STATE } = require('../../../utils/constants');
 const { intToHsb } = require('../../../utils/colors');

--- a/server/services/matter/lib/matter.setValue.js
+++ b/server/services/matter/lib/matter.setValue.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
 const {
   OnOff,
   WindowCovering,
@@ -8,7 +9,8 @@ const {
   RvcOperationalState,
   RvcRunMode,
   RvcCleanMode,
-  // eslint-disable-next-line import/no-unresolved
+  MediaPlayback,
+  KeypadInput,
 } = require('@matter/main/clusters');
 const { DEVICE_FEATURE_TYPES, DEVICE_FEATURE_CATEGORIES, COVER_STATE } = require('../../../utils/constants');
 const { intToHsb } = require('../../../utils/colors');
@@ -302,6 +304,75 @@ async function setValue(gladysDevice, gladysFeature, value) {
     const matterMode = convertGladysCleanModeToMatter(Number(value), supportedModesData);
     logger.debug(`Matter: Setting RvcCleanMode to ${matterMode} (Gladys value: ${value})`);
     await rvcCleanMode.changeToMode({ newMode: matterMode });
+  }
+
+  // Handle television media playback
+  if (
+    gladysFeature.category === DEVICE_FEATURE_CATEGORIES.TELEVISION &&
+    (gladysFeature.type === DEVICE_FEATURE_TYPES.TELEVISION.PLAY ||
+      gladysFeature.type === DEVICE_FEATURE_TYPES.TELEVISION.PAUSE ||
+      gladysFeature.type === DEVICE_FEATURE_TYPES.TELEVISION.STOP)
+  ) {
+    const mediaPlayback = targetDevice.getClusterClientById(MediaPlayback.Complete.id);
+
+    if (!mediaPlayback) {
+      throw new Error('Device does not support MediaPlayback cluster');
+    }
+
+    if (value === 1) {
+      if (gladysFeature.type === DEVICE_FEATURE_TYPES.TELEVISION.PLAY) {
+        await mediaPlayback.play();
+      } else if (gladysFeature.type === DEVICE_FEATURE_TYPES.TELEVISION.PAUSE) {
+        await mediaPlayback.pause();
+      } else if (gladysFeature.type === DEVICE_FEATURE_TYPES.TELEVISION.STOP) {
+        await mediaPlayback.stop();
+      }
+    }
+  }
+
+  // Handle television volume
+  if (
+    gladysFeature.category === DEVICE_FEATURE_CATEGORIES.TELEVISION &&
+    gladysFeature.type === DEVICE_FEATURE_TYPES.TELEVISION.VOLUME
+  ) {
+    const levelControl = targetDevice.getClusterClientById(LevelControl.Complete.id);
+
+    if (!levelControl) {
+      throw new Error('Device does not support LevelControl cluster');
+    }
+
+    await levelControl.moveToLevel({
+      level: value,
+      transitionTime: null,
+      optionsMask: {
+        coupleColorTempToLevel: false,
+        executeIfOff: true,
+      },
+      optionsOverride: {},
+    });
+  }
+
+  // Handle television keypad input
+  if (gladysFeature.category === DEVICE_FEATURE_CATEGORIES.TELEVISION) {
+    const keypadInputKeyByFeatureType = {
+      [DEVICE_FEATURE_TYPES.TELEVISION.UP]: 1,
+      [DEVICE_FEATURE_TYPES.TELEVISION.DOWN]: 2,
+      [DEVICE_FEATURE_TYPES.TELEVISION.LEFT]: 3,
+      [DEVICE_FEATURE_TYPES.TELEVISION.RIGHT]: 4,
+      [DEVICE_FEATURE_TYPES.TELEVISION.ENTER]: 43,
+      [DEVICE_FEATURE_TYPES.TELEVISION.RETURN]: 13,
+    };
+    const keyCode = keypadInputKeyByFeatureType[gladysFeature.type];
+
+    if (keyCode !== undefined) {
+      const keypadInput = targetDevice.getClusterClientById(KeypadInput.Complete.id);
+
+      if (!keypadInput) {
+        throw new Error('Device does not support KeypadInput cluster');
+      }
+
+      await keypadInput.sendKey({ keyCode });
+    }
   }
 }
 

--- a/server/services/matter/utils/convertToGladysDevice.js
+++ b/server/services/matter/utils/convertToGladysDevice.js
@@ -91,6 +91,7 @@ function convertMeasurementUnitToDeviceFeatureUnits(measurementUnit) {
  * @param {object} clusterClient - The LevelControl cluster client.
  * @param {number} defaultMin - Fallback min level.
  * @param {number} defaultMax - Fallback max level.
+ * @example const { minLevel, maxLevel } = await getLevelControlMinMax(clusterClient);
  * @returns {Promise<{ minLevel: number, maxLevel: number }>} The min and max levels.
  */
 async function getLevelControlMinMax(clusterClient, defaultMin = 0, defaultMax = 254) {

--- a/server/services/matter/utils/convertToGladysDevice.js
+++ b/server/services/matter/utils/convertToGladysDevice.js
@@ -25,6 +25,8 @@ const {
   RvcRunMode,
   RvcCleanMode,
   PowerSource,
+  MediaPlayback,
+  KeypadInput,
   // eslint-disable-next-line import/no-unresolved
 } = require('@matter/main/clusters');
 const Promise = require('bluebird');
@@ -82,6 +84,29 @@ function convertMeasurementUnitToDeviceFeatureUnits(measurementUnit) {
     }
   }
   return DEVICE_FEATURE_UNITS.MICROGRAM_PER_CUBIC_METER;
+}
+
+/**
+ * @description Read LevelControl min/max attributes with safe fallbacks.
+ * @param {object} clusterClient - The LevelControl cluster client.
+ * @param {number} defaultMin - Fallback min level.
+ * @param {number} defaultMax - Fallback max level.
+ * @returns {Promise<{ minLevel: number, maxLevel: number }>} The min and max levels.
+ */
+async function getLevelControlMinMax(clusterClient, defaultMin = 0, defaultMax = 254) {
+  let minLevel = defaultMin;
+  let maxLevel = defaultMax;
+  try {
+    minLevel = (await clusterClient.getMinLevelAttribute()) ?? defaultMin;
+  } catch (error) {
+    // Keep default when attribute is unavailable
+  }
+  try {
+    maxLevel = (await clusterClient.getMaxLevelAttribute()) ?? defaultMax;
+  } catch (error) {
+    // Keep default when attribute is unavailable
+  }
+  return { minLevel, maxLevel };
 }
 
 /**
@@ -226,23 +251,33 @@ async function convertToGladysDevice(serviceId, nodeId, device, nodeDetailDevice
           min: 0,
           max: 1,
         });
-      } else if (
-        clusterIndex === LevelControl.Complete.id &&
-        clusterClient.supportedFeatures &&
-        clusterClient.supportedFeatures.lighting
-      ) {
-        const minLevel = await clusterClient.getMinLevelAttribute();
-        const maxLevel = await clusterClient.getMaxLevelAttribute();
-        gladysDevice.features.push({
-          ...commonNewFeature,
-          category: DEVICE_FEATURE_CATEGORIES.LIGHT,
-          type: DEVICE_FEATURE_TYPES.LIGHT.BRIGHTNESS,
-          read_only: false,
-          has_feedback: true,
-          external_id: `matter:${nodeId}:${devicePath}:${clusterIndex}`,
-          min: minLevel,
-          max: maxLevel,
-        });
+      } else if (clusterIndex === LevelControl.Complete.id) {
+        if (clusterClient.supportedFeatures && clusterClient.supportedFeatures.lighting) {
+          const { minLevel, maxLevel } = await getLevelControlMinMax(clusterClient);
+          gladysDevice.features.push({
+            ...commonNewFeature,
+            category: DEVICE_FEATURE_CATEGORIES.LIGHT,
+            type: DEVICE_FEATURE_TYPES.LIGHT.BRIGHTNESS,
+            read_only: false,
+            has_feedback: true,
+            external_id: `matter:${nodeId}:${devicePath}:${clusterIndex}`,
+            min: minLevel,
+            max: maxLevel,
+          });
+        } else {
+          const { minLevel, maxLevel } = await getLevelControlMinMax(clusterClient);
+          gladysDevice.features.push({
+            name: `${clusterClient.name} - ${clusterClient.endpointId} (Volume)`,
+            selector: slugify(`matter-${device.name}-${clusterClient.name}-volume`, true),
+            category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+            type: DEVICE_FEATURE_TYPES.TELEVISION.VOLUME,
+            read_only: false,
+            has_feedback: true,
+            external_id: `matter:${nodeId}:${devicePath}:${clusterIndex}:volume`,
+            min: minLevel,
+            max: maxLevel,
+          });
+        }
       } else if (clusterIndex === ColorControl.Complete.id) {
         if (clusterClient.supportedFeatures.hueSaturation) {
           gladysDevice.features.push({
@@ -655,6 +690,107 @@ async function convertToGladysDevice(serviceId, nodeId, device, nodeDetailDevice
             max: 100,
           });
         }
+      } else if (clusterIndex === MediaPlayback.Complete.id) {
+        gladysDevice.features.push({
+          name: `${clusterClient.name} - ${clusterClient.endpointId} (Play)`,
+          selector: slugify(`matter-${device.name}-${clusterClient.name}-play`, true),
+          category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+          type: DEVICE_FEATURE_TYPES.TELEVISION.PLAY,
+          read_only: false,
+          has_feedback: true,
+          external_id: `matter:${nodeId}:${devicePath}:${clusterIndex}:play`,
+          min: 0,
+          max: 1,
+        });
+        gladysDevice.features.push({
+          name: `${clusterClient.name} - ${clusterClient.endpointId} (Pause)`,
+          selector: slugify(`matter-${device.name}-${clusterClient.name}-pause`, true),
+          category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+          type: DEVICE_FEATURE_TYPES.TELEVISION.PAUSE,
+          read_only: false,
+          has_feedback: true,
+          external_id: `matter:${nodeId}:${devicePath}:${clusterIndex}:pause`,
+          min: 0,
+          max: 1,
+        });
+        gladysDevice.features.push({
+          name: `${clusterClient.name} - ${clusterClient.endpointId} (Stop)`,
+          selector: slugify(`matter-${device.name}-${clusterClient.name}-stop`, true),
+          category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+          type: DEVICE_FEATURE_TYPES.TELEVISION.STOP,
+          read_only: false,
+          has_feedback: true,
+          external_id: `matter:${nodeId}:${devicePath}:${clusterIndex}:stop`,
+          min: 0,
+          max: 1,
+        });
+      } else if (clusterIndex === KeypadInput.Complete.id) {
+        gladysDevice.features.push({
+          name: `${clusterClient.name} - ${clusterClient.endpointId} (Up)`,
+          selector: slugify(`matter-${device.name}-${clusterClient.name}-up`, true),
+          category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+          type: DEVICE_FEATURE_TYPES.TELEVISION.UP,
+          read_only: false,
+          has_feedback: true,
+          external_id: `matter:${nodeId}:${devicePath}:${clusterIndex}:up`,
+          min: 0,
+          max: 1,
+        });
+        gladysDevice.features.push({
+          name: `${clusterClient.name} - ${clusterClient.endpointId} (Down)`,
+          selector: slugify(`matter-${device.name}-${clusterClient.name}-down`, true),
+          category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+          type: DEVICE_FEATURE_TYPES.TELEVISION.DOWN,
+          read_only: false,
+          has_feedback: true,
+          external_id: `matter:${nodeId}:${devicePath}:${clusterIndex}:down`,
+          min: 0,
+          max: 1,
+        });
+        gladysDevice.features.push({
+          name: `${clusterClient.name} - ${clusterClient.endpointId} (Left)`,
+          selector: slugify(`matter-${device.name}-${clusterClient.name}-left`, true),
+          category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+          type: DEVICE_FEATURE_TYPES.TELEVISION.LEFT,
+          read_only: false,
+          has_feedback: true,
+          external_id: `matter:${nodeId}:${devicePath}:${clusterIndex}:left`,
+          min: 0,
+          max: 1,
+        });
+        gladysDevice.features.push({
+          name: `${clusterClient.name} - ${clusterClient.endpointId} (Right)`,
+          selector: slugify(`matter-${device.name}-${clusterClient.name}-right`, true),
+          category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+          type: DEVICE_FEATURE_TYPES.TELEVISION.RIGHT,
+          read_only: false,
+          has_feedback: true,
+          external_id: `matter:${nodeId}:${devicePath}:${clusterIndex}:right`,
+          min: 0,
+          max: 1,
+        });
+        gladysDevice.features.push({
+          name: `${clusterClient.name} - ${clusterClient.endpointId} (Enter)`,
+          selector: slugify(`matter-${device.name}-${clusterClient.name}-enter`, true),
+          category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+          type: DEVICE_FEATURE_TYPES.TELEVISION.ENTER,
+          read_only: false,
+          has_feedback: true,
+          external_id: `matter:${nodeId}:${devicePath}:${clusterIndex}:enter`,
+          min: 0,
+          max: 1,
+        });
+        gladysDevice.features.push({
+          name: `${clusterClient.name} - ${clusterClient.endpointId} (Return)`,
+          selector: slugify(`matter-${device.name}-${clusterClient.name}-return`, true),
+          category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+          type: DEVICE_FEATURE_TYPES.TELEVISION.RETURN,
+          read_only: false,
+          has_feedback: true,
+          external_id: `matter:${nodeId}:${devicePath}:${clusterIndex}:return`,
+          min: 0,
+          max: 1,
+        });
       }
     });
   }

--- a/server/test/services/matter/lib/convertToGladysDevice.test.js
+++ b/server/test/services/matter/lib/convertToGladysDevice.test.js
@@ -1,8 +1,14 @@
+﻿const sinon = require('sinon');
 const { expect } = require('chai');
+
+const { fake } = sinon;
 
 const {
   BooleanState,
   Switch,
+  LevelControl,
+  MediaPlayback,
+  KeypadInput,
   FanControl,
   RvcOperationalState,
   RvcRunMode,
@@ -545,5 +551,242 @@ describe('Matter.convertToGladysDevice', () => {
 
     const modeFeatures = gladysDevice.features.filter((feature) => feature.type === 'mode');
     expect(modeFeatures).to.have.lengthOf(0);
+  });
+
+  it('should create a light brightness feature for LevelControl lighting cluster', async () => {
+    const clusterClient = {
+      id: LevelControl.Complete.id,
+      name: 'LevelControl',
+      endpointId: 3,
+      supportedFeatures: {
+        lighting: true,
+      },
+      getMinLevelAttribute: fake.resolves(10),
+      getMaxLevelAttribute: fake.resolves(200),
+    };
+
+    const device = {
+      name: 'Test Device',
+      number: 3,
+      getAllClusterClients: () => [clusterClient],
+      getChildEndpoints: () => [],
+    };
+
+    const gladysDevice = await convertToGladysDevice(serviceId, nodeId, device, basicInformation, '3');
+
+    expect(gladysDevice.features).to.have.lengthOf(1);
+    expect(gladysDevice.features[0]).to.deep.equal({
+      name: 'LevelControl - 3',
+      selector: gladysDevice.features[0].selector,
+      category: 'light',
+      type: 'brightness',
+      read_only: false,
+      has_feedback: true,
+      external_id: `matter:12345:3:${LevelControl.Complete.id}`,
+      min: 10,
+      max: 200,
+    });
+  });
+
+  it('should fallback to default min/max for LevelControl when attributes throw', async () => {
+    const clusterClient = {
+      id: LevelControl.Complete.id,
+      name: 'LevelControl',
+      endpointId: 4,
+      supportedFeatures: {
+        lighting: true,
+      },
+      getMinLevelAttribute: async () => {
+        throw new Error('not supported');
+      },
+      getMaxLevelAttribute: async () => {
+        throw new Error('not supported');
+      },
+    };
+
+    const device = {
+      name: 'Test Device',
+      number: 4,
+      getAllClusterClients: () => [clusterClient],
+      getChildEndpoints: () => [],
+    };
+
+    const gladysDevice = await convertToGladysDevice(serviceId, nodeId, device, basicInformation, '4');
+
+    expect(gladysDevice.features).to.have.lengthOf(1);
+    expect(gladysDevice.features[0].min).to.equal(0);
+    expect(gladysDevice.features[0].max).to.equal(254);
+  });
+
+  it('should create television features for MediaPlayback cluster', async () => {
+    const clusterClient = {
+      id: MediaPlayback.Complete.id,
+      name: 'MediaPlayback',
+      endpointId: 6,
+    };
+
+    const device = {
+      name: 'Test Device',
+      number: 6,
+      getAllClusterClients: () => [clusterClient],
+      getChildEndpoints: () => [],
+    };
+
+    const gladysDevice = await convertToGladysDevice(serviceId, nodeId, device, basicInformation, '6');
+
+    expect(gladysDevice.features).to.have.lengthOf(3);
+    expect(gladysDevice.features[0]).to.deep.equal({
+      name: 'MediaPlayback - 6 (Play)',
+      selector: gladysDevice.features[0].selector,
+      category: 'television',
+      type: 'play',
+      read_only: false,
+      has_feedback: true,
+      external_id: `matter:12345:6:${MediaPlayback.Complete.id}:play`,
+      min: 0,
+      max: 1,
+    });
+    expect(gladysDevice.features[1]).to.deep.equal({
+      name: 'MediaPlayback - 6 (Pause)',
+      selector: gladysDevice.features[1].selector,
+      category: 'television',
+      type: 'pause',
+      read_only: false,
+      has_feedback: true,
+      external_id: `matter:12345:6:${MediaPlayback.Complete.id}:pause`,
+      min: 0,
+      max: 1,
+    });
+    expect(gladysDevice.features[2]).to.deep.equal({
+      name: 'MediaPlayback - 6 (Stop)',
+      selector: gladysDevice.features[2].selector,
+      category: 'television',
+      type: 'stop',
+      read_only: false,
+      has_feedback: true,
+      external_id: `matter:12345:6:${MediaPlayback.Complete.id}:stop`,
+      min: 0,
+      max: 1,
+    });
+  });
+
+  it('should create a television volume feature for LevelControl non-lighting cluster', async () => {
+    const clusterClient = {
+      id: LevelControl.Complete.id,
+      name: 'LevelControl',
+      endpointId: 5,
+      supportedFeatures: {
+        lighting: false,
+      },
+      getMinLevelAttribute: fake.resolves(0),
+      getMaxLevelAttribute: fake.resolves(254),
+    };
+
+    const device = {
+      name: 'Test Device',
+      number: 5,
+      getAllClusterClients: () => [clusterClient],
+      getChildEndpoints: () => [],
+    };
+
+    const gladysDevice = await convertToGladysDevice(serviceId, nodeId, device, basicInformation, '5');
+
+    expect(gladysDevice.features).to.have.lengthOf(1);
+    expect(gladysDevice.features[0]).to.deep.equal({
+      name: 'LevelControl - 5 (Volume)',
+      selector: gladysDevice.features[0].selector,
+      category: 'television',
+      type: 'volume',
+      read_only: false,
+      has_feedback: true,
+      external_id: `matter:12345:5:${LevelControl.Complete.id}:volume`,
+      min: 0,
+      max: 254,
+    });
+  });
+
+  it('should create television keypad features for KeypadInput cluster', async () => {
+    const clusterClient = {
+      id: KeypadInput.Complete.id,
+      name: 'KeypadInput',
+      endpointId: 7,
+    };
+
+    const device = {
+      name: 'Test Device',
+      number: 7,
+      getAllClusterClients: () => [clusterClient],
+      getChildEndpoints: () => [],
+    };
+
+    const gladysDevice = await convertToGladysDevice(serviceId, nodeId, device, basicInformation, '7');
+
+    expect(gladysDevice.features).to.have.lengthOf(6);
+    expect(gladysDevice.features[0]).to.deep.equal({
+      name: 'KeypadInput - 7 (Up)',
+      selector: gladysDevice.features[0].selector,
+      category: 'television',
+      type: 'up',
+      read_only: false,
+      has_feedback: true,
+      external_id: `matter:12345:7:${KeypadInput.Complete.id}:up`,
+      min: 0,
+      max: 1,
+    });
+    expect(gladysDevice.features[1]).to.deep.equal({
+      name: 'KeypadInput - 7 (Down)',
+      selector: gladysDevice.features[1].selector,
+      category: 'television',
+      type: 'down',
+      read_only: false,
+      has_feedback: true,
+      external_id: `matter:12345:7:${KeypadInput.Complete.id}:down`,
+      min: 0,
+      max: 1,
+    });
+    expect(gladysDevice.features[2]).to.deep.equal({
+      name: 'KeypadInput - 7 (Left)',
+      selector: gladysDevice.features[2].selector,
+      category: 'television',
+      type: 'left',
+      read_only: false,
+      has_feedback: true,
+      external_id: `matter:12345:7:${KeypadInput.Complete.id}:left`,
+      min: 0,
+      max: 1,
+    });
+    expect(gladysDevice.features[3]).to.deep.equal({
+      name: 'KeypadInput - 7 (Right)',
+      selector: gladysDevice.features[3].selector,
+      category: 'television',
+      type: 'right',
+      read_only: false,
+      has_feedback: true,
+      external_id: `matter:12345:7:${KeypadInput.Complete.id}:right`,
+      min: 0,
+      max: 1,
+    });
+    expect(gladysDevice.features[4]).to.deep.equal({
+      name: 'KeypadInput - 7 (Enter)',
+      selector: gladysDevice.features[4].selector,
+      category: 'television',
+      type: 'enter',
+      read_only: false,
+      has_feedback: true,
+      external_id: `matter:12345:7:${KeypadInput.Complete.id}:enter`,
+      min: 0,
+      max: 1,
+    });
+    expect(gladysDevice.features[5]).to.deep.equal({
+      name: 'KeypadInput - 7 (Return)',
+      selector: gladysDevice.features[5].selector,
+      category: 'television',
+      type: 'return',
+      read_only: false,
+      has_feedback: true,
+      external_id: `matter:12345:7:${KeypadInput.Complete.id}:return`,
+      min: 0,
+      max: 1,
+    });
   });
 });

--- a/server/test/services/matter/lib/matter.setValue.test.js
+++ b/server/test/services/matter/lib/matter.setValue.test.js
@@ -1231,4 +1231,576 @@ describe('Matter.setValue', () => {
     const promise = matterHandler.setValue(gladysDevice, gladysFeature, value);
     await chaiAssert.isRejected(promise, 'Device does not support RvcCleanMode cluster');
   });
+
+  it('should control television media playback (play)', async () => {
+    const gladysDevice = {
+      external_id: 'matter:12345:1',
+    };
+
+    const gladysFeature = {
+      category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+      type: DEVICE_FEATURE_TYPES.TELEVISION.PLAY,
+    };
+
+    const value = 1;
+
+    const clusterClients = new Map();
+
+    const mediaPlayback = {
+      play: fake.resolves(null),
+      pause: fake.resolves(null),
+      stop: fake.resolves(null),
+    };
+    clusterClients.set(1286, mediaPlayback);
+
+    matterHandler.nodesMap.set(12345n, {
+      isConnected: false,
+      connect: fake.resolves(null),
+      events: {
+        initialized: new Promise((resolve) => {
+          resolve();
+        }),
+      },
+      getDevices: fake.returns([
+        {
+          number: 1,
+          getClusterClientById: (id) => clusterClients.get(id),
+          getChildEndpoints: () => [],
+        },
+      ]),
+    });
+
+    await matterHandler.setValue(gladysDevice, gladysFeature, value);
+    assert.calledOnce(mediaPlayback.play);
+    assert.notCalled(mediaPlayback.pause);
+    assert.notCalled(mediaPlayback.stop);
+  });
+
+  it('should control television media playback (pause)', async () => {
+    const gladysDevice = {
+      external_id: 'matter:12345:1',
+    };
+
+    const gladysFeature = {
+      category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+      type: DEVICE_FEATURE_TYPES.TELEVISION.PAUSE,
+    };
+
+    const value = 1;
+
+    const clusterClients = new Map();
+
+    const mediaPlayback = {
+      play: fake.resolves(null),
+      pause: fake.resolves(null),
+      stop: fake.resolves(null),
+    };
+    clusterClients.set(1286, mediaPlayback);
+
+    matterHandler.nodesMap.set(12345n, {
+      isConnected: false,
+      connect: fake.resolves(null),
+      events: {
+        initialized: new Promise((resolve) => {
+          resolve();
+        }),
+      },
+      getDevices: fake.returns([
+        {
+          number: 1,
+          getClusterClientById: (id) => clusterClients.get(id),
+          getChildEndpoints: () => [],
+        },
+      ]),
+    });
+
+    await matterHandler.setValue(gladysDevice, gladysFeature, value);
+    assert.calledOnce(mediaPlayback.pause);
+    assert.notCalled(mediaPlayback.play);
+    assert.notCalled(mediaPlayback.stop);
+  });
+
+  it('should control television media playback (stop)', async () => {
+    const gladysDevice = {
+      external_id: 'matter:12345:1',
+    };
+
+    const gladysFeature = {
+      category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+      type: DEVICE_FEATURE_TYPES.TELEVISION.STOP,
+    };
+
+    const value = 1;
+
+    const clusterClients = new Map();
+
+    const mediaPlayback = {
+      play: fake.resolves(null),
+      pause: fake.resolves(null),
+      stop: fake.resolves(null),
+    };
+    clusterClients.set(1286, mediaPlayback);
+
+    matterHandler.nodesMap.set(12345n, {
+      isConnected: false,
+      connect: fake.resolves(null),
+      events: {
+        initialized: new Promise((resolve) => {
+          resolve();
+        }),
+      },
+      getDevices: fake.returns([
+        {
+          number: 1,
+          getClusterClientById: (id) => clusterClients.get(id),
+          getChildEndpoints: () => [],
+        },
+      ]),
+    });
+
+    await matterHandler.setValue(gladysDevice, gladysFeature, value);
+    assert.calledOnce(mediaPlayback.stop);
+    assert.notCalled(mediaPlayback.play);
+    assert.notCalled(mediaPlayback.pause);
+  });
+
+  it('should control television volume', async () => {
+    const gladysDevice = {
+      external_id: 'matter:12345:1',
+    };
+
+    const gladysFeature = {
+      category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+      type: DEVICE_FEATURE_TYPES.TELEVISION.VOLUME,
+    };
+
+    const value = 42;
+
+    const clusterClients = new Map();
+
+    const levelControl = {
+      moveToLevel: fake.resolves(null),
+    };
+    clusterClients.set(8, levelControl);
+
+    matterHandler.nodesMap.set(12345n, {
+      isConnected: false,
+      connect: fake.resolves(null),
+      events: {
+        initialized: new Promise((resolve) => {
+          resolve();
+        }),
+      },
+      getDevices: fake.returns([
+        {
+          number: 1,
+          getClusterClientById: (id) => clusterClients.get(id),
+          getChildEndpoints: () => [],
+        },
+      ]),
+    });
+
+    await matterHandler.setValue(gladysDevice, gladysFeature, value);
+    assert.calledOnce(levelControl.moveToLevel);
+    assert.calledWith(levelControl.moveToLevel, {
+      level: value,
+      transitionTime: null,
+      optionsMask: {
+        coupleColorTempToLevel: false,
+        executeIfOff: true,
+      },
+      optionsOverride: {},
+    });
+  });
+
+  it('should send television keypad UP key', async () => {
+    const gladysDevice = {
+      external_id: 'matter:12345:1',
+    };
+
+    const gladysFeature = {
+      category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+      type: DEVICE_FEATURE_TYPES.TELEVISION.UP,
+    };
+
+    const value = 1;
+
+    const clusterClients = new Map();
+
+    const keypadInput = {
+      sendKey: fake.resolves(null),
+    };
+    clusterClients.set(1289, keypadInput);
+
+    matterHandler.nodesMap.set(12345n, {
+      isConnected: false,
+      connect: fake.resolves(null),
+      events: {
+        initialized: new Promise((resolve) => {
+          resolve();
+        }),
+      },
+      getDevices: fake.returns([
+        {
+          number: 1,
+          getClusterClientById: (id) => clusterClients.get(id),
+          getChildEndpoints: () => [],
+        },
+      ]),
+    });
+
+    await matterHandler.setValue(gladysDevice, gladysFeature, value);
+    assert.calledOnce(keypadInput.sendKey);
+    assert.calledWith(keypadInput.sendKey, { keyCode: 1 });
+  });
+
+  it('should send television keypad DOWN key', async () => {
+    const gladysDevice = {
+      external_id: 'matter:12345:1',
+    };
+
+    const gladysFeature = {
+      category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+      type: DEVICE_FEATURE_TYPES.TELEVISION.DOWN,
+    };
+
+    const value = 1;
+
+    const clusterClients = new Map();
+
+    const keypadInput = {
+      sendKey: fake.resolves(null),
+    };
+    clusterClients.set(1289, keypadInput);
+
+    matterHandler.nodesMap.set(12345n, {
+      isConnected: false,
+      connect: fake.resolves(null),
+      events: {
+        initialized: new Promise((resolve) => {
+          resolve();
+        }),
+      },
+      getDevices: fake.returns([
+        {
+          number: 1,
+          getClusterClientById: (id) => clusterClients.get(id),
+          getChildEndpoints: () => [],
+        },
+      ]),
+    });
+
+    await matterHandler.setValue(gladysDevice, gladysFeature, value);
+    assert.calledOnce(keypadInput.sendKey);
+    assert.calledWith(keypadInput.sendKey, { keyCode: 2 });
+  });
+
+  it('should send television keypad LEFT key', async () => {
+    const gladysDevice = {
+      external_id: 'matter:12345:1',
+    };
+
+    const gladysFeature = {
+      category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+      type: DEVICE_FEATURE_TYPES.TELEVISION.LEFT,
+    };
+
+    const value = 1;
+
+    const clusterClients = new Map();
+
+    const keypadInput = {
+      sendKey: fake.resolves(null),
+    };
+    clusterClients.set(1289, keypadInput);
+
+    matterHandler.nodesMap.set(12345n, {
+      isConnected: false,
+      connect: fake.resolves(null),
+      events: {
+        initialized: new Promise((resolve) => {
+          resolve();
+        }),
+      },
+      getDevices: fake.returns([
+        {
+          number: 1,
+          getClusterClientById: (id) => clusterClients.get(id),
+          getChildEndpoints: () => [],
+        },
+      ]),
+    });
+
+    await matterHandler.setValue(gladysDevice, gladysFeature, value);
+    assert.calledOnce(keypadInput.sendKey);
+    assert.calledWith(keypadInput.sendKey, { keyCode: 3 });
+  });
+
+  it('should send television keypad RIGHT key', async () => {
+    const gladysDevice = {
+      external_id: 'matter:12345:1',
+    };
+
+    const gladysFeature = {
+      category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+      type: DEVICE_FEATURE_TYPES.TELEVISION.RIGHT,
+    };
+
+    const value = 1;
+
+    const clusterClients = new Map();
+
+    const keypadInput = {
+      sendKey: fake.resolves(null),
+    };
+    clusterClients.set(1289, keypadInput);
+
+    matterHandler.nodesMap.set(12345n, {
+      isConnected: false,
+      connect: fake.resolves(null),
+      events: {
+        initialized: new Promise((resolve) => {
+          resolve();
+        }),
+      },
+      getDevices: fake.returns([
+        {
+          number: 1,
+          getClusterClientById: (id) => clusterClients.get(id),
+          getChildEndpoints: () => [],
+        },
+      ]),
+    });
+
+    await matterHandler.setValue(gladysDevice, gladysFeature, value);
+    assert.calledOnce(keypadInput.sendKey);
+    assert.calledWith(keypadInput.sendKey, { keyCode: 4 });
+  });
+
+  it('should send television keypad ENTER key', async () => {
+    const gladysDevice = {
+      external_id: 'matter:12345:1',
+    };
+
+    const gladysFeature = {
+      category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+      type: DEVICE_FEATURE_TYPES.TELEVISION.ENTER,
+    };
+
+    const value = 1;
+
+    const clusterClients = new Map();
+
+    const keypadInput = {
+      sendKey: fake.resolves(null),
+    };
+    clusterClients.set(1289, keypadInput);
+
+    matterHandler.nodesMap.set(12345n, {
+      isConnected: false,
+      connect: fake.resolves(null),
+      events: {
+        initialized: new Promise((resolve) => {
+          resolve();
+        }),
+      },
+      getDevices: fake.returns([
+        {
+          number: 1,
+          getClusterClientById: (id) => clusterClients.get(id),
+          getChildEndpoints: () => [],
+        },
+      ]),
+    });
+
+    await matterHandler.setValue(gladysDevice, gladysFeature, value);
+    assert.calledOnce(keypadInput.sendKey);
+    assert.calledWith(keypadInput.sendKey, { keyCode: 43 });
+  });
+
+  it('should send television keypad RETURN key', async () => {
+    const gladysDevice = {
+      external_id: 'matter:12345:1',
+    };
+
+    const gladysFeature = {
+      category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+      type: DEVICE_FEATURE_TYPES.TELEVISION.RETURN,
+    };
+
+    const value = 1;
+
+    const clusterClients = new Map();
+
+    const keypadInput = {
+      sendKey: fake.resolves(null),
+    };
+    clusterClients.set(1289, keypadInput);
+
+    matterHandler.nodesMap.set(12345n, {
+      isConnected: false,
+      connect: fake.resolves(null),
+      events: {
+        initialized: new Promise((resolve) => {
+          resolve();
+        }),
+      },
+      getDevices: fake.returns([
+        {
+          number: 1,
+          getClusterClientById: (id) => clusterClients.get(id),
+          getChildEndpoints: () => [],
+        },
+      ]),
+    });
+
+    await matterHandler.setValue(gladysDevice, gladysFeature, value);
+    assert.calledOnce(keypadInput.sendKey);
+    assert.calledWith(keypadInput.sendKey, { keyCode: 13 });
+  });
+
+  it('should return an error if television media playback cluster is missing', async () => {
+    const gladysDevice = {
+      external_id: 'matter:12345:1',
+    };
+
+    const gladysFeature = {
+      category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+      type: DEVICE_FEATURE_TYPES.TELEVISION.PLAY,
+    };
+
+    const value = 1;
+    const clusterClients = new Map();
+
+    matterHandler.nodesMap.set(12345n, {
+      isConnected: false,
+      connect: fake.resolves(null),
+      events: {
+        initialized: new Promise((resolve) => {
+          resolve();
+        }),
+      },
+      getDevices: fake.returns([
+        {
+          number: 1,
+          getClusterClientById: (id) => clusterClients.get(id),
+          getChildEndpoints: () => [],
+        },
+      ]),
+    });
+
+    const promise = matterHandler.setValue(gladysDevice, gladysFeature, value);
+    await chaiAssert.isRejected(promise, 'Device does not support MediaPlayback cluster');
+  });
+
+  it('should not call media playback commands when value is not 1', async () => {
+    const gladysDevice = {
+      external_id: 'matter:12345:1',
+    };
+
+    const gladysFeature = {
+      category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+      type: DEVICE_FEATURE_TYPES.TELEVISION.PLAY,
+    };
+
+    const value = 0;
+    const clusterClients = new Map();
+
+    const mediaPlayback = {
+      play: fake.resolves(null),
+      pause: fake.resolves(null),
+      stop: fake.resolves(null),
+    };
+    clusterClients.set(1286, mediaPlayback);
+
+    matterHandler.nodesMap.set(12345n, {
+      isConnected: false,
+      connect: fake.resolves(null),
+      events: {
+        initialized: new Promise((resolve) => {
+          resolve();
+        }),
+      },
+      getDevices: fake.returns([
+        {
+          number: 1,
+          getClusterClientById: (id) => clusterClients.get(id),
+          getChildEndpoints: () => [],
+        },
+      ]),
+    });
+
+    await matterHandler.setValue(gladysDevice, gladysFeature, value);
+    assert.notCalled(mediaPlayback.play);
+    assert.notCalled(mediaPlayback.pause);
+    assert.notCalled(mediaPlayback.stop);
+  });
+
+  it('should return an error if television volume cluster is missing', async () => {
+    const gladysDevice = {
+      external_id: 'matter:12345:1',
+    };
+
+    const gladysFeature = {
+      category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+      type: DEVICE_FEATURE_TYPES.TELEVISION.VOLUME,
+    };
+
+    const value = 42;
+    const clusterClients = new Map();
+
+    matterHandler.nodesMap.set(12345n, {
+      isConnected: false,
+      connect: fake.resolves(null),
+      events: {
+        initialized: new Promise((resolve) => {
+          resolve();
+        }),
+      },
+      getDevices: fake.returns([
+        {
+          number: 1,
+          getClusterClientById: (id) => clusterClients.get(id),
+          getChildEndpoints: () => [],
+        },
+      ]),
+    });
+
+    const promise = matterHandler.setValue(gladysDevice, gladysFeature, value);
+    await chaiAssert.isRejected(promise, 'Device does not support LevelControl cluster');
+  });
+
+  it('should return an error if television keypad cluster is missing', async () => {
+    const gladysDevice = {
+      external_id: 'matter:12345:1',
+    };
+
+    const gladysFeature = {
+      category: DEVICE_FEATURE_CATEGORIES.TELEVISION,
+      type: DEVICE_FEATURE_TYPES.TELEVISION.UP,
+    };
+
+    const value = 1;
+    const clusterClients = new Map();
+
+    matterHandler.nodesMap.set(12345n, {
+      isConnected: false,
+      connect: fake.resolves(null),
+      events: {
+        initialized: new Promise((resolve) => {
+          resolve();
+        }),
+      },
+      getDevices: fake.returns([
+        {
+          number: 1,
+          getClusterClientById: (id) => clusterClients.get(id),
+          getChildEndpoints: () => [],
+        },
+      ]),
+    });
+
+    const promise = matterHandler.setValue(gladysDevice, gladysFeature, value);
+    await chaiAssert.isRejected(promise, 'Device does not support KeypadInput cluster');
+  });
 });

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -1571,6 +1571,7 @@ const DASHBOARD_BOX_TYPE = {
   CLOCK: 'clock',
   SCENE: 'scene',
   MUSIC: 'music',
+  TELEVISION: 'television',
   GAUGE: 'gauge',
   ENERGY_CONSUMPTION: 'energy-consumption',
   VOICE_ASSISTANT: 'voice-assistant',


### PR DESCRIPTION
## What this PR does

Adds support for three new Matter clusters in the Gladys Matter integration, 
enabling media player devices (TV, set-top boxes, audio players) bridged 
via Matterbridge to be fully controlled from Gladys.

## New clusters supported

- **MediaPlayback** → play, pause, stop features (TELEVISION category)
- **LevelControl** (without lighting feature) → volume control (TELEVISION category)
- **KeypadInput** → navigation keys: up, down, left, right, enter, return (TELEVISION category)

## Why

These clusters are exposed by Matterbridge plugins for media devices 
(tested with a Freebox Player Delta via matterbridge-ai-plugin-factory #13).
Without this PR, only the OnOff switch was recognized by Gladys.

## Related

- https://community.gladysassistant.com/t/matter-support-des-clusters-mediaplayback-keypadinput-et-levelcontrol-pour-les-appareils-media/10223
- https://github.com/GladysAssistant/matterbridge-ai-plugin-factory/issues/13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added television media playback controls (play, pause, stop)
  * Added television volume control with improved min/max range handling and sensible defaults when device attributes are unavailable
  * Added remote control directional and action inputs (up, down, left, right, enter, return)
  * Now surfaces explicit errors when required television control capabilities are missing

* **Tests**
  * Added comprehensive tests for television playback, volume, keypad controls, edge cases, and missing-capability behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->