### PR TITLE
Node-RED : Add upgrade selector to upgrade major version

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -1102,7 +1102,11 @@
         "gladys": "Gladys",
         "usernameLabel": "Benutzername",
         "passwordLabel": "Passwort",
-        "urlLabel": "URL der Node-RED-Oberfläche: <a href=\"{{nodeRedUrl}}\" target=\"_blank\">{{nodeRedUrl}}</a> (nicht von Gladys Plus aus zugänglich)"
+        "urlLabel": "URL der Node-RED-Oberfläche: <a href=\"{{nodeRedUrl}}\" target=\"_blank\">{{nodeRedUrl}}</a> (nicht von Gladys Plus aus zugänglich)",
+        "majorVersionLabel": "Node-RED-Hauptversion",
+        "majorVersionHelp": "Wähle die Hauptversion von Node-RED aus. Bestehende Installationen bleiben standardmäßig bei Version 3. Neue Installationen verwenden Version 5.",
+        "majorVersionUpdateWarning": "Das Ändern der Node-RED-Version erstellt den Container neu. Deine Flows und deine Konfiguration bleiben erhalten, aber erstelle vor dem Upgrade unbedingt ein Backup.",
+        "majorVersionUpdateButton": "Node-RED-Version aktualisieren"
       }
     },
     "matterbridge": {

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -997,7 +997,11 @@
         "gladys": "Gladys",
         "usernameLabel": "Username",
         "passwordLabel": "Password",
-        "urlLabel": "Node-RED interface url: <a href=\"{{nodeRedUrl}}\" target=\"_blank\">{{nodeRedUrl}}</a> (Not accessible from Gladys Plus)"
+        "urlLabel": "Node-RED interface url: <a href=\"{{nodeRedUrl}}\" target=\"_blank\">{{nodeRedUrl}}</a> (Not accessible from Gladys Plus)",
+        "majorVersionLabel": "Node-RED major version",
+        "majorVersionHelp": "Select the major version of Node-RED to run. Existing installations default to version 3. New installations use version 5.",
+        "majorVersionUpdateWarning": "Changing the Node-RED version will recreate the container. Your flows and configuration will be kept, but make sure you have a backup before upgrading.",
+        "majorVersionUpdateButton": "Update Node-RED version"
       }
     },
     "matterbridge": {

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -1235,7 +1235,11 @@
         "gladys": "Gladys",
         "usernameLabel": "Nom d'utilisateur",
         "passwordLabel": "Mot de passe",
-        "urlLabel": "Url de l'interface Node-RED : <a href=\"{{nodeRedUrl}}\" target=\"_blank\">{{nodeRedUrl}}</a> (Pas accessible depuis Gladys Plus)"
+        "urlLabel": "Url de l'interface Node-RED : <a href=\"{{nodeRedUrl}}\" target=\"_blank\">{{nodeRedUrl}}</a> (Pas accessible depuis Gladys Plus)",
+        "majorVersionLabel": "Version majeure de Node-RED",
+        "majorVersionHelp": "Sélectionnez la version majeure de Node-RED à utiliser. Les installations existantes restent en version 3 par défaut. Les nouvelles installations utilisent la version 5.",
+        "majorVersionUpdateWarning": "Le changement de version va recréer le conteneur Node-RED. Vos flows et votre configuration seront conservés, mais pensez à faire une sauvegarde avant la mise à jour.",
+        "majorVersionUpdateButton": "Mettre à jour la version de Node-RED"
       }
     },
     "matterbridge": {

--- a/front/src/routes/integration/all/node-red/setup-page/SetupTab.jsx
+++ b/front/src/routes/integration/all/node-red/setup-page/SetupTab.jsx
@@ -83,7 +83,7 @@ class SetupTab extends Component {
 
   startContainer = async () => {
     let error = false;
-    const { selectedMajorVersion, dockerNodeRedVersion } = this.state;
+    const { selectedMajorVersion } = this.state;
 
     this.setState({
       nodeRedStatus: RequestStatus.Getting

--- a/front/src/routes/integration/all/node-red/setup-page/SetupTab.jsx
+++ b/front/src/routes/integration/all/node-red/setup-page/SetupTab.jsx
@@ -17,6 +17,17 @@ class SetupTab extends Component {
   };
 
   getConfiguration = async () => {
+    const stateUpdate = {};
+
+    try {
+      const nodeRedConfiguration = await this.props.httpClient.get('/api/v1/service/node-red/configuration');
+      stateUpdate.dockerNodeRedVersion = nodeRedConfiguration.dockerNodeRedVersion;
+      stateUpdate.availableMajorVersions = nodeRedConfiguration.availableMajorVersions;
+      stateUpdate.selectedMajorVersion = nodeRedConfiguration.dockerNodeRedVersion;
+    } catch (e) {
+      // Configuration not available yet
+    }
+
     try {
       const nodeRedUsernameVariable = await this.props.httpClient.get(
         '/api/v1/service/node-red/variable/NODE_RED_USERNAME'
@@ -35,13 +46,15 @@ class SetupTab extends Component {
         nodeRedUrl = `${url.protocol}//${url.hostname}:${nodeRedPortVariable.value}`;
       }
 
-      this.setState({
-        nodeRedUsername: nodeRedUsernameVariable.value,
-        nodeRedPassword: nodeRedPasswordVariable.value,
-        nodeRedUrl
-      });
+      stateUpdate.nodeRedUsername = nodeRedUsernameVariable.value;
+      stateUpdate.nodeRedPassword = nodeRedPasswordVariable.value;
+      stateUpdate.nodeRedUrl = nodeRedUrl;
     } catch (e) {
       // Variable is not set yet
+    }
+
+    if (Object.keys(stateUpdate).length > 0) {
+      this.setState(stateUpdate);
     }
   };
 
@@ -70,10 +83,28 @@ class SetupTab extends Component {
 
   startContainer = async () => {
     let error = false;
+    const { selectedMajorVersion, dockerNodeRedVersion } = this.state;
 
     this.setState({
       nodeRedStatus: RequestStatus.Getting
     });
+
+    if (selectedMajorVersion) {
+      try {
+        const nodeRedConfiguration = await this.props.httpClient.post('/api/v1/service/node-red/configuration', {
+          dockerNodeRedVersion: selectedMajorVersion
+        });
+        this.setState({
+          dockerNodeRedVersion: nodeRedConfiguration.dockerNodeRedVersion,
+          selectedMajorVersion: nodeRedConfiguration.dockerNodeRedVersion
+        });
+      } catch (e) {
+        this.setState({
+          nodeRedStatus: RequestStatus.Error
+        });
+        return;
+      }
+    }
 
     await this.props.httpClient.post('/api/v1/service/node-red/variable/NODERED_ENABLED', {
       value: true
@@ -168,6 +199,40 @@ class SetupTab extends Component {
     this.setState({ showConfirmDelete: false });
   };
 
+  onMajorVersionChange = event => {
+    this.setState({ selectedMajorVersion: event.target.value });
+  };
+
+  saveMajorVersion = async () => {
+    const { selectedMajorVersion, dockerNodeRedVersion } = this.state;
+
+    if (selectedMajorVersion === dockerNodeRedVersion) {
+      return;
+    }
+
+    this.setState({
+      nodeRedStatus: RequestStatus.Getting
+    });
+
+    try {
+      const nodeRedConfiguration = await this.props.httpClient.post('/api/v1/service/node-red/configuration', {
+        dockerNodeRedVersion: selectedMajorVersion
+      });
+
+      this.setState({
+        dockerNodeRedVersion: nodeRedConfiguration.dockerNodeRedVersion,
+        selectedMajorVersion: nodeRedConfiguration.dockerNodeRedVersion,
+        nodeRedStatus: RequestStatus.Success
+      });
+      await this.checkStatus();
+    } catch (e) {
+      this.setState({
+        nodeRedStatus: RequestStatus.Error,
+        selectedMajorVersion: dockerNodeRedVersion
+      });
+    }
+  };
+
   render(
     props,
     {
@@ -181,9 +246,14 @@ class SetupTab extends Component {
       nodeRedUrl,
       nodeRedStatus,
       showPassword,
-      showConfirmDelete
+      showConfirmDelete,
+      dockerNodeRedVersion,
+      availableMajorVersions,
+      selectedMajorVersion
     }
   ) {
+    const hasMajorVersionChanged =
+      selectedMajorVersion && dockerNodeRedVersion && selectedMajorVersion !== dockerNodeRedVersion;
     return (
       <div class="card">
         <div class="card-header">
@@ -212,6 +282,45 @@ class SetupTab extends Component {
             networkModeValid={networkModeValid}
             nodeRedStatus={nodeRedStatus}
           />
+
+          {dockerBased && networkModeValid && availableMajorVersions && (
+            <div class="form-group">
+              <label htmlFor="nodeRedMajorVersion" className="form-label">
+                <Text id="integration.nodeRed.setup.majorVersionLabel" />
+              </label>
+              <select
+                id="nodeRedMajorVersion"
+                name="nodeRedMajorVersion"
+                class="form-control"
+                value={selectedMajorVersion || dockerNodeRedVersion}
+                onChange={this.onMajorVersionChange}
+                disabled={nodeRedStatus === RequestStatus.Getting}
+              >
+                {availableMajorVersions.map(majorVersion => (
+                  <option key={majorVersion} value={majorVersion}>
+                    {majorVersion}
+                  </option>
+                ))}
+              </select>
+              <div class="help-block">
+                <Text id="integration.nodeRed.setup.majorVersionHelp" />
+              </div>
+              {hasMajorVersionChanged && (
+                <div class="mt-3">
+                  <div class="alert alert-warning">
+                    <Text id="integration.nodeRed.setup.majorVersionUpdateWarning" />
+                  </div>
+                  <button
+                    onClick={this.saveMajorVersion}
+                    class="btn btn-primary"
+                    disabled={nodeRedStatus === RequestStatus.Getting}
+                  >
+                    <Text id="integration.nodeRed.setup.majorVersionUpdateButton" />
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
 
           {nodeRedRunning && (
             <div>

--- a/front/src/routes/integration/all/node-red/setup-page/SetupTab.jsx
+++ b/front/src/routes/integration/all/node-red/setup-page/SetupTab.jsx
@@ -10,6 +10,14 @@ import config from '../../../../../config';
 
 let cx = classNames.bind(style);
 
+const normalizeMajorVersion = value => {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+
+  return String(value);
+};
+
 class SetupTab extends Component {
   componentDidMount = () => {
     this.checkStatus();
@@ -21,9 +29,9 @@ class SetupTab extends Component {
 
     try {
       const nodeRedConfiguration = await this.props.httpClient.get('/api/v1/service/node-red/configuration');
-      stateUpdate.dockerNodeRedVersion = nodeRedConfiguration.dockerNodeRedVersion;
+      stateUpdate.dockerNodeRedVersion = normalizeMajorVersion(nodeRedConfiguration.dockerNodeRedVersion);
       stateUpdate.availableMajorVersions = nodeRedConfiguration.availableMajorVersions;
-      stateUpdate.selectedMajorVersion = nodeRedConfiguration.dockerNodeRedVersion;
+      stateUpdate.selectedMajorVersion = normalizeMajorVersion(nodeRedConfiguration.dockerNodeRedVersion);
     } catch (e) {
       // Configuration not available yet
     }
@@ -83,20 +91,20 @@ class SetupTab extends Component {
 
   startContainer = async () => {
     let error = false;
-    const { selectedMajorVersion } = this.state;
+    const { selectedMajorVersion, dockerNodeRedVersion } = this.state;
 
     this.setState({
       nodeRedStatus: RequestStatus.Getting
     });
 
-    if (selectedMajorVersion) {
+    if (selectedMajorVersion && selectedMajorVersion !== dockerNodeRedVersion) {
       try {
         const nodeRedConfiguration = await this.props.httpClient.post('/api/v1/service/node-red/configuration', {
           dockerNodeRedVersion: selectedMajorVersion
         });
         this.setState({
-          dockerNodeRedVersion: nodeRedConfiguration.dockerNodeRedVersion,
-          selectedMajorVersion: nodeRedConfiguration.dockerNodeRedVersion
+          dockerNodeRedVersion: normalizeMajorVersion(nodeRedConfiguration.dockerNodeRedVersion),
+          selectedMajorVersion: normalizeMajorVersion(nodeRedConfiguration.dockerNodeRedVersion)
         });
       } catch (e) {
         this.setState({
@@ -200,7 +208,7 @@ class SetupTab extends Component {
   };
 
   onMajorVersionChange = event => {
-    this.setState({ selectedMajorVersion: event.target.value });
+    this.setState({ selectedMajorVersion: normalizeMajorVersion(event.target.value) });
   };
 
   saveMajorVersion = async () => {
@@ -220,15 +228,15 @@ class SetupTab extends Component {
       });
 
       this.setState({
-        dockerNodeRedVersion: nodeRedConfiguration.dockerNodeRedVersion,
-        selectedMajorVersion: nodeRedConfiguration.dockerNodeRedVersion,
+        dockerNodeRedVersion: normalizeMajorVersion(nodeRedConfiguration.dockerNodeRedVersion),
+        selectedMajorVersion: normalizeMajorVersion(nodeRedConfiguration.dockerNodeRedVersion),
         nodeRedStatus: RequestStatus.Success
       });
       await this.checkStatus();
     } catch (e) {
       this.setState({
         nodeRedStatus: RequestStatus.Error,
-        selectedMajorVersion: dockerNodeRedVersion
+        selectedMajorVersion: normalizeMajorVersion(dockerNodeRedVersion)
       });
     }
   };

--- a/server/services/node-red/api/node-red.controller.js
+++ b/server/services/node-red/api/node-red.controller.js
@@ -73,7 +73,8 @@ module.exports = function NodeRedController(gladys, nodeRedManager) {
    */
   async function updateConfiguration(req, res) {
     logger.debug('Update Node-RED configuration');
-    const configuration = await nodeRedManager.updateMajorVersion(req.body.dockerNodeRedVersion);
+    const { dockerNodeRedVersion } = req.body || {};
+    const configuration = await nodeRedManager.updateMajorVersion(dockerNodeRedVersion);
     res.json({
       dockerNodeRedVersion: configuration.dockerNodeRedVersion,
       availableMajorVersions: configuration.availableMajorVersions,

--- a/server/services/node-red/api/node-red.controller.js
+++ b/server/services/node-red/api/node-red.controller.js
@@ -52,6 +52,34 @@ module.exports = function NodeRedController(gladys, nodeRedManager) {
     });
   }
 
+  /**
+   * @api {get} /api/v1/service/node-red/configuration Get Node-RED configuration
+   * @apiName getConfiguration
+   * @apiGroup Node-RED
+   */
+  async function getConfiguration(req, res) {
+    logger.debug('Get Node-RED configuration');
+    const configuration = await nodeRedManager.getConfiguration();
+    res.json({
+      dockerNodeRedVersion: configuration.dockerNodeRedVersion,
+      availableMajorVersions: configuration.availableMajorVersions,
+    });
+  }
+
+  /**
+   * @api {post} /api/v1/service/node-red/configuration Update Node-RED major version
+   * @apiName updateConfiguration
+   * @apiGroup Node-RED
+   */
+  async function updateConfiguration(req, res) {
+    logger.debug('Update Node-RED configuration');
+    const configuration = await nodeRedManager.updateMajorVersion(req.body.dockerNodeRedVersion);
+    res.json({
+      dockerNodeRedVersion: configuration.dockerNodeRedVersion,
+      availableMajorVersions: configuration.availableMajorVersions,
+    });
+  }
+
   return {
     'get /api/v1/service/node-red/status': {
       authenticated: true,
@@ -68,6 +96,14 @@ module.exports = function NodeRedController(gladys, nodeRedManager) {
     'post /api/v1/service/node-red/disconnect': {
       authenticated: true,
       controller: asyncMiddleware(disconnect),
+    },
+    'get /api/v1/service/node-red/configuration': {
+      authenticated: true,
+      controller: asyncMiddleware(getConfiguration),
+    },
+    'post /api/v1/service/node-red/configuration': {
+      authenticated: true,
+      controller: asyncMiddleware(updateConfiguration),
     },
   };
 };

--- a/server/services/node-red/lib/checkForContainerUpdates.js
+++ b/server/services/node-red/lib/checkForContainerUpdates.js
@@ -1,38 +1,38 @@
 const logger = require('../../../utils/logger');
-const { DEFAULT } = require('./constants');
 
 const nodeRedContainerDescriptor = require('../docker/gladys-node-red-container.json');
+const { containerMatchesMajorVersion, resolveNodeRedMajorVersion } = require('./nodeRedVersion');
 
 /**
- * @description Checks if version is the latest for this service, if not, it removes existing containers.
+ * @description Checks if the running container matches the selected Node-RED major version.
  * @param {object} config - Service configuration properties.
  * @example
  * await nodeRed.checkForContainerUpdates(config);
  */
-async function checkForContainerUpdates(config) {
+async function checkForContainerUpdates(config = {}) {
   logger.info('Node-RED: Checking for current installed versions and required updates...');
 
-  // Check for NodeRed container version
-  if (config.dockerNodeRedVersion !== DEFAULT.DOCKER_NODE_RED_VERSION) {
-    logger.info(`Node-RED: update #${DEFAULT.DOCKER_NODE_RED_VERSION} of the container required...`);
+  const selectedMajorVersion = resolveNodeRedMajorVersion(config);
 
-    const containers = await this.gladys.system.getContainers({
-      all: true,
-      filters: { name: [nodeRedContainerDescriptor.name] },
-    });
+  const containers = await this.gladys.system.getContainers({
+    all: true,
+    filters: { name: [nodeRedContainerDescriptor.name] },
+  });
 
-    if (containers.length !== 0) {
-      logger.debug('Node-RED: Removing current installed Node-RED container...');
-      // If container is present, we remove it
-      // The init process will create it again
-      const [container] = containers;
-      await this.gladys.system.removeContainer(container.id, { force: true });
-    }
-
-    // Update to last version
-    config.dockerNodeRedVersion = DEFAULT.DOCKER_NODE_RED_VERSION;
-    logger.info(`Node-RED: update #${DEFAULT.DOCKER_NODE_RED_VERSION} of the container done`);
+  if (containers.length === 0) {
+    return;
   }
+
+  const [container] = containers;
+
+  if (containerMatchesMajorVersion(container.image, selectedMajorVersion)) {
+    return;
+  }
+
+  logger.info(`Node-RED: update to major version #${selectedMajorVersion} of the container required...`);
+  logger.debug('Node-RED: Removing current installed Node-RED container...');
+  await this.gladys.system.removeContainer(container.id, { force: true });
+  logger.info(`Node-RED: update to major version #${selectedMajorVersion} of the container done`);
 }
 
 module.exports = {

--- a/server/services/node-red/lib/constants.js
+++ b/server/services/node-red/lib/constants.js
@@ -6,15 +6,26 @@ const CONFIGURATION = {
   NODE_RED_PASSWORD: 'NODE_RED_PASSWORD',
   NODE_RED_PORT: 'NODE_RED_PORT',
 
-  DOCKER_NODE_RED_VERSION: 'DOCKER_NODE_RED_VERSION', // Variable to identify last version of NodeRed docker file is installed
+  DOCKER_NODE_RED_VERSION: 'DOCKER_NODE_RED_VERSION',
+};
+
+const NODE_RED_MAJOR_VERSIONS = ['3', '4', '5'];
+
+const NODE_RED_IMAGE_TAGS = {
+  3: '3.1',
+  4: '4.1',
+  5: '5.0',
 };
 
 const DEFAULT = {
-  DOCKER_NODE_RED_VERSION: '3', // Last version of NodeRed docker file,
+  NODE_RED_MAJOR_VERSION_EXISTING: '3',
+  NODE_RED_MAJOR_VERSION_NEW: '5',
   CONFIGURATION_PATH: 'node-red/settings.js',
 };
 
 module.exports = {
   CONFIGURATION,
+  NODE_RED_MAJOR_VERSIONS,
+  NODE_RED_IMAGE_TAGS,
   DEFAULT,
 };

--- a/server/services/node-red/lib/getConfiguration.js
+++ b/server/services/node-red/lib/getConfiguration.js
@@ -1,6 +1,7 @@
 const { SYSTEM_VARIABLE_NAMES } = require('../../../utils/constants');
 const logger = require('../../../utils/logger');
-const { CONFIGURATION } = require('./constants');
+const { CONFIGURATION, NODE_RED_MAJOR_VERSIONS } = require('./constants');
+const { resolveNodeRedMajorVersion } = require('./nodeRedVersion');
 
 /**
  * @description Get Node-RED configuration.
@@ -22,11 +23,17 @@ async function getConfiguration() {
   // Gladys params
   const timezone = await this.gladys.variable.getValue(SYSTEM_VARIABLE_NAMES.TIMEZONE);
 
-  return {
+  const configuration = {
     nodeRedUsername,
     nodeRedPassword,
     dockerNodeRedVersion,
     timezone,
+  };
+
+  return {
+    ...configuration,
+    dockerNodeRedVersion: resolveNodeRedMajorVersion(configuration),
+    availableMajorVersions: NODE_RED_MAJOR_VERSIONS,
   };
 }
 

--- a/server/services/node-red/lib/index.js
+++ b/server/services/node-red/lib/index.js
@@ -7,6 +7,7 @@ const { disconnect } = require('./disconnect');
 const { isEnabled } = require('./isEnabled');
 const { status } = require('./status');
 const { configureContainer } = require('./configureContainer');
+const { updateMajorVersion } = require('./updateMajorVersion');
 
 /**
  * @description Add ability to connect to Node-RED.
@@ -38,5 +39,6 @@ NodeRedManager.prototype.disconnect = disconnect;
 NodeRedManager.prototype.isEnabled = isEnabled;
 NodeRedManager.prototype.status = status;
 NodeRedManager.prototype.configureContainer = configureContainer;
+NodeRedManager.prototype.updateMajorVersion = updateMajorVersion;
 
 module.exports = NodeRedManager;

--- a/server/services/node-red/lib/init.js
+++ b/server/services/node-red/lib/init.js
@@ -1,7 +1,8 @@
 const logger = require('../../../utils/logger');
-const { CONFIGURATION } = require('./constants');
+const { CONFIGURATION, NODE_RED_MAJOR_VERSIONS } = require('./constants');
 const { generate } = require('../../../utils/password');
 const { PlatformNotCompatible } = require('../../../utils/coreErrors');
+const { isExistingNodeRedUser, resolveNodeRedMajorVersion } = require('./nodeRedVersion');
 
 /**
  * @description Prepares service and starts connection with broker if needed.
@@ -29,6 +30,22 @@ async function init() {
 
   // Load stored configuration
   const configuration = await this.getConfiguration();
+  const existingUserBeforeInit = isExistingNodeRedUser(configuration);
+
+  const storedMajorVersion = await this.gladys.variable.getValue(
+    CONFIGURATION.DOCKER_NODE_RED_VERSION,
+    this.serviceId,
+  );
+
+  if (!storedMajorVersion || !NODE_RED_MAJOR_VERSIONS.includes(storedMajorVersion)) {
+    configuration.dockerNodeRedVersion = resolveNodeRedMajorVersion({
+      nodeRedUsername: existingUserBeforeInit ? configuration.nodeRedUsername : null,
+      nodeRedPassword: existingUserBeforeInit ? configuration.nodeRedPassword : null,
+      dockerNodeRedVersion: storedMajorVersion,
+    });
+  } else {
+    configuration.dockerNodeRedVersion = storedMajorVersion;
+  }
 
   if (!configuration.nodeRedPassword) {
     configuration.nodeRedUsername = CONFIGURATION.NODE_RED_USERNAME_VALUE;
@@ -38,6 +55,7 @@ async function init() {
       uppercase: true,
     });
   }
+
   await this.saveConfiguration(configuration);
 
   logger.debug('Node-RED: installing and starting required docker containers...');

--- a/server/services/node-red/lib/init.js
+++ b/server/services/node-red/lib/init.js
@@ -32,10 +32,7 @@ async function init() {
   const configuration = await this.getConfiguration();
   const existingUserBeforeInit = isExistingNodeRedUser(configuration);
 
-  const storedMajorVersion = await this.gladys.variable.getValue(
-    CONFIGURATION.DOCKER_NODE_RED_VERSION,
-    this.serviceId,
-  );
+  const storedMajorVersion = await this.gladys.variable.getValue(CONFIGURATION.DOCKER_NODE_RED_VERSION, this.serviceId);
 
   if (!storedMajorVersion || !NODE_RED_MAJOR_VERSIONS.includes(storedMajorVersion)) {
     configuration.dockerNodeRedVersion = resolveNodeRedMajorVersion({

--- a/server/services/node-red/lib/installContainer.js
+++ b/server/services/node-red/lib/installContainer.js
@@ -8,6 +8,7 @@ const { EVENTS, WEBSOCKET_MESSAGE_TYPES } = require('../../../utils/constants');
 const containerDescriptor = require('../docker/gladys-node-red-container.json');
 const { PlatformNotCompatible } = require('../../../utils/coreErrors');
 const { DEFAULT } = require('./constants');
+const { getNodeRedDockerImage, resolveNodeRedMajorVersion } = require('./nodeRedVersion');
 
 const sleep = promisify(setTimeout);
 
@@ -17,7 +18,7 @@ const sleep = promisify(setTimeout);
  * @example
  * await nodeRed.installContainer(config);
  */
-async function installContainer(config) {
+async function installContainer(config = {}) {
   if (!(await this.isEnabled())) {
     logger.info('Nodered: is not enabled, skipping...');
     return;
@@ -43,11 +44,14 @@ async function installContainer(config) {
   });
   let [container] = dockerContainers;
 
+  const majorVersion = resolveNodeRedMajorVersion(config);
+  const nodeRedDockerImage = getNodeRedDockerImage(majorVersion);
+
   if (dockerContainers.length === 0) {
     try {
       logger.info('Nodered: is being installed as Docker container...');
-      logger.info(`Pulling ${containerDescriptor.Image} image...`);
-      await this.gladys.system.pull(containerDescriptor.Image);
+      logger.info(`Pulling ${nodeRedDockerImage} image...`);
+      await this.gladys.system.pull(nodeRedDockerImage);
 
       // Prepare broker env
       logger.info(`Nodered: Preparing environment...`);
@@ -55,6 +59,7 @@ async function installContainer(config) {
 
       logger.info(`Creation of container...`);
       const containerDescriptorToMutate = cloneDeep(containerDescriptor);
+      containerDescriptorToMutate.Image = nodeRedDockerImage;
 
       const configFilepath = path.join(basePathOnHost, path.dirname(DEFAULT.CONFIGURATION_PATH));
 

--- a/server/services/node-red/lib/nodeRedVersion.js
+++ b/server/services/node-red/lib/nodeRedVersion.js
@@ -1,0 +1,64 @@
+const { DEFAULT, NODE_RED_IMAGE_TAGS, NODE_RED_MAJOR_VERSIONS } = require('./constants');
+
+/**
+ * @description Check if a user already had Node-RED configured before.
+ * @param {object} config - Node-RED configuration.
+ * @returns {boolean} True when existing Node-RED data is present.
+ */
+function isExistingNodeRedUser(config) {
+  return Boolean(config.nodeRedUsername || config.nodeRedPassword);
+}
+
+/**
+ * @description Resolve the Node-RED major version to use.
+ * @param {object} config - Node-RED configuration.
+ * @returns {string} Node-RED major version.
+ */
+function resolveNodeRedMajorVersion(config) {
+  const { dockerNodeRedVersion } = config;
+
+  if (dockerNodeRedVersion && NODE_RED_MAJOR_VERSIONS.includes(dockerNodeRedVersion)) {
+    return dockerNodeRedVersion;
+  }
+
+  if (isExistingNodeRedUser(config)) {
+    return DEFAULT.NODE_RED_MAJOR_VERSION_EXISTING;
+  }
+
+  return DEFAULT.NODE_RED_MAJOR_VERSION_NEW;
+}
+
+/**
+ * @description Get Docker image for a Node-RED major version.
+ * @param {string} majorVersion - Node-RED major version.
+ * @returns {string} Docker image reference.
+ */
+function getNodeRedDockerImage(majorVersion) {
+  const imageTag = NODE_RED_IMAGE_TAGS[majorVersion];
+
+  if (!imageTag) {
+    throw new Error(`NODE_RED_INVALID_MAJOR_VERSION: ${majorVersion}`);
+  }
+
+  return `nodered/node-red:${imageTag}`;
+}
+
+/**
+ * @description Check if a running container matches the selected major version.
+ * @param {string} containerImage - Container image reference.
+ * @param {string} majorVersion - Node-RED major version.
+ * @returns {boolean} True when the container image matches the major version.
+ */
+function containerMatchesMajorVersion(containerImage, majorVersion) {
+  const expectedImage = getNodeRedDockerImage(majorVersion);
+  const expectedTag = expectedImage.split(':')[1];
+
+  return containerImage === expectedImage || containerImage.endsWith(`:${expectedTag}`);
+}
+
+module.exports = {
+  isExistingNodeRedUser,
+  resolveNodeRedMajorVersion,
+  getNodeRedDockerImage,
+  containerMatchesMajorVersion,
+};

--- a/server/services/node-red/lib/nodeRedVersion.js
+++ b/server/services/node-red/lib/nodeRedVersion.js
@@ -4,6 +4,8 @@ const { DEFAULT, NODE_RED_IMAGE_TAGS, NODE_RED_MAJOR_VERSIONS } = require('./con
  * @description Check if a user already had Node-RED configured before.
  * @param {object} config - Node-RED configuration.
  * @returns {boolean} True when existing Node-RED data is present.
+ * @example
+ * isExistingNodeRedUser({ nodeRedUsername: 'admin' });
  */
 function isExistingNodeRedUser(config) {
   return Boolean(config.nodeRedUsername || config.nodeRedPassword);
@@ -13,6 +15,8 @@ function isExistingNodeRedUser(config) {
  * @description Resolve the Node-RED major version to use.
  * @param {object} config - Node-RED configuration.
  * @returns {string} Node-RED major version.
+ * @example
+ * resolveNodeRedMajorVersion({ dockerNodeRedVersion: '5' });
  */
 function resolveNodeRedMajorVersion(config) {
   const { dockerNodeRedVersion } = config;
@@ -32,6 +36,8 @@ function resolveNodeRedMajorVersion(config) {
  * @description Get Docker image for a Node-RED major version.
  * @param {string} majorVersion - Node-RED major version.
  * @returns {string} Docker image reference.
+ * @example
+ * getNodeRedDockerImage('5');
  */
 function getNodeRedDockerImage(majorVersion) {
   const imageTag = NODE_RED_IMAGE_TAGS[majorVersion];
@@ -48,6 +54,8 @@ function getNodeRedDockerImage(majorVersion) {
  * @param {string} containerImage - Container image reference.
  * @param {string} majorVersion - Node-RED major version.
  * @returns {boolean} True when the container image matches the major version.
+ * @example
+ * containerMatchesMajorVersion('nodered/node-red:5.0', '5');
  */
 function containerMatchesMajorVersion(containerImage, majorVersion) {
   const expectedImage = getNodeRedDockerImage(majorVersion);

--- a/server/services/node-red/lib/updateMajorVersion.js
+++ b/server/services/node-red/lib/updateMajorVersion.js
@@ -1,0 +1,45 @@
+const logger = require('../../../utils/logger');
+const { CONFIGURATION, NODE_RED_MAJOR_VERSIONS } = require('./constants');
+const { NotFoundError } = require('../../../utils/coreErrors');
+
+/**
+ * @description Update Node-RED major version and recreate container if needed.
+ * @param {string} majorVersion - Node-RED major version.
+ * @returns {Promise<object>} Updated Node-RED configuration.
+ * @example
+ * await nodeRed.updateMajorVersion('5');
+ */
+async function updateMajorVersion(majorVersion) {
+  if (!NODE_RED_MAJOR_VERSIONS.includes(majorVersion)) {
+    throw new NotFoundError('NODE_RED_INVALID_MAJOR_VERSION');
+  }
+
+  const storedMajorVersion = await this.gladys.variable.getValue(
+    CONFIGURATION.DOCKER_NODE_RED_VERSION,
+    this.serviceId,
+  );
+
+  if (storedMajorVersion === majorVersion) {
+    return this.getConfiguration();
+  }
+
+  const configuration = await this.getConfiguration();
+
+  logger.info(
+    `Node-RED: updating major version from ${storedMajorVersion || configuration.dockerNodeRedVersion} to ${majorVersion}...`,
+  );
+
+  configuration.dockerNodeRedVersion = majorVersion;
+  await this.saveConfiguration(configuration);
+
+  if (await this.isEnabled()) {
+    await this.checkForContainerUpdates(configuration);
+    await this.installContainer(configuration);
+  }
+
+  return this.getConfiguration();
+}
+
+module.exports = {
+  updateMajorVersion,
+};

--- a/server/services/node-red/lib/updateMajorVersion.js
+++ b/server/services/node-red/lib/updateMajorVersion.js
@@ -14,10 +14,7 @@ async function updateMajorVersion(majorVersion) {
     throw new NotFoundError('NODE_RED_INVALID_MAJOR_VERSION');
   }
 
-  const storedMajorVersion = await this.gladys.variable.getValue(
-    CONFIGURATION.DOCKER_NODE_RED_VERSION,
-    this.serviceId,
-  );
+  const storedMajorVersion = await this.gladys.variable.getValue(CONFIGURATION.DOCKER_NODE_RED_VERSION, this.serviceId);
 
   if (storedMajorVersion === majorVersion) {
     return this.getConfiguration();
@@ -26,7 +23,8 @@ async function updateMajorVersion(majorVersion) {
   const configuration = await this.getConfiguration();
 
   logger.info(
-    `Node-RED: updating major version from ${storedMajorVersion || configuration.dockerNodeRedVersion} to ${majorVersion}...`,
+    `Node-RED: updating major version from ${storedMajorVersion ||
+      configuration.dockerNodeRedVersion} to ${majorVersion}...`,
   );
 
   configuration.dockerNodeRedVersion = majorVersion;

--- a/server/test/services/node-red/api/node-red.controller.test.js
+++ b/server/test/services/node-red/api/node-red.controller.test.js
@@ -108,4 +108,14 @@ describe('NodeRed API', () => {
       availableMajorVersions: ['3', '4', '5'],
     });
   });
+
+  it('post /api/v1/service/node-red/configuration without body', async () => {
+    const req = {};
+    const res = {
+      json: fake.returns(null),
+    };
+
+    await controller['post /api/v1/service/node-red/configuration'].controller(req, res);
+    assert.calledOnceWithExactly(NodeRedManager.updateMajorVersion, undefined);
+  });
 });

--- a/server/test/services/node-red/api/node-red.controller.test.js
+++ b/server/test/services/node-red/api/node-red.controller.test.js
@@ -15,6 +15,14 @@ const NodeRedManager = {
   init: fake.returns(true),
   installContainer: fake.returns(true),
   disconnect: fake.returns(true),
+  getConfiguration: fake.resolves({
+    dockerNodeRedVersion: '3',
+    availableMajorVersions: ['3', '4', '5'],
+  }),
+  updateMajorVersion: fake.resolves({
+    dockerNodeRedVersion: '5',
+    availableMajorVersions: ['3', '4', '5'],
+  }),
 };
 
 describe('NodeRed API', () => {
@@ -67,5 +75,37 @@ describe('NodeRed API', () => {
     await controller['post /api/v1/service/node-red/disconnect'].controller(req, res);
     assert.calledOnce(NodeRedManager.disconnect);
     assert.calledWith(res.json, { success: true });
+  });
+
+  it('get /api/v1/service/node-red/configuration', async () => {
+    const req = {};
+    const res = {
+      json: fake.returns(null),
+    };
+
+    await controller['get /api/v1/service/node-red/configuration'].controller(req, res);
+    assert.calledOnce(NodeRedManager.getConfiguration);
+    assert.calledWith(res.json, {
+      dockerNodeRedVersion: '3',
+      availableMajorVersions: ['3', '4', '5'],
+    });
+  });
+
+  it('post /api/v1/service/node-red/configuration', async () => {
+    const req = {
+      body: {
+        dockerNodeRedVersion: '5',
+      },
+    };
+    const res = {
+      json: fake.returns(null),
+    };
+
+    await controller['post /api/v1/service/node-red/configuration'].controller(req, res);
+    assert.calledOnceWithExactly(NodeRedManager.updateMajorVersion, '5');
+    assert.calledWith(res.json, {
+      dockerNodeRedVersion: '5',
+      availableMajorVersions: ['3', '4', '5'],
+    });
   });
 });

--- a/server/test/services/node-red/lib/checkForContainerUpdates.test.js
+++ b/server/test/services/node-red/lib/checkForContainerUpdates.test.js
@@ -4,7 +4,6 @@ const sinon = require('sinon');
 const { assert, fake } = sinon;
 
 const NodeRedManager = require('../../../../services/node-red/lib');
-const { DEFAULT } = require('../../../../services/node-red/lib/constants');
 
 const serviceId = 'f87b7af2-ca8e-44fc-b754-444354b42fee';
 
@@ -34,60 +33,57 @@ describe('NodeRed checkForContainerUpdates', () => {
     sinon.reset();
   });
 
-  it('not updated, but no containers runnning -> it should only update config', async () => {
-    // PREPARE
+  it('should remove container when image does not match selected major version', async () => {
+    gladys.system.getContainers = fake.resolves([
+      {
+        id: 'container-id',
+        image: 'nodered/node-red:3.1',
+      },
+    ]);
     const config = {
-      dockerNodeRedVersion: 'BAD_REVISION',
+      dockerNodeRedVersion: '5',
     };
-    // EXECUTE
+
     await nodeRedManager.checkForContainerUpdates(config);
-    // ASSERT
+
     assert.calledWithExactly(gladys.system.getContainers, {
       all: true,
       filters: { name: ['gladys-node-red'] },
     });
-    assert.notCalled(gladys.system.removeContainer);
-
-    expect(config).deep.equal({
-      dockerNodeRedVersion: DEFAULT.DOCKER_NODE_RED_VERSION,
-    });
-  });
-
-  it('not updated, found both containers -> it should remove containers and update config', async () => {
-    // PREPARE
-    gladys.system.getContainers = fake.resolves([{ id: 'container-id' }]);
-    const config = {
-      dockerNodeRedVersion: 'BAD_REVISION',
-    };
-    // EXECUTE
-    await nodeRedManager.checkForContainerUpdates(config);
-    // ASSERT
-    assert.calledWithExactly(gladys.system.getContainers, {
-      all: true,
-      filters: { name: ['gladys-node-red'] },
-    });
-
     assert.calledWithExactly(gladys.system.removeContainer, 'container-id', { force: true });
-
-    expect(config).deep.equal({
-      dockerNodeRedVersion: DEFAULT.DOCKER_NODE_RED_VERSION,
-    });
   });
 
-  it('already updated -> it should do nothing', async () => {
-    // PREPARE
-    gladys.system.getContainers = fake.resolves([{ id: 'container-id' }]);
+  it('should do nothing when container image matches selected major version', async () => {
+    gladys.system.getContainers = fake.resolves([
+      {
+        id: 'container-id',
+        image: 'nodered/node-red:3.1',
+      },
+    ]);
     const config = {
-      dockerNodeRedVersion: DEFAULT.DOCKER_NODE_RED_VERSION,
+      dockerNodeRedVersion: '3',
     };
-    // EXECUTE
-    await nodeRedManager.checkForContainerUpdates(config);
-    // ASSERT
-    assert.notCalled(gladys.system.getContainers);
-    assert.notCalled(gladys.system.removeContainer);
 
+    await nodeRedManager.checkForContainerUpdates(config);
+
+    assert.calledWithExactly(gladys.system.getContainers, {
+      all: true,
+      filters: { name: ['gladys-node-red'] },
+    });
+    assert.notCalled(gladys.system.removeContainer);
+  });
+
+  it('should do nothing when no container is installed', async () => {
+    const config = {
+      dockerNodeRedVersion: '3',
+    };
+
+    await nodeRedManager.checkForContainerUpdates(config);
+
+    assert.calledOnce(gladys.system.getContainers);
+    assert.notCalled(gladys.system.removeContainer);
     expect(config).deep.equal({
-      dockerNodeRedVersion: DEFAULT.DOCKER_NODE_RED_VERSION,
+      dockerNodeRedVersion: '3',
     });
   });
 });

--- a/server/test/services/node-red/lib/getConfiguration.test.js
+++ b/server/test/services/node-red/lib/getConfiguration.test.js
@@ -35,7 +35,8 @@ describe('NodeRed getConfiguration', () => {
     assert.calledWithExactly(gladys.variable.getValue, 'TIMEZONE');
 
     expect(result).to.deep.equal({
-      dockerNodeRedVersion: 'fake',
+      dockerNodeRedVersion: '3',
+      availableMajorVersions: ['3', '4', '5'],
       nodeRedPassword: 'fake',
       nodeRedUsername: 'fake',
       timezone: 'fake',

--- a/server/test/services/node-red/lib/init.test.js
+++ b/server/test/services/node-red/lib/init.test.js
@@ -112,6 +112,30 @@ describe('NodeRed init', () => {
     assert.calledOnceWithExactly(nodeRedManager.installContainer, expectedConfig);
   });
 
+  it('it should keep a valid stored major version for existing users', async () => {
+    const config = {
+      nodeRedPassword: 'nodeRedPassword',
+    };
+    const expectedConfig = {
+      ...config,
+      dockerNodeRedVersion: '4',
+    };
+    nodeRedManager.getConfiguration.resolves({ ...config });
+    gladys.variable.getValue = sinon.stub().callsFake((key) => {
+      if (key === 'DOCKER_NODE_RED_VERSION') {
+        return '4';
+      }
+
+      return '1';
+    });
+
+    await nodeRedManager.init();
+
+    assert.calledOnceWithExactly(nodeRedManager.saveConfiguration, expectedConfig);
+    assert.calledOnceWithExactly(nodeRedManager.checkForContainerUpdates, expectedConfig);
+    assert.calledOnceWithExactly(nodeRedManager.installContainer, expectedConfig);
+  });
+
   it('it should save node-red params with version 5 for new users', async () => {
     const config = {};
     nodeRedManager.getConfiguration.resolves({ ...config });

--- a/server/test/services/node-red/lib/init.test.js
+++ b/server/test/services/node-red/lib/init.test.js
@@ -91,25 +91,44 @@ describe('NodeRed init', () => {
     const config = {
       nodeRedPassword: 'nodeRedPassword',
     };
+    const expectedConfig = {
+      ...config,
+      dockerNodeRedVersion: '3',
+    };
     nodeRedManager.getConfiguration.resolves({ ...config });
+    gladys.variable.getValue = sinon.stub().callsFake((key) => {
+      if (key === 'DOCKER_NODE_RED_VERSION') {
+        return null;
+      }
+
+      return '1';
+    });
 
     await nodeRedManager.init();
 
     assert.calledOnceWithExactly(nodeRedManager.getConfiguration);
-    assert.calledOnceWithExactly(nodeRedManager.saveConfiguration, config);
-    assert.calledOnceWithExactly(nodeRedManager.checkForContainerUpdates, config);
-    assert.calledOnceWithExactly(nodeRedManager.installContainer, config);
+    assert.calledOnceWithExactly(nodeRedManager.saveConfiguration, expectedConfig);
+    assert.calledOnceWithExactly(nodeRedManager.checkForContainerUpdates, expectedConfig);
+    assert.calledOnceWithExactly(nodeRedManager.installContainer, expectedConfig);
   });
 
-  it('it should save node-red params', async () => {
+  it('it should save node-red params with version 5 for new users', async () => {
     const config = {};
     nodeRedManager.getConfiguration.resolves({ ...config });
+    gladys.variable.getValue = sinon.stub().callsFake((key) => {
+      if (key === 'DOCKER_NODE_RED_VERSION') {
+        return null;
+      }
+
+      return '1';
+    });
 
     await nodeRedManager.init();
 
     const expectedNewConfig = {
       nodeRedPassword: 'password',
       nodeRedUsername: 'admin',
+      dockerNodeRedVersion: '5',
     };
 
     assert.calledOnceWithExactly(nodeRedManager.getConfiguration);

--- a/server/test/services/node-red/lib/installContainer.test.js
+++ b/server/test/services/node-red/lib/installContainer.test.js
@@ -11,7 +11,9 @@ const container = {
   state: 'running',
 };
 
-const config = {};
+const config = {
+  dockerNodeRedVersion: '3',
+};
 
 const containerStopped = {
   id: 'docker-test',

--- a/server/test/services/node-red/lib/nodeRedVersion.test.js
+++ b/server/test/services/node-red/lib/nodeRedVersion.test.js
@@ -1,0 +1,42 @@
+const { expect } = require('chai');
+
+const {
+  isExistingNodeRedUser,
+  resolveNodeRedMajorVersion,
+  getNodeRedDockerImage,
+  containerMatchesMajorVersion,
+} = require('../../../../services/node-red/lib/nodeRedVersion');
+const { DEFAULT } = require('../../../../services/node-red/lib/constants');
+
+describe('NodeRed nodeRedVersion', () => {
+  it('should detect existing users from stored credentials', () => {
+    expect(isExistingNodeRedUser({ nodeRedUsername: 'admin' })).to.equal(true);
+    expect(isExistingNodeRedUser({ nodeRedPassword: 'secret' })).to.equal(true);
+    expect(isExistingNodeRedUser({})).to.equal(false);
+  });
+
+  it('should keep a valid stored major version', () => {
+    expect(resolveNodeRedMajorVersion({ dockerNodeRedVersion: '4' })).to.equal('4');
+  });
+
+  it('should default existing users to version 3', () => {
+    expect(
+      resolveNodeRedMajorVersion({
+        nodeRedUsername: 'admin',
+      }),
+    ).to.equal(DEFAULT.NODE_RED_MAJOR_VERSION_EXISTING);
+  });
+
+  it('should default new users to version 5', () => {
+    expect(resolveNodeRedMajorVersion({})).to.equal(DEFAULT.NODE_RED_MAJOR_VERSION_NEW);
+  });
+
+  it('should return docker image for a major version', () => {
+    expect(getNodeRedDockerImage('5')).to.equal('nodered/node-red:5.0');
+  });
+
+  it('should match container image with selected major version', () => {
+    expect(containerMatchesMajorVersion('nodered/node-red:3.1', '3')).to.equal(true);
+    expect(containerMatchesMajorVersion('nodered/node-red:5.0', '3')).to.equal(false);
+  });
+});

--- a/server/test/services/node-red/lib/nodeRedVersion.test.js
+++ b/server/test/services/node-red/lib/nodeRedVersion.test.js
@@ -35,8 +35,13 @@ describe('NodeRed nodeRedVersion', () => {
     expect(getNodeRedDockerImage('5')).to.equal('nodered/node-red:5.0');
   });
 
+  it('should reject invalid major versions', () => {
+    expect(() => getNodeRedDockerImage('99')).to.throw('NODE_RED_INVALID_MAJOR_VERSION: 99');
+  });
+
   it('should match container image with selected major version', () => {
     expect(containerMatchesMajorVersion('nodered/node-red:3.1', '3')).to.equal(true);
+    expect(containerMatchesMajorVersion('registry.io/nodered/node-red:3.1', '3')).to.equal(true);
     expect(containerMatchesMajorVersion('nodered/node-red:5.0', '3')).to.equal(false);
   });
 });

--- a/server/test/services/node-red/lib/updateMajorVersion.test.js
+++ b/server/test/services/node-red/lib/updateMajorVersion.test.js
@@ -1,4 +1,3 @@
-const { expect } = require('chai');
 const sinon = require('sinon');
 
 const { assert, fake } = sinon;

--- a/server/test/services/node-red/lib/updateMajorVersion.test.js
+++ b/server/test/services/node-red/lib/updateMajorVersion.test.js
@@ -1,3 +1,4 @@
+const { expect } = require('chai');
 const sinon = require('sinon');
 
 const { assert, fake } = sinon;
@@ -51,5 +52,30 @@ describe('NodeRed updateMajorVersion', () => {
     assert.calledOnce(nodeRedManager.saveConfiguration);
     assert.calledOnce(nodeRedManager.checkForContainerUpdates);
     assert.calledOnce(nodeRedManager.installContainer);
+  });
+
+  it('should return current configuration when stored version already matches', async () => {
+    gladys.variable.getValue = fake.resolves('5');
+
+    const configuration = await nodeRedManager.updateMajorVersion('5');
+
+    assert.notCalled(nodeRedManager.saveConfiguration);
+    assert.notCalled(nodeRedManager.checkForContainerUpdates);
+    assert.notCalled(nodeRedManager.installContainer);
+    expect(configuration).to.deep.equal({
+      dockerNodeRedVersion: '5',
+      availableMajorVersions: ['3', '4', '5'],
+    });
+  });
+
+  it('should reject invalid major versions', async () => {
+    try {
+      await nodeRedManager.updateMajorVersion('99');
+      assert.fail();
+    } catch (e) {
+      expect(e.message).to.equal('NODE_RED_INVALID_MAJOR_VERSION');
+    }
+
+    assert.notCalled(nodeRedManager.saveConfiguration);
   });
 });

--- a/server/test/services/node-red/lib/updateMajorVersion.test.js
+++ b/server/test/services/node-red/lib/updateMajorVersion.test.js
@@ -1,0 +1,56 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const { assert, fake } = sinon;
+
+const NodeRedManager = require('../../../../services/node-red/lib');
+
+const serviceId = 'f87b7af2-ca8e-44fc-b754-444354b42fee';
+
+describe('NodeRed updateMajorVersion', () => {
+  let nodeRedManager;
+  let gladys;
+
+  beforeEach(() => {
+    gladys = {
+      variable: {
+        getValue: fake.resolves(null),
+        setValue: fake.resolves(true),
+      },
+    };
+
+    nodeRedManager = new NodeRedManager(gladys, serviceId);
+    nodeRedManager.getConfiguration = fake.resolves({
+      dockerNodeRedVersion: '5',
+      availableMajorVersions: ['3', '4', '5'],
+    });
+    nodeRedManager.saveConfiguration = fake.resolves(true);
+    nodeRedManager.isEnabled = fake.resolves(false);
+    nodeRedManager.checkForContainerUpdates = fake.resolves(true);
+    nodeRedManager.installContainer = fake.resolves(true);
+  });
+
+  afterEach(() => {
+    sinon.reset();
+  });
+
+  it('should persist selected version even when resolved default already matches', async () => {
+    await nodeRedManager.updateMajorVersion('5');
+
+    assert.calledOnce(nodeRedManager.saveConfiguration);
+    assert.calledWithMatch(nodeRedManager.saveConfiguration, sinon.match({ dockerNodeRedVersion: '5' }));
+    assert.notCalled(nodeRedManager.checkForContainerUpdates);
+    assert.notCalled(nodeRedManager.installContainer);
+  });
+
+  it('should recreate container when version changes and service is enabled', async () => {
+    gladys.variable.getValue = fake.resolves('3');
+    nodeRedManager.isEnabled = fake.resolves(true);
+
+    await nodeRedManager.updateMajorVersion('5');
+
+    assert.calledOnce(nodeRedManager.saveConfiguration);
+    assert.calledOnce(nodeRedManager.checkForContainerUpdates);
+    assert.calledOnce(nodeRedManager.installContainer);
+  });
+});


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

Node-RED : Add upgrade selector to upgrade major version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add Node-RED major-version selection and update flow: UI dropdown, update button, and upgrade warning. Changing the major version recreates the Node-RED container while preserving flows/configuration (supports versions 3, 4, 5).

* **Internationalization**
  * Updated German, English and French texts for Node-RED setup: labels, help text, upgrade warning, and update button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->