### PR TITLE
Dashboard : Add link widget

### DIFF
--- a/front/src/components/boxs/link/EditLinkBox.jsx
+++ b/front/src/components/boxs/link/EditLinkBox.jsx
@@ -1,0 +1,72 @@
+import { Component } from 'preact';
+import { Localizer, Text } from 'preact-i18n';
+import BaseEditBox from '../baseEditBox';
+
+const DEFAULT_ICON = 'link';
+
+const LINK_ICONS = ['link', 'globe', 'server', 'hard-drive', 'wifi', 'monitor', 'cpu', 'home'];
+
+class EditLinkBox extends Component {
+  updateTitle = e => {
+    this.props.updateBoxConfig(this.props.x, this.props.y, { title: e.target.value });
+  };
+
+  updateUrl = e => {
+    this.props.updateBoxConfig(this.props.x, this.props.y, { url: e.target.value });
+  };
+
+  updateIcon = e => {
+    this.props.updateBoxConfig(this.props.x, this.props.y, { icon: e.target.value });
+  };
+
+  render(props) {
+    const icon = props.box.icon || DEFAULT_ICON;
+
+    return (
+      <BaseEditBox {...props} titleKey="dashboard.boxTitle.link">
+        <div class="form-group">
+          <label>
+            <Text id="dashboard.boxes.link.editTitleLabel" />
+          </label>
+          <Localizer>
+            <input
+              type="text"
+              class="form-control"
+              placeholder={<Text id="dashboard.boxes.link.editTitlePlaceholder" />}
+              value={props.box.title || ''}
+              onInput={this.updateTitle}
+            />
+          </Localizer>
+        </div>
+        <div class="form-group">
+          <label>
+            <Text id="dashboard.boxes.link.editUrlLabel" />
+          </label>
+          <Localizer>
+            <input
+              type="url"
+              class="form-control"
+              placeholder={<Text id="dashboard.boxes.link.editUrlPlaceholder" />}
+              value={props.box.url || ''}
+              onInput={this.updateUrl}
+            />
+          </Localizer>
+        </div>
+        <div class="form-group">
+          <label>
+            <Text id="dashboard.boxes.link.editIconLabel" />
+          </label>
+          <select value={icon} onChange={this.updateIcon} class="form-control">
+            {LINK_ICONS.map(linkIcon => (
+              <option value={linkIcon}>
+                <Text id={`dashboard.boxes.link.icons.${linkIcon}`} />
+              </option>
+            ))}
+          </select>
+        </div>
+      </BaseEditBox>
+    );
+  }
+}
+
+export default EditLinkBox;

