### PR TITLE
Zigbee2mqtt : Add trigger_alarm, stop_alarm

### DIFF
--- a/server/services/zigbee2mqtt/exposes/enumType.js
+++ b/server/services/zigbee2mqtt/exposes/enumType.js
@@ -2,6 +2,7 @@ const {
   DEVICE_FEATURE_CATEGORIES,
   DEVICE_FEATURE_TYPES,
   BUTTON_STATUS,
+  BUTTON_PUSH,
   COVER_STATE,
   SIREN_LMH_VOLUME,
   PILOT_WIRE_MODE,
@@ -149,6 +150,11 @@ addMapping('liquid_state', LIQUID_STATE.LOW, 'low');
 addMapping('liquid_state', LIQUID_STATE.NORMAL, 'normal');
 addMapping('liquid_state', LIQUID_STATE.HIGH, 'high');
 
+// Bosch BSIR-EZ outdoor siren
+// https://www.zigbee2mqtt.io/devices/BSIR-EZ.html
+addMapping('trigger_alarm', BUTTON_PUSH.PRESSED, 'trigger');
+addMapping('stop_alarm', BUTTON_PUSH.PRESSED, 'stop');
+
 module.exports = {
   type: 'enum',
   writeValue: (expose, value) => {
@@ -217,6 +223,18 @@ module.exports = {
       feature: {
         category: DEVICE_FEATURE_CATEGORIES.LEVEL_SENSOR,
         type: DEVICE_FEATURE_TYPES.LEVEL_SENSOR.LIQUID_STATE,
+      },
+    },
+    trigger_alarm: {
+      feature: {
+        category: DEVICE_FEATURE_CATEGORIES.BUTTON,
+        type: DEVICE_FEATURE_TYPES.BUTTON.PUSH,
+      },
+    },
+    stop_alarm: {
+      feature: {
+        category: DEVICE_FEATURE_CATEGORIES.BUTTON,
+        type: DEVICE_FEATURE_TYPES.BUTTON.PUSH,
       },
     },
   },

--- a/server/test/services/zigbee2mqtt/exposes/sirenAlarmEnumType.test.js
+++ b/server/test/services/zigbee2mqtt/exposes/sirenAlarmEnumType.test.js
@@ -1,0 +1,67 @@
+const { assert } = require('chai');
+
+const enumType = require('../../../../services/zigbee2mqtt/exposes/enumType');
+const { buildFeatures } = require('../../../../services/zigbee2mqtt/utils/features/buildFeatures');
+const { BUTTON_PUSH } = require('../../../../utils/constants');
+
+describe('zigbee2mqtt Bosch siren alarm enumType', () => {
+  const triggerAlarmExpose = {
+    name: 'trigger_alarm',
+    property: 'trigger_alarm',
+    type: 'enum',
+    access: 2,
+    values: ['trigger'],
+  };
+
+  const stopAlarmExpose = {
+    name: 'stop_alarm',
+    property: 'stop_alarm',
+    type: 'enum',
+    access: 2,
+    values: ['stop'],
+  };
+
+  it('should write trigger_alarm value', () => {
+    const result = enumType.writeValue(triggerAlarmExpose, BUTTON_PUSH.PRESSED);
+    assert.equal(result, 'trigger');
+  });
+
+  it('should write stop_alarm value', () => {
+    const result = enumType.writeValue(stopAlarmExpose, BUTTON_PUSH.PRESSED);
+    assert.equal(result, 'stop');
+  });
+
+  it('should build trigger_alarm feature as writable button push', () => {
+    const [feature] = buildFeatures('bosch-siren', triggerAlarmExpose);
+
+    assert.deepEqual(feature, {
+      read_only: false,
+      has_feedback: false,
+      min: 0,
+      max: 1,
+      category: 'button',
+      type: 'push',
+      name: 'Trigger alarm',
+      external_id: 'zigbee2mqtt:bosch-siren:button:push:trigger_alarm',
+      selector: 'zigbee2mqtt-bosch-siren-button-push-trigger-alarm',
+      unit: null,
+    });
+  });
+
+  it('should build stop_alarm feature as writable button push', () => {
+    const [feature] = buildFeatures('bosch-siren', stopAlarmExpose);
+
+    assert.deepEqual(feature, {
+      read_only: false,
+      has_feedback: false,
+      min: 0,
+      max: 1,
+      category: 'button',
+      type: 'push',
+      name: 'Stop alarm',
+      external_id: 'zigbee2mqtt:bosch-siren:button:push:stop_alarm',
+      selector: 'zigbee2mqtt-bosch-siren-button-push-stop-alarm',
+      unit: null,
+    });
+  });
+});

--- a/server/test/services/zigbee2mqtt/lib/payloads/event_device_result.json
+++ b/server/test/services/zigbee2mqtt/lib/payloads/event_device_result.json
@@ -268,5 +268,38 @@
     ],
     "should_poll": false,
     "service_id": "f87b7af2-ca8e-44fc-b754-444354b42fee"
+  },
+  {
+    "name": "bosch-outdoor-siren",
+    "model": "BSIR-EZ",
+    "external_id": "zigbee2mqtt:bosch-outdoor-siren",
+    "features": [
+      {
+        "read_only": false,
+        "has_feedback": false,
+        "min": 0,
+        "max": 1,
+        "category": "button",
+        "type": "push",
+        "unit": null,
+        "name": "Trigger alarm",
+        "external_id": "zigbee2mqtt:bosch-outdoor-siren:button:push:trigger_alarm",
+        "selector": "zigbee2mqtt-bosch-outdoor-siren-button-push-trigger-alarm"
+      },
+      {
+        "read_only": false,
+        "has_feedback": false,
+        "min": 0,
+        "max": 1,
+        "category": "button",
+        "type": "push",
+        "unit": null,
+        "name": "Stop alarm",
+        "external_id": "zigbee2mqtt:bosch-outdoor-siren:button:push:stop_alarm",
+        "selector": "zigbee2mqtt-bosch-outdoor-siren-button-push-stop-alarm"
+      }
+    ],
+    "should_poll": false,
+    "service_id": "f87b7af2-ca8e-44fc-b754-444354b42fee"
   }
 ]

