### PR TITLE
Netatmo: Trigger reconnect cycle on auth errors from business API calls

### DIFF
--- a/front/src/routes/integration/all/netatmo/discover-page/DiscoverTab.jsx
+++ b/front/src/routes/integration/all/netatmo/discover-page/DiscoverTab.jsx
@@ -53,6 +53,9 @@ class DiscoverTab extends Component {
         errorLoading: true
       });
     }
+    if (this.props.loadStatus) {
+      await this.props.loadStatus();
+    }
   };
   refreshDiscoveredDevices = async () => {
     this.setState({
@@ -71,6 +74,9 @@ class DiscoverTab extends Component {
         loading: false,
         errorLoading: true
       });
+    }
+    if (this.props.loadStatus) {
+      await this.props.loadStatus();
     }
   };
 

--- a/front/src/routes/integration/all/netatmo/discover-page/index.js
+++ b/front/src/routes/integration/all/netatmo/discover-page/index.js
@@ -108,7 +108,10 @@ class NetatmoDiscoverPage extends Component {
 
   componentWillUnmount() {
     this.props.session.dispatcher.removeListener(WEBSOCKET_MESSAGE_TYPES.NETATMO.STATUS, this.updateStatus);
-    this.props.session.dispatcher.removeListener(WEBSOCKET_MESSAGE_TYPES.NETATMO.ERROR.CONNECTING, this.updateStatus);
+    this.props.session.dispatcher.removeListener(
+      WEBSOCKET_MESSAGE_TYPES.NETATMO.ERROR.CONNECTING,
+      this.updateStatusError
+    );
     this.props.session.dispatcher.removeListener(
       WEBSOCKET_MESSAGE_TYPES.NETATMO.ERROR.PROCESSING_TOKEN,
       this.updateStatus
@@ -123,6 +126,7 @@ class NetatmoDiscoverPage extends Component {
           {...state}
           loading={loading}
           loadProps={this.loadProps}
+          loadStatus={this.loadStatus}
           updateStateInIndex={this.handleStateUpdateFromChild}
         />
       </NetatmoPage>

--- a/server/services/netatmo/lib/index.js
+++ b/server/services/netatmo/lib/index.js
@@ -23,6 +23,7 @@ const {
   refreshNetatmoTokens,
   scheduleReconnectAttempt,
 } = require('./netatmo.pollRefreshingToken');
+const { handleApiAuthError } = require('./netatmo.handleApiAuthError');
 const { pollRefreshingValues, refreshNetatmoValues } = require('./netatmo.pollRefreshingValues');
 const { setValue } = require('./netatmo.setValue');
 const { updateValues } = require('./netatmo.updateValues');
@@ -88,6 +89,7 @@ NetatmoHandler.prototype.refreshNetatmoValues = refreshNetatmoValues;
 NetatmoHandler.prototype.pollRefreshingToken = pollRefreshingToken;
 NetatmoHandler.prototype.refreshNetatmoTokens = refreshNetatmoTokens;
 NetatmoHandler.prototype.scheduleReconnectAttempt = scheduleReconnectAttempt;
+NetatmoHandler.prototype.handleApiAuthError = handleApiAuthError;
 NetatmoHandler.prototype.setValue = setValue;
 NetatmoHandler.prototype.updateValues = updateValues;
 NetatmoHandler.prototype.updateNAPlug = updateNAPlug;

--- a/server/services/netatmo/lib/netatmo.discoverDevices.js
+++ b/server/services/netatmo/lib/netatmo.discoverDevices.js
@@ -50,11 +50,15 @@ async function discoverDevices() {
       const existInGladys = this.gladys.stateManager.get('deviceByExternalId', device.external_id);
       return existInGladys === null;
     });
-    await this.saveStatus({ statusType: STATUS.CONNECTED, message: null });
+    if (this.status !== STATUS.RECONNECTING && this.status !== STATUS.DISCONNECTED) {
+      await this.saveStatus({ statusType: STATUS.CONNECTED, message: null });
+    }
     logger.debug(`${discoveredDevices.length} new Netatmo devices found`);
     return discoveredDevices;
   }
-  await this.saveStatus({ statusType: STATUS.CONNECTED, message: null });
+  if (this.status !== STATUS.RECONNECTING && this.status !== STATUS.DISCONNECTED) {
+    await this.saveStatus({ statusType: STATUS.CONNECTED, message: null });
+  }
   logger.debug('No devices found');
   return [];
 }

--- a/server/services/netatmo/lib/netatmo.handleApiAuthError.js
+++ b/server/services/netatmo/lib/netatmo.handleApiAuthError.js
@@ -1,0 +1,41 @@
+const logger = require('../../../utils/logger');
+const { STATUS } = require('./utils/netatmo.constants');
+
+const NETATMO_AUTH_ERROR_STATUSES = new Set([401, 403, 406]);
+
+/**
+ * @description Trigger an auto-reconnect cycle when a Netatmo business API call returns an auth/app status.
+ *
+ * Statuses considered as auth/app errors:
+ * - 401 Unauthorized (token rejected)
+ * - 403 Forbidden (missing scopes / permission revoked)
+ * - 406 Not Acceptable (Netatmo's way of signaling "Application is deactivated", error code 5)
+ *
+ * The status is always flipped to `RECONNECTING` so the UI and downstream callers
+ * (e.g. `refreshNetatmoValues`, `discoverDevices`) do not overwrite it with `CONNECTED`
+ * on their happy-path tail. The scheduling itself is idempotent: a new reconnect
+ * cycle is only triggered when none is already in progress.
+ *
+ * Keeps the existing tokens; `scheduleReconnectAttempt` will call `refreshingTokens` which
+ * decides whether the failure is transient (keep tokens) or fatal (clear tokens + disconnect).
+ * @param {number} status - HTTP status returned by the failing call.
+ * @returns {boolean} True if a reconnect cycle was triggered.
+ * @example
+ * this.handleApiAuthError(406);
+ */
+function handleApiAuthError(status) {
+  if (!NETATMO_AUTH_ERROR_STATUSES.has(status)) {
+    return false;
+  }
+  this.saveStatus({ statusType: STATUS.RECONNECTING, message: 'api_auth_error' });
+  if (this.reconnectAttempt && this.reconnectAttempt > 0) {
+    return false;
+  }
+  logger.warn(`Netatmo API call rejected with status ${status}, triggering reconnect cycle`);
+  this.scheduleReconnectAttempt();
+  return true;
+}
+
+module.exports = {
+  handleApiAuthError,
+};

--- a/server/services/netatmo/lib/netatmo.loadDevices.js
+++ b/server/services/netatmo/lib/netatmo.loadDevices.js
@@ -25,6 +25,7 @@ async function loadDevices() {
       const rawBody = await responsePage.text();
       if (!responsePage.ok) {
         logger.error('Netatmo error: ', responsePage.status, rawBody);
+        this.handleApiAuthError(responsePage.status);
       }
 
       const data = JSON.parse(rawBody);

--- a/server/services/netatmo/lib/netatmo.loadThermostatDetails.js
+++ b/server/services/netatmo/lib/netatmo.loadThermostatDetails.js
@@ -24,6 +24,7 @@ async function loadThermostatDetails() {
     const rawBody = await responseGetThermostat.text();
     if (!responseGetThermostat.ok) {
       logger.error('Netatmo error: ', responseGetThermostat.status, rawBody);
+      this.handleApiAuthError(responseGetThermostat.status);
     }
     const data = JSON.parse(rawBody);
     const { body, status } = data;

--- a/server/services/netatmo/lib/netatmo.loadWeatherStationDetails.js
+++ b/server/services/netatmo/lib/netatmo.loadWeatherStationDetails.js
@@ -24,6 +24,7 @@ async function loadWeatherStationDetails() {
     const rawBody = await response.text();
     if (!response.ok) {
       logger.error('Netatmo error: ', response.status, rawBody);
+      this.handleApiAuthError(response.status);
     }
 
     const data = JSON.parse(rawBody);

--- a/server/services/netatmo/lib/netatmo.pollRefreshingToken.js
+++ b/server/services/netatmo/lib/netatmo.pollRefreshingToken.js
@@ -1,5 +1,5 @@
 const logger = require('../../../utils/logger');
-const { RECONNECT_BACKOFF_MS, RECONNECT_RECURRENT_MS } = require('./utils/netatmo.constants');
+const { STATUS, RECONNECT_BACKOFF_MS, RECONNECT_RECURRENT_MS } = require('./utils/netatmo.constants');
 
 /**
  * @description Schedule the next short-retry attempt after a transient refresh failure.
@@ -18,10 +18,20 @@ function scheduleReconnectAttempt() {
   this.reconnectTimeout = setTimeout(async () => {
     try {
       await this.refreshingTokens();
-      this.reconnectAttempt = 0;
       this.reconnectTimeout = undefined;
       clearInterval(this.pollRefreshToken);
       await this.pollRefreshingToken();
+      if (!this.pollRefreshValues) {
+        await this.refreshNetatmoValues();
+      }
+      if (this.status === STATUS.RECONNECTING) {
+        this.scheduleReconnectAttempt();
+        return;
+      }
+      if (!this.pollRefreshValues) {
+        await this.pollRefreshingValues();
+      }
+      this.reconnectAttempt = 0;
     } catch (e) {
       if (e && e.transient) {
         this.scheduleReconnectAttempt();

--- a/server/services/netatmo/lib/netatmo.pollRefreshingValues.js
+++ b/server/services/netatmo/lib/netatmo.pollRefreshingValues.js
@@ -34,7 +34,9 @@ async function refreshNetatmoValues() {
     },
     { concurrency: 2 },
   );
-  await this.saveStatus({ statusType: STATUS.CONNECTED, message: null });
+  if (this.status !== STATUS.RECONNECTING && this.status !== STATUS.DISCONNECTED) {
+    await this.saveStatus({ statusType: STATUS.CONNECTED, message: null });
+  }
 }
 
 /**

--- a/server/test/services/netatmo/lib/netatmo.discoverDevices.test.js
+++ b/server/test/services/netatmo/lib/netatmo.discoverDevices.test.js
@@ -100,4 +100,30 @@ describe('Netatmo Discover devices', () => {
     expect(netatmoHandler.status).to.equal('connected');
     expect(netatmoHandler.gladys.event.emit.callCount).to.equal(2);
   });
+
+  it('should preserve RECONNECTING status after loadDevices triggered handleApiAuthError (no devices)', async () => {
+    netatmoHandler.status = 'connected';
+    netatmoHandler.loadDevices = sinon.stub().callsFake(async () => {
+      netatmoHandler.status = 'reconnecting';
+      return [];
+    });
+
+    const discoveredDevices = await netatmoHandler.discoverDevices();
+
+    expect(discoveredDevices).to.deep.equal([]);
+    expect(netatmoHandler.status).to.equal('reconnecting');
+  });
+
+  it('should preserve RECONNECTING status after loadDevices triggered handleApiAuthError (devices)', async () => {
+    netatmoHandler.status = 'connected';
+    netatmoHandler.gladys.stateManager.get = sinon.stub().returns(null);
+    netatmoHandler.loadDevices = sinon.stub().callsFake(async () => {
+      netatmoHandler.status = 'reconnecting';
+      return devicesMock;
+    });
+
+    await netatmoHandler.discoverDevices();
+
+    expect(netatmoHandler.status).to.equal('reconnecting');
+  });
 });

--- a/server/test/services/netatmo/lib/netatmo.handleApiAuthError.test.js
+++ b/server/test/services/netatmo/lib/netatmo.handleApiAuthError.test.js
@@ -1,0 +1,98 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const { fake } = sinon;
+
+const NetatmoHandler = require('../../../../services/netatmo/lib/index');
+
+const gladys = {
+  event: {
+    emit: fake.resolves(null),
+  },
+  variable: {
+    setValue: fake.resolves(null),
+  },
+};
+const serviceId = 'serviceId';
+
+describe('Netatmo handleApiAuthError', () => {
+  let netatmoHandler;
+  let clock;
+
+  beforeEach(() => {
+    sinon.reset();
+    clock = sinon.useFakeTimers();
+    netatmoHandler = new NetatmoHandler(gladys, serviceId);
+    netatmoHandler.accessToken = 'valid_access_token';
+    netatmoHandler.refreshToken = 'valid_refresh_token';
+    netatmoHandler.configuration = {
+      clientId: 'valid_client_id',
+      clientSecret: 'valid_client_secret',
+      scopes: { scopeEnergy: 'scope' },
+    };
+  });
+
+  afterEach(() => {
+    clearTimeout(netatmoHandler.reconnectTimeout);
+    clock.restore();
+    sinon.reset();
+  });
+
+  it('should return false for non auth statuses (200)', () => {
+    const result = netatmoHandler.handleApiAuthError(200);
+    expect(result).to.equal(false);
+  });
+
+  it('should return false for non auth statuses (500)', () => {
+    const result = netatmoHandler.handleApiAuthError(500);
+    expect(result).to.equal(false);
+  });
+
+  it('should trigger reconnect cycle and switch to RECONNECTING on 401', () => {
+    const spy = sinon.spy(netatmoHandler, 'scheduleReconnectAttempt');
+    const result = netatmoHandler.handleApiAuthError(401);
+    expect(result).to.equal(true);
+    expect(netatmoHandler.status).to.equal('reconnecting');
+    expect(spy.calledOnce).to.equal(true);
+    expect(netatmoHandler.reconnectAttempt).to.equal(1);
+    spy.restore();
+  });
+
+  it('should trigger reconnect cycle on 403', () => {
+    const spy = sinon.spy(netatmoHandler, 'scheduleReconnectAttempt');
+    const result = netatmoHandler.handleApiAuthError(403);
+    expect(result).to.equal(true);
+    expect(netatmoHandler.status).to.equal('reconnecting');
+    expect(spy.calledOnce).to.equal(true);
+    spy.restore();
+  });
+
+  it('should trigger reconnect cycle on 406 (Application is deactivated)', () => {
+    const spy = sinon.spy(netatmoHandler, 'scheduleReconnectAttempt');
+    const result = netatmoHandler.handleApiAuthError(406);
+    expect(result).to.equal(true);
+    expect(netatmoHandler.status).to.equal('reconnecting');
+    expect(spy.calledOnce).to.equal(true);
+    spy.restore();
+  });
+
+  it('should be idempotent when a reconnect is already in progress', () => {
+    netatmoHandler.reconnectAttempt = 2;
+    const spy = sinon.spy(netatmoHandler, 'scheduleReconnectAttempt');
+    const result = netatmoHandler.handleApiAuthError(401);
+    expect(result).to.equal(false);
+    expect(spy.called).to.equal(false);
+    spy.restore();
+  });
+
+  it('should still flip status to RECONNECTING even when idempotent (no new schedule)', () => {
+    netatmoHandler.reconnectAttempt = 1;
+    netatmoHandler.status = 'connected';
+    const spy = sinon.spy(netatmoHandler, 'scheduleReconnectAttempt');
+    const result = netatmoHandler.handleApiAuthError(406);
+    expect(result).to.equal(false);
+    expect(spy.called).to.equal(false);
+    expect(netatmoHandler.status).to.equal('reconnecting');
+    spy.restore();
+  });
+});

--- a/server/test/services/netatmo/lib/netatmo.loadDevices.test.js
+++ b/server/test/services/netatmo/lib/netatmo.loadDevices.test.js
@@ -191,6 +191,26 @@ describe('Netatmo Load Devices', () => {
     expect(devices).to.deep.eq([]);
   });
 
+  it('should trigger handleApiAuthError on 403 from homesdata', async () => {
+    netatmoHandler.configuration.energyApi = true;
+    netatmoHandler.loadThermostatDetails = sinon.stub().resolves({ plugs: [], thermostats: [] });
+    const authErrorSpy = sinon.spy(netatmoHandler, 'handleApiAuthError');
+    try {
+      netatmoMock
+        .intercept({
+          method: 'GET',
+          path: '/api/homesdata',
+        })
+        .reply(403, { error: { code: 13, message: 'forbidden' } });
+
+      await netatmoHandler.loadDevices();
+
+      sinon.assert.calledWith(authErrorSpy, 403);
+    } finally {
+      authErrorSpy.restore();
+    }
+  });
+
   it('should handle unexpected API responses', async () => {
     netatmoHandler.configuration.energyApi = true;
     netatmoHandler.loadThermostatDetails = sinon.stub().resolves({ plugs: [], thermostats: [] });

--- a/server/test/services/netatmo/lib/netatmo.loadThermostatDetails.test.js
+++ b/server/test/services/netatmo/lib/netatmo.loadThermostatDetails.test.js
@@ -141,4 +141,22 @@ describe('Netatmo Load Thermostat Details', () => {
     expect(thermostats).to.be.an('array');
     expect(thermostats).to.have.lengthOf(0);
   });
+
+  it('should trigger handleApiAuthError on 401 from getthermostatsdata', async () => {
+    const authErrorSpy = sinon.spy(netatmoHandler, 'handleApiAuthError');
+    try {
+      netatmoMock
+        .intercept({
+          method: 'GET',
+          path: '/api/getthermostatsdata',
+        })
+        .reply(401, { error: { code: 2, message: 'invalid_token' } });
+
+      await netatmoHandler.loadThermostatDetails();
+
+      sinon.assert.calledWith(authErrorSpy, 401);
+    } finally {
+      authErrorSpy.restore();
+    }
+  });
 });

--- a/server/test/services/netatmo/lib/netatmo.loadWeatherStationDetails.test.js
+++ b/server/test/services/netatmo/lib/netatmo.loadWeatherStationDetails.test.js
@@ -142,4 +142,22 @@ describe('Netatmo Load Weather Station Details', () => {
     expect(modulesWeatherStations).to.be.an('array');
     expect(modulesWeatherStations).to.have.lengthOf(0);
   });
+
+  it('should trigger handleApiAuthError on 403 from getstationsdata', async () => {
+    const authErrorSpy = sinon.spy(netatmoHandler, 'handleApiAuthError');
+    try {
+      netatmoMock
+        .intercept({
+          method: 'GET',
+          path: '/api/getstationsdata?get_favorites=false',
+        })
+        .reply(403, { error: { code: 13, message: 'forbidden' } });
+
+      await netatmoHandler.loadWeatherStationDetails();
+
+      sinon.assert.calledWith(authErrorSpy, 403);
+    } finally {
+      authErrorSpy.restore();
+    }
+  });
 });

--- a/server/test/services/netatmo/lib/netatmo.pollRefreshingTokens.test.js
+++ b/server/test/services/netatmo/lib/netatmo.pollRefreshingTokens.test.js
@@ -168,6 +168,105 @@ describe('Netatmo pollRefreshingToken', () => {
     refreshingTokensSpy.restore();
   });
 
+  it('should bootstrap value polling on retry success when not already started', async () => {
+    const transient = new Error('transient');
+    transient.transient = true;
+    netatmoHandler.refreshingTokens = sinon
+      .stub()
+      .onFirstCall()
+      .rejects(transient)
+      .onSecondCall()
+      .resolves({ success: true });
+    const refreshNetatmoValuesStub = sinon.stub().resolves();
+    const pollRefreshingValuesStub = sinon.stub();
+    netatmoHandler.refreshNetatmoValues = refreshNetatmoValuesStub;
+    netatmoHandler.pollRefreshingValues = pollRefreshingValuesStub;
+    netatmoHandler.pollRefreshValues = undefined;
+
+    await netatmoHandler.pollRefreshingToken();
+
+    clock.tick(3600 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    clock.tick(30 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    sinon.assert.calledOnce(refreshNetatmoValuesStub);
+    sinon.assert.calledOnce(pollRefreshingValuesStub);
+
+    netatmoHandler.refreshingTokens = refreshingTokens;
+  });
+
+  it('should skip arming pollRefreshingValues and keep reconnectAttempt > 0 when bootstrap leaves status RECONNECTING', async () => {
+    const transient = new Error('transient');
+    transient.transient = true;
+    netatmoHandler.refreshingTokens = sinon
+      .stub()
+      .onFirstCall()
+      .rejects(transient)
+      .onSecondCall()
+      .resolves({ success: true });
+    const pollRefreshingValuesStub = sinon.stub();
+    netatmoHandler.refreshNetatmoValues = sinon.stub().callsFake(async () => {
+      netatmoHandler.status = 'reconnecting';
+    });
+    netatmoHandler.pollRefreshingValues = pollRefreshingValuesStub;
+    netatmoHandler.pollRefreshValues = undefined;
+
+    await netatmoHandler.pollRefreshingToken();
+
+    clock.tick(3600 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    clock.tick(30 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    sinon.assert.notCalled(pollRefreshingValuesStub);
+    expect(netatmoHandler.reconnectAttempt).to.be.greaterThan(0);
+
+    clearTimeout(netatmoHandler.reconnectTimeout);
+    netatmoHandler.reconnectTimeout = undefined;
+    netatmoHandler.reconnectAttempt = 0;
+    netatmoHandler.refreshingTokens = refreshingTokens;
+  });
+
+  it('should not bootstrap value polling on retry success when already started', async () => {
+    const transient = new Error('transient');
+    transient.transient = true;
+    netatmoHandler.refreshingTokens = sinon
+      .stub()
+      .onFirstCall()
+      .rejects(transient)
+      .onSecondCall()
+      .resolves({ success: true });
+    const refreshNetatmoValuesStub = sinon.stub().resolves();
+    const pollRefreshingValuesStub = sinon.stub();
+    netatmoHandler.refreshNetatmoValues = refreshNetatmoValuesStub;
+    netatmoHandler.pollRefreshingValues = pollRefreshingValuesStub;
+    netatmoHandler.pollRefreshValues = setInterval(() => {}, 120 * 1000);
+
+    await netatmoHandler.pollRefreshingToken();
+
+    clock.tick(3600 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    clock.tick(30 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    sinon.assert.notCalled(refreshNetatmoValuesStub);
+    sinon.assert.notCalled(pollRefreshingValuesStub);
+
+    clearInterval(netatmoHandler.pollRefreshValues);
+    netatmoHandler.pollRefreshValues = undefined;
+    netatmoHandler.refreshingTokens = refreshingTokens;
+  });
+
   it('should schedule a 30s retry after a transient error', async () => {
     const transient = new Error('transient');
     transient.transient = true;
@@ -187,6 +286,9 @@ describe('Netatmo pollRefreshingToken', () => {
     expect(netatmoHandler.reconnectAttempt).to.equal(1);
 
     clock.tick(30 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
     sinon.assert.calledTwice(netatmoHandler.refreshingTokens);

--- a/server/test/services/netatmo/lib/netatmo.pollRefreshingValues.test.js
+++ b/server/test/services/netatmo/lib/netatmo.pollRefreshingValues.test.js
@@ -132,4 +132,18 @@ describe('Netatmo pollRefreshingValues', () => {
       payload: { status: 'connected' },
     });
   });
+
+  it('should preserve RECONNECTING status after loadDevices triggered handleApiAuthError', async () => {
+    netatmoHandler.status = 'connected';
+    netatmoHandler.loadDevices = sinon.stub().callsFake(async () => {
+      netatmoHandler.status = 'reconnecting';
+      return [];
+    });
+
+    await netatmoHandler.refreshNetatmoValues();
+
+    restoreClock();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(netatmoHandler.status).to.equal('reconnecting');
+  });
 });

--- a/server/test/services/netatmo/lib/netatmo.saveStatus.test.js
+++ b/server/test/services/netatmo/lib/netatmo.saveStatus.test.js
@@ -144,20 +144,26 @@ describe('Netatmo saveStatus', () => {
   });
 
   it('should clear the reconnect timeout when transitioning to DISCONNECTED', () => {
-    netatmoHandler.reconnectTimeout = setTimeout(() => {}, 100000);
+    const clearTimeoutSpy = sinon.spy(clock, 'clearTimeout');
+    const timeoutHandle = setTimeout(() => {}, 100000);
+    netatmoHandler.reconnectTimeout = timeoutHandle;
     netatmoHandler.reconnectAttempt = 2;
 
     netatmoHandler.saveStatus({ statusType: STATUS.DISCONNECTED, message: null });
 
+    sinon.assert.calledWith(clearTimeoutSpy, timeoutHandle);
     expect(netatmoHandler.reconnectAttempt).to.equal(0);
   });
 
   it('should clear the reconnect timeout when transitioning to NOT_INITIALIZED', () => {
-    netatmoHandler.reconnectTimeout = setTimeout(() => {}, 100000);
+    const clearTimeoutSpy = sinon.spy(clock, 'clearTimeout');
+    const timeoutHandle = setTimeout(() => {}, 100000);
+    netatmoHandler.reconnectTimeout = timeoutHandle;
     netatmoHandler.reconnectAttempt = 3;
 
     netatmoHandler.saveStatus({ statusType: STATUS.NOT_INITIALIZED, message: null });
 
+    sinon.assert.calledWith(clearTimeoutSpy, timeoutHandle);
     expect(netatmoHandler.reconnectAttempt).to.equal(0);
   });
 


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.
- [ ] ~If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~
- [ ] ~If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).~
- [ ] ~Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).~

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change
## Summary

Follow-up to #2561. The OAuth refresh fix covers `/oauth2/token`, but business API calls (`homesdata`, `getthermostatsdata`, `getstationsdata`) also need to trigger the auto-reconnect cycle when Netatmo rejects the access token. Without this, clicking "Refresh" on the Discovery page when the Netatmo app is deactivated returned silently while the status stayed `connected` — confusing for the user.

> ⚠️ **Stacked on top of #2561.** Once #2561 is merged, this PR will rebase cleanly and the displayed diff will shrink to only the changes below.

## Details

- **New `handleApiAuthError(status)` helper.** On HTTP `401`, `403` or `406` (Netatmo's code for "Application is deactivated", confirmed by runtime testing: `406 { "error": { "code": 5, "message": "Application is deactivated" } }`), it switches the status to `RECONNECTING` and calls the `scheduleReconnectAttempt()` cycle introduced in #2561. Idempotent: no-op if a reconnect cycle is already in progress.
- **Wired into the 3 cloud loaders**: `loadDevices`, `loadThermostatDetails`, `loadWeatherStationDetails` — right after detecting a non-OK response.
- **`discoverDevices` and `refreshNetatmoValues`** no longer overwrite the status with `CONNECTED` when `handleApiAuthError` just moved it to `RECONNECTING`/`DISCONNECTED`. The UI keeps showing the auto-reconnect banner.
- **Tokens are never cleared by this helper itself.** `refreshingTokens` remains the single source of truth for token lifecycle decisions (24h grace window before clearing on fatal OAuth errors).

Runtime validated by the integration maintainer: deactivating the app on `dev.netatmo.com` while Gladys is up → click "Refresh" → status switches to `reconnecting`, banner appears in the 3 Netatmo pages, automatic retry cycles kick in; reactivating the app → reconnect succeeds at the next retry.

## Scope

| Area | Insertions | Deletions |
|---|---|---|
| Production code (server) | 67 | 3 |
| Tests | 159 | 0 |
| **Total vs #2561** | **226** | **3** |

Touched files reach 100% statements / branches / functions / lines coverage. Full netatmo suite: 197 passing.

## Test plan

- [x] `npm run test-service --service=netatmo` → 197 passing
- [x] 100% coverage on the 6 touched files
- [x] `npm run prettier` + `npm run eslint` on server (no new issues)
- [x] Runtime: app deactivation/reactivation → status transitions correctly + UI banner shows up in all 3 pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Netatmo auth-related HTTP errors (401, 403, 406) to reliably switch to reconnect mode and avoid duplicate reconnect scheduling.
  * Refined service status transitions so “connected” status is only set when not reconnecting/disconnected.
  * Enhanced device discovery/details loading to trigger auth-error handling on failed API calls.
* **New Features**
  * Added optional status-loading support to the Netatmo discover page so it can refresh status after discovery actions.
* **Tests**
  * Expanded unit tests for reconnection idempotency, discovery/status preservation, and auth error propagation across API flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->