### PR TITLE
Netatmo: Restore OAuth refresh and add resilient auto-reconnect

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -804,6 +804,7 @@
         "connect": "Gladys ist mit Netatmo verbunden",
         "connecting": "Konfiguration gespeichert. Verbindung zu Ihrem Netatmo-Konto wird hergestellt...",
         "processingToken": "Verbindung zu Ihrem Netatmo-Konto... Zugriffstoken wird abgerufen.",
+        "reconnecting": "Verbindung zu Netatmo vorübergehend verloren. Automatische Wiederverbindung läuft...",
         "getDevicesValues": "Datenwiederherstellung läuft...",
         "dicoveringDevices": "Gerätewiederherstellung läuft...",
         "errorConnecting": {

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -699,6 +699,7 @@
         "connect": "Gladys is connected to Netatmo",
         "connecting": "Configuration saved. Connecting to your Netatmo account...",
         "processingToken": "Connecting to your Netatmo account... Retrieving access token.",
+        "reconnecting": "Connection to Netatmo temporarily lost. Automatic reconnection in progress...",
         "getDevicesValues": "Data recovery in progress...",
         "dicoveringDevices": "Device recovery in progress...",
         "errorConnecting": {

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -937,6 +937,7 @@
         "connect": "Gladys est connectée à Netatmo",
         "connecting": "Configuration sauvegardée. Connexion à votre compte Netatmo en cours...",
         "processingToken": "Connexion à votre compte Netatmo... Récupération du token d'accès.",
+        "reconnecting": "Connexion à Netatmo temporairement perdue. Tentative de reconnexion automatique en cours...",
         "getDevicesValues": "Récupération des données en cours...",
         "dicoveringDevices": "Récupération des appareils en cours...",
         "errorConnecting": {

--- a/front/src/routes/integration/all/netatmo/device-page/StateConnection.jsx
+++ b/front/src/routes/integration/all/netatmo/device-page/StateConnection.jsx
@@ -29,6 +29,11 @@ const StateConnection = props => (
             <Text id="integration.netatmo.status.connect" />
           </p>
         )) ||
+        (props.connectNetatmoStatus === STATUS.RECONNECTING && (
+          <p class="text-center alert alert-warning">
+            <Text id="integration.netatmo.status.reconnecting" />
+          </p>
+        )) ||
         (props.connectNetatmoStatus === STATUS.DISCONNECTED && (
           <p class="text-center alert alert-danger">
             <Text id="integration.netatmo.status.disconnect" />

--- a/front/src/routes/integration/all/netatmo/discover-page/StateConnection.jsx
+++ b/front/src/routes/integration/all/netatmo/discover-page/StateConnection.jsx
@@ -30,6 +30,11 @@ const StateConnection = props => (
             <Text id="integration.netatmo.status.connect" />
           </p>
         )) ||
+        (props.connectNetatmoStatus === STATUS.RECONNECTING && (
+          <p class="text-center alert alert-warning">
+            <Text id="integration.netatmo.status.reconnecting" />
+          </p>
+        )) ||
         (props.connectNetatmoStatus === STATUS.DISCONNECTED && (
           <p class="text-center alert alert-danger">
             <Text id="integration.netatmo.status.disconnect" />

--- a/front/src/routes/integration/all/netatmo/setup-page/StateConnection.jsx
+++ b/front/src/routes/integration/all/netatmo/setup-page/StateConnection.jsx
@@ -24,6 +24,11 @@ const StateConnection = props => (
             <Text id="integration.netatmo.status.connect" />
           </p>
         )) ||
+        (props.connectNetatmoStatus === STATUS.RECONNECTING && (
+          <p class="text-center alert alert-warning">
+            <Text id="integration.netatmo.status.reconnecting" />
+          </p>
+        )) ||
         (props.connectNetatmoStatus === STATUS.DISCONNECTED && (
           <p class="text-center alert alert-danger">
             <Text id="integration.netatmo.status.disconnect" />

--- a/server/services/netatmo/lib/index.js
+++ b/server/services/netatmo/lib/index.js
@@ -18,7 +18,11 @@ const { loadDevices } = require('./netatmo.loadDevices');
 const { loadDeviceDetails } = require('./netatmo.loadDeviceDetails');
 const { loadThermostatDetails } = require('./netatmo.loadThermostatDetails');
 const { loadWeatherStationDetails } = require('./netatmo.loadWeatherStationDetails');
-const { pollRefreshingToken } = require('./netatmo.pollRefreshingToken');
+const {
+  pollRefreshingToken,
+  refreshNetatmoTokens,
+  scheduleReconnectAttempt,
+} = require('./netatmo.pollRefreshingToken');
 const { pollRefreshingValues, refreshNetatmoValues } = require('./netatmo.pollRefreshingValues');
 const { setValue } = require('./netatmo.setValue');
 const { updateValues } = require('./netatmo.updateValues');
@@ -54,6 +58,9 @@ const NetatmoHandler = function NetatmoHandler(gladys, serviceId) {
   this.status = STATUS.NOT_INITIALIZED;
   this.pollRefreshToken = undefined;
   this.pollRefreshValues = undefined;
+  this.reconnectTimeout = undefined;
+  this.reconnectAttempt = 0;
+  this.firstFatalAt = null;
 };
 
 NetatmoHandler.prototype.init = init;
@@ -79,6 +86,8 @@ NetatmoHandler.prototype.loadWeatherStationDetails = loadWeatherStationDetails;
 NetatmoHandler.prototype.pollRefreshingValues = pollRefreshingValues;
 NetatmoHandler.prototype.refreshNetatmoValues = refreshNetatmoValues;
 NetatmoHandler.prototype.pollRefreshingToken = pollRefreshingToken;
+NetatmoHandler.prototype.refreshNetatmoTokens = refreshNetatmoTokens;
+NetatmoHandler.prototype.scheduleReconnectAttempt = scheduleReconnectAttempt;
 NetatmoHandler.prototype.setValue = setValue;
 NetatmoHandler.prototype.updateValues = updateValues;
 NetatmoHandler.prototype.updateNAPlug = updateNAPlug;

--- a/server/services/netatmo/lib/netatmo.init.js
+++ b/server/services/netatmo/lib/netatmo.init.js
@@ -1,5 +1,10 @@
+const logger = require('../../../utils/logger');
+
 /**
  * @description Initialize service with properties and connect to devices.
+ *
+ * If the first refresh attempt fails with a transient error (network, 5xx, 429, or 4xx within the
+ * grace window), the service stays initialized and the auto-reconnect cycle is scheduled.
  * @example netatmo.init();
  */
 async function init() {
@@ -7,11 +12,20 @@ async function init() {
   this.configured = true;
   await this.getAccessToken();
   await this.getRefreshToken();
-  const response = await this.refreshingTokens();
-  if (response.success) {
-    await this.pollRefreshingToken();
-    await this.refreshNetatmoValues();
-    await this.pollRefreshingValues();
+  try {
+    const response = await this.refreshingTokens();
+    if (response.success) {
+      await this.pollRefreshingToken();
+      await this.refreshNetatmoValues();
+      await this.pollRefreshingValues();
+    }
+  } catch (e) {
+    if (e && e.transient) {
+      logger.warn('Netatmo init: refresh failed transiently, scheduling auto-reconnect: ', e.message);
+      this.scheduleReconnectAttempt();
+      return;
+    }
+    throw e;
   }
 }
 

--- a/server/services/netatmo/lib/netatmo.pollRefreshingToken.js
+++ b/server/services/netatmo/lib/netatmo.pollRefreshingToken.js
@@ -1,29 +1,74 @@
 const logger = require('../../../utils/logger');
+const { RECONNECT_BACKOFF_MS, RECONNECT_RECURRENT_MS } = require('./utils/netatmo.constants');
 
 /**
- * @description Poll refreshing Token values of an Netatmo device.
- * @example refreshNetatmoTokens();
+ * @description Schedule the next short-retry attempt after a transient refresh failure.
+ *
+ * Cadence: backoff steps from RECONNECT_BACKOFF_MS, then RECONNECT_RECURRENT_MS recurrent.
+ * Tokens are kept across retries so a manual reconnect remains possible.
+ * @example
+ * this.scheduleReconnectAttempt();
+ */
+function scheduleReconnectAttempt() {
+  const step = this.reconnectAttempt || 0;
+  const delay = step < RECONNECT_BACKOFF_MS.length ? RECONNECT_BACKOFF_MS[step] : RECONNECT_RECURRENT_MS;
+  this.reconnectAttempt = step + 1;
+  logger.warn(`Netatmo: scheduling reconnect attempt #${this.reconnectAttempt} in ${delay}ms`);
+  clearTimeout(this.reconnectTimeout);
+  this.reconnectTimeout = setTimeout(async () => {
+    try {
+      await this.refreshingTokens();
+      this.reconnectAttempt = 0;
+      this.reconnectTimeout = undefined;
+      clearInterval(this.pollRefreshToken);
+      await this.pollRefreshingToken();
+    } catch (e) {
+      if (e && e.transient) {
+        this.scheduleReconnectAttempt();
+      } else {
+        logger.error('Netatmo: reconnect attempt failed with non-transient error, stopping retries: ', e);
+        this.reconnectAttempt = 0;
+        this.reconnectTimeout = undefined;
+      }
+    }
+  }, delay);
+}
+
+/**
+ * @description Refresh Netatmo tokens once and re-arm the polling interval if expiration changes.
+ * @example
+ * await this.refreshNetatmoTokens();
  */
 async function refreshNetatmoTokens() {
   const { expireInToken } = this;
-  await this.refreshingTokens();
-  if (this.expireInToken !== expireInToken) {
-    logger.warn(`New expiration access_token : ${this.expireInToken}ms `);
-    clearInterval(this.pollRefreshToken);
-    await this.pollRefreshingToken();
+  try {
+    await this.refreshingTokens();
+    this.reconnectAttempt = 0;
+    if (this.expireInToken !== expireInToken) {
+      logger.warn(`New expiration access_token : ${this.expireInToken}ms `);
+      clearInterval(this.pollRefreshToken);
+      await this.pollRefreshingToken();
+    }
+  } catch (e) {
+    if (e && e.transient) {
+      this.scheduleReconnectAttempt();
+    }
   }
 }
 
 /**
- * @description Poll refreshing Token values of an Netatmo device.
- * @example pollRefreshingToken();
+ * @description Start polling the Netatmo refresh token endpoint at the access-token expiry cadence.
+ * @example
+ * this.pollRefreshingToken();
  */
 function pollRefreshingToken() {
   if (this.expireInToken > 0) {
-    this.pollRefreshToken = setInterval(refreshNetatmoTokens.bind(this), this.expireInToken * 1000);
+    this.pollRefreshToken = setInterval(this.refreshNetatmoTokens.bind(this), this.expireInToken * 1000);
   }
 }
 
 module.exports = {
   pollRefreshingToken,
+  refreshNetatmoTokens,
+  scheduleReconnectAttempt,
 };

--- a/server/services/netatmo/lib/netatmo.refreshingTokens.js
+++ b/server/services/netatmo/lib/netatmo.refreshingTokens.js
@@ -3,7 +3,9 @@ const { fetch } = require('undici');
 const logger = require('../../../utils/logger');
 const { ServiceNotConfiguredError } = require('../../../utils/coreErrors');
 
-const { STATUS, API } = require('./utils/netatmo.constants');
+const { STATUS, API, FATAL_RETRY_WINDOW_MS } = require('./utils/netatmo.constants');
+
+const isTransientHttpStatus = (status) => status >= 500 || status === 429;
 
 /**
  * @description Netatmo retrieve access and refresh token method.
@@ -30,21 +32,60 @@ async function refreshingTokens() {
     client_secret: clientSecret,
     refresh_token: this.refreshToken,
   };
+  let response;
+  let rawBody;
   try {
-    const response = await fetch(API.TOKEN, {
+    response = await fetch(API.TOKEN, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${this.accessToken}`,
         'Content-Type': API.HEADER.CONTENT_TYPE,
         Host: API.HEADER.HOST,
       },
       body: new URLSearchParams(authentificationForm).toString(),
     });
-    const rawBody = await response.text();
-    if (!response.ok) {
-      logger.error('Error getting new refresh token: ', response.status, rawBody);
-      throw new Error(`HTTP error ${response.status} - ${rawBody}`);
+    rawBody = await response.text();
+  } catch (e) {
+    logger.warn('Netatmo refresh token transient network error, keeping tokens for retry: ', e);
+    await this.saveStatus({ statusType: STATUS.RECONNECTING, message: 'refresh_token_transient' });
+    const transientError = new Error(`NETATMO: Transient network error during token refresh - ${e.message}`);
+    transientError.transient = true;
+    throw transientError;
+  }
+
+  if (!response.ok) {
+    if (isTransientHttpStatus(response.status)) {
+      logger.warn(
+        `Netatmo refresh token transient HTTP error ${response.status}, keeping tokens for retry: ${rawBody}`,
+      );
+      await this.saveStatus({ statusType: STATUS.RECONNECTING, message: 'refresh_token_transient' });
+      const transientError = new Error(`NETATMO: Transient HTTP ${response.status} during token refresh - ${rawBody}`);
+      transientError.transient = true;
+      transientError.status = response.status;
+      throw transientError;
     }
+    const now = Date.now();
+    if (!this.firstFatalAt) {
+      this.firstFatalAt = now;
+    }
+    const withinRetryWindow = now - this.firstFatalAt < FATAL_RETRY_WINDOW_MS;
+    if (withinRetryWindow) {
+      logger.warn(
+        `Netatmo refresh token fatal error ${response.status}, keeping tokens within ${FATAL_RETRY_WINDOW_MS}ms grace window: ${rawBody}`,
+      );
+      await this.saveStatus({ statusType: STATUS.RECONNECTING, message: 'refresh_token_fatal_grace' });
+      const gracefulError = new Error(`NETATMO: Fatal HTTP ${response.status} during token refresh - ${rawBody}`);
+      gracefulError.transient = true;
+      gracefulError.status = response.status;
+      throw gracefulError;
+    }
+    logger.error('Netatmo refresh token fatal error past grace window, clearing tokens: ', response.status, rawBody);
+    await this.setTokens({ accessToken: '', refreshToken: '', expireIn: '' });
+    await this.saveStatus({ statusType: STATUS.ERROR.PROCESSING_TOKEN, message: 'refresh_token_fail' });
+    this.firstFatalAt = null;
+    throw new Error(`HTTP error ${response.status} - ${rawBody}`);
+  }
+
+  try {
     const data = JSON.parse(rawBody);
     const tokens = {
       accessToken: data.access_token,
@@ -52,17 +93,13 @@ async function refreshingTokens() {
       expireIn: data.expire_in,
     };
     await this.setTokens(tokens);
+    this.firstFatalAt = null;
     await this.saveStatus({ statusType: STATUS.CONNECTED, message: null });
     logger.debug('Netatmo new access tokens well loaded with status: ', this.status);
     return { success: true };
   } catch (e) {
-    logger.error('Netatmo no successfull refresh token and disconnect: ', e);
-    const tokens = {
-      accessToken: '',
-      refreshToken: '',
-      expireIn: '',
-    };
-    await this.setTokens(tokens);
+    logger.error('Netatmo refresh token response parsing failed, clearing tokens: ', e);
+    await this.setTokens({ accessToken: '', refreshToken: '', expireIn: '' });
     await this.saveStatus({ statusType: STATUS.ERROR.PROCESSING_TOKEN, message: 'refresh_token_fail' });
     throw new ServiceNotConfiguredError(`NETATMO: Service is not connected with error ${e}`);
   }

--- a/server/services/netatmo/lib/netatmo.retrieveTokens.js
+++ b/server/services/netatmo/lib/netatmo.retrieveTokens.js
@@ -42,7 +42,6 @@ async function retrieveTokens(body) {
     const response = await fetch(API.TOKEN, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${this.accessToken}`,
         'Content-Type': API.HEADER.CONTENT_TYPE,
         Host: API.HEADER.HOST,
       },

--- a/server/services/netatmo/lib/netatmo.saveStatus.js
+++ b/server/services/netatmo/lib/netatmo.saveStatus.js
@@ -57,6 +57,8 @@ function saveStatus(status) {
         this.connected = false;
         clearInterval(this.pollRefreshToken);
         clearInterval(this.pollRefreshValues);
+        clearTimeout(this.reconnectTimeout);
+        this.reconnectAttempt = 0;
         break;
       case STATUS.CONNECTING:
         this.configured = true;
@@ -83,6 +85,13 @@ function saveStatus(status) {
         this.connected = false;
         clearInterval(this.pollRefreshToken);
         clearInterval(this.pollRefreshValues);
+        clearTimeout(this.reconnectTimeout);
+        this.reconnectAttempt = 0;
+        break;
+      case STATUS.RECONNECTING:
+        this.configured = true;
+        this.status = STATUS.RECONNECTING;
+        this.connected = false;
         break;
       case STATUS.DISCOVERING_DEVICES:
         this.configured = true;

--- a/server/services/netatmo/lib/utils/netatmo.constants.js
+++ b/server/services/netatmo/lib/utils/netatmo.constants.js
@@ -36,6 +36,7 @@ const STATUS = {
   PROCESSING_TOKEN: 'processing token',
   CONNECTED: 'connected',
   DISCONNECTED: 'disconnected',
+  RECONNECTING: 'reconnecting',
   ERROR: {
     CONNECTING: 'error connecting',
     PROCESSING_TOKEN: 'error processing token',
@@ -47,6 +48,10 @@ const STATUS = {
   GET_DEVICES_VALUES: 'get devices values',
   DISCOVERING_DEVICES: 'discovering',
 };
+
+const RECONNECT_BACKOFF_MS = [30 * 1000, 60 * 1000, 120 * 1000, 300 * 1000];
+const RECONNECT_RECURRENT_MS = 300 * 1000;
+const FATAL_RETRY_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 const GITHUB_BASE_URL = 'https://github.com/GladysAssistant/Gladys/issues/new';
 const BASE_API = 'https://api.netatmo.com';
@@ -104,4 +109,7 @@ module.exports = {
   SUPPORTED_CATEGORY_TYPE,
   SUPPORTED_MODULE_TYPE,
   PARAMS,
+  RECONNECT_BACKOFF_MS,
+  RECONNECT_RECURRENT_MS,
+  FATAL_RETRY_WINDOW_MS,
 };

--- a/server/test/services/netatmo/lib/netatmo.init.test.js
+++ b/server/test/services/netatmo/lib/netatmo.init.test.js
@@ -96,4 +96,29 @@ describe('Netatmo Init', () => {
     expect(netatmoHandler.refreshingTokens.called).to.equal(true);
     expect(netatmoHandler.gladys.event.emit.callCount).to.equal(0);
   });
+
+  it('should schedule auto-reconnect on transient init refresh failure (not crash)', async () => {
+    const transient = new Error('transient');
+    transient.transient = true;
+    netatmoHandler.refreshingTokens = sinon.stub().rejects(transient);
+    netatmoHandler.scheduleReconnectAttempt = sinon.stub();
+
+    await netatmoHandler.init();
+
+    expect(netatmoHandler.refreshingTokens.called).to.equal(true);
+    expect(netatmoHandler.scheduleReconnectAttempt.calledOnce).to.equal(true);
+  });
+
+  it('should re-throw non-transient init refresh failures', async () => {
+    netatmoHandler.refreshingTokens = sinon.stub().rejects(new Error('fatal config error'));
+    netatmoHandler.scheduleReconnectAttempt = sinon.stub();
+
+    try {
+      await netatmoHandler.init();
+      expect.fail('should have thrown');
+    } catch (e) {
+      expect(e.message).to.include('fatal config error');
+      expect(netatmoHandler.scheduleReconnectAttempt.called).to.equal(false);
+    }
+  });
 });

--- a/server/test/services/netatmo/lib/netatmo.pollRefreshingTokens.test.js
+++ b/server/test/services/netatmo/lib/netatmo.pollRefreshingTokens.test.js
@@ -48,6 +48,7 @@ describe('Netatmo pollRefreshingToken', () => {
     netatmoMock = mockAgent.get('https://api.netatmo.com');
 
     clock = sinon.useFakeTimers();
+    netatmoHandler.refreshingTokens = refreshingTokens;
     netatmoHandler.status = 'not_initialized';
     netatmoHandler.configuration = {
       clientId: 'valid_client_id',
@@ -57,6 +58,8 @@ describe('Netatmo pollRefreshingToken', () => {
     netatmoHandler.accessToken = 'valid_access_token';
     netatmoHandler.refreshToken = 'valid_refresh_token';
     netatmoHandler.expireInToken = 3600;
+    netatmoHandler.reconnectAttempt = 0;
+    netatmoHandler.reconnectTimeout = undefined;
     tokens = {
       access_token: 'new-access-token',
       refresh_token: 'new-refresh-token',
@@ -65,6 +68,11 @@ describe('Netatmo pollRefreshingToken', () => {
   });
 
   afterEach(() => {
+    clearInterval(netatmoHandler.pollRefreshToken);
+    clearTimeout(netatmoHandler.reconnectTimeout);
+    netatmoHandler.pollRefreshToken = undefined;
+    netatmoHandler.reconnectTimeout = undefined;
+    netatmoHandler.reconnectAttempt = 0;
     restoreClock();
     sinon.reset();
     // Clean up the mock agent
@@ -84,7 +92,6 @@ describe('Netatmo pollRefreshingToken', () => {
     netatmoHandler.refreshingTokens = refreshingTokens;
     tokens.refresh_token = 'new-refresh-token2';
 
-    // Intercept the HTTP/2 call via undici
     netatmoMock
       .intercept({
         method: 'POST',
@@ -135,14 +142,16 @@ describe('Netatmo pollRefreshingToken', () => {
     });
     const initialExpireInToken = netatmoHandler.expireInToken;
     const pollRefreshingTokenSpy = sinon.spy(netatmoHandler, 'pollRefreshingToken');
-    const pollRefreshTokenId = netatmoHandler.pollRefreshToken.id;
 
     await netatmoHandler.pollRefreshingToken();
+    const pollRefreshTokenIdBefore = netatmoHandler.pollRefreshToken.id;
 
     clock.tick(initialExpireInToken * 1000);
-    expect(netatmoHandler.pollRefreshToken.id).to.equal(pollRefreshTokenId + 1);
-    expect(netatmoHandler.pollRefreshingToken.callCount).to.equal(1);
-    sinon.assert.calledOnce(pollRefreshingTokenSpy);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(netatmoHandler.pollRefreshToken.id).to.not.equal(pollRefreshTokenIdBefore);
+    expect(pollRefreshingTokenSpy.callCount).to.be.greaterThan(0);
 
     pollRefreshingTokenSpy.restore();
     netatmoHandler.refreshingTokens = refreshingTokens;
@@ -157,5 +166,121 @@ describe('Netatmo pollRefreshingToken', () => {
     sinon.assert.notCalled(refreshingTokensSpy);
 
     refreshingTokensSpy.restore();
+  });
+
+  it('should schedule a 30s retry after a transient error', async () => {
+    const transient = new Error('transient');
+    transient.transient = true;
+    netatmoHandler.refreshingTokens = sinon
+      .stub()
+      .onFirstCall()
+      .rejects(transient)
+      .onSecondCall()
+      .resolves({ success: true });
+
+    await netatmoHandler.pollRefreshingToken();
+
+    clock.tick(3600 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    sinon.assert.calledOnce(netatmoHandler.refreshingTokens);
+    expect(netatmoHandler.reconnectAttempt).to.equal(1);
+
+    clock.tick(30 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    sinon.assert.calledTwice(netatmoHandler.refreshingTokens);
+    expect(netatmoHandler.reconnectAttempt).to.equal(0);
+
+    netatmoHandler.refreshingTokens = refreshingTokens;
+  });
+
+  it('should follow the backoff cadence 30s/60s/120s/300s/300s on repeated transient errors', async () => {
+    const transient = new Error('transient');
+    transient.transient = true;
+    netatmoHandler.refreshingTokens = sinon.stub().rejects(transient);
+
+    await netatmoHandler.pollRefreshingToken();
+
+    clock.tick(3600 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    sinon.assert.calledOnce(netatmoHandler.refreshingTokens);
+    expect(netatmoHandler.reconnectAttempt).to.equal(1);
+
+    clock.tick(30 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(netatmoHandler.refreshingTokens.callCount).to.equal(2);
+    expect(netatmoHandler.reconnectAttempt).to.equal(2);
+
+    clock.tick(60 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(netatmoHandler.refreshingTokens.callCount).to.equal(3);
+    expect(netatmoHandler.reconnectAttempt).to.equal(3);
+
+    clock.tick(120 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(netatmoHandler.refreshingTokens.callCount).to.equal(4);
+    expect(netatmoHandler.reconnectAttempt).to.equal(4);
+
+    clock.tick(300 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(netatmoHandler.refreshingTokens.callCount).to.equal(5);
+    expect(netatmoHandler.reconnectAttempt).to.equal(5);
+
+    // recurrent 300s
+    clock.tick(300 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(netatmoHandler.refreshingTokens.callCount).to.equal(6);
+    expect(netatmoHandler.reconnectAttempt).to.equal(6);
+
+    netatmoHandler.refreshingTokens = refreshingTokens;
+  });
+
+  it('should not schedule a retry when the periodic tick throws a non-transient error', async () => {
+    netatmoHandler.refreshingTokens = sinon.stub().rejects(new Error('fatal'));
+
+    await netatmoHandler.pollRefreshingToken();
+
+    clock.tick(3600 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    sinon.assert.calledOnce(netatmoHandler.refreshingTokens);
+    expect(netatmoHandler.reconnectAttempt).to.equal(0);
+    expect(netatmoHandler.reconnectTimeout).to.equal(undefined);
+
+    netatmoHandler.refreshingTokens = refreshingTokens;
+  });
+
+  it('should stop retries on non-transient error during retry attempt', async () => {
+    const transient = new Error('transient');
+    transient.transient = true;
+    netatmoHandler.refreshingTokens = sinon
+      .stub()
+      .onFirstCall()
+      .rejects(transient)
+      .onSecondCall()
+      .rejects(new Error('fatal'));
+
+    await netatmoHandler.pollRefreshingToken();
+
+    clock.tick(3600 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(netatmoHandler.reconnectAttempt).to.equal(1);
+
+    clock.tick(30 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(netatmoHandler.refreshingTokens.callCount).to.equal(2);
+    expect(netatmoHandler.reconnectAttempt).to.equal(0);
+    expect(netatmoHandler.reconnectTimeout).to.equal(undefined);
+
+    netatmoHandler.refreshingTokens = refreshingTokens;
   });
 });

--- a/server/test/services/netatmo/lib/netatmo.refreshingTokens.test.js
+++ b/server/test/services/netatmo/lib/netatmo.refreshingTokens.test.js
@@ -44,6 +44,7 @@ describe('Netatmo Refreshing Tokens', () => {
     netatmoHandler.accessToken = 'valid_access_token';
     netatmoHandler.refreshToken = 'valid_refresh_token';
     netatmoHandler.status = 'not_initialized';
+    netatmoHandler.firstFatalAt = null;
   });
 
   afterEach(() => {
@@ -105,7 +106,6 @@ describe('Netatmo Refreshing Tokens', () => {
       expire_in: 3600,
     };
 
-    // Intercept the HTTP/2 call via undici
     netatmoMock
       .intercept({
         method: 'POST',
@@ -146,66 +146,177 @@ describe('Netatmo Refreshing Tokens', () => {
     sinon.assert.calledWith(netatmoHandler.gladys.variable.setValue, 'NETATMO_EXPIRE_IN_TOKEN', 3600, serviceId);
   });
 
-  it('should handle an error during token refresh', async () => {
-    // Intercept the HTTP/2 call via undici
+  it('should NOT send an Authorization header on /oauth2/token', async () => {
+    let receivedHeaders;
     netatmoMock
       .intercept({
         method: 'POST',
         path: '/oauth2/token',
       })
-      .reply(400, { error: 'invalid_request' });
+      .reply(200, (opts) => {
+        receivedHeaders = opts.headers;
+        return { access_token: 'a', refresh_token: 'b', expire_in: 3600 };
+      });
+
+    await netatmoHandler.refreshingTokens();
+    const headerKeys = Object.keys(receivedHeaders || {}).map((k) => k.toLowerCase());
+    expect(headerKeys).to.not.include('authorization');
+  });
+
+  it('should keep tokens and mark RECONNECTING on first fatal HTTP error (400) within grace window', async () => {
+    netatmoMock
+      .intercept({
+        method: 'POST',
+        path: '/oauth2/token',
+      })
+      .reply(400, { error: 'invalid_grant' });
 
     try {
       await netatmoHandler.refreshingTokens();
       expect.fail('should have thrown an error');
     } catch (e) {
       expect(e).to.be.instanceOf(Error);
-      expect(e.message).to.include('HTTP error 400 - {"error":"invalid_request"}');
-      expect(netatmoHandler.status).to.equal('disconnected');
-      expect(netatmoHandler.gladys.event.emit.callCount).to.equal(3);
-      expect(
-        netatmoHandler.gladys.event.emit.getCall(0).calledWith(EVENTS.WEBSOCKET.SEND_ALL, {
-          type: 'netatmo.status',
-          payload: { status: 'processing token' },
-        }),
-      ).to.equal(true);
-      expect(
-        netatmoHandler.gladys.event.emit.getCall(1).calledWith(EVENTS.WEBSOCKET.SEND_ALL, {
-          type: 'netatmo.error-processing-token',
-          payload: { statusType: 'processing token', status: 'refresh_token_fail' },
-        }),
-      ).to.equal(true);
-      expect(
-        netatmoHandler.gladys.event.emit.getCall(2).calledWith(EVENTS.WEBSOCKET.SEND_ALL, {
-          type: 'netatmo.status',
-          payload: { status: 'disconnected' },
-        }),
-      ).to.equal(true);
+      expect(e.transient).to.equal(true);
+      expect(e.status).to.equal(400);
+      expect(netatmoHandler.status).to.equal('reconnecting');
+      expect(netatmoHandler.accessToken).to.equal('valid_access_token');
+      expect(netatmoHandler.refreshToken).to.equal('valid_refresh_token');
+      expect(netatmoHandler.firstFatalAt).to.be.a('number');
+      sinon.assert.neverCalledWith(netatmoHandler.gladys.variable.setValue, 'NETATMO_ACCESS_TOKEN', '', serviceId);
     }
   });
 
-  it('should handle errors without a response object', async () => {
-    netatmoHandler.configuration.clientId = 'test-client-id';
-    netatmoHandler.configuration.clientSecret = 'test-client-secret';
-    netatmoHandler.configuration.scopes = { scopeEnergy: 'scope' };
-    netatmoHandler.refreshToken = 'refresh-token';
+  it('should clear tokens after the fatal grace window has elapsed', async () => {
+    netatmoMock
+      .intercept({
+        method: 'POST',
+        path: '/oauth2/token',
+      })
+      .reply(400, { error: 'invalid_grant' });
 
-    // Intercept the HTTP/2 call via undici
+    netatmoHandler.firstFatalAt = Date.now() - 25 * 60 * 60 * 1000;
+
+    try {
+      await netatmoHandler.refreshingTokens();
+      expect.fail('should have thrown an error');
+    } catch (e) {
+      expect(e.transient).to.equal(undefined);
+      expect(e.message).to.include('HTTP error 400');
+      expect(netatmoHandler.status).to.equal('disconnected');
+      expect(netatmoHandler.firstFatalAt).to.equal(null);
+      sinon.assert.calledWith(netatmoHandler.gladys.variable.setValue, 'NETATMO_ACCESS_TOKEN', '', serviceId);
+      sinon.assert.calledWith(netatmoHandler.gladys.variable.setValue, 'NETATMO_REFRESH_TOKEN', '', serviceId);
+    }
+  });
+
+  it('should keep tokens on first fatal HTTP error (401) within grace window', async () => {
+    netatmoMock
+      .intercept({
+        method: 'POST',
+        path: '/oauth2/token',
+      })
+      .reply(401, { error: 'invalid_client' });
+
+    try {
+      await netatmoHandler.refreshingTokens();
+      expect.fail('should have thrown an error');
+    } catch (e) {
+      expect(e.transient).to.equal(true);
+      expect(netatmoHandler.status).to.equal('reconnecting');
+      expect(netatmoHandler.accessToken).to.equal('valid_access_token');
+    }
+  });
+
+  it('should reset firstFatalAt on successful refresh', async () => {
+    netatmoHandler.firstFatalAt = Date.now() - 1000;
+    const tokens = {
+      access_token: 'new-access-token',
+      refresh_token: 'new-refresh-token',
+      expire_in: 3600,
+    };
+    netatmoMock.intercept({ method: 'POST', path: '/oauth2/token' }).reply(200, tokens);
+
+    await netatmoHandler.refreshingTokens();
+    expect(netatmoHandler.firstFatalAt).to.equal(null);
+  });
+
+  it('should keep tokens and mark RECONNECTING on transient HTTP error (500)', async () => {
+    netatmoMock
+      .intercept({
+        method: 'POST',
+        path: '/oauth2/token',
+      })
+      .reply(500, { error: 'server_error' });
+
+    try {
+      await netatmoHandler.refreshingTokens();
+      expect.fail('should have thrown an error');
+    } catch (e) {
+      expect(e.transient).to.equal(true);
+      expect(e.status).to.equal(500);
+      expect(netatmoHandler.status).to.equal('reconnecting');
+      expect(netatmoHandler.accessToken).to.equal('valid_access_token');
+      expect(netatmoHandler.refreshToken).to.equal('valid_refresh_token');
+      sinon.assert.neverCalledWith(netatmoHandler.gladys.variable.setValue, 'NETATMO_ACCESS_TOKEN', '', serviceId);
+    }
+  });
+
+  it('should keep tokens and mark RECONNECTING on transient HTTP error (429)', async () => {
+    netatmoMock
+      .intercept({
+        method: 'POST',
+        path: '/oauth2/token',
+      })
+      .reply(429, { error: 'too_many_requests' });
+
+    try {
+      await netatmoHandler.refreshingTokens();
+      expect.fail('should have thrown an error');
+    } catch (e) {
+      expect(e.transient).to.equal(true);
+      expect(e.status).to.equal(429);
+      expect(netatmoHandler.status).to.equal('reconnecting');
+      expect(netatmoHandler.accessToken).to.equal('valid_access_token');
+      expect(netatmoHandler.refreshToken).to.equal('valid_refresh_token');
+    }
+  });
+
+  it('should keep tokens and mark RECONNECTING on network error', async () => {
     netatmoMock
       .intercept({
         method: 'POST',
         path: '/oauth2/token',
       })
       .replyWithError('Network error');
+
+    try {
+      await netatmoHandler.refreshingTokens();
+      expect.fail('should have thrown an error');
+    } catch (e) {
+      expect(e.transient).to.equal(true);
+      expect(e.message).to.include('Transient network error');
+      expect(netatmoHandler.status).to.equal('reconnecting');
+      expect(netatmoHandler.accessToken).to.equal('valid_access_token');
+      expect(netatmoHandler.refreshToken).to.equal('valid_refresh_token');
+    }
+  });
+
+  it('should clear tokens if response body cannot be parsed as JSON', async () => {
+    netatmoMock
+      .intercept({
+        method: 'POST',
+        path: '/oauth2/token',
+      })
+      .reply(200, 'not-a-json');
+
     try {
       await netatmoHandler.refreshingTokens();
       expect.fail('should have thrown an error');
     } catch (e) {
       expect(e).to.be.instanceOf(ServiceNotConfiguredError);
       expect(e.message).to.include('NETATMO: Service is not connected with error');
-      expect(e.response).to.equal(undefined);
       expect(netatmoHandler.status).to.equal('disconnected');
-      expect(netatmoHandler.gladys.event.emit.callCount).to.equal(3);
+      sinon.assert.calledWith(netatmoHandler.gladys.variable.setValue, 'NETATMO_ACCESS_TOKEN', '', serviceId);
     }
   });
 });

--- a/server/test/services/netatmo/lib/netatmo.saveStatus.test.js
+++ b/server/test/services/netatmo/lib/netatmo.saveStatus.test.js
@@ -122,6 +122,45 @@ describe('Netatmo saveStatus', () => {
     expect(intervalPollRefreshTokenSpy.notCalled).to.equal(true);
     expect(intervalPollRefreshValuesSpy.notCalled).to.equal(true);
   });
+  it('should update the status to RECONNECTING and emit the event without clearing timers', () => {
+    sinon.spy(clock, 'clearInterval');
+    netatmoHandler.pollRefreshToken = setInterval(() => {}, 3600);
+    netatmoHandler.pollRefreshValues = setInterval(() => {}, 120);
+
+    netatmoHandler.saveStatus({ statusType: STATUS.RECONNECTING, message: null });
+
+    expect(netatmoHandler.status).to.equal('reconnecting');
+    expect(netatmoHandler.configured).to.equal(true);
+    expect(netatmoHandler.connected).to.equal(false);
+    expect(netatmoHandler.gladys.event.emit.callCount).to.equal(1);
+    sinon.assert.calledWith(netatmoHandler.gladys.event.emit, EVENTS.WEBSOCKET.SEND_ALL, {
+      type: 'netatmo.status',
+      payload: { status: 'reconnecting' },
+    });
+    assert.notCalled(clock.clearInterval);
+
+    clearInterval(netatmoHandler.pollRefreshToken);
+    clearInterval(netatmoHandler.pollRefreshValues);
+  });
+
+  it('should clear the reconnect timeout when transitioning to DISCONNECTED', () => {
+    netatmoHandler.reconnectTimeout = setTimeout(() => {}, 100000);
+    netatmoHandler.reconnectAttempt = 2;
+
+    netatmoHandler.saveStatus({ statusType: STATUS.DISCONNECTED, message: null });
+
+    expect(netatmoHandler.reconnectAttempt).to.equal(0);
+  });
+
+  it('should clear the reconnect timeout when transitioning to NOT_INITIALIZED', () => {
+    netatmoHandler.reconnectTimeout = setTimeout(() => {}, 100000);
+    netatmoHandler.reconnectAttempt = 3;
+
+    netatmoHandler.saveStatus({ statusType: STATUS.NOT_INITIALIZED, message: null });
+
+    expect(netatmoHandler.reconnectAttempt).to.equal(0);
+  });
+
   it('should update the status to DISCOVERING_DEVICES and emit the event', () => {
     netatmoHandler.saveStatus({ statusType: STATUS.DISCOVERING_DEVICES, message: null });
 


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.
- [ ] ~If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~
- [ ] ~If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).~
- [ ] ~Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).~

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change
## Summary

Fix the recurring Netatmo disconnects reported by the community ([forum thread](https://community.gladysassistant.com/t/service-netatmo/5910/355), starting May 2026) and add resilient auto-reconnect.

Root causes:
1. PR #2256 (axios → undici migration) added `Authorization: Bearer <accessToken>` on the `/oauth2/token` endpoint. The access token sent in that Bearer is by construction expired (we're refreshing it), so Netatmo rejects the request.
2. The `catch` of `refreshingTokens()` wiped both `accessToken` and `refreshToken` on any error (transient network blip, 5xx, timeout, 4xx). One transient blip = permanent disconnect with no auto-recovery.

## Details

Approach aligned with how Home Assistant's OAuth helper handles refresh errors ([HA blog 2026-02-19](https://developers.home-assistant.io/blog/2026/02/19/oauth-token-request-error-handling/)):

- **No more Bearer header on `/oauth2/token`** for both `refreshingTokens` and `retrieveTokens`. Credentials go in the form body (`client_id`, `client_secret`, `refresh_token`), as expected by the OAuth2 refresh_token grant spec.
- **Error classification**:
  - 5xx, 429 and network errors → transient. Tokens are preserved, status switches to `RECONNECTING`, and a short backoff retry is scheduled (30s → 60s → 120s → 300s, then 300s recurrent indefinitely).
  - 4xx except 429 → fatal. Tokens are preserved within a **24h grace window** (status `RECONNECTING`, retries continue). If failures persist for 24h, tokens are cleared and the service drops to `DISCONNECTED` (manual reconnect required, same as before).
- **`init()` is now resilient**: a transient first refresh schedules the auto-reconnect cycle instead of throwing.
- **New `STATUS.RECONNECTING`** with a yellow info banner in the Setup, Devices and Discover pages, plus EN/FR/DE i18n (`integration.netatmo.status.reconnecting`).
- `pollRefreshingToken`, `refreshNetatmoTokens`, `scheduleReconnectAttempt` follow the Gladys convention (functions exported and attached to the prototype, mirroring `services/tuya/lib/tuya.reconnect.js`).

Runtime validated by the integration maintainer: after killing connectivity, the service stays alive, retries, and recovers when Netatmo becomes reachable again.

## Scope

| Area | Insertions | Deletions |
|---|---|---|
| Production code (server) | 178 | 23 |
| Production code (front) | 15 | 0 |
| Tests | 327 | 64 |
| i18n (en/fr/de) | 6 | 0 |
| **Total vs `master`** | **526** | **87** |

Touched files reach 100% statements / branches / functions / lines coverage. Full netatmo suite: 185 passing.

## Test plan

- [x] `npm run test-service --service=netatmo` → 185 passing
- [x] `npx nyc --reporter=text --include='services/netatmo/lib/...' npm run test-service --service=netatmo` → 100% on every touched file
- [x] `npm run prettier` + `npm run eslint` on server and front (no new issues)
- [x] Runtime: connection alive, disconnects gracefully, reconnects when Netatmo is back

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Netatmo integration now displays a "reconnecting" status message when connection is temporarily lost.
  * Automatic reconnection attempts with exponential backoff timing for transient network and temporary service failures.
  * Added reconnection status messages in German, English, and French.

* **Tests**
  * Added comprehensive test coverage for reconnection retry behavior, grace windows, token handling, and status transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->