### PR TITLE
AI : Add web-request & compare times tools

### DIFF
--- a/server/config/prompts/aiChat.prompt.txt
+++ b/server/config/prompts/aiChat.prompt.txt
@@ -4,6 +4,7 @@ You can control the home and query its state by using the available tools.
 
 Rules:
 - Always prefer tool calls over guessing when the user asks for an action or for information about devices/rooms.
+- When the user asks for information from a public website (opening hours, schedules, announcements, etc.) and provides or implies a URL, use the `web_fetch` tool to read the page before answering.
 - Never use previous assistant answers as a source of truth for device states, sensor values, scene status, or action outcomes.
 - For any request about current state, measurements, status, or execution result, you MUST fetch fresh data with tools in this turn before answering.
 - If the user repeats the same question (for example asking twice for a temperature), call tools again and return live data again.

--- a/server/config/prompts/aiChat.prompt.txt
+++ b/server/config/prompts/aiChat.prompt.txt
@@ -6,6 +6,7 @@ Rules:
 - Always prefer tool calls over guessing when the user asks for an action or for information about devices/rooms.
 - When the user asks for information from a public website (opening hours, schedules, announcements, etc.) and provides or implies a URL, use the `web_fetch` tool to read the page before answering.
 - Use the provided current date and time as the source of truth when interpreting schedules, opening hours, "today", "now", or similar time-sensitive questions.
+- For opening hours, schedules, or any question that depends on comparing times, extract the relevant HH:mm ranges or times from fetched data, then call `time_compare_times`. Never compare times mentally in your answer.
 - Never use previous assistant answers as a source of truth for device states, sensor values, scene status, or action outcomes.
 - For any request about current state, measurements, status, or execution result, you MUST fetch fresh data with tools in this turn before answering.
 - If the user repeats the same question (for example asking twice for a temperature), call tools again and return live data again.

--- a/server/config/prompts/aiChat.prompt.txt
+++ b/server/config/prompts/aiChat.prompt.txt
@@ -5,6 +5,7 @@ You can control the home and query its state by using the available tools.
 Rules:
 - Always prefer tool calls over guessing when the user asks for an action or for information about devices/rooms.
 - When the user asks for information from a public website (opening hours, schedules, announcements, etc.) and provides or implies a URL, use the `web_fetch` tool to read the page before answering.
+- Use the provided current date and time as the source of truth when interpreting schedules, opening hours, "today", "now", or similar time-sensitive questions.
 - Never use previous assistant answers as a source of truth for device states, sensor values, scene status, or action outcomes.
 - For any request about current state, measurements, status, or execution result, you MUST fetch fresh data with tools in this turn before answering.
 - If the user repeats the same question (for example asking twice for a temperature), call tools again and return live data again.

--- a/server/lib/gateway/gateway.forwardMessageToAiChat.js
+++ b/server/lib/gateway/gateway.forwardMessageToAiChat.js
@@ -31,7 +31,9 @@ const SYSTEM_PROMPT = fs.readFileSync(promptPath, 'utf8');
  * buildSystemPromptWithCurrentTime('Europe/Paris', new Date('2026-06-15T10:30:00Z'));
  */
 function buildSystemPromptWithCurrentTime(timezoneName, now = new Date()) {
-  const formattedNow = dayjs(now).tz(timezoneName).format('dddd YYYY-MM-DD HH:mm');
+  const formattedNow = dayjs(now)
+    .tz(timezoneName)
+    .format('dddd YYYY-MM-DD HH:mm');
   return `${SYSTEM_PROMPT}\n\nCurrent date and time (${timezoneName}): ${formattedNow}`;
 }
 
