### PR TITLE
Add DeviceFeature supported options

### DIFF
--- a/server/lib/device/camera/camera.get.js
+++ b/server/lib/device/camera/camera.get.js
@@ -1,5 +1,6 @@
 const db = require('../../../models');
 const { DEVICE_FEATURE_CATEGORIES } = require('../../../utils/constants');
+const { getFeaturesInclude } = require('../../../utils/deviceQueryIncludes');
 
 /**
  * @description Get list of cameras.
@@ -10,14 +11,12 @@ const { DEVICE_FEATURE_CATEGORIES } = require('../../../utils/constants');
 async function get() {
   const cameras = await db.Device.findAll({
     include: [
-      {
-        model: db.DeviceFeature,
-        as: 'features',
+      getFeaturesInclude({
         attributes: ['name', 'selector'],
         where: {
           category: DEVICE_FEATURE_CATEGORIES.CAMERA,
         },
-      },
+      }),
       {
         model: db.Room,
         as: 'room',

--- a/server/lib/device/device.create.js
+++ b/server/lib/device/device.create.js
@@ -134,13 +134,9 @@ async function create(device) {
     deviceToReturn.params = deviceToReturn.params || [];
 
     const energyParentIdByExternalId = new Map();
-    const supportedOptionsByExternalId = new Map();
     const featuresToSave = features.map((feature) => {
       if (Object.prototype.hasOwnProperty.call(feature, 'energy_parent_id')) {
         energyParentIdByExternalId.set(feature.external_id, feature.energy_parent_id);
-      }
-      if (Object.prototype.hasOwnProperty.call(feature, 'supported_options')) {
-        supportedOptionsByExternalId.set(feature.external_id, feature.supported_options);
       }
       const featureToSave = { ...feature };
       delete featureToSave.energy_parent_id;
@@ -196,7 +192,8 @@ async function create(device) {
     });
 
     deviceToReturn.features = await Promise.map(newFeatures, async (savedFeature) => {
-      if (!supportedOptionsByExternalId.has(savedFeature.external_id)) {
+      const payloadFeature = matchFeatureInList(savedFeature, features);
+      if (!payloadFeature || !Object.prototype.hasOwnProperty.call(payloadFeature, 'supported_options')) {
         const existingFeature = matchFeatureInList(savedFeature, deviceToReturn.features);
         savedFeature.supported_options = existingFeature?.supported_options ?? [];
         return savedFeature;
@@ -204,7 +201,7 @@ async function create(device) {
 
       savedFeature.supported_options = await syncFeatureSupportedOptions(
         savedFeature.id,
-        supportedOptionsByExternalId.get(savedFeature.external_id),
+        payloadFeature.supported_options,
         transaction,
       );
       return savedFeature;

--- a/server/lib/device/device.create.js
+++ b/server/lib/device/device.create.js
@@ -3,31 +3,16 @@ const { BadParameters } = require('../../utils/coreErrors');
 const db = require('../../models');
 const { EVENTS } = require('../../utils/constants');
 const { resolveEnergyParentId } = require('../../utils/resolveEnergyParentId');
+const { getStandardDeviceIncludes } = require('../../utils/deviceQueryIncludes');
 const logger = require('../../utils/logger');
+const { syncFeatureSupportedOptions } = require('./device.syncFeatureSupportedOptions');
 
 const getById = async (id) => {
   return db.Device.findOne({
     where: {
       id,
     },
-    include: [
-      {
-        model: db.DeviceFeature,
-        as: 'features',
-      },
-      {
-        model: db.DeviceParam,
-        as: 'params',
-      },
-      {
-        model: db.Room,
-        as: 'room',
-      },
-      {
-        model: db.Service,
-        as: 'service',
-      },
-    ],
+    include: getStandardDeviceIncludes(),
   });
 };
 
@@ -36,24 +21,7 @@ const getByExternalId = async (externalId) => {
     where: {
       external_id: externalId,
     },
-    include: [
-      {
-        model: db.DeviceFeature,
-        as: 'features',
-      },
-      {
-        model: db.DeviceParam,
-        as: 'params',
-      },
-      {
-        model: db.Room,
-        as: 'room',
-      },
-      {
-        model: db.Service,
-        as: 'service',
-      },
-    ],
+    include: getStandardDeviceIncludes(),
   });
 };
 
@@ -166,12 +134,17 @@ async function create(device) {
     deviceToReturn.params = deviceToReturn.params || [];
 
     const energyParentIdByExternalId = new Map();
+    const supportedOptionsByExternalId = new Map();
     const featuresToSave = features.map((feature) => {
       if (Object.prototype.hasOwnProperty.call(feature, 'energy_parent_id')) {
         energyParentIdByExternalId.set(feature.external_id, feature.energy_parent_id);
       }
+      if (Object.prototype.hasOwnProperty.call(feature, 'supported_options')) {
+        supportedOptionsByExternalId.set(feature.external_id, feature.supported_options);
+      }
       const featureToSave = { ...feature };
       delete featureToSave.energy_parent_id;
+      delete featureToSave.supported_options;
       return featureToSave;
     });
 
@@ -222,7 +195,20 @@ async function create(device) {
       savedFeature.energy_parent_id = validParentId;
     });
 
-    deviceToReturn.features = newFeatures;
+    deviceToReturn.features = await Promise.map(newFeatures, async (savedFeature) => {
+      if (!supportedOptionsByExternalId.has(savedFeature.external_id)) {
+        const existingFeature = matchFeatureInList(savedFeature, deviceToReturn.features);
+        savedFeature.supported_options = existingFeature?.supported_options ?? [];
+        return savedFeature;
+      }
+
+      savedFeature.supported_options = await syncFeatureSupportedOptions(
+        savedFeature.id,
+        supportedOptionsByExternalId.get(savedFeature.external_id),
+        transaction,
+      );
+      return savedFeature;
+    });
 
     const newParams = await Promise.map(params, async (param) => {
       // if the param already already exist

--- a/server/lib/device/device.destroyParam.js
+++ b/server/lib/device/device.destroyParam.js
@@ -1,4 +1,5 @@
 const db = require('../../models');
+const { getStandardDeviceIncludes } = require('../../utils/deviceQueryIncludes');
 
 /**
  * @description Create/Update a deviceParam.
@@ -20,24 +21,7 @@ async function destroyParam(device, name) {
   // Reload the full device from DB with all features (same pattern as device.init)
   const fullDevice = await db.Device.findOne({
     where: { id: device.id },
-    include: [
-      {
-        model: db.DeviceFeature,
-        as: 'features',
-      },
-      {
-        model: db.DeviceParam,
-        as: 'params',
-      },
-      {
-        model: db.Room,
-        as: 'room',
-      },
-      {
-        model: db.Service,
-        as: 'service',
-      },
-    ],
+    include: getStandardDeviceIncludes(),
   });
 
   if (fullDevice) {

--- a/server/lib/device/device.get.js
+++ b/server/lib/device/device.get.js
@@ -4,6 +4,7 @@ const db = require('../../models');
 const { isNumeric } = require('../../utils/device');
 const { NotFoundError } = require('../../utils/coreErrors');
 const { SYSTEM_VARIABLE_NAMES } = require('../../utils/constants');
+const { getStandardDeviceIncludes } = require('../../utils/deviceQueryIncludes');
 
 const DEFAULT_OPTIONS = {
   skip: 0,
@@ -27,24 +28,7 @@ async function get(options) {
   const optionsWithDefault = { ...DEFAULT_OPTIONS, ...options };
 
   const queryParams = {
-    include: [
-      {
-        model: db.DeviceFeature,
-        as: 'features',
-      },
-      {
-        model: db.DeviceParam,
-        as: 'params',
-      },
-      {
-        model: db.Room,
-        as: 'room',
-      },
-      {
-        model: db.Service,
-        as: 'service',
-      },
-    ],
+    include: getStandardDeviceIncludes(),
     offset: optionsWithDefault.skip,
     order: [[optionsWithDefault.order_by, optionsWithDefault.order_dir]],
   };

--- a/server/lib/device/device.init.js
+++ b/server/lib/device/device.init.js
@@ -1,5 +1,6 @@
 const db = require('../../models');
 const logger = require('../../utils/logger');
+const { getStandardDeviceIncludes } = require('../../utils/deviceQueryIncludes');
 
 /**
  * @description Init devices in local RAM.
@@ -11,24 +12,7 @@ const logger = require('../../utils/logger');
 async function init(startDuckDbMigration = true) {
   // load all devices in RAM
   const devices = await db.Device.findAll({
-    include: [
-      {
-        model: db.DeviceFeature,
-        as: 'features',
-      },
-      {
-        model: db.DeviceParam,
-        as: 'params',
-      },
-      {
-        model: db.Room,
-        as: 'room',
-      },
-      {
-        model: db.Service,
-        as: 'service',
-      },
-    ],
+    include: getStandardDeviceIncludes(),
   });
   logger.debug(`Device : init : Found ${devices.length} devices`);
   const plainDevices = devices.map((device) => {

--- a/server/lib/device/device.syncFeatureSupportedOptions.js
+++ b/server/lib/device/device.syncFeatureSupportedOptions.js
@@ -1,0 +1,68 @@
+const Promise = require('bluebird');
+const db = require('../../models');
+const { normalizeSupportedOptions } = require('../../utils/normalizeSupportedOptions');
+
+const matchSupportedOptionInList = (existingOption, options) => {
+  return options.find((newOption) => newOption.id === existingOption.id || newOption.value === existingOption.value);
+};
+
+/**
+ * @description Sync supported options for a device feature.
+ * @param {string} deviceFeatureId - The device feature id.
+ * @param {Array} supportedOptions - The supported options payload.
+ * @param {object} transaction - Sequelize transaction.
+ * @returns {Promise<Array>} Saved supported options.
+ * @example
+ * syncFeatureSupportedOptions('fc235c88-b10d-4706-8b59-fef92a7119b2', [{ value: 1, label: 'On' }], transaction);
+ */
+async function syncFeatureSupportedOptions(deviceFeatureId, supportedOptions, transaction) {
+  const normalizedOptions = normalizeSupportedOptions(supportedOptions);
+
+  const existingOptions = await db.DeviceFeatureSupportedOption.findAll({
+    where: {
+      device_feature_id: deviceFeatureId,
+    },
+    transaction,
+  });
+
+  await Promise.map(existingOptions, async (existingOption) => {
+    if (!matchSupportedOptionInList(existingOption, normalizedOptions)) {
+      await existingOption.destroy({ transaction });
+    }
+  });
+
+  const savedOptions = await Promise.map(normalizedOptions, async (option) => {
+    const matchedOption = existingOptions.find(
+      (existingOption) => existingOption.id === option.id || existingOption.value === option.value,
+    );
+
+    if (matchedOption) {
+      await matchedOption.update(
+        {
+          value: option.value,
+          label: option.label,
+          sort_order: option.sort_order,
+        },
+        { transaction },
+      );
+      return matchedOption.get({ plain: true });
+    }
+
+    const createdOption = await db.DeviceFeatureSupportedOption.create(
+      {
+        device_feature_id: deviceFeatureId,
+        value: option.value,
+        label: option.label,
+        sort_order: option.sort_order,
+      },
+      { transaction },
+    );
+    return createdOption.get({ plain: true });
+  });
+
+  return savedOptions.sort((a, b) => a.sort_order - b.sort_order);
+}
+
+module.exports = {
+  syncFeatureSupportedOptions,
+};