--- a/front/src/components/boxs/link/LinkBox.jsx
+++ b/front/src/components/boxs/link/LinkBox.jsx
@@ -1,0 +1,35 @@
+import { Text } from 'preact-i18n';
+import get from 'get-value';
+import style from './style.css';
+
+const DEFAULT_ICON = 'link';
+
+const LinkBox = ({ box }) => {
+  const title = get(box, 'title', '');
+  const url = get(box, 'url', '');
+  const icon = get(box, 'icon', DEFAULT_ICON);
+
+  if (!url) {
+    return (
+      <div class="card">
+        <div class="card-body text-muted text-center">
+          <Text id="dashboard.boxes.link.emptyUrl" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <a href={url} target="_blank" rel="noopener noreferrer" class={style.linkCard}>
+      <div class="card mb-0">
+        <div class={style.linkContent}>
+          <i class={`fe fe-${icon} ${style.linkIcon}`} />
+          <span class={style.linkTitle}>{title || url}</span>
+          <i class={`fe fe-external-link ${style.linkArrow}`} />
+        </div>
+      </div>
+    </a>
+  );
+};
+
+export default LinkBox;

--- a/front/src/components/boxs/link/style.css
+++ b/front/src/components/boxs/link/style.css
@@ -1,0 +1,40 @@
+.linkCard {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.linkCard:hover {
+  text-decoration: none;
+  color: inherit;
+}
+
+.linkContent {
+  display: flex;
+  align-items: center;
+  padding: 1.25rem 1.5rem;
+  gap: 0.75rem;
+}
+
+.linkIcon {
+  font-size: 1.5rem;
+  flex-shrink: 0;
+}
+
+.linkTitle {
+  flex: 1;
+  font-size: 1rem;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.linkArrow {
+  flex-shrink: 0;
+  opacity: 0.5;
+}
+
+.linkCard:hover .linkArrow {
+  opacity: 1;
+}

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -286,7 +286,8 @@
       "music": "Musik",
       "gauge": "Messanzeige",
       "energy-consumption": "Energieverbrauch",
-      "voice-assistant": "Sprachassistent"
+      "voice-assistant": "Sprachassistent",
+      "link": "Link"
     },
     "boxes": {
       "column": "Spalte {{index}}",
@@ -466,6 +467,24 @@
         "editNameLabel": "Widget-Name (optional)",
         "editNamePlaceholder": "Name auf dem Dashboard angezeigt",
         "editSceneLabel": "Wähle die Szene aus, die hier angezeigt werden soll."
+      },
+      "link": {
+        "editTitleLabel": "Titel",
+        "editTitlePlaceholder": "z. B. Tasmota - Steckdose Wohnzimmer",
+        "editUrlLabel": "URL",
+        "editUrlPlaceholder": "http://192.168.1.50",
+        "editIconLabel": "Symbol",
+        "emptyUrl": "Keine URL konfiguriert.",
+        "icons": {
+          "link": "Link",
+          "globe": "Webseite",
+          "server": "Server",
+          "hard-drive": "Speicher (NAS)",
+          "wifi": "WLAN-Netzwerk",
+          "monitor": "Weboberfläche",
+          "cpu": "Verbundenes Gerät",
+          "home": "Zuhause"
+        }
       },
       "alarm": {
         "armButton": "Einschalten",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -286,7 +286,8 @@
       "music": "Music",
       "gauge": "Gauge",
       "energy-consumption": "Energy Consumption",
-      "voice-assistant": "Voice assistant"
+      "voice-assistant": "Voice assistant",
+      "link": "Link"
     },
     "boxes": {
       "column": "Column {{index}}",
@@ -483,6 +484,24 @@
         "editNameLabel": "Widget Name (optional)",
         "editNamePlaceholder": "Name displayed on the dashboard",
         "editSceneLabel": "Select the scene you want to display here."
+      },
+      "link": {
+        "editTitleLabel": "Title",
+        "editTitlePlaceholder": "E.g. Tasmota - Living room plug",
+        "editUrlLabel": "URL",
+        "editUrlPlaceholder": "http://192.168.1.50",
+        "editIconLabel": "Icon",
+        "emptyUrl": "No URL configured.",
+        "icons": {
+          "link": "Link",
+          "globe": "Website",
+          "server": "Server",
+          "hard-drive": "Storage (NAS)",
+          "wifi": "Wi-Fi network",
+          "monitor": "Web interface",
+          "cpu": "Connected device",
+          "home": "Home"
+        }
       },
       "alarm": {
         "armButton": "Arm",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -286,7 +286,8 @@
       "music": "Musique",
       "gauge": "Jauge",
       "energy-consumption": "Consommation Énergétique",
-      "voice-assistant": "Assistant vocal"
+      "voice-assistant": "Assistant vocal",
+      "link": "Lien"
     },
     "boxes": {
       "column": "Colonne {{index}}",
@@ -453,6 +454,24 @@
         "editNameLabel": "Nom du widget (optionnel)",
         "editNamePlaceholder": "Nom affiché sur le tableau de bord",
         "editSceneLabel": "Sélectionnez la scène que vous souhaitez afficher ici."
+      },
+      "link": {
+        "editTitleLabel": "Titre",
+        "editTitlePlaceholder": "Ex : Tasmota - Prise salon",
+        "editUrlLabel": "URL",
+        "editUrlPlaceholder": "http://192.168.1.50",
+        "editIconLabel": "Icône",
+        "emptyUrl": "Aucune URL configurée.",
+        "icons": {
+          "link": "Lien",
+          "globe": "Site web",
+          "server": "Serveur",
+          "hard-drive": "Stockage (NAS)",
+          "wifi": "Réseau Wi-Fi",
+          "monitor": "Interface web",
+          "cpu": "Appareil connecté",
+          "home": "Maison"
+        }
       },
       "alarm": {
         "armButton": "Armer",

--- a/front/src/routes/dashboard/Box.jsx
+++ b/front/src/routes/dashboard/Box.jsx
@@ -15,6 +15,7 @@ import EdfTempoBox from '../../components/boxs/edf-tempo/EdfTempo';
 import GaugeBox from '../../components/boxs/gauge/GaugeBox';
 import EnergyConsumptionBox from '../../components/boxs/energy-consumption/EnergyConsumption';
 import VoiceAssistantBox from '../../components/boxs/voice-assistant/VoiceAssistantBox';
+import LinkBox from '../../components/boxs/link/LinkBox';
 
 const Box = ({ children, ...props }) => {
   switch (props.box.type) {
@@ -52,6 +53,8 @@ const Box = ({ children, ...props }) => {
       return <EnergyConsumptionBox {...props} />;
     case 'voice-assistant':
       return <VoiceAssistantBox {...props} />;
+    case 'link':
+      return <LinkBox {...props} />;
   }
 };
 

--- a/front/src/routes/dashboard/edit-dashboard/EditBox.jsx
+++ b/front/src/routes/dashboard/edit-dashboard/EditBox.jsx
@@ -18,6 +18,7 @@ import EditEdfTempoBox from '../../../components/boxs/edf-tempo/EditEdfTempo';
 import EditGaugeBox from '../../../components/boxs/gauge/EditGaugeBox';
 import EditEnergyConsumptionBox from '../../../components/boxs/energy-consumption/EditEnergyConsumption';
 import EditVoiceAssistantBox from '../../../components/boxs/voice-assistant/EditVoiceAssistantBox';
+import EditLinkBox from '../../../components/boxs/link/EditLinkBox';
 
 const Box = ({ children, ...props }) => {
   switch (props.box.type) {
@@ -55,6 +56,8 @@ const Box = ({ children, ...props }) => {
       return <EditEnergyConsumptionBox {...props} />;
     case 'voice-assistant':
       return <EditVoiceAssistantBox {...props} />;
+    case 'link':
+      return <EditLinkBox {...props} />;
     default:
       return <SelectBoxType {...props} />;
   }

--- a/server/models/dashboard.js
+++ b/server/models/dashboard.js
@@ -46,6 +46,8 @@ const boxesSchema = Joi.array().items(
       gauge_color_high: Joi.string(),
       colors: Joi.array().items(Joi.string()),
       show_subscription_prices: Joi.boolean(),
+      url: Joi.string().uri({ scheme: ['http', 'https'] }),
+      icon: Joi.string(),
     }),
   ),
 );

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -1439,6 +1439,7 @@ const DASHBOARD_BOX_TYPE = {
   GAUGE: 'gauge',
   ENERGY_CONSUMPTION: 'energy-consumption',
   VOICE_ASSISTANT: 'voice-assistant',
+  LINK: 'link',
 };
 
 const ERROR_MESSAGES = {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

From: https://community.gladysassistant.com/t/simple-link-in-the-dhshboard/10256 & https://community.gladysassistant.com/t/mettre-des-liens-vers-des-sites-sur-le-tableau-de-bord/9172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Link widget type for dashboards. Users can create link cards with custom titles, URLs, and choose from multiple icon options. Link widgets display titles with an external link indicator and securely open URLs in new tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->