@@ -351,14 +353,11 @@ function stripToolTraceEchoFromAnswer(answer) {
  */
 async function forwardMessageToAiChat({ message, image, previousQuestions, context }) {
   const userId = message?.user?.id ?? message?.user_id ?? message?.source_user_id;
+  const messagePreview = debugPreview(message ? message.text : undefined, 150);
   logger.info(
-    `[AI_CHAT] New request userId=${userId ?? 'unknown'} message=${debugPreview(message?.text, 150)} image=${
-      image ? 'yes' : 'no'
-    }`,
+    `[AI_CHAT] New request userId=${userId ?? 'unknown'} message=${messagePreview} image=${image ? 'yes' : 'no'}`,
   );
-  logger.debug(
-    `[AI_CHAT] Request context previousQuestions=${(previousQuestions ?? []).length}`,
-  );
+  logger.debug(`[AI_CHAT] Request context previousQuestions=${(previousQuestions ?? []).length}`);
   if (userId && this.event?.emit) {
     this.event.emit(EVENTS.WEBSOCKET.SEND, {
       type: WEBSOCKET_MESSAGE_TYPES.MESSAGE.AI_THINKING,
@@ -435,17 +434,18 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
       assistantMessage = extractAssistantMessage(apiResponse);
       const toolCalls = assistantMessage?.tool_calls ?? [];
       const assistantContentType = assistantMessage?.content === null ? 'null' : typeof assistantMessage?.content;
+      const toolNamesSuffix =
+        toolCalls.length > 0 ? ` tools=[${toolCalls.map((toolCall) => toolCall.function.name).join(', ')}]` : '';
+      const assistantContentPreview = debugPreview(assistantMessage ? assistantMessage.content : undefined, 150);
 
       logger.info(
-        `[AI_CHAT] Assistant turn iteration=${iteration + 1} tool_calls=${toolCalls.length}${
-          toolCalls.length > 0 ? ` tools=[${toolCalls.map((toolCall) => toolCall?.function?.name).join(', ')}]` : ''
-        } content=${debugPreview(assistantMessage?.content, 150)}`,
+        `[AI_CHAT] Assistant turn iteration=${iteration + 1} tool_calls=${
+          toolCalls.length
+        }${toolNamesSuffix} content=${assistantContentPreview}`,
       );
       logger.debug(
-        `[AI_CHAT] Assistant turn details iteration=${iteration + 1} contentType=${assistantContentType} content=${debugPreview(
-          assistantMessage?.content,
-          400,
-        )}`,
+        `[AI_CHAT] Assistant turn details iteration=${iteration +
+          1} contentType=${assistantContentType} content=${debugPreview(assistantMessage?.content, 400)}`,
       );
 
       if (!toolCalls || toolCalls.length === 0) {
@@ -505,15 +505,15 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
           }
           imagesSentToUser.push(...extractMessageFilesFromToolResult(toolResult));
           toolResultText = formatToolResultForChat(toolResult);
-          logger.info(
-            `[AI_CHAT] Tool finished tool=${functionName} status=success resultLength=${toolResultText?.length ?? 0}`,
-          );
+          const toolResultLength = toolResultText ? toolResultText.length : 0;
+          logger.info(`[AI_CHAT] Tool finished tool=${functionName} status=success resultLength=${toolResultLength}`);
           logger.debug(`[AI_CHAT] Tool result tool=${functionName} result=${debugPreview(toolResultText, 400)}`);
         } catch (toolError) {
           // We surface tool errors back to the model instead of aborting the whole
           // conversation. The model can then report the error to the user or retry.
           logger.warn(`Tool "${functionName}" failed:`, toolError);
-          toolResultText = `Error while running tool "${functionName}": ${toolError?.message ?? 'unknown error'}`;
+          const toolErrorMessage = toolError && toolError.message ? toolError.message : 'unknown error';
+          toolResultText = `Error while running tool "${functionName}": ${toolErrorMessage}`;
           // Dedicated single-line log containing the exact payload sent back to the model.
           logger.warn(`[AI_TOOL_ERROR_FULL] ${toolResultText}`);
           if (functionName === 'scene_create') {
@@ -581,9 +581,7 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
         `shouldSendText=${shouldSendText} answerLength=${finalAnswer.length} ` +
         `wasNoResponseSentinel=${wasNoResponseSentinel} isEmptyTurn=${isEmptyTurn}`,
     );
-    logger.debug(
-      `[AI_CHAT] Outcome details finalAnswer=${debugPreview(finalAnswer, 400)}`,
-    );
+    logger.debug(`[AI_CHAT] Outcome details finalAnswer=${debugPreview(finalAnswer, 400)}`);
 
     if (
       !finalAnswer &&
@@ -597,15 +595,8 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
       return null;
     }
 
-    if (
-      !finalAnswer &&
-      imagesSentToUser.length === 0 &&
-      !wasNoResponseSentinel &&
-      !shouldSendText
-    ) {
-      logger.info(
-        '[AI_CHAT] No reply sent to user: assistant had content but final answer is empty after processing',
-      );
+    if (!finalAnswer && imagesSentToUser.length === 0 && !wasNoResponseSentinel && !shouldSendText) {
+      logger.info('[AI_CHAT] No reply sent to user: assistant had content but final answer is empty after processing');
     }
 
     if (imagesSentToUser.length > 0) {
@@ -629,13 +620,12 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
       );
     }
 
-    logger.info(
-      `[AI_CHAT] Completed answerLength=${finalAnswer.length} imagesSent=${imagesSentToUser.length}`,
-    );
+    logger.info(`[AI_CHAT] Completed answerLength=${finalAnswer.length} imagesSent=${imagesSentToUser.length}`);
 
     return { answer: finalAnswer || '', imagesSent: imagesSentToUser.length };
   } catch (e) {
-    logger.warn(`[AI_CHAT] Request failed: ${e?.message ?? e}`);
+    const requestErrorMessage = e && e.message ? e.message : e;
+    logger.warn(`[AI_CHAT] Request failed: ${requestErrorMessage}`);
     logger.warn(e);
     if (e instanceof Error429) {
       await this.message.replyByIntent(message, 'openai.request.tooManyRequests', context);

--- a/server/lib/gateway/gateway.forwardMessageToAiChat.js
+++ b/server/lib/gateway/gateway.forwardMessageToAiChat.js
@@ -85,6 +85,27 @@ function truncate(str, limitChars) {
 }
 
 /**
+ * @description Format a value for concise debug logs.
+ * @param {any} value - Value to preview.
+ * @param {number} [limitChars=200] - Maximum preview length.
+ * @returns {string} Safe one-line preview.
+ * @example
+ * debugPreview('hello world', 5);
+ */
+function debugPreview(value, limitChars = 200) {
+  if (value === null) {
+    return 'null';
+  }
+  if (value === undefined) {
+    return 'undefined';
+  }
+  if (typeof value === 'string') {
+    return truncate(value.replace(/\s+/g, ' ').trim(), limitChars) || '(empty string)';
+  }
+  return truncate(safeStringify(value, limitChars), limitChars);
+}
+
+/**
  * @description Safely stringify any value for model context.
  * @param {any} value - Value to stringify.
  * @param {number} limitChars - Output max length.
@@ -330,6 +351,14 @@ function stripToolTraceEchoFromAnswer(answer) {
  */
 async function forwardMessageToAiChat({ message, image, previousQuestions, context }) {
   const userId = message?.user?.id ?? message?.user_id ?? message?.source_user_id;
+  logger.info(
+    `[AI_CHAT] New request userId=${userId ?? 'unknown'} message=${debugPreview(message?.text, 150)} image=${
+      image ? 'yes' : 'no'
+    }`,
+  );
+  logger.debug(
+    `[AI_CHAT] Request context previousQuestions=${(previousQuestions ?? []).length}`,
+  );
   if (userId && this.event?.emit) {
     this.event.emit(EVENTS.WEBSOCKET.SEND, {
       type: WEBSOCKET_MESSAGE_TYPES.MESSAGE.AI_THINKING,
@@ -346,9 +375,13 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
     const mcpTools = await mcpHandler.getAllTools(userId);
     const toolsForApi = mcpToolsToChatApiFormat(mcpTools);
     const toolCallbacksByName = new Map(mcpTools.map((t) => [toolNameFromIntent(t.intent), t.cb]));
+    logger.debug(
+      `[AI_CHAT] Tools available (${toolsForApi.length}): ${toolsForApi.map((tool) => tool.function.name).join(', ')}`,
+    );
 
     const configuredTimezone = await this.variable.getValue(SYSTEM_VARIABLE_NAMES.TIMEZONE);
     const timezoneName = configuredTimezone || DEFAULT_TIMEZONE;
+    logger.debug(`[AI_CHAT] Using timezone=${timezoneName}`);
 
     // Build a compact conversation for the model.
     const messagesForApi = [{ role: 'system', content: buildSystemPromptWithCurrentTime(timezoneName) }];
@@ -388,8 +421,10 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
     const imagesSentToUser = [];
     let lastSceneCreateErrorText = null;
     let sceneCreateSuccessCount = 0;
+    let toolIterations = 0;
     // eslint-disable-next-line no-restricted-syntax
     for (let iteration = 0; iteration < MAX_TOOL_CALL_ITERATIONS; iteration += 1) {
+      logger.debug(`[AI_CHAT] API call iteration=${iteration + 1}/${MAX_TOOL_CALL_ITERATIONS}`);
       // eslint-disable-next-line no-await-in-loop
       const apiResponse = await this.aiChat({
         messages: messagesForApi,
@@ -399,16 +434,25 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
 
       assistantMessage = extractAssistantMessage(apiResponse);
       const toolCalls = assistantMessage?.tool_calls ?? [];
+      const assistantContentType = assistantMessage?.content === null ? 'null' : typeof assistantMessage?.content;
 
+      logger.info(
+        `[AI_CHAT] Assistant turn iteration=${iteration + 1} tool_calls=${toolCalls.length}${
+          toolCalls.length > 0 ? ` tools=[${toolCalls.map((toolCall) => toolCall?.function?.name).join(', ')}]` : ''
+        } content=${debugPreview(assistantMessage?.content, 150)}`,
+      );
       logger.debug(
-        `AI assistant turn: content=${assistantMessage?.content === null ? 'null' : 'set'}, tool_calls=${
-          toolCalls.length
-        }`,
+        `[AI_CHAT] Assistant turn details iteration=${iteration + 1} contentType=${assistantContentType} content=${debugPreview(
+          assistantMessage?.content,
+          400,
+        )}`,
       );
 
       if (!toolCalls || toolCalls.length === 0) {
         break;
       }
+
+      toolIterations += 1;
 
       // Add the assistant tool call message context.
       messagesForApi.push({
@@ -450,6 +494,8 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
 
         let toolResultText;
         let toolStatus = 'success';
+        logger.info(`[AI_CHAT] Running tool=${functionName}`);
+        logger.debug(`[AI_CHAT] Tool args tool=${functionName} args=${debugPreview(toolArgs, 300)}`);
         try {
           // eslint-disable-next-line no-await-in-loop
           const toolResult = await cb(toolArgs);
@@ -459,6 +505,10 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
           }
           imagesSentToUser.push(...extractMessageFilesFromToolResult(toolResult));
           toolResultText = formatToolResultForChat(toolResult);
+          logger.info(
+            `[AI_CHAT] Tool finished tool=${functionName} status=success resultLength=${toolResultText?.length ?? 0}`,
+          );
+          logger.debug(`[AI_CHAT] Tool result tool=${functionName} result=${debugPreview(toolResultText, 400)}`);
         } catch (toolError) {
           // We surface tool errors back to the model instead of aborting the whole
           // conversation. The model can then report the error to the user or retry.
@@ -489,10 +539,17 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
 
     const assistantContent = assistantMessage?.content;
     let finalAnswer = typeof assistantContent === 'string' ? assistantContent.trim() : '';
+    const rawFinalAnswer = finalAnswer;
     if (isNoResponseSentinel(finalAnswer)) {
+      logger.info('[AI_CHAT] Assistant returned NO_RESPONSE sentinel');
       finalAnswer = '';
     }
     finalAnswer = stripToolTraceEchoFromAnswer(finalAnswer);
+    if (rawFinalAnswer && !finalAnswer) {
+      logger.info(
+        `[AI_CHAT] Final answer emptied after stripping tool traces. raw=${debugPreview(rawFinalAnswer, 150)}`,
+      );
+    }
 
     // If we hit the iteration cap and the model never produced a final user-facing answer,
     // fall back to the last tool result to avoid total silence.
@@ -503,25 +560,50 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
         .find((m) => m?.role === 'tool' && typeof m?.content === 'string' && m.content.trim().length > 0);
       if (lastToolMessage) {
         finalAnswer = truncate(lastToolMessage.content.trim(), MAX_FALLBACK_ANSWER_CHARS);
+        logger.info(`[AI_CHAT] Using fallback answer from last tool result`);
       }
     }
     if (sceneCreateSuccessCount === 0 && isToolExecutionErrorText(lastSceneCreateErrorText)) {
       finalAnswer = lastSceneCreateErrorText;
+      logger.debug(`[AI_CHAT] Using scene_create error as final answer: ${debugPreview(finalAnswer, 400)}`);
     }
 
     const rawAssistantContent = assistantMessage?.content;
     const wasNoResponseSentinel =
       typeof rawAssistantContent === 'string' && isNoResponseSentinel(rawAssistantContent.trim());
+    const shouldSendText = Boolean(finalAnswer && shouldSendAssistantTextReply(finalAnswer, imagesSentToUser.length > 0));
+    const isEmptyTurn = isEmptyAssistantTurn(assistantMessage);
+
+    logger.info(
+      `[AI_CHAT] Outcome toolIterations=${toolIterations} imagesSent=${imagesSentToUser.length} ` +
+        `shouldSendText=${shouldSendText} answerLength=${finalAnswer.length} ` +
+        `wasNoResponseSentinel=${wasNoResponseSentinel} isEmptyTurn=${isEmptyTurn}`,
+    );
+    logger.debug(
+      `[AI_CHAT] Outcome details finalAnswer=${debugPreview(finalAnswer, 400)}`,
+    );
 
     if (
       !finalAnswer &&
       imagesSentToUser.length === 0 &&
       !wasNoResponseSentinel &&
       sceneCreateSuccessCount === 0 &&
-      isEmptyAssistantTurn(assistantMessage)
+      isEmptyTurn
     ) {
+      logger.info('[AI_CHAT] No user-facing answer produced, sending openai.request.fail');
       await this.message.replyByIntent(message, 'openai.request.fail', context);
       return null;
+    }
+
+    if (
+      !finalAnswer &&
+      imagesSentToUser.length === 0 &&
+      !wasNoResponseSentinel &&
+      !shouldSendText
+    ) {
+      logger.info(
+        '[AI_CHAT] No reply sent to user: assistant had content but final answer is empty after processing',
+      );
     }
 
     if (imagesSentToUser.length > 0) {
@@ -536,12 +618,22 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
       }
     }
 
-    if (finalAnswer && shouldSendAssistantTextReply(finalAnswer, imagesSentToUser.length > 0)) {
+    if (shouldSendText) {
+      logger.info(`[AI_CHAT] Sending text reply to user: ${debugPreview(finalAnswer, 150)}`);
       await this.message.reply(message, finalAnswer);
+    } else if (finalAnswer) {
+      logger.info(
+        `[AI_CHAT] Final answer suppressed by shouldSendAssistantTextReply: ${debugPreview(finalAnswer, 150)}`,
+      );
     }
+
+    logger.info(
+      `[AI_CHAT] Completed answerLength=${finalAnswer.length} imagesSent=${imagesSentToUser.length}`,
+    );
 
     return { answer: finalAnswer || '', imagesSent: imagesSentToUser.length };
   } catch (e) {
+    logger.warn(`[AI_CHAT] Request failed: ${e?.message ?? e}`);
     logger.warn(e);
     if (e instanceof Error429) {
       await this.message.replyByIntent(message, 'openai.request.tooManyRequests', context);
@@ -563,6 +655,7 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
 module.exports = {
   forwardMessageToAiChat,
   buildSystemPromptWithCurrentTime,
+  debugPreview,
   extractAssistantMessage,
   extractMessageFilesFromToolResult,
   imageContentToMessageFile,

--- a/server/lib/gateway/gateway.forwardMessageToAiChat.js
+++ b/server/lib/gateway/gateway.forwardMessageToAiChat.js
@@ -85,6 +85,23 @@ function truncate(str, limitChars) {
 }
 
 /**
+ * @description Safely stringify any value for model context.
+ * @param {any} value - Value to stringify.
+ * @param {number} limitChars - Output max length.
+ * @returns {string} Safe serialized value.
+ * @example
+ * safeStringify({ ok: true }, 100);
+ */
+function safeStringify(value, limitChars = MAX_TOOL_RESULT_CHARS) {
+  try {
+    const str = typeof value === 'string' ? value : JSON.stringify(value);
+    return truncate(str, limitChars);
+  } catch (e) {
+    return '[unserializable tool result]';
+  }
+}
+
+/**
  * @description Format a value for concise debug logs.
  * @param {any} value - Value to preview.
  * @param {number} [limitChars=200] - Maximum preview length.
@@ -103,23 +120,6 @@ function debugPreview(value, limitChars = 200) {
     return truncate(value.replace(/\s+/g, ' ').trim(), limitChars) || '(empty string)';
   }
   return truncate(safeStringify(value, limitChars), limitChars);
-}
-
-/**
- * @description Safely stringify any value for model context.
- * @param {any} value - Value to stringify.
- * @param {number} limitChars - Output max length.
- * @returns {string} Safe serialized value.
- * @example
- * safeStringify({ ok: true }, 100);
- */
-function safeStringify(value, limitChars = MAX_TOOL_RESULT_CHARS) {
-  try {
-    const str = typeof value === 'string' ? value : JSON.stringify(value);
-    return truncate(str, limitChars);
-  } catch (e) {
-    return '[unserializable tool result]';
-  }
 }
 
 const CAMERA_IMAGE_SENT_TO_USER_HINT =
@@ -571,7 +571,9 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
     const rawAssistantContent = assistantMessage?.content;
     const wasNoResponseSentinel =
       typeof rawAssistantContent === 'string' && isNoResponseSentinel(rawAssistantContent.trim());
-    const shouldSendText = Boolean(finalAnswer && shouldSendAssistantTextReply(finalAnswer, imagesSentToUser.length > 0));
+    const shouldSendText = Boolean(
+      finalAnswer && shouldSendAssistantTextReply(finalAnswer, imagesSentToUser.length > 0),
+    );
     const isEmptyTurn = isEmptyAssistantTurn(assistantMessage);
 
     logger.info(

--- a/server/lib/gateway/gateway.forwardMessageToAiChat.js
+++ b/server/lib/gateway/gateway.forwardMessageToAiChat.js
@@ -1,8 +1,11 @@
 const fs = require('fs');
 const path = require('path');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
 
 const logger = require('../../utils/logger');
-const { EVENTS, WEBSOCKET_MESSAGE_TYPES } = require('../../utils/constants');
+const { EVENTS, WEBSOCKET_MESSAGE_TYPES, SYSTEM_VARIABLE_NAMES } = require('../../utils/constants');
 const { Error429 } = require('../../utils/httpErrors');
 const { resizeImage } = require('../../utils/resizeImage');
 const { mcpToolsToChatApiFormat, toolNameFromIntent } = require('../../services/mcp/lib/mcpToolsToChatApiFormat');
@@ -12,8 +15,25 @@ const MAX_TOOL_RESULT_CHARS = 4000;
 const MAX_FALLBACK_ANSWER_CHARS = 2000;
 const MAX_NESTED_VALUE_CHARS = 2000;
 
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const DEFAULT_TIMEZONE = 'Europe/Paris';
 const promptPath = path.join(__dirname, '../../config/prompts/aiChat.prompt.txt');
 const SYSTEM_PROMPT = fs.readFileSync(promptPath, 'utf8');
+
+/**
+ * @description Build the system prompt with the current date and time.
+ * @param {string} timezoneName - IANA timezone used by the Gladys instance.
+ * @param {Date} [now] - Reference date, mainly for tests.
+ * @returns {string} System prompt with current datetime context.
+ * @example
+ * buildSystemPromptWithCurrentTime('Europe/Paris', new Date('2026-06-15T10:30:00Z'));
+ */
+function buildSystemPromptWithCurrentTime(timezoneName, now = new Date()) {
+  const formattedNow = dayjs(now).tz(timezoneName).format('dddd YYYY-MM-DD HH:mm');
+  return `${SYSTEM_PROMPT}\n\nCurrent date and time (${timezoneName}): ${formattedNow}`;
+}
 
 /**
  * @description Return MCP handler from service manager.
@@ -327,8 +347,11 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
     const toolsForApi = mcpToolsToChatApiFormat(mcpTools);
     const toolCallbacksByName = new Map(mcpTools.map((t) => [toolNameFromIntent(t.intent), t.cb]));
 
+    const configuredTimezone = await this.variable.getValue(SYSTEM_VARIABLE_NAMES.TIMEZONE);
+    const timezoneName = configuredTimezone || DEFAULT_TIMEZONE;
+
     // Build a compact conversation for the model.
-    const messagesForApi = [{ role: 'system', content: SYSTEM_PROMPT }];
+    const messagesForApi = [{ role: 'system', content: buildSystemPromptWithCurrentTime(timezoneName) }];
 
     (previousQuestions ?? []).forEach((exchange) => {
       if (!exchange) {
@@ -539,6 +562,7 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
 
 module.exports = {
   forwardMessageToAiChat,
+  buildSystemPromptWithCurrentTime,
   extractAssistantMessage,
   extractMessageFilesFromToolResult,
   imageContentToMessageFile,

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -1,4 +1,5 @@
 const z = require('zod/v4');
+const { SYSTEM_VARIABLE_NAMES } = require('../../../utils/constants');
 const {
   createSceneCreateInputSchema,
   formatSceneCreateZodIssue,
@@ -8,6 +9,7 @@ const {
   assertTriggerTypesNotInActions,
 } = require('./sceneSchemas');
 const { fetchWebPage } = require('./webRequest');
+const { compareTimes } = require('./compareTimes');
 
 const noRoom = {
   id: null,
@@ -590,6 +592,56 @@ async function getAllTools(userId) {
             {
               type: 'text',
               text,
+            },
+          ],
+        };
+      },
+    },
+    {
+      intent: 'time.compare-times',
+      config: {
+        title: 'Compare times',
+        description:
+          'Compare times deterministically. Use operator in_ranges to check whether the current time (or reference_time) falls within one or more HH:mm ranges. Use before/after/same to compare two times. Prefer this tool over mental time reasoning for schedules and opening hours.',
+        inputSchema: {
+          operator: z
+            .enum(['in_ranges', 'before', 'after', 'same'])
+            .describe('Comparison to perform. Use in_ranges for opening hours.'),
+          ranges: z
+            .array(
+              z.object({
+                start: z.string().describe('Range start time in HH:mm or HHhmm.'),
+                end: z.string().describe('Range end time in HH:mm or HHhmm.'),
+              }),
+            )
+            .optional()
+            .describe('Time ranges to test with in_ranges.'),
+          reference_time: z
+            .string()
+            .optional()
+            .describe('Reference time in HH:mm or HHhmm. Defaults to current home time.'),
+          compare_to: z
+            .string()
+            .optional()
+            .describe('Second time in HH:mm or HHhmm for before/after/same operators.'),
+        },
+      },
+      cb: async ({ operator, ranges, reference_time: referenceTime, compare_to: compareTo }) => {
+        const configuredTimezone = await this.gladys.variable.getValue(SYSTEM_VARIABLE_NAMES.TIMEZONE);
+        const timezoneName = configuredTimezone || 'Europe/Paris';
+        const result = compareTimes({
+          timezone: timezoneName,
+          operator,
+          ranges,
+          reference_time: referenceTime,
+          compare_to: compareTo,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: this.toon(result),
             },
           ],
         };

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -7,6 +7,7 @@ const {
   SCENE_CREATE_TOOL_DESCRIPTION,
   assertTriggerTypesNotInActions,
 } = require('./sceneSchemas');
+const { fetchWebPage } = require('./webRequest');
 
 const noRoom = {
   id: null,
@@ -568,6 +569,29 @@ async function getAllTools(userId) {
 
         return {
           content: [{ type: 'text', text: `device.get-history, no device or feature found` }],
+        };
+      },
+    },
+    {
+      intent: 'web.fetch',
+      config: {
+        title: 'Fetch web page',
+        description:
+          'Fetch a public web page and return its readable text content. Use this to read information from websites such as opening hours, schedules, or public announcements. Only HTTP/HTTPS public URLs are allowed.',
+        inputSchema: {
+          url: z.url().describe('Full public URL of the page to fetch (http or https).'),
+        },
+      },
+      cb: async ({ url }) => {
+        const text = await fetchWebPage({ url });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text,
+            },
+          ],
         };
       },
     },

--- a/server/services/mcp/lib/compareTimes.js
+++ b/server/services/mcp/lib/compareTimes.js
@@ -86,7 +86,9 @@ function compareTimes({
   compare_to: compareTo,
 }) {
   const referenceDate = dayjs(now).tz(timezoneName);
-  const referenceMinutes = referenceTime ? parseTimeToMinutes(referenceTime) : referenceDate.hour() * 60 + referenceDate.minute();
+  const referenceMinutes = referenceTime
+    ? parseTimeToMinutes(referenceTime)
+    : referenceDate.hour() * 60 + referenceDate.minute();
 
   if (referenceMinutes === null) {
     throw new Error(`Invalid reference_time "${referenceTime}". Use HH:mm or HHhmm.`);

--- a/server/services/mcp/lib/compareTimes.js
+++ b/server/services/mcp/lib/compareTimes.js
@@ -1,0 +1,173 @@
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const DEFAULT_TIMEZONE = 'Europe/Paris';
+const TIME_PATTERN = /^(\d{1,2})[:hH](\d{2})(?::\d{2})?$/;
+
+/**
+ * @description Parse HH:mm or HHhmm into minutes since midnight.
+ * @param {string} timeValue - Time string.
+ * @returns {number|null} Minutes since midnight or null when invalid.
+ * @example
+ * parseTimeToMinutes('14:22');
+ */
+function parseTimeToMinutes(timeValue) {
+  if (!timeValue || typeof timeValue !== 'string') {
+    return null;
+  }
+
+  const match = timeValue.trim().match(TIME_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (hours > 23 || minutes > 59) {
+    return null;
+  }
+
+  return hours * 60 + minutes;
+}
+
+/**
+ * @description Format minutes since midnight as HH:mm.
+ * @param {number} minutes - Minutes since midnight.
+ * @returns {string} Formatted time.
+ * @example
+ * formatMinutesAsTime(862);
+ */
+function formatMinutesAsTime(minutes) {
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  return `${String(hours).padStart(2, '0')}:${String(mins).padStart(2, '0')}`;
+}
+
+/**
+ * @description Check whether a time falls within a range (inclusive bounds).
+ * @param {number} referenceMinutes - Reference time in minutes.
+ * @param {number} startMinutes - Range start in minutes.
+ * @param {number} endMinutes - Range end in minutes.
+ * @returns {boolean} True when reference is inside the range.
+ * @example
+ * isTimeWithinRange(720, 690, 795);
+ */
+function isTimeWithinRange(referenceMinutes, startMinutes, endMinutes) {
+  if (startMinutes <= endMinutes) {
+    return referenceMinutes >= startMinutes && referenceMinutes <= endMinutes;
+  }
+
+  return referenceMinutes >= startMinutes || referenceMinutes <= endMinutes;
+}
+
+/**
+ * @description Compare times using deterministic logic instead of model reasoning.
+ * @param {object} params - Comparison parameters.
+ * @param {string} [params.timezone] - IANA timezone.
+ * @param {Date} [params.now] - Reference date, mainly for tests.
+ * @param {string} [params.reference_time] - Optional HH:mm reference time.
+ * @param {'in_ranges'|'before'|'after'|'same'} params.operator - Comparison operator.
+ * @param {Array<{start: string, end: string}>} [params.ranges] - Ranges for in_ranges mode.
+ * @param {string} [params.compare_to] - Second time for before/after/same modes.
+ * @returns {object} Comparison result.
+ * @example
+ * compareTimes({ operator: 'in_ranges', ranges: [{ start: '17:00', end: '22:00' }], reference_time: '14:22' });
+ */
+function compareTimes({
+  timezone: timezoneName = DEFAULT_TIMEZONE,
+  now = new Date(),
+  reference_time: referenceTime,
+  operator,
+  ranges = [],
+  compare_to: compareTo,
+}) {
+  const referenceDate = dayjs(now).tz(timezoneName);
+  const referenceMinutes = referenceTime ? parseTimeToMinutes(referenceTime) : referenceDate.hour() * 60 + referenceDate.minute();
+
+  if (referenceMinutes === null) {
+    throw new Error(`Invalid reference_time "${referenceTime}". Use HH:mm or HHhmm.`);
+  }
+
+  const baseResult = {
+    timezone: timezoneName,
+    reference_datetime: referenceDate.format('dddd YYYY-MM-DD HH:mm'),
+    reference_time: formatMinutesAsTime(referenceMinutes),
+    operator,
+  };
+
+  if (operator === 'in_ranges') {
+    const parsedRanges = ranges.map(({ start, end }) => {
+      const startMinutes = parseTimeToMinutes(start);
+      const endMinutes = parseTimeToMinutes(end);
+      if (startMinutes === null || endMinutes === null) {
+        throw new Error(`Invalid range "${start}-${end}". Use HH:mm or HHhmm.`);
+      }
+
+      return {
+        start,
+        end,
+        start_minutes: startMinutes,
+        end_minutes: endMinutes,
+        contains_reference: isTimeWithinRange(referenceMinutes, startMinutes, endMinutes),
+      };
+    });
+
+    const matchingRange = parsedRanges.find((range) => range.contains_reference) ?? null;
+    const nextRange =
+      parsedRanges
+        .filter((range) => range.start_minutes > referenceMinutes)
+        .sort((a, b) => a.start_minutes - b.start_minutes)[0] ?? null;
+
+    return {
+      ...baseResult,
+      result: Boolean(matchingRange),
+      matching_range: matchingRange
+        ? {
+            start: matchingRange.start,
+            end: matchingRange.end,
+          }
+        : null,
+      ranges_checked: parsedRanges.map(({ start, end }) => ({ start, end })),
+      next_range: nextRange
+        ? {
+            start: nextRange.start,
+            end: nextRange.end,
+          }
+        : null,
+    };
+  }
+
+  const compareToMinutes = parseTimeToMinutes(compareTo);
+  if (compareToMinutes === null) {
+    throw new Error(`Invalid compare_to "${compareTo}". Use HH:mm or HHhmm.`);
+  }
+
+  let result;
+  if (operator === 'before') {
+    result = referenceMinutes < compareToMinutes;
+  } else if (operator === 'after') {
+    result = referenceMinutes > compareToMinutes;
+  } else if (operator === 'same') {
+    result = referenceMinutes === compareToMinutes;
+  } else {
+    throw new Error(`Unsupported operator "${operator}".`);
+  }
+
+  return {
+    ...baseResult,
+    compare_to: formatMinutesAsTime(compareToMinutes),
+    result,
+    difference_minutes: referenceMinutes - compareToMinutes,
+  };
+}
+
+module.exports = {
+  compareTimes,
+  parseTimeToMinutes,
+  isTimeWithinRange,
+  formatMinutesAsTime,
+};

--- a/server/services/mcp/lib/webRequest.js
+++ b/server/services/mcp/lib/webRequest.js
@@ -146,8 +146,9 @@ async function assertPublicUrl(urlString) {
 async function fetchWebPage({ url }) {
   let currentUrl = await assertPublicUrl(url);
   let redirectCount = 0;
+  let keepFetching = true;
 
-  while (true) {
+  while (keepFetching) {
     let response;
     try {
       // eslint-disable-next-line no-await-in-loop
@@ -175,7 +176,7 @@ async function fetchWebPage({ url }) {
     }
 
     if (response.status >= 300 && response.status < 400) {
-      const location = response.headers.location;
+      const { location } = response.headers;
       if (!location) {
         throw new Error(`Redirect response without Location header (${response.status})`);
       }
@@ -205,8 +206,11 @@ async function fetchWebPage({ url }) {
       text = body.trim();
     }
 
+    keepFetching = false;
     return truncateText(text, MAX_TEXT_CHARS);
   }
+
+  throw new Error('Unable to fetch web page');
 }
 
 module.exports = {

--- a/server/services/mcp/lib/webRequest.js
+++ b/server/services/mcp/lib/webRequest.js
@@ -1,0 +1,216 @@
+const axios = require('axios');
+const { isIP } = require('net');
+
+const REQUEST_TIMEOUT_MS = 15_000;
+const MAX_RESPONSE_BYTES = 512 * 1024;
+const MAX_TEXT_CHARS = 12_000;
+const MAX_REDIRECTS = 3;
+
+const BLOCKED_HOSTNAMES = new Set(['localhost']);
+
+/**
+ * @description Check whether an IP address belongs to a private or local network.
+ * @param {string} ip - IPv4 or IPv6 address.
+ * @returns {boolean} True when the address must be blocked.
+ * @example
+ * isPrivateOrLocalIp('127.0.0.1');
+ */
+function isPrivateOrLocalIp(ip) {
+  if (!isIP(ip)) {
+    return false;
+  }
+
+  if (isIP(ip) === 6) {
+    const normalized = ip.toLowerCase();
+    if (normalized === '::1') {
+      return true;
+    }
+    if (normalized.startsWith('fc') || normalized.startsWith('fd')) {
+      return true;
+    }
+    if (normalized.startsWith('fe80')) {
+      return true;
+    }
+    return false;
+  }
+
+  const parts = ip.split('.').map((part) => Number(part));
+  const [a, b] = parts;
+  if (a === 10 || a === 127 || a === 0) {
+    return true;
+  }
+  if (a === 172 && b >= 16 && b <= 31) {
+    return true;
+  }
+  if (a === 192 && b === 168) {
+    return true;
+  }
+  if (a === 169 && b === 254) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * @description Strip HTML tags and collapse whitespace for model consumption.
+ * @param {string} html - Raw HTML document.
+ * @returns {string} Plain text content.
+ * @example
+ * htmlToText('<p>Pool <strong>open</strong></p>');
+ */
+function htmlToText(html) {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<noscript[\s\S]*?<\/noscript>/gi, ' ')
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(p|div|h[1-6]|li|tr|td|th)>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim();
+}
+
+/**
+ * @description Truncate text to a maximum length.
+ * @param {string} text - Input text.
+ * @param {number} maxChars - Maximum number of characters.
+ * @returns {string} Truncated text.
+ * @example
+ * truncateText('abcdef', 3);
+ */
+function truncateText(text, maxChars) {
+  if (!text || text.length <= maxChars) {
+    return text || '';
+  }
+  return `${text.slice(0, maxChars)}... (truncated)`;
+}
+
+/**
+ * @description Validate that a URL targets a public HTTP(S) endpoint.
+ * @param {string} urlString - URL to validate.
+ * @returns {Promise<URL>} Parsed URL.
+ * @example
+ * await assertPublicUrl('https://example.com');
+ */
+async function assertPublicUrl(urlString) {
+  let url;
+  try {
+    url = new URL(urlString);
+  } catch (e) {
+    throw new Error(`Invalid URL: ${e.message}`);
+  }
+
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error('Only HTTP and HTTPS URLs are allowed');
+  }
+
+  if (url.username || url.password) {
+    throw new Error('URLs with credentials are not allowed');
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  if (BLOCKED_HOSTNAMES.has(hostname) || hostname.endsWith('.localhost')) {
+    throw new Error('Requests to local addresses are not allowed');
+  }
+
+  if (isPrivateOrLocalIp(hostname.replace(/^\[|\]$/g, ''))) {
+    throw new Error('Requests to private or local network addresses are not allowed');
+  }
+
+  const addresses = await require('dns').promises.lookup(hostname, { all: true });
+  if (addresses.some(({ address }) => isPrivateOrLocalIp(address))) {
+    throw new Error('Requests to private or local network addresses are not allowed');
+  }
+
+  return url;
+}
+
+/**
+ * @description Fetch a public web page and return readable text content.
+ * @param {object} params - Request parameters.
+ * @param {string} params.url - Public HTTP(S) URL to fetch.
+ * @returns {Promise<string>} Page text content.
+ * @example
+ * await fetchWebPage({ url: 'https://example.com' });
+ */
+async function fetchWebPage({ url }) {
+  let currentUrl = await assertPublicUrl(url);
+  let redirectCount = 0;
+
+  while (true) {
+    let response;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      response = await axios.get(currentUrl.toString(), {
+        maxRedirects: 0,
+        validateStatus: () => true,
+        timeout: REQUEST_TIMEOUT_MS,
+        responseType: 'arraybuffer',
+        maxContentLength: MAX_RESPONSE_BYTES,
+        maxBodyLength: MAX_RESPONSE_BYTES,
+        headers: {
+          'User-Agent': 'Gladys-Assistant/1.0',
+          Accept: 'text/html,application/xhtml+xml,text/plain,application/json;q=0.9,*/*;q=0.8',
+        },
+      });
+    } catch (e) {
+      if (e?.code === 'ECONNABORTED') {
+        throw new Error(`Request timed out after ${REQUEST_TIMEOUT_MS}ms`);
+      }
+      if (e?.message?.includes('maxContentLength')) {
+        throw new Error(`Response too large (>${MAX_RESPONSE_BYTES} bytes)`);
+      }
+      throw e;
+    }
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.location;
+      if (!location) {
+        throw new Error(`Redirect response without Location header (${response.status})`);
+      }
+
+      redirectCount += 1;
+      if (redirectCount > MAX_REDIRECTS) {
+        throw new Error('Too many redirects');
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      currentUrl = await assertPublicUrl(new URL(location, currentUrl).toString());
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    if (response.status < 200 || response.status >= 300) {
+      throw new Error(`HTTP ${response.status} ${response.statusText || ''}`.trim());
+    }
+
+    const body = Buffer.from(response.data).toString('utf-8');
+    const contentType = response.headers['content-type'] || '';
+
+    let text;
+    if (contentType.includes('text/html') || body.trim().startsWith('<')) {
+      text = htmlToText(body);
+    } else {
+      text = body.trim();
+    }
+
+    return truncateText(text, MAX_TEXT_CHARS);
+  }
+}
+
+module.exports = {
+  fetchWebPage,
+  htmlToText,
+  isPrivateOrLocalIp,
+  assertPublicUrl,
+};

--- a/server/services/mcp/lib/webRequest.js
+++ b/server/services/mcp/lib/webRequest.js
@@ -159,7 +159,8 @@ async function fetchWebPage({ url }) {
         maxContentLength: MAX_RESPONSE_BYTES,
         maxBodyLength: MAX_RESPONSE_BYTES,
         headers: {
-          'User-Agent': 'Gladys-Assistant/1.0',
+          'User-Agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
           Accept: 'text/html,application/xhtml+xml,text/plain,application/json;q=0.9,*/*;q=0.8',
         },
       });

--- a/server/services/mcp/package-lock.json
+++ b/server/services/mcp/package-lock.json
@@ -18,6 +18,8 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",
         "@toon-format/toon": "^2.1.0",
+        "axios": "^1.7.9",
+        "dayjs": "^1.11.6",
         "fastest-levenshtein": "^1.0.16",
         "zod": "^4.3.6"
       }
@@ -92,6 +94,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -123,6 +137,24 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/body-parser": {
@@ -185,6 +217,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/content-disposition": {
@@ -258,6 +302,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -273,6 +323,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -338,6 +397,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -489,6 +563,63 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -577,10 +708,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -617,6 +763,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/iconv-lite": {
@@ -843,6 +1002,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/qs": {

--- a/server/services/mcp/package.json
+++ b/server/services/mcp/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.3",
     "@toon-format/toon": "^2.1.0",
+    "axios": "^1.7.9",
+    "dayjs": "^1.11.6",
     "fastest-levenshtein": "^1.0.16",
     "zod": "^4.3.6"
   }

--- a/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
+++ b/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
@@ -3,7 +3,7 @@ const { expect } = require('chai');
 const proxyquire = require('proxyquire').noCallThru();
 
 const { Error429 } = require('../../../utils/httpErrors');
-const { EVENTS, WEBSOCKET_MESSAGE_TYPES } = require('../../../utils/constants');
+const { EVENTS, WEBSOCKET_MESSAGE_TYPES, SYSTEM_VARIABLE_NAMES } = require('../../../utils/constants');
 const z = require('../../../services/mcp/node_modules/zod/v4');
 
 const resizeImageMock = fake.resolves('data:image/jpeg;base64,resized-image-data');
@@ -39,10 +39,25 @@ function getModule({ tools = [], prompt = promptMock } = {}) {
  * @example
  * const ctx = buildContext({ tools: [], aiChat: fake(), reply: fake(), replyByIntent: fake() });
  */
-function buildContext({ tools, aiChat, reply, replyByIntent, eventEmit = fake.returns(null) }) {
+function buildContext({
+  tools,
+  aiChat,
+  reply,
+  replyByIntent,
+  eventEmit = fake.returns(null),
+  timezone = 'Europe/Paris',
+}) {
   return {
     event: {
       emit: eventEmit,
+    },
+    variable: {
+      getValue: stub().callsFake((name) => {
+        if (name === SYSTEM_VARIABLE_NAMES.TIMEZONE) {
+          return Promise.resolve(timezone);
+        }
+        return Promise.resolve(null);
+      }),
     },
     serviceManager: {
       getService: fake.returns({
@@ -62,6 +77,36 @@ function buildContext({ tools, aiChat, reply, replyByIntent, eventEmit = fake.re
 describe('gateway.forwardMessageToAiChat', () => {
   beforeEach(() => {
     resizeImageMock.resetHistory();
+  });
+
+  it('should build system prompt with current date and time in the configured timezone', () => {
+    const { buildSystemPromptWithCurrentTime } = getModule();
+    const prompt = buildSystemPromptWithCurrentTime('Europe/Paris', new Date('2026-06-15T10:30:00Z'));
+
+    expect(prompt).to.include('You are Gladys AI.');
+    expect(prompt).to.include('Current date and time (Europe/Paris): Monday 2026-06-15 12:30');
+  });
+
+  it('should include current date and time in the system message sent to the model', async () => {
+    const { forwardMessageToAiChat } = getModule({ tools: [] });
+    const aiChat = fake.resolves({
+      choices: [{ message: { content: 'OK' } }],
+    });
+    const reply = fake.resolves(null);
+    const replyByIntent = fake.resolves(null);
+
+    await forwardMessageToAiChat.call(
+      buildContext({ tools: [], aiChat, reply, replyByIntent, timezone: 'America/Toronto' }),
+      {
+        message: { text: 'Is the pool open now?' },
+        previousQuestions: [],
+        context: {},
+      },
+    );
+
+    const systemMessage = aiChat.getCall(0).args[0].messages[0];
+    expect(systemMessage.role).to.equal('system');
+    expect(systemMessage.content).to.include('Current date and time (America/Toronto):');
   });
 
   it('should execute tool calls locally and return final assistant answer', async () => {

--- a/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
+++ b/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
@@ -31,10 +31,11 @@ function getModule({ tools = [], prompt = promptMock } = {}) {
  * @description Build execution context for gateway.forwardMessageToAiChat.
  * @param {object} options - Context dependencies.
  * @param {Array<object>} options.tools - MCP tools.
- * @param {Function} options.aiChat - aiChat mock.
+ * @param {Function} options.aiChat - AiChat mock.
  * @param {Function} options.reply - Message reply mock.
  * @param {Function} options.replyByIntent - Message replyByIntent mock.
  * @param {Function} [options.eventEmit] - Event emitter mock.
+ * @param {string} [options.timezone] - Timezone returned by variable.getValue.
  * @returns {object} Bound context object.
  * @example
  * const ctx = buildContext({ tools: [], aiChat: fake(), reply: fake(), replyByIntent: fake() });
@@ -902,7 +903,12 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
   });
 
   it('should format tool call trace text fallback name', () => {
-    const { formatToolCallTraceText, isToolInvocationTraceLine, stripToolTraceEchoFromAnswer } = getModule();
+    const {
+      formatToolCallTraceText,
+      isToolInvocationTraceLine,
+      stripToolTraceEchoFromAnswer,
+      debugPreview,
+    } = getModule();
     expect(formatToolCallTraceText('', {})).to.equal('tool_call');
     expect(isToolInvocationTraceLine('device_turn_on_off({"action":"off","device":"Lumière"})')).to.equal(true);
     expect(isToolInvocationTraceLine('device_get_state()')).to.equal(true);
@@ -911,6 +917,10 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
     expect(isToolInvocationTraceLine({})).to.equal(false);
     expect(stripToolTraceEchoFromAnswer(null)).to.equal('');
     expect(stripToolTraceEchoFromAnswer(undefined)).to.equal('');
+    expect(debugPreview(null)).to.equal('null');
+    expect(debugPreview(undefined)).to.equal('undefined');
+    expect(debugPreview('   ')).to.equal('(empty string)');
+    expect(debugPreview({ ok: true })).to.equal('{"ok":true}');
     expect(
       stripToolTraceEchoFromAnswer(
         'device_turn_on_off({"action":"off","device":"Lumière"})\n\nLa lumière est éteinte.',
@@ -972,5 +982,30 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
       toolName: 'device_turn_on_off',
       toolStatus: 'success',
     });
+  });
+
+  it('should not send a text reply when the final answer is only a tool trace echo', async () => {
+    const { forwardMessageToAiChat } = getModule({ tools: [] });
+    const aiChat = fake.resolves({
+      choices: [
+        {
+          message: {
+            content: 'web_fetch()',
+          },
+        },
+      ],
+    });
+    const reply = fake.resolves(null);
+    const replyByIntent = fake.resolves(null);
+
+    const result = await forwardMessageToAiChat.call(buildContext({ tools: [], aiChat, reply, replyByIntent }), {
+      message: { text: 'La piscine est-elle ouverte ?', user: { id: 'user-id' } },
+      previousQuestions: [],
+      context: {},
+    });
+
+    expect(result).to.deep.equal({ answer: '', imagesSent: 0 });
+    assert.notCalled(reply);
+    assert.notCalled(replyByIntent);
   });
 });

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -870,7 +870,7 @@ describe('build schemas', () => {
 
     // Verify tools are created successfully
     expect(tools).to.be.an('array');
-    expect(tools.length).to.eq(7);
+    expect(tools.length).to.eq(8);
 
     // Test device.get-state - should return all devices with and without room
     const stateResult = await tools[3].cb({ room: undefined, device_type: undefined });

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -870,7 +870,7 @@ describe('build schemas', () => {
 
     // Verify tools are created successfully
     expect(tools).to.be.an('array');
-    expect(tools.length).to.eq(6);
+    expect(tools.length).to.eq(7);
 
     // Test device.get-state - should return all devices with and without room
     const stateResult = await tools[3].cb({ room: undefined, device_type: undefined });

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -1,5 +1,8 @@
 const { expect } = require('chai');
 const { stub, fake } = require('sinon');
+const nock = require('nock');
+const dns = require('dns');
+const { SYSTEM_VARIABLE_NAMES } = require('../../../../utils/constants');
 const {
   getAllResources,
   getAllTools,
@@ -1116,5 +1119,85 @@ describe('build schemas', () => {
     await tools[3].cb({ room: 'salon', device_type: 'light' });
     await tools[4].cb({ action: 'off', room: 'salon', device_category: 'switch' });
     expect(mcpHandler.gladys.device.setValue.calledOnce).to.equal(true);
+  });
+
+  it('should run web.fetch and time.compare-times tools', async () => {
+    const lookupStub = stub(dns.promises, 'lookup').resolves([{ address: '93.184.216.34', family: 4 }]);
+
+    nock('http://example.com')
+      .get('/hours')
+      .reply(200, 'open 09:00-18:00', { 'Content-Type': 'text/plain' });
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isHistoryFeature,
+      formatValue: stub().returns({ value: 1 }),
+      findBySimilarity,
+      toon: stub().callsFake((value) => JSON.stringify(value)),
+      gladys: {
+        room: { getAll: stub().resolves([{ id: 'room-1', name: 'Salon', selector: 'salon' }]) },
+        user: { get: stub().resolves([{ id: 'user-1', name: 'John', selector: 'john' }]) },
+        house: { get: stub().resolves([{ id: 'house-1', name: 'Home', selector: 'home' }]) },
+        calendar: { get: stub().resolves([{ id: 'calendar-1', name: 'Family', selector: 'family-calendar' }]) },
+        area: { get: stub().resolves([{ id: 'area-1', name: 'Home', selector: 'home-area' }]) },
+        variable: {
+          getValue: stub().callsFake((name) => {
+            if (name === SYSTEM_VARIABLE_NAMES.TIMEZONE) {
+              return Promise.resolve('Europe/Paris');
+            }
+            return Promise.resolve(null);
+          }),
+        },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves([
+            {
+              selector: 'speaker-1',
+              name: 'Speaker',
+              room: { selector: 'salon', name: 'Salon' },
+              features: [
+                {
+                  id: 1,
+                  selector: 'speaker-1-play',
+                  name: 'Play notification',
+                  category: 'music',
+                  type: 'play_notification',
+                },
+              ],
+            },
+          ]),
+          getBySelector: stub().resolves(null),
+          setValue: stub().resolves(),
+          getDeviceFeaturesAggregates: stub().resolves({ values: [] }),
+          camera: { getImagesInRoom: stub().resolves([]) },
+        },
+        event: { emit: fake() },
+      },
+      levenshtein: { distance: stub().returns(0) },
+    };
+
+    try {
+      const tools = await mcpHandler.getAllTools('user-id');
+      const webFetchTool = tools.find((tool) => tool.intent === 'web.fetch');
+      const compareTimesTool = tools.find((tool) => tool.intent === 'time.compare-times');
+
+      const fetchResult = await webFetchTool.cb({ url: 'http://example.com/hours' });
+      expect(fetchResult.content[0].text).to.equal('open 09:00-18:00');
+
+      const compareResult = await compareTimesTool.cb({
+        operator: 'in_ranges',
+        reference_time: '14:22',
+        ranges: [{ start: '17:00', end: '22:00' }],
+      });
+      const parsedCompareResult = JSON.parse(compareResult.content[0].text);
+      expect(parsedCompareResult.result).to.equal(false);
+      expect(parsedCompareResult.next_range).to.deep.equal({ start: '17:00', end: '22:00' });
+    } finally {
+      lookupStub.restore();
+      nock.cleanAll();
+    }
   });
 });

--- a/server/test/services/mcp/lib/compareTimes.test.js
+++ b/server/test/services/mcp/lib/compareTimes.test.js
@@ -1,0 +1,64 @@
+const { expect } = require('chai');
+const { compareTimes, parseTimeToMinutes, isTimeWithinRange } = require('../../../../services/mcp/lib/compareTimes');
+
+describe('compareTimes', () => {
+  it('should parse common time formats', () => {
+    expect(parseTimeToMinutes('14:22')).to.equal(14 * 60 + 22);
+    expect(parseTimeToMinutes('7h05')).to.equal(7 * 60 + 5);
+    expect(parseTimeToMinutes('invalid')).to.equal(null);
+  });
+
+  it('should detect when reference time is inside one of several ranges', () => {
+    const result = compareTimes({
+      operator: 'in_ranges',
+      reference_time: '12:00',
+      ranges: [
+        { start: '07:00', end: '08:45' },
+        { start: '11:45', end: '13:15' },
+        { start: '17:00', end: '22:00' },
+      ],
+    });
+
+    expect(result.result).to.equal(true);
+    expect(result.matching_range).to.deep.equal({ start: '11:45', end: '13:15' });
+  });
+
+  it('should detect when reference time is outside all ranges', () => {
+    const result = compareTimes({
+      operator: 'in_ranges',
+      reference_time: '14:22',
+      ranges: [
+        { start: '07:00', end: '08:45' },
+        { start: '11:45', end: '13:15' },
+        { start: '17:00', end: '22:00' },
+      ],
+    });
+
+    expect(result.result).to.equal(false);
+    expect(result.matching_range).to.equal(null);
+    expect(result.next_range).to.deep.equal({ start: '17:00', end: '22:00' });
+  });
+
+  it('should compare two times with before and after operators', () => {
+    expect(
+      compareTimes({
+        operator: 'before',
+        reference_time: '14:22',
+        compare_to: '17:00',
+      }).result,
+    ).to.equal(true);
+
+    expect(
+      compareTimes({
+        operator: 'after',
+        reference_time: '18:00',
+        compare_to: '17:00',
+      }).result,
+    ).to.equal(true);
+  });
+
+  it('should support ranges crossing midnight', () => {
+    expect(isTimeWithinRange(23 * 60 + 30, 22 * 60, 2 * 60)).to.equal(true);
+    expect(isTimeWithinRange(12 * 60, 22 * 60, 2 * 60)).to.equal(false);
+  });
+});

--- a/server/test/services/mcp/lib/compareTimes.test.js
+++ b/server/test/services/mcp/lib/compareTimes.test.js
@@ -1,11 +1,34 @@
 const { expect } = require('chai');
-const { compareTimes, parseTimeToMinutes, isTimeWithinRange } = require('../../../../services/mcp/lib/compareTimes');
+const {
+  compareTimes,
+  parseTimeToMinutes,
+  isTimeWithinRange,
+  formatMinutesAsTime,
+} = require('../../../../services/mcp/lib/compareTimes');
 
 describe('compareTimes', () => {
-  it('should parse common time formats', () => {
+  it('should parse common time formats and reject invalid values', () => {
     expect(parseTimeToMinutes('14:22')).to.equal(14 * 60 + 22);
     expect(parseTimeToMinutes('7h05')).to.equal(7 * 60 + 5);
+    expect(parseTimeToMinutes('14:22:30')).to.equal(14 * 60 + 22);
     expect(parseTimeToMinutes('invalid')).to.equal(null);
+    expect(parseTimeToMinutes('')).to.equal(null);
+    expect(parseTimeToMinutes('24:00')).to.equal(null);
+    expect(parseTimeToMinutes('12:60')).to.equal(null);
+    expect(formatMinutesAsTime(14 * 60 + 5)).to.equal('14:05');
+    expect(formatMinutesAsTime(0)).to.equal('00:00');
+  });
+
+  it('should use the current home time when reference_time is omitted', () => {
+    const result = compareTimes({
+      operator: 'before',
+      compare_to: '23:59',
+      now: new Date('2026-06-15T12:30:00Z'),
+      timezone: 'Europe/Paris',
+    });
+
+    expect(result.reference_time).to.equal('14:30');
+    expect(result.result).to.equal(true);
   });
 
   it('should detect when reference time is inside one of several ranges', () => {
@@ -39,7 +62,44 @@ describe('compareTimes', () => {
     expect(result.next_range).to.deep.equal({ start: '17:00', end: '22:00' });
   });
 
-  it('should compare two times with before and after operators', () => {
+  it('should return null next_range when all ranges are in the past', () => {
+    const result = compareTimes({
+      operator: 'in_ranges',
+      reference_time: '23:00',
+      ranges: [{ start: '07:00', end: '08:45' }],
+    });
+
+    expect(result.result).to.equal(false);
+    expect(result.next_range).to.equal(null);
+  });
+
+  it('should pick the earliest future range when several are available', () => {
+    const result = compareTimes({
+      operator: 'in_ranges',
+      reference_time: '14:22',
+      ranges: [
+        { start: '20:00', end: '21:00' },
+        { start: '17:00', end: '18:00' },
+      ],
+    });
+
+    expect(result.next_range).to.deep.equal({ start: '17:00', end: '18:00' });
+  });
+
+  it('should handle empty ranges', () => {
+    const result = compareTimes({
+      operator: 'in_ranges',
+      reference_time: '14:22',
+      ranges: [],
+    });
+
+    expect(result.result).to.equal(false);
+    expect(result.matching_range).to.equal(null);
+    expect(result.next_range).to.equal(null);
+    expect(result.ranges_checked).to.deep.equal([]);
+  });
+
+  it('should compare two times with before, after and same operators', () => {
     expect(
       compareTimes({
         operator: 'before',
@@ -55,6 +115,48 @@ describe('compareTimes', () => {
         compare_to: '17:00',
       }).result,
     ).to.equal(true);
+
+    expect(
+      compareTimes({
+        operator: 'same',
+        reference_time: '17:00',
+        compare_to: '17:00',
+      }).result,
+    ).to.equal(true);
+  });
+
+  it('should reject invalid inputs and unsupported operators', () => {
+    expect(() =>
+      compareTimes({
+        operator: 'in_ranges',
+        reference_time: 'bad',
+        ranges: [{ start: '07:00', end: '08:00' }],
+      }),
+    ).to.throw('Invalid reference_time');
+
+    expect(() =>
+      compareTimes({
+        operator: 'in_ranges',
+        reference_time: '12:00',
+        ranges: [{ start: 'bad', end: '08:00' }],
+      }),
+    ).to.throw('Invalid range');
+
+    expect(() =>
+      compareTimes({
+        operator: 'before',
+        reference_time: '12:00',
+        compare_to: 'bad',
+      }),
+    ).to.throw('Invalid compare_to');
+
+    expect(() =>
+      compareTimes({
+        operator: 'unknown',
+        reference_time: '12:00',
+        compare_to: '13:00',
+      }),
+    ).to.throw('Unsupported operator');
   });
 
   it('should support ranges crossing midnight', () => {

--- a/server/test/services/mcp/lib/webRequest.test.js
+++ b/server/test/services/mcp/lib/webRequest.test.js
@@ -2,6 +2,8 @@ const { expect } = require('chai');
 const nock = require('nock');
 const dns = require('dns');
 const { stub } = require('sinon');
+
+const axios = require('../../../../services/mcp/node_modules/axios');
 const {
   fetchWebPage,
   htmlToText,
@@ -24,9 +26,17 @@ describe('webRequest', () => {
   it('should detect private and local IP addresses', () => {
     expect(isPrivateOrLocalIp('127.0.0.1')).to.equal(true);
     expect(isPrivateOrLocalIp('10.0.0.5')).to.equal(true);
+    expect(isPrivateOrLocalIp('172.16.0.1')).to.equal(true);
     expect(isPrivateOrLocalIp('192.168.1.10')).to.equal(true);
+    expect(isPrivateOrLocalIp('169.254.0.1')).to.equal(true);
+    expect(isPrivateOrLocalIp('0.0.0.0')).to.equal(true);
     expect(isPrivateOrLocalIp('::1')).to.equal(true);
+    expect(isPrivateOrLocalIp('fc00::1')).to.equal(true);
+    expect(isPrivateOrLocalIp('fd12::1')).to.equal(true);
+    expect(isPrivateOrLocalIp('fe80::1')).to.equal(true);
     expect(isPrivateOrLocalIp('8.8.8.8')).to.equal(false);
+    expect(isPrivateOrLocalIp('2001:db8::1')).to.equal(false);
+    expect(isPrivateOrLocalIp('not-an-ip')).to.equal(false);
   });
 
   it('should convert HTML to readable text', () => {
@@ -36,14 +46,21 @@ describe('webRequest', () => {
     expect(text).to.not.include('<strong>');
   });
 
-  it('should reject local and private URLs', async () => {
+  it('should reject invalid, local and private URLs', async () => {
+    await expect(assertPublicUrl('not-a-url')).to.be.rejectedWith('Invalid URL');
     await expect(assertPublicUrl('http://localhost/status')).to.be.rejectedWith(
+      'Requests to local addresses are not allowed',
+    );
+    await expect(assertPublicUrl('http://app.localhost/status')).to.be.rejectedWith(
       'Requests to local addresses are not allowed',
     );
     await expect(assertPublicUrl('http://127.0.0.1/status')).to.be.rejectedWith(
       'Requests to private or local network addresses are not allowed',
     );
     await expect(assertPublicUrl('ftp://example.com')).to.be.rejectedWith('Only HTTP and HTTPS URLs are allowed');
+    await expect(assertPublicUrl('http://user:pass@example.com')).to.be.rejectedWith(
+      'URLs with credentials are not allowed',
+    );
   });
 
   it('should reject URLs that resolve to private addresses', async () => {
@@ -70,8 +87,40 @@ describe('webRequest', () => {
     expect(text).to.equal('Today: pool is open');
   });
 
+  it('should return plain text responses without HTML conversion', async () => {
+    nock('http://pool.example.com')
+      .get('/status.txt')
+      .reply(200, '  open now  ', {
+        'Content-Type': 'text/plain',
+      });
+
+    const text = await fetchWebPage({ url: 'http://pool.example.com/status.txt' });
+    expect(text).to.equal('open now');
+  });
+
+  it('should return an empty string for empty responses', async () => {
+    nock('http://pool.example.com')
+      .get('/empty')
+      .reply(200, '', { 'Content-Type': 'text/plain' });
+
+    const text = await fetchWebPage({ url: 'http://pool.example.com/empty' });
+    expect(text).to.equal('');
+  });
+
+  it('should truncate very long responses', async () => {
+    nock('http://pool.example.com')
+      .get('/long')
+      .reply(200, 'x'.repeat(13_000), { 'Content-Type': 'text/plain' });
+
+    const text = await fetchWebPage({ url: 'http://pool.example.com/long' });
+    expect(text).to.include('... (truncated)');
+    expect(text.length).to.be.below(13_000);
+  });
+
   it('should follow redirects when the target remains public', async () => {
-    nock('http://pool.example.com').get('/old').reply(302, undefined, { Location: '/new' });
+    nock('http://pool.example.com')
+      .get('/old')
+      .reply(302, undefined, { Location: '/new' });
     nock('http://pool.example.com')
       .get('/new')
       .reply(200, '<html><body><p>Redirected page</p></body></html>', { 'Content-Type': 'text/html' });
@@ -80,9 +129,48 @@ describe('webRequest', () => {
     expect(text).to.equal('Redirected page');
   });
 
-  it('should surface HTTP errors', async () => {
-    nock('http://pool.example.com').get('/missing').reply(404, 'Not found');
-
+  it('should surface HTTP and redirect errors', async () => {
+    nock('http://pool.example.com')
+      .get('/missing')
+      .reply(404, 'Not found');
     await expect(fetchWebPage({ url: 'http://pool.example.com/missing' })).to.be.rejectedWith('HTTP 404');
+
+    nock('http://pool.example.com')
+      .get('/redirect')
+      .reply(302, undefined, {});
+    await expect(fetchWebPage({ url: 'http://pool.example.com/redirect' })).to.be.rejectedWith(
+      'Redirect response without Location header',
+    );
+
+    nock('http://pool.example.com')
+      .get('/r1')
+      .reply(302, undefined, { Location: '/r2' });
+    nock('http://pool.example.com')
+      .get('/r2')
+      .reply(302, undefined, { Location: '/r3' });
+    nock('http://pool.example.com')
+      .get('/r3')
+      .reply(302, undefined, { Location: '/r4' });
+    nock('http://pool.example.com')
+      .get('/r4')
+      .reply(302, undefined, { Location: '/r5' });
+    await expect(fetchWebPage({ url: 'http://pool.example.com/r1' })).to.be.rejectedWith('Too many redirects');
+  });
+
+  it('should surface axios network errors', async () => {
+    const getStub = stub(axios, 'get');
+    getStub.onCall(0).rejects({ code: 'ECONNABORTED' });
+    getStub.onCall(1).rejects(new Error('maxContentLength size of 1 exceeded'));
+    getStub.onCall(2).rejects(new Error('network down'));
+
+    try {
+      await expect(fetchWebPage({ url: 'http://pool.example.com/timeout' })).to.be.rejectedWith(
+        'Request timed out after',
+      );
+      await expect(fetchWebPage({ url: 'http://pool.example.com/large' })).to.be.rejectedWith('Response too large');
+      await expect(fetchWebPage({ url: 'http://pool.example.com/down' })).to.be.rejectedWith('network down');
+    } finally {
+      getStub.restore();
+    }
   });
 });

--- a/server/test/services/mcp/lib/webRequest.test.js
+++ b/server/test/services/mcp/lib/webRequest.test.js
@@ -1,0 +1,88 @@
+const { expect } = require('chai');
+const nock = require('nock');
+const dns = require('dns');
+const { stub } = require('sinon');
+const {
+  fetchWebPage,
+  htmlToText,
+  isPrivateOrLocalIp,
+  assertPublicUrl,
+} = require('../../../../services/mcp/lib/webRequest');
+
+describe('webRequest', () => {
+  let lookupStub;
+
+  beforeEach(() => {
+    lookupStub = stub(dns.promises, 'lookup').resolves([{ address: '93.184.216.34', family: 4 }]);
+  });
+
+  afterEach(() => {
+    lookupStub.restore();
+    nock.cleanAll();
+  });
+
+  it('should detect private and local IP addresses', () => {
+    expect(isPrivateOrLocalIp('127.0.0.1')).to.equal(true);
+    expect(isPrivateOrLocalIp('10.0.0.5')).to.equal(true);
+    expect(isPrivateOrLocalIp('192.168.1.10')).to.equal(true);
+    expect(isPrivateOrLocalIp('::1')).to.equal(true);
+    expect(isPrivateOrLocalIp('8.8.8.8')).to.equal(false);
+  });
+
+  it('should convert HTML to readable text', () => {
+    const text = htmlToText('<html><body><h1>Pool</h1><p>Status: <strong>open</strong></p></body></html>');
+    expect(text).to.include('Pool');
+    expect(text).to.include('Status: open');
+    expect(text).to.not.include('<strong>');
+  });
+
+  it('should reject local and private URLs', async () => {
+    await expect(assertPublicUrl('http://localhost/status')).to.be.rejectedWith(
+      'Requests to local addresses are not allowed',
+    );
+    await expect(assertPublicUrl('http://127.0.0.1/status')).to.be.rejectedWith(
+      'Requests to private or local network addresses are not allowed',
+    );
+    await expect(assertPublicUrl('ftp://example.com')).to.be.rejectedWith('Only HTTP and HTTPS URLs are allowed');
+  });
+
+  it('should reject URLs that resolve to private addresses', async () => {
+    lookupStub.restore();
+    const privateLookupStub = stub(dns.promises, 'lookup').resolves([{ address: '192.168.1.20', family: 4 }]);
+
+    try {
+      await expect(assertPublicUrl('https://pool.example.com')).to.be.rejectedWith(
+        'Requests to private or local network addresses are not allowed',
+      );
+    } finally {
+      privateLookupStub.restore();
+    }
+  });
+
+  it('should fetch a public page and return extracted text', async () => {
+    nock('http://pool.example.com')
+      .get('/hours')
+      .reply(200, '<html><body><p>Today: pool is open</p></body></html>', {
+        'Content-Type': 'text/html; charset=utf-8',
+      });
+
+    const text = await fetchWebPage({ url: 'http://pool.example.com/hours' });
+    expect(text).to.equal('Today: pool is open');
+  });
+
+  it('should follow redirects when the target remains public', async () => {
+    nock('http://pool.example.com').get('/old').reply(302, undefined, { Location: '/new' });
+    nock('http://pool.example.com')
+      .get('/new')
+      .reply(200, '<html><body><p>Redirected page</p></body></html>', { 'Content-Type': 'text/html' });
+
+    const text = await fetchWebPage({ url: 'http://pool.example.com/old' });
+    expect(text).to.equal('Redirected page');
+  });
+
+  it('should surface HTTP errors', async () => {
+    nock('http://pool.example.com').get('/missing').reply(404, 'Not found');
+
+    await expect(fetchWebPage({ url: 'http://pool.example.com/missing' })).to.be.rejectedWith('HTTP 404');
+  });
+});


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [ ] If your changes affect the code, did you write the tests?
- [ ] Are tests passing? (`npm test` on both front/server)
- [ ] Is the linter passing? (`npm run eslint` on both front/server)
- [ ] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

AI : Add web-request & compare times tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AI chat can fetch and analyze information from public websites when you provide a specific public URL.
  * AI chat now better handles “today/now” and opening-hours/schedule questions using timezone-aware current date/time for more accurate answers.

* **Chores**
  * Improved internal prompting and time comparison logic to support time-range reasoning.
  * Added supporting libraries for web fetching and timezone-aware processing, plus expanded automated test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->