--- a/server/lib/device/device.updateFeature.js
+++ b/server/lib/device/device.updateFeature.js
@@ -1,5 +1,6 @@
 const db = require('../../models');
 const { NotFoundError, BadParameters } = require('../../utils/coreErrors');
+const { getStandardDeviceIncludes } = require('../../utils/deviceQueryIncludes');
 
 /**
  * @description Update a device feature (by selector).
@@ -57,24 +58,7 @@ async function updateFeature(selector, updates) {
   // Reload the full device from DB with all features (same pattern as device.init)
   const fullDevice = await db.Device.findOne({
     where: { id: plain.device_id },
-    include: [
-      {
-        model: db.DeviceFeature,
-        as: 'features',
-      },
-      {
-        model: db.DeviceParam,
-        as: 'params',
-      },
-      {
-        model: db.Room,
-        as: 'room',
-      },
-      {
-        model: db.Service,
-        as: 'service',
-      },
-    ],
+    include: getStandardDeviceIncludes(),
   });
 
   if (fullDevice) {

--- a/server/lib/device/light/light.getLightsInRoom.js
+++ b/server/lib/device/light/light.getLightsInRoom.js
@@ -1,6 +1,7 @@
 const logger = require('../../../utils/logger');
 const db = require('../../../models');
 const { DEVICE_FEATURE_CATEGORIES } = require('../../../utils/constants');
+const { getFeaturesInclude } = require('../../../utils/deviceQueryIncludes');
 
 /**
  * @description Return a list of light devices in a room.
@@ -14,13 +15,11 @@ async function getLightsInRoom(roomId) {
 
   const devices = await db.Device.findAll({
     include: [
-      {
-        model: db.DeviceFeature,
-        as: 'features',
+      getFeaturesInclude({
         where: {
           category: DEVICE_FEATURE_CATEGORIES.LIGHT,
         },
-      },
+      }),
       {
         model: db.Service,
         as: 'service',

--- a/server/lib/device/light/light.init.js
+++ b/server/lib/device/light/light.init.js
@@ -1,6 +1,7 @@
 const db = require('../../../models');
 const logger = require('../../../utils/logger');
 const { DEVICE_FEATURE_CATEGORIES } = require('../../../utils/constants');
+const { getFeaturesInclude } = require('../../../utils/deviceQueryIncludes');
 
 /**
  * @description Get all lights and store them in memory.
@@ -11,13 +12,11 @@ const { DEVICE_FEATURE_CATEGORIES } = require('../../../utils/constants');
 async function init() {
   const lights = await db.Device.findAll({
     include: [
-      {
-        model: db.DeviceFeature,
-        as: 'features',
+      getFeaturesInclude({
         where: {
           category: DEVICE_FEATURE_CATEGORIES.LIGHT,
         },
-      },
+      }),
       {
         model: db.Room,
         as: 'room',

--- a/server/lib/room/room.get.js
+++ b/server/lib/room/room.get.js
@@ -1,4 +1,5 @@
 const db = require('../../models');
+const { getFeaturesInclude } = require('../../utils/deviceQueryIncludes');
 
 const DEFAULT_OPTIONS = {
   expand: [],
@@ -40,11 +41,9 @@ async function get(options) {
       as: 'devices',
       attributes: DEVICE_ATTRIBUTES,
       include: [
-        {
-          model: db.DeviceFeature,
-          as: 'features',
+        getFeaturesInclude({
           attributes: DEVICE_FEATURES_ATTRIBUTES,
-        },
+        }),
         {
           model: db.Service,
           as: 'service',

--- a/server/lib/room/room.getBySelector.js
+++ b/server/lib/room/room.getBySelector.js
@@ -1,6 +1,7 @@
 const { Op } = require('sequelize');
 const db = require('../../models');
 const { DEVICE_FEATURE_CATEGORIES } = require('../../utils/constants');
+const { getFeaturesInclude } = require('../../utils/deviceQueryIncludes');
 
 const { NotFoundError } = require('../../utils/coreErrors');
 
@@ -41,16 +42,14 @@ async function getBySelector(selector, options) {
       as: 'devices',
       attributes: DEVICE_ATTRIBUTES,
       include: [
-        {
-          model: db.DeviceFeature,
-          as: 'features',
+        getFeaturesInclude({
           attributes: DEVICE_FEATURES_ATTRIBUTES,
           where: {
             category: {
               [Op.not]: DEVICE_FEATURE_CATEGORIES.CAMERA,
             },
           },
-        },
+        }),
         {
           model: db.Service,
           as: 'service',

--- a/server/migrations/20260619120000-create-device-feature-supported-option.js
+++ b/server/migrations/20260619120000-create-device-feature-supported-option.js
@@ -18,7 +18,7 @@ module.exports = {
       },
       value: {
         allowNull: false,
-        type: Sequelize.DOUBLE,
+        type: Sequelize.INTEGER,
       },
       label: {
         allowNull: false,

--- a/server/migrations/20260619120000-create-device-feature-supported-option.js
+++ b/server/migrations/20260619120000-create-device-feature-supported-option.js
@@ -1,0 +1,48 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('t_device_feature_supported_option', {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.UUID,
+      },
+      device_feature_id: {
+        allowNull: false,
+        type: Sequelize.UUID,
+        references: {
+          model: 't_device_feature',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      value: {
+        allowNull: false,
+        type: Sequelize.DOUBLE,
+      },
+      label: {
+        allowNull: false,
+        type: Sequelize.STRING,
+      },
+      sort_order: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+        defaultValue: 0,
+      },
+      created_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updated_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+
+    await queryInterface.addIndex('t_device_feature_supported_option', ['device_feature_id']);
+    await queryInterface.addIndex('t_device_feature_supported_option', ['device_feature_id', 'value'], {
+      unique: true,
+    });
+  },
+  down: async (queryInterface) => queryInterface.dropTable('t_device_feature_supported_option'),
+};

--- a/server/models/device_feature.js
+++ b/server/models/device_feature.js
@@ -133,6 +133,11 @@ module.exports = (sequelize, DataTypes) => {
       sourceKey: 'id',
       as: 'energy_children',
     });
+    deviceFeature.hasMany(models.DeviceFeatureSupportedOption, {
+      foreignKey: 'device_feature_id',
+      sourceKey: 'id',
+      as: 'supported_options',
+    });
   };
 
   return deviceFeature;

--- a/server/models/device_feature_supported_option.js
+++ b/server/models/device_feature_supported_option.js
@@ -1,0 +1,52 @@
+module.exports = (sequelize, DataTypes) => {
+  const deviceFeatureSupportedOption = sequelize.define(
+    't_device_feature_supported_option',
+    {
+      id: {
+        type: DataTypes.UUID,
+        primaryKey: true,
+        defaultValue: DataTypes.UUIDV4,
+      },
+      device_feature_id: {
+        allowNull: false,
+        type: DataTypes.UUID,
+        references: {
+          model: 't_device_feature',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      value: {
+        allowNull: false,
+        type: DataTypes.DOUBLE,
+        validate: {
+          isFloat: true,
+        },
+      },
+      label: {
+        allowNull: false,
+        type: DataTypes.STRING,
+        validate: {
+          notEmpty: true,
+        },
+      },
+      sort_order: {
+        allowNull: false,
+        type: DataTypes.INTEGER,
+        defaultValue: 0,
+      },
+    },
+    {},
+  );
+
+  deviceFeatureSupportedOption.associate = (models) => {
+    deviceFeatureSupportedOption.belongsTo(models.DeviceFeature, {
+      foreignKey: 'device_feature_id',
+      targetKey: 'id',
+      as: 'device_feature',
+    });
+  };
+
+  return deviceFeatureSupportedOption;
+};

--- a/server/models/device_feature_supported_option.js
+++ b/server/models/device_feature_supported_option.js
@@ -19,9 +19,9 @@ module.exports = (sequelize, DataTypes) => {
       },
       value: {
         allowNull: false,
-        type: DataTypes.DOUBLE,
+        type: DataTypes.INTEGER,
         validate: {
-          isFloat: true,
+          isInt: true,
         },
       },
       label: {

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -35,6 +35,7 @@ const DashboardModel = require('./dashboard');
 const DeviceFeatureStateModel = require('./device_feature_state');
 const DeviceFeatureAggregateModel = require('./device_feature_state_aggregate');
 const DeviceFeatureModel = require('./device_feature');
+const DeviceFeatureSupportedOptionModel = require('./device_feature_supported_option');
 const DeviceParamModel = require('./device_param');
 const DeviceModel = require('./device');
 const EnergyPriceModel = require('./energy_price');
@@ -61,6 +62,7 @@ const models = {
   DeviceFeatureState: DeviceFeatureStateModel(sequelize, Sequelize),
   DeviceFeatureStateAggregate: DeviceFeatureAggregateModel(sequelize, Sequelize),
   DeviceFeature: DeviceFeatureModel(sequelize, Sequelize),
+  DeviceFeatureSupportedOption: DeviceFeatureSupportedOptionModel(sequelize, Sequelize),
   DeviceParam: DeviceParamModel(sequelize, Sequelize),
   Device: DeviceModel(sequelize, Sequelize),
   EnergyPrice: EnergyPriceModel(sequelize, Sequelize),

--- a/server/test/lib/device/device.create.test.js
+++ b/server/test/lib/device/device.create.test.js
@@ -802,6 +802,60 @@ describe('Device', () => {
     ).get({ plain: true });
     expect(storedDevice.features[0].supported_options).to.have.lengthOf(2);
   });
+  it('should sync supported_options when feature payload only has id', async () => {
+    const stateManager = new StateManager(event);
+    const serviceManager = new ServiceManager({}, stateManager);
+    const device = new Device(event, {}, stateManager, serviceManager, {}, {}, job, brain);
+    const created = await device.create({
+      service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
+      name: 'Vacuum device by id',
+      external_id: 'vacuum-supported-options-by-id',
+      features: [
+        {
+          name: 'Run mode',
+          external_id: 'vacuum-by-id:run-mode',
+          category: 'vacuum-cleaner',
+          type: 'mode',
+          read_only: false,
+          keep_history: true,
+          has_feedback: true,
+          min: 0,
+          max: 5,
+          supported_options: [{ value: 0, label: 'Idle', sort_order: 0 }],
+        },
+      ],
+      params: [],
+    });
+
+    const feature = created.features[0];
+    const updated = await device.create({
+      id: created.id,
+      service_id: created.service_id,
+      name: created.name,
+      external_id: created.external_id,
+      features: [
+        {
+          id: feature.id,
+          name: feature.name,
+          category: feature.category,
+          type: feature.type,
+          read_only: feature.read_only,
+          keep_history: feature.keep_history,
+          has_feedback: feature.has_feedback,
+          min: feature.min,
+          max: feature.max,
+          supported_options: [{ value: 3, label: 'Paused', sort_order: 0 }],
+        },
+      ],
+      params: [],
+    });
+
+    expect(updated.features[0].supported_options).to.have.lengthOf(1);
+    expect(updated.features[0].supported_options[0]).to.include({
+      value: 3,
+      label: 'Paused',
+    });
+  });
   it('should reject invalid supported_options during device create', async () => {
     const stateManager = new StateManager(event);
     const serviceManager = new ServiceManager({}, stateManager);

--- a/server/test/lib/device/device.create.test.js
+++ b/server/test/lib/device/device.create.test.js
@@ -3,6 +3,8 @@ const { fake, assert } = require('sinon');
 const EventEmitter = require('events');
 
 const { DEVICE_POLL_FREQUENCIES, EVENTS } = require('../../../utils/constants');
+const { BadParameters } = require('../../../utils/coreErrors');
+const { getStandardDeviceIncludes } = require('../../../utils/deviceQueryIncludes');
 const Device = require('../../../lib/device');
 const StateManager = require('../../../lib/state');
 const ServiceManager = require('../../../lib/service');
@@ -246,6 +248,7 @@ describe('Device', () => {
         last_value_changed: null,
         last_value_string: null,
         unit: null,
+        supported_options: [],
         created_at: newDevice.features[0] && newDevice.features[0].created_at,
         updated_at: newDevice.features[0] && newDevice.features[0].updated_at,
       },
@@ -320,6 +323,7 @@ describe('Device', () => {
         last_value_changed: null,
         last_value_string: null,
         unit: null,
+        supported_options: [],
         created_at: newDevice.features[0] && newDevice.features[0].created_at,
         updated_at: newDevice.features[0] && newDevice.features[0].updated_at,
       },
@@ -721,5 +725,266 @@ describe('Device', () => {
     });
 
     expect(updated.features[0].energy_parent_id).to.equal(null);
+  });
+  it('should create and sync supported_options on device features', async () => {
+    const stateManager = new StateManager(event);
+    const serviceManager = new ServiceManager({}, stateManager);
+    const device = new Device(event, {}, stateManager, serviceManager, {}, {}, job, brain);
+    const created = await device.create({
+      service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
+      name: 'Vacuum device',
+      external_id: 'vacuum-supported-options',
+      features: [
+        {
+          name: 'Run mode',
+          external_id: 'vacuum:run-mode',
+          category: 'vacuum-cleaner',
+          type: 'mode',
+          read_only: false,
+          keep_history: true,
+          has_feedback: true,
+          min: 0,
+          max: 5,
+          supported_options: [
+            { value: 0, label: 'Idle', sort_order: 0 },
+            { value: 1, label: 'Cleaning', sort_order: 1 },
+          ],
+        },
+      ],
+      params: [],
+    });
+
+    expect(created.features).to.have.lengthOf(1);
+    expect(created.features[0].supported_options).to.have.lengthOf(2);
+    expect(created.features[0].supported_options[0]).to.include({
+      value: 0,
+      label: 'Idle',
+      sort_order: 0,
+    });
+    expect(created.features[0].supported_options[1]).to.include({
+      value: 1,
+      label: 'Cleaning',
+      sort_order: 1,
+    });
+
+    const updated = await device.create({
+      id: created.id,
+      service_id: created.service_id,
+      name: created.name,
+      external_id: created.external_id,
+      features: [
+        {
+          ...created.features[0],
+          supported_options: [
+            { id: created.features[0].supported_options[0].id, value: 0, label: 'Idle updated', sort_order: 0 },
+            { value: 2, label: 'Mapping', sort_order: 2 },
+          ],
+        },
+      ],
+      params: [],
+    });
+
+    expect(updated.features[0].supported_options).to.have.lengthOf(2);
+    expect(updated.features[0].supported_options[0]).to.include({
+      value: 0,
+      label: 'Idle updated',
+    });
+    expect(updated.features[0].supported_options[1]).to.include({
+      value: 2,
+      label: 'Mapping',
+    });
+
+    const storedDevice = (
+      await db.Device.findOne({
+        where: { external_id: 'vacuum-supported-options' },
+        include: getStandardDeviceIncludes(),
+      })
+    ).get({ plain: true });
+    expect(storedDevice.features[0].supported_options).to.have.lengthOf(2);
+  });
+  it('should reject invalid supported_options during device create', async () => {
+    const stateManager = new StateManager(event);
+    const serviceManager = new ServiceManager({}, stateManager);
+    const device = new Device(event, {}, stateManager, serviceManager, {}, {}, job, brain);
+
+    try {
+      await device.create({
+        service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
+        name: 'Invalid options device',
+        external_id: 'invalid-supported-options',
+        features: [
+          {
+            name: 'Run mode',
+            external_id: 'invalid:run-mode',
+            category: 'vacuum-cleaner',
+            type: 'mode',
+            read_only: false,
+            keep_history: true,
+            has_feedback: true,
+            min: 0,
+            max: 5,
+            supported_options: [{ value: 1, label: '' }],
+          },
+        ],
+        params: [],
+      });
+      expect.fail('should have thrown');
+    } catch (error) {
+      expect(error).to.be.instanceOf(BadParameters);
+    }
+  });
+  it('should reject device create without external_id', async () => {
+    const stateManager = new StateManager(event);
+    const serviceManager = new ServiceManager({}, stateManager);
+    const device = new Device(event, {}, stateManager, serviceManager, {}, {}, job, brain);
+
+    try {
+      await device.create({
+        service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
+        name: 'Missing external id',
+        params: [],
+      });
+      expect.fail('should have thrown');
+    } catch (error) {
+      expect(error).to.be.instanceOf(BadParameters);
+      expect(error.message).to.equal('A device must have an external_id.');
+    }
+  });
+  it('should preserve supported_options when feature payload omits them', async () => {
+    const stateManager = new StateManager(event);
+    const serviceManager = new ServiceManager({}, stateManager);
+    const device = new Device(event, {}, stateManager, serviceManager, {}, {}, job, brain);
+    const created = await device.create({
+      service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
+      name: 'Preserve options device',
+      external_id: 'preserve-supported-options',
+      features: [
+        {
+          name: 'Run mode',
+          external_id: 'preserve:run-mode',
+          category: 'vacuum-cleaner',
+          type: 'mode',
+          read_only: false,
+          keep_history: true,
+          has_feedback: true,
+          min: 0,
+          max: 5,
+          supported_options: [{ value: 0, label: 'Idle', sort_order: 0 }],
+        },
+      ],
+      params: [],
+    });
+
+    const { supported_options, ...featureWithoutOptions } = created.features[0];
+    expect(supported_options).to.have.lengthOf(1);
+
+    const updated = await device.create({
+      id: created.id,
+      service_id: created.service_id,
+      name: created.name,
+      external_id: created.external_id,
+      features: [
+        {
+          ...featureWithoutOptions,
+          id: '00000000-0000-0000-0000-000000000099',
+        },
+      ],
+      params: [],
+    });
+
+    expect(updated.features[0].supported_options).to.have.lengthOf(1);
+    expect(updated.features[0].supported_options[0]).to.include({
+      value: 0,
+      label: 'Idle',
+    });
+  });
+  it('should clear supported_options when feature payload sends an empty array', async () => {
+    const stateManager = new StateManager(event);
+    const serviceManager = new ServiceManager({}, stateManager);
+    const device = new Device(event, {}, stateManager, serviceManager, {}, {}, job, brain);
+    const created = await device.create({
+      service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
+      name: 'Clear options device',
+      external_id: 'clear-supported-options',
+      features: [
+        {
+          name: 'Run mode',
+          external_id: 'clear:run-mode',
+          category: 'vacuum-cleaner',
+          type: 'mode',
+          read_only: false,
+          keep_history: true,
+          has_feedback: true,
+          min: 0,
+          max: 5,
+          supported_options: [{ value: 0, label: 'Idle', sort_order: 0 }],
+        },
+      ],
+      params: [],
+    });
+
+    const updated = await device.create({
+      id: created.id,
+      service_id: created.service_id,
+      name: created.name,
+      external_id: created.external_id,
+      features: [
+        {
+          ...created.features[0],
+          supported_options: [],
+        },
+      ],
+      params: [],
+    });
+
+    expect(updated.features[0].supported_options).to.deep.equal([]);
+  });
+  it('should create feature without supported_options payload', async () => {
+    const stateManager = new StateManager(event);
+    const serviceManager = new ServiceManager({}, stateManager);
+    const device = new Device(event, {}, stateManager, serviceManager, {}, {}, job, brain);
+    const created = await device.create({
+      service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
+      name: 'Feature without options',
+      external_id: 'feature-without-options',
+      features: [
+        {
+          name: 'Temperature',
+          external_id: 'feature-without-options:temperature',
+          category: 'temperature',
+          type: 'decimal',
+          read_only: true,
+          keep_history: true,
+          has_feedback: false,
+          min: 0,
+          max: 100,
+        },
+      ],
+      params: [],
+    });
+
+    expect(created.features[0].supported_options).to.deep.equal([]);
+  });
+  it('should find device by external_id when id is unknown', async () => {
+    const stateManager = new StateManager(event);
+    const serviceManager = new ServiceManager({}, stateManager);
+    const device = new Device(event, {}, stateManager, serviceManager, {}, {}, job, brain);
+    const updated = await device.create({
+      id: '00000000-0000-0000-0000-000000000099',
+      name: 'RENAMED_DEVICE',
+      external_id: 'test-device-external',
+      service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
+      params: [
+        {
+          id: 'c24b1f96-69d7-4e6e-aa44-f14406694c59',
+          name: 'TEST_PARAM',
+          value: 'UPDATED_VALUE',
+          device_id: '7f85c2f8-86cc-4600-84db-6c074dadb4e8',
+        },
+      ],
+    });
+
+    expect(updated).to.have.property('name', 'RENAMED_DEVICE');
+    expect(updated).to.have.property('selector', 'test-device');
   });
 });

--- a/server/test/lib/device/device.create.test.js
+++ b/server/test/lib/device/device.create.test.js
@@ -875,8 +875,8 @@ describe('Device', () => {
       params: [],
     });
 
-    const { supported_options, ...featureWithoutOptions } = created.features[0];
-    expect(supported_options).to.have.lengthOf(1);
+    const { supported_options: supportedOptions, ...featureWithoutOptions } = created.features[0];
+    expect(supportedOptions).to.have.lengthOf(1);
 
     const updated = await device.create({
       id: created.id,

--- a/server/test/utils/deviceQueryIncludes.test.js
+++ b/server/test/utils/deviceQueryIncludes.test.js
@@ -1,0 +1,40 @@
+const { expect } = require('chai');
+const db = require('../../models');
+const { getFeaturesInclude, getStandardDeviceIncludes } = require('../../utils/deviceQueryIncludes');
+
+describe('deviceQueryIncludes', () => {
+  it('should return default features include', () => {
+    const include = getFeaturesInclude();
+
+    expect(include.model).to.equal(db.DeviceFeature);
+    expect(include.as).to.equal('features');
+    expect(include.include).to.have.lengthOf(1);
+    expect(include.include[0].model).to.equal(db.DeviceFeatureSupportedOption);
+    expect(include.include[0].as).to.equal('supported_options');
+    expect(include.where).to.equal(undefined);
+    expect(include.attributes).to.equal(undefined);
+  });
+
+  it('should return features include with where and attributes', () => {
+    const include = getFeaturesInclude({
+      where: { category: 'light' },
+      attributes: ['name', 'selector'],
+    });
+
+    expect(include.where).to.deep.equal({ category: 'light' });
+    expect(include.attributes).to.deep.equal(['name', 'selector']);
+  });
+
+  it('should return standard device includes', () => {
+    const includes = getStandardDeviceIncludes({
+      where: { category: 'light' },
+    });
+
+    expect(includes).to.have.lengthOf(4);
+    expect(includes[0].as).to.equal('features');
+    expect(includes[0].where).to.deep.equal({ category: 'light' });
+    expect(includes[1].as).to.equal('params');
+    expect(includes[2].as).to.equal('room');
+    expect(includes[3].as).to.equal('service');
+  });
+});

--- a/server/test/utils/normalizeSupportedOptions.test.js
+++ b/server/test/utils/normalizeSupportedOptions.test.js
@@ -1,0 +1,68 @@
+const { expect } = require('chai');
+const { BadParameters } = require('../../utils/coreErrors');
+const { normalizeSupportedOptions } = require('../../utils/normalizeSupportedOptions');
+
+describe('normalizeSupportedOptions', () => {
+  it('should normalize supported options with default sort_order', () => {
+    const options = normalizeSupportedOptions([
+      { value: 1, label: 'On' },
+      { value: 0, label: 'Off' },
+    ]);
+
+    expect(options).to.deep.equal([
+      { value: 1, label: 'On', sort_order: 0 },
+      { value: 0, label: 'Off', sort_order: 1 },
+    ]);
+  });
+
+  it('should keep provided sort_order', () => {
+    const options = normalizeSupportedOptions([{ value: 2, label: 'Auto', sort_order: 10 }]);
+
+    expect(options).to.deep.equal([{ value: 2, label: 'Auto', sort_order: 10 }]);
+  });
+
+  it('should reject missing value', () => {
+    expect(() => normalizeSupportedOptions([{ label: 'On' }])).to.throw(BadParameters);
+  });
+
+  it('should reject empty label', () => {
+    expect(() => normalizeSupportedOptions([{ value: 1, label: '   ' }])).to.throw(BadParameters);
+  });
+
+  it('should reject duplicate values', () => {
+    expect(() =>
+      normalizeSupportedOptions([
+        { value: 1, label: 'On' },
+        { value: 1, label: 'On again' },
+      ]),
+    ).to.throw(BadParameters, /duplicate values/);
+  });
+
+  it('should reject invalid types', () => {
+    expect(() => normalizeSupportedOptions([{ value: '1', label: 'On' }])).to.throw(BadParameters);
+  });
+
+  it('should accept an empty array', () => {
+    expect(normalizeSupportedOptions([])).to.deep.equal([]);
+  });
+
+  it('should keep sort_order when it is zero', () => {
+    expect(normalizeSupportedOptions([{ value: 0, label: 'Off', sort_order: 0 }])).to.deep.equal([
+      { value: 0, label: 'Off', sort_order: 0 },
+    ]);
+  });
+
+  it('should reject invalid option id', () => {
+    expect(() => normalizeSupportedOptions([{ id: 'not-a-uuid', value: 1, label: 'On' }])).to.throw(BadParameters);
+  });
+
+  it('should aggregate multiple validation errors', () => {
+    try {
+      normalizeSupportedOptions([{ value: 'bad', label: '' }]);
+      expect.fail('should have thrown');
+    } catch (error) {
+      expect(error).to.be.instanceOf(BadParameters);
+      expect(error.message).to.include(',');
+    }
+  });
+});

--- a/server/test/utils/normalizeSupportedOptions.test.js
+++ b/server/test/utils/normalizeSupportedOptions.test.js
@@ -50,6 +50,14 @@ describe('normalizeSupportedOptions', () => {
     expect(normalizeSupportedOptions([])).to.deep.equal([]);
   });
 
+  it('should reject undefined input', () => {
+    expect(() => normalizeSupportedOptions(undefined)).to.throw(BadParameters);
+  });
+
+  it('should reject null input', () => {
+    expect(() => normalizeSupportedOptions(null)).to.throw(BadParameters);
+  });
+
   it('should keep sort_order when it is zero', () => {
     expect(normalizeSupportedOptions([{ value: 0, label: 'Off', sort_order: 0 }])).to.deep.equal([
       { value: 0, label: 'Off', sort_order: 0 },

--- a/server/test/utils/normalizeSupportedOptions.test.js
+++ b/server/test/utils/normalizeSupportedOptions.test.js
@@ -42,6 +42,10 @@ describe('normalizeSupportedOptions', () => {
     expect(() => normalizeSupportedOptions([{ value: '1', label: 'On' }])).to.throw(BadParameters);
   });
 
+  it('should reject decimal values', () => {
+    expect(() => normalizeSupportedOptions([{ value: 1.5, label: 'On' }])).to.throw(BadParameters);
+  });
+
   it('should accept an empty array', () => {
     expect(normalizeSupportedOptions([])).to.deep.equal([]);
   });

--- a/server/utils/deviceQueryIncludes.js
+++ b/server/utils/deviceQueryIncludes.js
@@ -1,0 +1,63 @@
+const db = require('../models');
+
+const SUPPORTED_OPTIONS_INCLUDE = {
+  model: db.DeviceFeatureSupportedOption,
+  as: 'supported_options',
+};
+
+/**
+ * @description Get Sequelize include for device features with supported options.
+ * @param {object} [options] - Optional include options.
+ * @param {object} [options.where] - Where clause for features.
+ * @param {Array<string>} [options.attributes] - Attributes to select for features.
+ * @returns {object} Sequelize include object.
+ * @example
+ * getFeaturesInclude({ where: { category: 'light' } });
+ */
+function getFeaturesInclude(options = {}) {
+  const include = {
+    model: db.DeviceFeature,
+    as: 'features',
+    include: [SUPPORTED_OPTIONS_INCLUDE],
+  };
+
+  if (options.where) {
+    include.where = options.where;
+  }
+
+  if (options.attributes) {
+    include.attributes = options.attributes;
+  }
+
+  return include;
+}
+
+/**
+ * @description Get standard Sequelize includes for loading a device.
+ * @param {object} [featuresOptions] - Options passed to getFeaturesInclude.
+ * @returns {Array} Sequelize include array.
+ * @example
+ * getStandardDeviceIncludes();
+ */
+function getStandardDeviceIncludes(featuresOptions = {}) {
+  return [
+    getFeaturesInclude(featuresOptions),
+    {
+      model: db.DeviceParam,
+      as: 'params',
+    },
+    {
+      model: db.Room,
+      as: 'room',
+    },
+    {
+      model: db.Service,
+      as: 'service',
+    },
+  ];
+}
+
+module.exports = {
+  getFeaturesInclude,
+  getStandardDeviceIncludes,
+};

