### PR TITLE
Fix save device bug when energy_parent_id is invalid

### DIFF
--- a/server/lib/device/device.create.js
+++ b/server/lib/device/device.create.js
@@ -2,6 +2,8 @@ const Promise = require('bluebird');
 const { BadParameters } = require('../../utils/coreErrors');
 const db = require('../../models');
 const { EVENTS } = require('../../utils/constants');
+const { resolveEnergyParentId } = require('../../utils/resolveEnergyParentId');
+const logger = require('../../utils/logger');
 
 const getById = async (id) => {
   return db.Device.findOne({
@@ -163,8 +165,18 @@ async function create(device) {
     deviceToReturn.features = deviceToReturn.features || [];
     deviceToReturn.params = deviceToReturn.params || [];
 
-    // if we need to create features
-    const newFeatures = await Promise.map(features, async (feature) => {
+    const energyParentIdByExternalId = new Map();
+    const featuresToSave = features.map((feature) => {
+      if (Object.prototype.hasOwnProperty.call(feature, 'energy_parent_id')) {
+        energyParentIdByExternalId.set(feature.external_id, feature.energy_parent_id);
+      }
+      const featureToSave = { ...feature };
+      delete featureToSave.energy_parent_id;
+      return featureToSave;
+    });
+
+    // Save features first without energy_parent_id, then resolve parent links in a second pass
+    const newFeatures = await Promise.map(featuresToSave, async (feature) => {
       // if the device feature already exist
       const matchedFeature = matchFeatureInList(feature, deviceToReturn.features);
       if (matchedFeature) {
@@ -184,6 +196,32 @@ async function create(device) {
       const featureCreated = await db.DeviceFeature.create(feature, { transaction });
       return featureCreated.get({ plain: true });
     });
+
+    await Promise.map(newFeatures, async (savedFeature) => {
+      if (!energyParentIdByExternalId.has(savedFeature.external_id)) {
+        return;
+      }
+
+      const requestedParentId = energyParentIdByExternalId.get(savedFeature.external_id);
+      const validParentId = await resolveEnergyParentId(requestedParentId, { transaction });
+
+      if (requestedParentId && !validParentId) {
+        logger.warn(
+          `Invalid energy_parent_id "${requestedParentId}" for feature "${savedFeature.selector}", clearing parent link`,
+        );
+      }
+
+      if (savedFeature.energy_parent_id === validParentId) {
+        return;
+      }
+
+      await db.DeviceFeature.update(
+        { energy_parent_id: validParentId },
+        { where: { id: savedFeature.id }, transaction },
+      );
+      savedFeature.energy_parent_id = validParentId;
+    });
+
     deviceToReturn.features = newFeatures;
 
     const newParams = await Promise.map(params, async (param) => {

--- a/server/lib/energy-price/price.getDefaultElectricMeterFeatureId.js
+++ b/server/lib/energy-price/price.getDefaultElectricMeterFeatureId.js
@@ -22,7 +22,12 @@ async function getDefaultElectricMeterFeatureId() {
     return null;
   }
   const feature = device.features.find((f) => f.category === DEVICE_FEATURE_CATEGORIES.ENERGY_SENSOR);
-  return feature ? feature.id : null;
+  if (!feature) {
+    return null;
+  }
+
+  const featureInDb = await db.DeviceFeature.findByPk(feature.id);
+  return featureInDb ? feature.id : null;
 }
 
 module.exports = { getDefaultElectricMeterFeatureId };

--- a/server/test/lib/device/device.create.test.js
+++ b/server/test/lib/device/device.create.test.js
@@ -683,4 +683,43 @@ describe('Device', () => {
       'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4',
     );
   });
+  it('should ignore invalid energy_parent_id when updating a device', async () => {
+    const stateManager = new StateManager(event);
+    const serviceManager = new ServiceManager({}, stateManager);
+    const device = new Device(event, {}, stateManager, serviceManager, {}, {}, job, brain);
+    const created = await device.create({
+      service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
+      name: 'Energy device',
+      external_id: 'energy-device-invalid-parent',
+      features: [
+        {
+          name: 'Power',
+          external_id: 'energy-device:power',
+          category: 'switch',
+          type: 'power',
+          read_only: true,
+          keep_history: true,
+          has_feedback: false,
+          min: 0,
+          max: 10000,
+        },
+      ],
+    });
+
+    const updated = await device.create({
+      id: created.id,
+      service_id: created.service_id,
+      name: created.name,
+      external_id: created.external_id,
+      features: [
+        {
+          ...created.features[0],
+          energy_parent_id: '00000000-0000-0000-0000-000000000099',
+        },
+      ],
+      params: [],
+    });
+
+    expect(updated.features[0].energy_parent_id).to.equal(null);
+  });
 });

--- a/server/test/lib/energy-price/price.getDefaultElectricMeterFeatureId.test.js
+++ b/server/test/lib/energy-price/price.getDefaultElectricMeterFeatureId.test.js
@@ -18,38 +18,46 @@ describe('EnergyPrice.getDefaultElectricMeterFeatureId', () => {
   });
 
   it('should return the default electric meter feature ID', async () => {
-    // Create an energy price entry with an electric meter device ID
-    const electricMeterDeviceId = '7f85c2f8-86cc-4600-84db-6c074dadb4e8';
-    const electricMeterFeatureId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    const electricMeterDevice = await db.Device.create({
+      name: 'Electric Meter',
+      selector: 'electric-meter-test',
+      external_id: 'electric-meter-test-external',
+      service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
+    });
+    const electricMeterFeature = await db.DeviceFeature.create({
+      device_id: electricMeterDevice.id,
+      name: 'Index',
+      selector: 'electric-meter-test-index',
+      external_id: 'electric-meter-test:index',
+      category: DEVICE_FEATURE_CATEGORIES.ENERGY_SENSOR,
+      type: 'energy-index',
+      read_only: true,
+      keep_history: true,
+      has_feedback: false,
+      min: 0,
+      max: 1000000,
+    });
+
     await db.EnergyPrice.create({
       contract: 'base',
       price_type: 'consumption',
       currency: 'euro',
       start_date: '2025-01-01',
       price: 20,
-      electric_meter_device_id: electricMeterDeviceId,
+      electric_meter_device_id: electricMeterDevice.id,
     });
 
-    // Set up the device in state manager with an energy sensor feature
     const mockDevice = {
-      id: electricMeterDeviceId,
+      id: electricMeterDevice.id,
       name: 'Electric Meter',
-      selector: 'electric-meter',
-      features: [
-        {
-          id: electricMeterFeatureId,
-          category: DEVICE_FEATURE_CATEGORIES.ENERGY_SENSOR,
-          type: 'energy-index',
-        },
-      ],
+      selector: 'electric-meter-test',
+      features: [electricMeterFeature.get({ plain: true })],
     };
-    stateManager.setState('deviceById', electricMeterDeviceId, mockDevice);
+    stateManager.setState('deviceById', electricMeterDevice.id, mockDevice);
 
-    // Call the function
     const featureId = await energyPrice.getDefaultElectricMeterFeatureId();
 
-    // Verify the result
-    expect(featureId).to.equal(electricMeterFeatureId);
+    expect(featureId).to.equal(electricMeterFeature.id);
   });
 
   it('should return null when no energy price exists', async () => {
@@ -114,6 +122,36 @@ describe('EnergyPrice.getDefaultElectricMeterFeatureId', () => {
     const featureId = await energyPrice.getDefaultElectricMeterFeatureId();
 
     // Verify the result is null
+    expect(featureId).to.equal(null);
+  });
+
+  it('should return null when energy sensor feature id is stale in state manager', async () => {
+    const electricMeterDeviceId = '7f85c2f8-86cc-4600-84db-6c074dadb4e8';
+    await db.EnergyPrice.create({
+      contract: 'base',
+      price_type: 'consumption',
+      currency: 'euro',
+      start_date: '2025-01-01',
+      price: 20,
+      electric_meter_device_id: electricMeterDeviceId,
+    });
+
+    const mockDevice = {
+      id: electricMeterDeviceId,
+      name: 'Electric Meter',
+      selector: 'electric-meter',
+      features: [
+        {
+          id: 'stale-feature-id-not-in-db',
+          category: DEVICE_FEATURE_CATEGORIES.ENERGY_SENSOR,
+          type: 'energy-index',
+        },
+      ],
+    };
+    stateManager.setState('deviceById', electricMeterDeviceId, mockDevice);
+
+    const featureId = await energyPrice.getDefaultElectricMeterFeatureId();
+
     expect(featureId).to.equal(null);
   });
 });

--- a/server/utils/resolveEnergyParentId.js
+++ b/server/utils/resolveEnergyParentId.js
@@ -1,0 +1,21 @@
+const db = require('../models');
+
+/**
+ * @description Resolve energy_parent_id to a valid feature id or null.
+ * @param {string|null|undefined} energyParentId - Requested parent feature id.
+ * @param {object} [options] - Query options.
+ * @param {object} [options.transaction] - Sequelize transaction.
+ * @returns {Promise<string|null>} Valid parent id or null.
+ */
+async function resolveEnergyParentId(energyParentId, { transaction } = {}) {
+  if (!energyParentId) {
+    return null;
+  }
+
+  const parent = await db.DeviceFeature.findByPk(energyParentId, { transaction });
+  return parent ? energyParentId : null;
+}
+
+module.exports = {
+  resolveEnergyParentId,
+};

--- a/server/utils/resolveEnergyParentId.js
+++ b/server/utils/resolveEnergyParentId.js
@@ -6,6 +6,8 @@ const db = require('../models');
  * @param {object} [options] - Query options.
  * @param {object} [options.transaction] - Sequelize transaction.
  * @returns {Promise<string|null>} Valid parent id or null.
+ * @example
+ * await resolveEnergyParentId('uuid-of-parent-feature', { transaction });
  */
 async function resolveEnergyParentId(energyParentId, { transaction } = {}) {
   if (!energyParentId) {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

Fix save device bug when energy_parent_id is invalid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of energy feature parent relationships to prevent invalid or orphaned links. The system now automatically detects nonexistent parent features and clears invalid references, ensuring data integrity across the energy feature hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->