### PR TITLE
Scene: Widen scene value input for sensor thresholds

### DIFF
--- a/front/src/routes/scene/edit-scene/triggers/DeviceFeatureState.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/DeviceFeatureState.jsx
@@ -103,7 +103,7 @@ class TurnOnLight extends Component {
     return (
       <div>
         <div class="row">
-          <div class="col-12 col-md-6">
+          <div class="col-12 col-md-5">
             <div class="form-group">
               <SelectDeviceFeature
                 value={props.trigger.device_feature}

--- a/front/src/routes/scene/edit-scene/triggers/device-states/DefaultDeviceState.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/device-states/DefaultDeviceState.jsx
@@ -33,7 +33,7 @@ class DefaultDeviceState extends Component {
 
     return (
       <Fragment>
-        <div class="col-md-3">
+        <div class="col-12 col-md-3">
           <div class="form-group">
             <select class="form-control" onChange={this.handleOperatorChange} value={trigger.operator}>
               <option value="">
@@ -68,7 +68,7 @@ class DefaultDeviceState extends Component {
             </select>
           </div>
         </div>
-        <div class="col-md-3">
+        <div class="col-12 col-md-4">
           <div class="form-group">
             <div class="input-group">
               <Localizer>


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

Scene: Widen scene value input for sensor thresholds

https://community.gladysassistant.com/t/nbr-de-caractere-pour-affichage-valeur-capteur-de-luminosite/10269/3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated responsive grid layout for device trigger configuration panels to improve display on mobile and tablet devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->