--- a/server/utils/normalizeSupportedOptions.js
+++ b/server/utils/normalizeSupportedOptions.js
@@ -5,7 +5,9 @@ const supportedOptionSchema = Joi.object({
   id: Joi.string()
     .uuid()
     .optional(),
-  value: Joi.number().required(),
+  value: Joi.number()
+    .integer()
+    .required(),
   label: Joi.string()
     .trim()
     .min(1)

--- a/server/utils/normalizeSupportedOptions.js
+++ b/server/utils/normalizeSupportedOptions.js
@@ -19,6 +19,7 @@ const supportedOptionSchema = Joi.object({
 
 const supportedOptionsSchema = Joi.array()
   .items(supportedOptionSchema)
+  .required()
   .custom((options, helpers) => {
     const values = options.map((option) => option.value);
     const uniqueValues = new Set(values);

--- a/server/utils/normalizeSupportedOptions.js
+++ b/server/utils/normalizeSupportedOptions.js
@@ -1,0 +1,57 @@
+const Joi = require('joi');
+const { BadParameters } = require('./coreErrors');
+
+const supportedOptionSchema = Joi.object({
+  id: Joi.string()
+    .uuid()
+    .optional(),
+  value: Joi.number().required(),
+  label: Joi.string()
+    .trim()
+    .min(1)
+    .required(),
+  sort_order: Joi.number()
+    .integer()
+    .optional(),
+});
+
+const supportedOptionsSchema = Joi.array()
+  .items(supportedOptionSchema)
+  .custom((options, helpers) => {
+    const values = options.map((option) => option.value);
+    const uniqueValues = new Set(values);
+    if (uniqueValues.size !== values.length) {
+      return helpers.error('any.custom', { message: 'supported_options must not contain duplicate values' });
+    }
+    return options;
+  })
+  .messages({
+    'any.custom': '{{#message}}',
+  });
+
+/**
+ * @description Validate and normalize supported_options for a device feature.
+ * @param {Array} options - The supported options to normalize.
+ * @returns {Array} Normalized supported options.
+ * @example
+ * normalizeSupportedOptions([{ value: 1, label: 'On' }]);
+ */
+function normalizeSupportedOptions(options) {
+  const { error, value } = supportedOptionsSchema.validate(options, {
+    abortEarly: false,
+    convert: false,
+  });
+
+  if (error) {
+    throw new BadParameters(error.details.map((detail) => detail.message).join(', '));
+  }
+
+  return value.map((option, index) => ({
+    ...option,
+    sort_order: option.sort_order !== undefined ? option.sort_order : index,
+  }));
+}
+
+module.exports = {
+  normalizeSupportedOptions,
+};


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

```
 const created = await device.create({
      service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
      name: 'Preserve options device',
      external_id: 'preserve-supported-options',
      features: [
        {
          name: 'Run mode',
          external_id: 'preserve:run-mode',
          category: 'vacuum-cleaner',
          type: 'mode',
          read_only: false,
          keep_history: true,
          has_feedback: true,
          min: 0,
          max: 5,
          supported_options: [{ value: 0, label: 'Idle', sort_order: 0 }],
        },
      ],
      params: [],
    });
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Device features now support configurable supported options with labels and custom sort ordering
  * Supported options automatically sync during device creation and updates
  * Invalid supported options are rejected with validation errors

* **Bug Fixes**
  * Fixed preservation of existing supported options when updating device features without specifying new options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->