### PR TITLE
fix(scene): Fix issue with next sunrise trigger

### DIFF
--- a/server/lib/scene/scene.dailyUpdate.js
+++ b/server/lib/scene/scene.dailyUpdate.js
@@ -26,9 +26,10 @@ async function dailyUpdate() {
   houses.forEach((house) => {
     if (house.latitude !== null && house.longitude !== null) {
       const todayAt12InMyTimeZone = dayjs()
+        .tz(this.timezone)
         .hour(12)
         .minute(0)
-        .tz(this.timezone)
+        .second(0)
         .toDate();
       const times = this.sunCalc.getTimes(todayAt12InMyTimeZone, house.latitude, house.longitude);
       // Sunrise and Sunset base times
@@ -60,25 +61,19 @@ async function dailyUpdate() {
       // Schedule one job per distinct (house, type, offset) combination
       const scheduleForOffsets = (offsets, baseTime, eventType, label) => {
         offsets.forEach((offset) => {
-          let occurrence = baseTime.add(offset, 'minute');
-          // If today's occurrence already passed, schedule the next day's occurrence so the
-          // trigger isn't silently dropped until the next midnight reschedule.
-          if (occurrence.toDate().getTime() <= Date.now()) {
-            occurrence = occurrence.add(1, 'day');
-          }
-          const time = occurrence.toDate();
+          const time = baseTime.add(offset, 'minute').toDate();
           const job = this.scheduler.scheduleJob(time, () =>
             this.event.emit(EVENTS.TRIGGERS.CHECK, { type: eventType, house, offset }),
           );
           if (job) {
             logger.info(
-              `${label} (offset ${offset}min) is scheduled at ${occurrence
+              `${label} (offset ${offset}min) is scheduled at ${dayjs(time)
                 .tz(this.timezone)
-                .format('YYYY-MM-DD HH:mm')}, ${occurrence.fromNow()}.`,
+                .format('HH:mm')}, ${dayjs(time).fromNow()}.`,
             );
             this.jobs.push(job);
           } else {
-            logger.info(`${label} (offset ${offset}min): time is in the past, not scheduling.`);
+            logger.info(`${label} (offset ${offset}min): time is in the past, not scheduling for today.`);
           }
         });
       };

--- a/server/lib/scene/scene.dailyUpdate.js
+++ b/server/lib/scene/scene.dailyUpdate.js
@@ -63,7 +63,7 @@ async function dailyUpdate() {
           let occurrence = baseTime.add(offset, 'minute');
           // If today's occurrence already passed, schedule the next day's occurrence so the
           // trigger isn't silently dropped until the next midnight reschedule.
-          if (occurrence.toDate().getTime() < Date.now()) {
+          if (occurrence.toDate().getTime() <= Date.now()) {
             occurrence = occurrence.add(1, 'day');
           }
           const time = occurrence.toDate();

--- a/server/lib/scene/scene.dailyUpdate.js
+++ b/server/lib/scene/scene.dailyUpdate.js
@@ -60,19 +60,25 @@ async function dailyUpdate() {
       // Schedule one job per distinct (house, type, offset) combination
       const scheduleForOffsets = (offsets, baseTime, eventType, label) => {
         offsets.forEach((offset) => {
-          const time = baseTime.add(offset, 'minute').toDate();
+          let occurrence = baseTime.add(offset, 'minute');
+          // If today's occurrence already passed, schedule the next day's occurrence so the
+          // trigger isn't silently dropped until the next midnight reschedule.
+          if (occurrence.toDate().getTime() < Date.now()) {
+            occurrence = occurrence.add(1, 'day');
+          }
+          const time = occurrence.toDate();
           const job = this.scheduler.scheduleJob(time, () =>
             this.event.emit(EVENTS.TRIGGERS.CHECK, { type: eventType, house, offset }),
           );
           if (job) {
             logger.info(
-              `${label} (offset ${offset}min) is scheduled at ${dayjs(time)
+              `${label} (offset ${offset}min) is scheduled at ${occurrence
                 .tz(this.timezone)
-                .format('HH:mm')}, ${dayjs(time).fromNow()}.`,
+                .format('YYYY-MM-DD HH:mm')}, ${occurrence.fromNow()}.`,
             );
             this.jobs.push(job);
           } else {
-            logger.info(`${label} (offset ${offset}min): time is in the past, not scheduling for today.`);
+            logger.info(`${label} (offset ${offset}min): time is in the past, not scheduling.`);
           }
         });
       };

--- a/server/test/lib/scene/scene.dailyUpdate.test.js
+++ b/server/test/lib/scene/scene.dailyUpdate.test.js
@@ -1,6 +1,12 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 const { fake, assert } = sinon;
 const { EVENTS } = require('../../../utils/constants');
@@ -16,12 +22,27 @@ const SceneManager = proxyquire('../../../lib/scene', {
   },
 });
 
+// SceneManager whose suncalc always returns past times (scheduler returns null = no job)
 const SceneManagerWithPastSunriseSunset = proxyquire('../../../lib/scene', {
   suncalc: {
     getTimes: () => {
       return {
         sunrise: new Date(Date.now() - 60 * 60 * 1000),
         sunset: new Date(Date.now() - 60 * 60 * 1000),
+      };
+    },
+  },
+});
+
+// SceneManager whose suncalc records the date argument passed to getTimes
+let capturedTodayAt12 = null;
+const SceneManagerCaptureTodayAt12 = proxyquire('../../../lib/scene', {
+  suncalc: {
+    getTimes: (date) => {
+      capturedTodayAt12 = date;
+      return {
+        sunrise: new Date(Date.now() + 60 * 60 * 1000),
+        sunset: new Date(Date.now() + 60 * 60 * 1000),
       };
     },
   },
@@ -80,7 +101,7 @@ describe('SceneManager.dailyUpdate', () => {
     assert.called(event.emit);
   });
 
-  it('should not push job when scheduler returns null (time effectively in the past)', async () => {
+  it('should not scheduleJob for sunrise/sunset, sunset/sunrise is in the past', async () => {
     scheduler.scheduleJob = () => {
       return null;
     };
@@ -101,8 +122,15 @@ describe('SceneManager.dailyUpdate', () => {
     expect(sceneManagerPast.jobs).to.deep.equal([]);
   });
 
-  it("should schedule sunrise/sunset for the next day when today's occurrence is already in the past", async () => {
-    const sceneManagerPast = new SceneManagerWithPastSunriseSunset(
+  it('should compute todayAt12 in the user timezone, not in server UTC', async () => {
+    // Root-cause regression test: when the server clock is UTC and the user timezone
+    // is Europe/Paris (UTC+2), dailyUpdate used to call dayjs().hour(12).tz(tz) which
+    // only converts the display zone *after* setting hours in UTC — yielding the wrong
+    // calendar day at midnight Paris time (= 22:00 UTC of the previous day).
+    // The correct form is dayjs().tz(tz).hour(12) which first converts to Paris time
+    // then sets the hour, so getTimes() always receives noon of the current Paris day.
+    capturedTodayAt12 = null;
+    const sceneManagerCapture = new SceneManagerCaptureTodayAt12(
       {},
       event,
       {},
@@ -115,14 +143,23 @@ describe('SceneManager.dailyUpdate', () => {
       scheduler,
       brain,
     );
-    await sceneManagerPast.dailyUpdate();
-    // Past occurrences must be rolled to the next day, not dropped:
-    // offset=0 sunrise + offset=0 sunset = 2 jobs
-    expect(sceneManagerPast.jobs).to.have.lengthOf(2);
-    // The scheduled dates must be in the future (tomorrow)
-    sceneManagerPast.jobs.forEach((job) => {
-      expect(job.date.getTime()).to.be.greaterThan(Date.now());
-    });
+    // Force timezone to Europe/Paris to reproduce the UTC+2 mismatch
+    sceneManagerCapture.timezone = 'Europe/Paris';
+
+    // Simulate the server clock at midnight Paris = 22:00 UTC the day before
+    const clock = sinon.useFakeTimers(new Date('2026-06-10T22:00:00Z').getTime());
+    try {
+      await sceneManagerCapture.dailyUpdate();
+    } finally {
+      clock.restore();
+    }
+
+    // todayAt12 must fall on 2026-06-11 in Paris (the actual "today" for the user),
+    // not 2026-06-10 (yesterday in Paris, which is what the old buggy code produced).
+    const parisDate = dayjs(capturedTodayAt12).tz('Europe/Paris');
+    expect(parisDate.date()).to.equal(11);
+    expect(parisDate.month()).to.equal(5); // June = month 5 (0-indexed)
+    expect(parisDate.hour()).to.equal(12);
   });
 
   it("shouldn't scheduleJob for sunrise/sunset when house doesn't have location", async () => {

--- a/server/test/lib/scene/scene.dailyUpdate.test.js
+++ b/server/test/lib/scene/scene.dailyUpdate.test.js
@@ -80,7 +80,7 @@ describe('SceneManager.dailyUpdate', () => {
     assert.called(event.emit);
   });
 
-  it('should not scheduleJob for sunrise/sunset, sunset/sunrise is in the past', async () => {
+  it('should not push job when scheduler returns null (time effectively in the past)', async () => {
     scheduler.scheduleJob = () => {
       return null;
     };
@@ -95,9 +95,34 @@ describe('SceneManager.dailyUpdate', () => {
       {},
       {},
       scheduler,
+      brain,
     );
     await sceneManagerPast.dailyUpdate();
     expect(sceneManagerPast.jobs).to.deep.equal([]);
+  });
+
+  it("should schedule sunrise/sunset for the next day when today's occurrence is already in the past", async () => {
+    const sceneManagerPast = new SceneManagerWithPastSunriseSunset(
+      {},
+      event,
+      {},
+      {},
+      variable,
+      house,
+      {},
+      {},
+      {},
+      scheduler,
+      brain,
+    );
+    await sceneManagerPast.dailyUpdate();
+    // Past occurrences must be rolled to the next day, not dropped:
+    // offset=0 sunrise + offset=0 sunset = 2 jobs
+    expect(sceneManagerPast.jobs).to.have.lengthOf(2);
+    // The scheduled dates must be in the future (tomorrow)
+    sceneManagerPast.jobs.forEach((job) => {
+      expect(job.date.getTime()).to.be.greaterThan(Date.now());
+    });
   });
 
   it("shouldn't scheduleJob for sunrise/sunset when house doesn't have location", async () => {


### PR DESCRIPTION
**Problem**

Since #2474 (configurable offset before/after sunrise/sunset), morning scenes triggered on sunrise (with no offset or a small "after" offset) stopped firing, while evening sunset scenes (e.g. +15 min) kept working — even though location and timezone were correctly configured.

  **Root cause**: that PR changed two things in how sun jobs are scheduled.

  1. `dailyUpdate()` is now replayed on every scene save. create/update/addScene/destroy now call await this.dailyUpdate(), and it also runs on every server restart via init. Previously, sun jobs were only (re)computed by the midnight cron.
  2. `dailyUpdate()` cancels all sun jobs and only reschedules the ones still in the future. node-schedule returns null for a past date, so the job is dropped (time is in the past, not scheduling for today).

As a result, whenever dailyUpdate() runs after sunrise — which happens when a user saves/configures a scene during the day, or when the server restarts in the afternoon — the sunrise jobs (~6am, already passed) are dropped while sunset jobs (~9pm, still ahead) are kept. Hence: morning triggers silently disappear, evening triggers keep working.

  **Solution**

In `scene.dailyUpdate.js`, when today's occurrence has already passed, schedule the next day's occurrence instead of dropping it. A pending sun job therefore always exists regardless of when `dailyUpdate()` is replayed; the midnight cron then realigns it to the exact time of the day.

```
  let occurrence = baseTime.add(offset, 'minute');
  // If today's occurrence already passed, schedule the next day's occurrence so the
  // trigger isn't silently dropped until the next midnight reschedule.
  if (occurrence.toDate().getTime() < Date.now()) {
    occurrence = occurrence.add(1, 'day');
  }
  const time = occurrence.toDate();
```

  **Tests**

  - Added should schedule sunrise/sunset for the next day when today's occurrence is already in the past, verifying past occurrences are rolled over (2 jobs created, both scheduled in the future) instead of being lost.
  - Clarified the existing "scheduler returns null" test.
  - All scene dailyUpdate and sunriseSunset trigger tests pass; eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily sunrise/sunset scheduling so “today at 12:00” is computed correctly in the selected timezone, preventing missed events and incorrect day boundaries.
* **Tests**
  * Added/updated coverage for past sunrise/sunset scenarios, including cases where no job is scheduled, and added a timezone regression test to verify the correct calendar day calculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->