--- a/server/test/services/zigbee2mqtt/lib/payloads/mqtt_devices_get.json
+++ b/server/test/services/zigbee2mqtt/lib/payloads/mqtt_devices_get.json
@@ -350,5 +350,37 @@
     "software_build_id": "3000-0001",
     "supported": false,
     "type": "EndDevice"
+  },
+  {
+    "definition": {
+      "description": "Outdoor siren",
+      "exposes": [
+        {
+          "access": 2,
+          "description": "Trigger an alarm on the device",
+          "name": "trigger_alarm",
+          "property": "trigger_alarm",
+          "type": "enum",
+          "values": ["trigger"]
+        },
+        {
+          "access": 2,
+          "description": "Stop an active alarm on the device",
+          "name": "stop_alarm",
+          "property": "stop_alarm",
+          "type": "enum",
+          "values": ["stop"]
+        }
+      ],
+      "model": "BSIR-EZ",
+      "supports_ota": true,
+      "vendor": "Bosch"
+    },
+    "friendly_name": "bosch-outdoor-siren",
+    "ieee_address": "0x00124b0023a1b2c3",
+    "interview_completed": true,
+    "interviewing": false,
+    "supported": true,
+    "type": "Router"
   }
 ]

--- a/server/test/services/zigbee2mqtt/lib/setValue.test.js
+++ b/server/test/services/zigbee2mqtt/lib/setValue.test.js
@@ -2,6 +2,7 @@ const sinon = require('sinon');
 
 const { assert, fake } = sinon;
 const { expect } = require('chai');
+const { BUTTON_PUSH } = require('../../../../utils/constants');
 
 const Zigbee2MqttManager = require('../../../../services/zigbee2mqtt/lib');
 
@@ -39,6 +40,16 @@ const featureBinary = {
 const featureColor = {
   external_id: 'zigbee2mqtt:0x00158d00045b2740:light:color:color',
   type: 'color',
+};
+
+const featureTriggerAlarm = {
+  external_id: 'zigbee2mqtt:bosch-outdoor-siren:button:push:trigger_alarm',
+  type: 'push',
+};
+
+const featureStopAlarm = {
+  external_id: 'zigbee2mqtt:bosch-outdoor-siren:button:push:stop_alarm',
+  type: 'push',
 };
 
 describe('zigbee2mqtt setValue', () => {
@@ -129,6 +140,24 @@ describe('zigbee2mqtt setValue', () => {
       mqttClient.publish,
       `zigbee2mqtt/0x00158d00045b2740/set`,
       JSON.stringify({ alarm: false }),
+    );
+  });
+
+  it('set Bosch siren trigger_alarm', async () => {
+    await zigbee2MqttManager.setValue(null, featureTriggerAlarm, BUTTON_PUSH.PRESSED);
+    assert.calledOnceWithExactly(
+      mqttClient.publish,
+      'zigbee2mqtt/bosch-outdoor-siren/set',
+      JSON.stringify({ trigger_alarm: 'trigger' }),
+    );
+  });
+
+  it('set Bosch siren stop_alarm', async () => {
+    await zigbee2MqttManager.setValue(null, featureStopAlarm, BUTTON_PUSH.PRESSED);
+    assert.calledOnceWithExactly(
+      mqttClient.publish,
+      'zigbee2mqtt/bosch-outdoor-siren/set',
+      JSON.stringify({ stop_alarm: 'stop' }),
     );
   });
 });

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -92,6 +92,10 @@ const BUTTON_STATUS = {
   OFF_DOUBLE: 86,
 };
 
+const BUTTON_PUSH = {
+  PRESSED: 1,
+};
+
 const COVER_STATE = {
   STOP: 0,
   OPEN: 1,
@@ -1562,6 +1566,7 @@ const ENERGY_PRICE_DAY_TYPES_LIST = createList(ENERGY_PRICE_DAY_TYPES);
 
 module.exports.STATE = STATE;
 module.exports.BUTTON_STATUS = BUTTON_STATUS;
+module.exports.BUTTON_PUSH = BUTTON_PUSH;
 module.exports.COVER_STATE = COVER_STATE;
 module.exports.LOCK = LOCK;
 module.exports.SIREN_LMH_VOLUME = SIREN_LMH_VOLUME;


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

Implement: https://community.gladysassistant.com/t/zigbee2mqtt-ajout-fonctionnalites-trigger-alarm-stop-alarm-pour-sirene-bosch-dans-gladys/10239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Bosch BSIR‑EZ outdoor siren with button controls to trigger and stop alarms.

* **Tests**
  * Added unit/integration tests and fixtures verifying siren exposes, feature creation, and MQTT payloads for trigger/stop actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->