### PR TITLE
AI: Add sensor.set-state tool

### DIFF
--- a/server/config/prompts/aiChat.prompt.txt
+++ b/server/config/prompts/aiChat.prompt.txt
@@ -17,6 +17,7 @@ Rules:
 - For scene actions, strictly include all required fields for each action type. In particular, `ai.ask` requires both `user` and `text`.
 - In scene `ai.ask` text, when referencing previous `device.get-value` action outputs, use Handlebars coordinates such as `{{1.1.last_value}}` (or `{{0.0.last_value}}`) and `{{1.1.last_value_string}}`.
 - Scene actions in the same action group run in parallel. If an action depends on outputs from another action, place it in a later action group. Example: run `device.get-value` in one group, then `ai.ask` in the next group.
+- When the user asks to save, store, or record a value in a virtual sensor (for example a value read from a camera image), use the `sensor_set_state` tool.
 - Use the tool names and arguments exactly as provided by the tool schema.
 - After you receive tool results, provide a concise and accurate answer in plain language only.
 - Never repeat tool names, arguments, or invocation syntax (for example `device_turn_on_off({...})`) in your reply text. Tool execution is shown separately in the chat UI.

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -1,5 +1,5 @@
 const z = require('zod/v4');
-const { SYSTEM_VARIABLE_NAMES } = require('../../../utils/constants');
+const { SYSTEM_VARIABLE_NAMES, DEVICE_FEATURE_CATEGORIES } = require('../../../utils/constants');
 const {
   createSceneCreateInputSchema,
   formatSceneCreateZodIssue,
@@ -71,7 +71,7 @@ async function getAllResources() {
         selector: feature.selector,
         category: feature.category,
         type: feature.type,
-        access: ['read'],
+        access: feature.read_only === false ? ['write', 'read'] : ['read'],
       })),
     };
 
@@ -231,8 +231,17 @@ async function getAllTools(userId) {
         .flat(),
     ),
   ];
+  const writableSensorDevices = allDevices
+    .filter((device) => device.features.some((feature) => this.isWritableSensorFeature(feature)))
+    .map((device) => ({
+      ...device,
+      features: device.features.filter((feature) => this.isWritableSensorFeature(feature)),
+    }));
+  const writableSensorFeatureNames = [
+    ...new Set(writableSensorDevices.map((device) => device.features.map((feature) => feature.name)).flat()),
+  ];
 
-  return [
+  const tools = [
     {
       intent: 'camera.get-image',
       config: {
@@ -574,6 +583,87 @@ async function getAllTools(userId) {
         };
       },
     },
+  ];
+
+  if (writableSensorDevices.length > 0) {
+    tools.push({
+      intent: 'sensor.set-state',
+      config: {
+        title: 'Set sensor state',
+        description:
+          'Write a value to a writable virtual sensor (for example after reading a value from a camera image). Use numeric values for numeric sensors and strings for text sensors such as license plates.',
+        inputSchema: {
+          device: z
+            .enum([...new Set(writableSensorDevices.map(({ name }) => name))])
+            .describe('Writable virtual sensor device name.'),
+          feature: z
+            .enum(writableSensorFeatureNames)
+            .optional()
+            .describe('Sensor feature name. Required when the device has multiple writable features.'),
+          value: z
+            .union([z.number(), z.string()])
+            .describe('Value to write. Use a number for numeric sensors and a string for text sensors.'),
+        },
+      },
+      cb: async ({ device, feature, value }) => {
+        const selectedDevice = this.findBySimilarity(writableSensorDevices, device);
+        const writableFeatures = selectedDevice.features;
+
+        let selectedFeature;
+        if (feature) {
+          selectedFeature = this.findBySimilarity(writableFeatures, feature);
+        } else if (writableFeatures.length === 1) {
+          [selectedFeature] = writableFeatures;
+        } else {
+          throw new Error(
+            'sensor.set-state validation failed (422): feature is required when device has multiple writable sensor features',
+          );
+        }
+
+        const isTextFeature = selectedFeature.category === DEVICE_FEATURE_CATEGORIES.TEXT;
+        const useStringValue = isTextFeature || (typeof value === 'string' && Number.isNaN(Number(value)));
+        const parsedValue = useStringValue ? String(value) : Number(value);
+
+        if (!useStringValue && Number.isNaN(parsedValue)) {
+          throw new Error('sensor.set-state validation failed (422): value must be a number or string');
+        }
+
+        try {
+          await this.gladys.device.setValue(selectedDevice, selectedFeature, parsedValue);
+        } catch (e) {
+          if (useStringValue) {
+            await this.gladys.device.saveStringState(selectedDevice, selectedFeature, parsedValue);
+          } else {
+            await this.gladys.device.saveState(selectedFeature, parsedValue);
+          }
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `sensor.set-state: set ${selectedDevice.name} / ${selectedFeature.name} to ${parsedValue}`,
+              },
+            ],
+          };
+        }
+
+        if (useStringValue) {
+          await this.gladys.device.saveStringState(selectedDevice, selectedFeature, parsedValue);
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `sensor.set-state: set ${selectedDevice.name} / ${selectedFeature.name} to ${parsedValue}`,
+            },
+          ],
+        };
+      },
+    });
+  }
+
+  tools.push(
     {
       intent: 'web.fetch',
       config: {
@@ -647,7 +737,9 @@ async function getAllTools(userId) {
         };
       },
     },
-  ];
+  );
+
+  return tools;
 }
 
 module.exports = {

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -71,7 +71,7 @@ async function getAllResources() {
         selector: feature.selector,
         category: feature.category,
         type: feature.type,
-        access: this.isWritableSensorFeature(feature) ? ['write', 'read'] : ['read'],
+        access: this.isWritableSensorFeature(feature, device) ? ['write', 'read'] : ['read'],
       })),
     };
 
@@ -96,7 +96,7 @@ async function getAllResources() {
         selector: feature.selector,
         category: feature.category,
         type: feature.type,
-        access: this.isWritableSensorFeature(feature) ? ['write', 'read'] : ['read'],
+        access: this.isWritableSensorFeature(feature, device) ? ['write', 'read'] : ['read'],
       })),
     };
 
@@ -263,10 +263,10 @@ async function getAllTools(userId) {
     ),
   ];
   const writableSensorDevices = allDevices
-    .filter((device) => device.features.some((feature) => this.isWritableSensorFeature(feature)))
+    .filter((device) => device.features.some((feature) => this.isWritableSensorFeature(feature, device)))
     .map((device) => ({
       ...device,
-      features: device.features.filter((feature) => this.isWritableSensorFeature(feature)),
+      features: device.features.filter((feature) => this.isWritableSensorFeature(feature, device)),
     }));
 
   const tools = [
@@ -619,11 +619,11 @@ async function getAllTools(userId) {
       config: {
         title: 'Set sensor state',
         description:
-          'Write a value to a virtual sensor (read-only sensor feature, for example after reading a value from a camera image). Use numeric values for numeric sensors and strings for text sensors such as license plates.',
+          'Write a value to an MQTT virtual sensor (read-only sensor feature, for example after reading a value from a camera image). Use numeric values for numeric sensors and strings for text sensors such as license plates. Only MQTT virtual devices are supported.',
         inputSchema: {
           device: z
             .enum([...new Set(writableSensorDevices.map(({ name }) => name))])
-            .describe('Virtual sensor device name (read-only sensor).'),
+            .describe('MQTT virtual sensor device name (read-only sensor).'),
           feature: z
             .string()
             .optional()

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -71,9 +71,40 @@ async function getAllResources() {
         selector: feature.selector,
         category: feature.category,
         type: feature.type,
-        access: feature.read_only === false ? ['write', 'read'] : ['read'],
+        access: this.isWritableSensorFeature(feature) ? ['write', 'read'] : ['read'],
       })),
     };
+
+    homeSchema[device.room?.selector || noRoom.selector].devices[device.selector] = d;
+  });
+
+  const textDevices = allDevices
+    .filter((device) => {
+      return device.features.some((feature) => feature.category === DEVICE_FEATURE_CATEGORIES.TEXT);
+    })
+    .map((device) => ({
+      ...device,
+      features: device.features.filter((feature) => feature.category === DEVICE_FEATURE_CATEGORIES.TEXT),
+    }));
+
+  textDevices.forEach((device) => {
+    const d = {
+      name: device.name,
+      selector: device.selector,
+      features: device.features.map((feature) => ({
+        name: feature.name,
+        selector: feature.selector,
+        category: feature.category,
+        type: feature.type,
+        access: this.isWritableSensorFeature(feature) ? ['write', 'read'] : ['read'],
+      })),
+    };
+
+    if (homeSchema[device.room?.selector || noRoom.selector].devices[device.selector]?.name) {
+      homeSchema[device.room?.selector || noRoom.selector].devices[device.selector].features.push(...d.features);
+
+      return;
+    }
 
     homeSchema[device.room?.selector || noRoom.selector].devices[device.selector] = d;
   });
@@ -591,11 +622,11 @@ async function getAllTools(userId) {
       config: {
         title: 'Set sensor state',
         description:
-          'Write a value to a writable virtual sensor (for example after reading a value from a camera image). Use numeric values for numeric sensors and strings for text sensors such as license plates.',
+          'Write a value to a virtual sensor (read-only sensor feature, for example after reading a value from a camera image). Use numeric values for numeric sensors and strings for text sensors such as license plates.',
         inputSchema: {
           device: z
             .enum([...new Set(writableSensorDevices.map(({ name }) => name))])
-            .describe('Writable virtual sensor device name.'),
+            .describe('Virtual sensor device name (read-only sensor).'),
           feature: z
             .enum(writableSensorFeatureNames)
             .optional()

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -268,9 +268,6 @@ async function getAllTools(userId) {
       ...device,
       features: device.features.filter((feature) => this.isWritableSensorFeature(feature)),
     }));
-  const writableSensorFeatureNames = [
-    ...new Set(writableSensorDevices.map((device) => device.features.map((feature) => feature.name)).flat()),
-  ];
 
   const tools = [
     {
@@ -628,9 +625,13 @@ async function getAllTools(userId) {
             .enum([...new Set(writableSensorDevices.map(({ name }) => name))])
             .describe('Virtual sensor device name (read-only sensor).'),
           feature: z
-            .enum(writableSensorFeatureNames)
+            .string()
             .optional()
-            .describe('Sensor feature name. Required when the device has multiple writable features.'),
+            .describe(
+              `Sensor feature name on the selected device. Required when the device has multiple features. Available: ${writableSensorDevices
+                .map((d) => `${d.name}: [${d.features.map((f) => f.name).join(', ')}]`)
+                .join('; ')}`,
+            ),
           value: z
             .union([z.number(), z.string()])
             .describe('Value to write. Use a number for numeric sensors and a string for text sensors.'),
@@ -643,6 +644,11 @@ async function getAllTools(userId) {
         let selectedFeature;
         if (feature) {
           selectedFeature = this.findBySimilarity(writableFeatures, feature);
+          if (!writableFeatures.some((writableFeature) => writableFeature.id === selectedFeature.id)) {
+            throw new Error(
+              `sensor.set-state validation failed (422): feature "${feature}" is not available on device ${selectedDevice.name}`,
+            );
+          }
         } else if (writableFeatures.length === 1) {
           [selectedFeature] = writableFeatures;
         } else {
@@ -652,11 +658,23 @@ async function getAllTools(userId) {
         }
 
         const isTextFeature = selectedFeature.category === DEVICE_FEATURE_CATEGORIES.TEXT;
-        const useStringValue = isTextFeature || (typeof value === 'string' && Number.isNaN(Number(value)));
-        const parsedValue = useStringValue ? String(value) : Number(value);
+        let parsedValue;
+        let useStringValue;
 
-        if (!useStringValue && Number.isNaN(parsedValue)) {
-          throw new Error('sensor.set-state validation failed (422): value must be a number or string');
+        if (isTextFeature) {
+          useStringValue = true;
+          parsedValue = String(value);
+        } else {
+          if (typeof value === 'string' && Number.isNaN(Number(value))) {
+            throw new Error('sensor.set-state validation failed (422): value must be a number for numeric sensors');
+          }
+
+          parsedValue = Number(value);
+          useStringValue = false;
+
+          if (Number.isNaN(parsedValue)) {
+            throw new Error('sensor.set-state validation failed (422): value must be a number for numeric sensors');
+          }
         }
 
         try {

--- a/server/services/mcp/lib/createServer.js
+++ b/server/services/mcp/lib/createServer.js
@@ -1,4 +1,5 @@
 const { EVENTS } = require('../../../utils/constants');
+const { toolNameFromIntent } = require('./mcpToolsToChatApiFormat');
 
 /**
  * @description Create MCP server.
@@ -34,7 +35,7 @@ async function createServer() {
     return this.server.registerResource(name, uri, config, cb);
   });
   (await this.getAllTools()).map(({ intent, config, cb }) => {
-    return this.server.registerTool(intent.replace('.', '_'), config, cb);
+    return this.server.registerTool(toolNameFromIntent(intent), config, cb);
   });
 }
 

--- a/server/services/mcp/lib/index.js
+++ b/server/services/mcp/lib/index.js
@@ -3,7 +3,7 @@ const { stopServer } = require('./stopServer');
 const { getAllResources, getAllTools } = require('./buildSchemas');
 const { formatValue } = require('./formatValue');
 const { proxy } = require('./mcp.proxy');
-const { isSensorFeature, isSwitchableFeature, isHistoryFeature } = require('./selectFeature');
+const { isSensorFeature, isSwitchableFeature, isHistoryFeature, isWritableSensorFeature } = require('./selectFeature');
 const { findBySimilarity } = require('./findBySimilarity');
 const { eventFunctionWrapper } = require('../../../utils/functionsWrapper');
 
@@ -36,6 +36,7 @@ MCPHandler.prototype.getAllTools = getAllTools;
 MCPHandler.prototype.isSensorFeature = isSensorFeature;
 MCPHandler.prototype.isSwitchableFeature = isSwitchableFeature;
 MCPHandler.prototype.isHistoryFeature = isHistoryFeature;
+MCPHandler.prototype.isWritableSensorFeature = isWritableSensorFeature;
 MCPHandler.prototype.findBySimilarity = findBySimilarity;
 MCPHandler.prototype.formatValue = formatValue;
 MCPHandler.prototype.proxy = proxy;

--- a/server/services/mcp/lib/selectFeature.js
+++ b/server/services/mcp/lib/selectFeature.js
@@ -80,8 +80,12 @@ const isHistoryFeature = (deviceFeature) => {
   );
 };
 
-const isWritableSensorFeature = (deviceFeature) => {
+const isWritableSensorFeature = (deviceFeature, device) => {
   if (deviceFeature.read_only !== true) {
+    return false;
+  }
+
+  if (device?.service?.name !== 'mqtt') {
     return false;
   }
 

--- a/server/services/mcp/lib/selectFeature.js
+++ b/server/services/mcp/lib/selectFeature.js
@@ -81,7 +81,7 @@ const isHistoryFeature = (deviceFeature) => {
 };
 
 const isWritableSensorFeature = (deviceFeature) => {
-  if (deviceFeature.read_only !== false) {
+  if (deviceFeature.read_only !== true) {
     return false;
   }
 

--- a/server/services/mcp/lib/selectFeature.js
+++ b/server/services/mcp/lib/selectFeature.js
@@ -80,8 +80,17 @@ const isHistoryFeature = (deviceFeature) => {
   );
 };
 
+const isWritableSensorFeature = (deviceFeature) => {
+  if (deviceFeature.read_only !== false) {
+    return false;
+  }
+
+  return isSensorFeature(deviceFeature) || deviceFeature.category === DEVICE_FEATURE_CATEGORIES.TEXT;
+};
+
 module.exports = {
   isSensorFeature,
   isSwitchableFeature,
   isHistoryFeature,
+  isWritableSensorFeature,
 };

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -212,6 +212,7 @@ describe('build schemas', () => {
       {
         selector: 'device-sensor-text',
         name: 'Mixed Sensor',
+        service: { name: 'mqtt' },
         room: { selector: 'salon' },
         features: [
           {
@@ -235,6 +236,7 @@ describe('build schemas', () => {
       {
         selector: 'device-text-only',
         name: 'License Plate Sensor',
+        service: { name: 'mqtt' },
         room: { selector: 'salon' },
         features: [
           {
@@ -1310,6 +1312,7 @@ describe('build schemas', () => {
     const writableSensorDevice = {
       selector: 'virtual-ph-sensor',
       name: 'Virtual pH Sensor',
+      service: { name: 'mqtt' },
       room: { selector: 'salon', name: 'Salon' },
       features: [
         {
@@ -1326,6 +1329,7 @@ describe('build schemas', () => {
     const writableTextDevice = {
       selector: 'virtual-plate-sensor',
       name: 'License Plate Sensor',
+      service: { name: 'mqtt' },
       room: { selector: 'salon', name: 'Salon' },
       features: [
         {
@@ -1396,6 +1400,7 @@ describe('build schemas', () => {
     const writableSensorDevice = {
       selector: 'virtual-sensor',
       name: 'Virtual Sensor',
+      service: { name: 'mqtt' },
       room: { selector: 'salon', name: 'Salon' },
       features: [
         {
@@ -1450,6 +1455,7 @@ describe('build schemas', () => {
     const writableSensorDevice = {
       selector: 'virtual-multi-sensor',
       name: 'Virtual Multi Sensor',
+      service: { name: 'mqtt' },
       room: { selector: 'salon', name: 'Salon' },
       features: [
         {
@@ -1555,6 +1561,7 @@ describe('build schemas', () => {
     const writableTextDevice = {
       selector: 'virtual-plate-sensor',
       name: 'License Plate Sensor',
+      service: { name: 'mqtt' },
       room: { selector: 'salon', name: 'Salon' },
       features: [
         {
@@ -1609,6 +1616,7 @@ describe('build schemas', () => {
     const phSensorDevice = {
       selector: 'virtual-ph-sensor',
       name: 'Virtual pH Sensor',
+      service: { name: 'mqtt' },
       room: { selector: 'salon', name: 'Salon' },
       features: [
         {
@@ -1624,6 +1632,7 @@ describe('build schemas', () => {
     const plateSensorDevice = {
       selector: 'virtual-plate-sensor',
       name: 'License Plate Sensor',
+      service: { name: 'mqtt' },
       room: { selector: 'salon', name: 'Salon' },
       features: [
         {
@@ -1681,11 +1690,127 @@ describe('build schemas', () => {
     expect(mcpHandler.gladys.device.setValue.callCount).to.eq(0);
   });
 
+  it('should not expose sensor.set-state for physical sensors from other integrations', async () => {
+    const mqttVirtualSensor = {
+      selector: 'virtual-ph-sensor',
+      name: 'Virtual pH Sensor',
+      service: { name: 'mqtt' },
+      room: { selector: 'salon', name: 'Salon' },
+      features: [
+        {
+          id: 30,
+          selector: 'virtual-ph-sensor-ph',
+          name: 'pH',
+          category: 'level-sensor',
+          type: 'decimal',
+          read_only: true,
+        },
+      ],
+    };
+    const physicalTemperatureSensor = {
+      selector: 'zigbee-temp-1',
+      name: 'Living Room Temperature',
+      service: { name: 'zigbee2mqtt' },
+      room: { selector: 'salon', name: 'Salon' },
+      features: [
+        {
+          id: 31,
+          selector: 'zigbee-temp-1-temp',
+          name: 'Temperature',
+          category: 'temperature-sensor',
+          type: 'decimal',
+          read_only: true,
+        },
+      ],
+    };
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves([{ id: 'room-1', name: 'Salon', selector: 'salon' }]) },
+        user: { get: stub().resolves([]) },
+        house: { get: stub().resolves([]) },
+        calendar: { get: stub().resolves([]) },
+        area: { get: stub().resolves([]) },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves([mqttVirtualSensor, physicalTemperatureSensor]),
+          setValue: stub().resolves(),
+          saveState: stub().resolves(),
+          saveStringState: stub().resolves(),
+        },
+      },
+      levenshtein: { distance: stub().returns(0) },
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    const sensorSetStateTool = tools.find((tool) => tool.intent === 'sensor.set-state');
+
+    expect(sensorSetStateTool).to.not.equal(undefined);
+    expect(sensorSetStateTool.config.inputSchema.device.options).to.deep.equal(['Virtual pH Sensor']);
+  });
+
+  it('should not register sensor.set-state when only physical sensors are available', async () => {
+    const physicalTemperatureSensor = {
+      selector: 'hue-temp-1',
+      name: 'Living Room Temperature',
+      service: { name: 'philips-hue' },
+      room: { selector: 'salon', name: 'Salon' },
+      features: [
+        {
+          id: 32,
+          selector: 'hue-temp-1-temp',
+          name: 'Temperature',
+          category: 'temperature-sensor',
+          type: 'decimal',
+          read_only: true,
+        },
+      ],
+    };
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves([{ id: 'room-1', name: 'Salon', selector: 'salon' }]) },
+        user: { get: stub().resolves([]) },
+        house: { get: stub().resolves([]) },
+        calendar: { get: stub().resolves([]) },
+        area: { get: stub().resolves([]) },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves([physicalTemperatureSensor]),
+          setValue: stub().resolves(),
+          saveState: stub().resolves(),
+          saveStringState: stub().resolves(),
+        },
+      },
+      levenshtein: { distance: stub().returns(0) },
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    const sensorSetStateTool = tools.find((tool) => tool.intent === 'sensor.set-state');
+
+    expect(sensorSetStateTool).to.equal(undefined);
+  });
+
   it('should not expose sensor.set-state for actuators (read_only false)', async () => {
     const devices = [
       {
         selector: 'virtual-ph-sensor',
         name: 'Virtual pH Sensor',
+        service: { name: 'mqtt' },
         room: { selector: 'salon', name: 'Salon' },
         features: [
           {
@@ -1751,6 +1876,7 @@ describe('build schemas', () => {
     const writableTextDevice = {
       selector: 'virtual-plate-sensor',
       name: 'License Plate Sensor',
+      service: { name: 'mqtt' },
       room: { selector: 'salon', name: 'Salon' },
       features: [
         {

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -206,6 +206,102 @@ describe('build schemas', () => {
     expect(mcpHandler.gladys.device.get.callCount).to.eq(1);
   });
 
+  it('should include text virtual sensors in home structure resources schema', async () => {
+    const rooms = [{ id: 'room-1', name: 'Salon', selector: 'salon' }];
+    const devices = [
+      {
+        selector: 'device-sensor-text',
+        name: 'Mixed Sensor',
+        room: { selector: 'salon' },
+        features: [
+          {
+            id: 1,
+            selector: 'device-sensor-text-temp',
+            name: 'Temperature',
+            category: 'temperature-sensor',
+            type: 'decimal',
+            read_only: true,
+          },
+          {
+            id: 2,
+            selector: 'device-sensor-text-plate',
+            name: 'Plate',
+            category: 'text',
+            type: 'text',
+            read_only: true,
+          },
+        ],
+      },
+      {
+        selector: 'device-text-only',
+        name: 'License Plate Sensor',
+        room: { selector: 'salon' },
+        features: [
+          {
+            id: 3,
+            selector: 'device-text-only-value',
+            name: 'Plate',
+            category: 'text',
+            type: 'text',
+            read_only: true,
+          },
+        ],
+      },
+    ];
+
+    const mcpHandler = {
+      serviceId: '7056e3d4-31cc-4d2a-bbdd-128cd49755e6',
+      getAllResources,
+      isSensorFeature,
+      isSwitchableFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      gladys: {
+        room: { getAll: stub().resolves(rooms) },
+        device: { get: stub().resolves(devices) },
+      },
+    };
+
+    const resources = await mcpHandler.getAllResources();
+    const result = await resources[0].cb({ href: 'schema://home' });
+    const homeSchema = JSON.parse(result.contents[0].text);
+
+    expect(homeSchema.salon.devices['device-sensor-text']).to.deep.equal({
+      name: 'Mixed Sensor',
+      selector: 'device-sensor-text',
+      features: [
+        {
+          name: 'Temperature',
+          selector: 'device-sensor-text-temp',
+          category: 'temperature-sensor',
+          type: 'decimal',
+          access: ['write', 'read'],
+        },
+        {
+          name: 'Plate',
+          selector: 'device-sensor-text-plate',
+          category: 'text',
+          type: 'text',
+          access: ['write', 'read'],
+        },
+      ],
+    });
+
+    expect(homeSchema.salon.devices['device-text-only']).to.deep.equal({
+      name: 'License Plate Sensor',
+      selector: 'device-text-only',
+      features: [
+        {
+          name: 'Plate',
+          selector: 'device-text-only-value',
+          category: 'text',
+          type: 'text',
+          access: ['write', 'read'],
+        },
+      ],
+    });
+  });
+
   it('should handle devices without room assignment in getAllResources', async () => {
     const rooms = [
       {

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -1222,7 +1222,7 @@ describe('build schemas', () => {
           name: 'pH',
           category: 'level-sensor',
           type: 'decimal',
-          read_only: false,
+          read_only: true,
           last_value: 7.2,
         },
       ],
@@ -1238,7 +1238,7 @@ describe('build schemas', () => {
           name: 'Plate',
           category: 'text',
           type: 'text',
-          read_only: false,
+          read_only: true,
         },
       ],
     };
@@ -1308,7 +1308,7 @@ describe('build schemas', () => {
           name: 'Value',
           category: 'temperature-sensor',
           type: 'decimal',
-          read_only: false,
+          read_only: true,
         },
       ],
     };
@@ -1362,7 +1362,7 @@ describe('build schemas', () => {
           name: 'pH',
           category: 'level-sensor',
           type: 'decimal',
-          read_only: false,
+          read_only: true,
         },
         {
           id: 14,
@@ -1370,7 +1370,7 @@ describe('build schemas', () => {
           name: 'Temperature',
           category: 'temperature-sensor',
           type: 'decimal',
-          read_only: false,
+          read_only: true,
         },
       ],
     };
@@ -1454,7 +1454,7 @@ describe('build schemas', () => {
           name: 'Plate',
           category: 'text',
           type: 'text',
-          read_only: false,
+          read_only: true,
         },
       ],
     };
@@ -1494,5 +1494,126 @@ describe('build schemas', () => {
 
     expect(mcpHandler.gladys.device.saveStringState.callCount).to.eq(1);
     expect(mcpHandler.gladys.device.saveStringState.firstCall.args[2]).to.eq('EF-456-GH');
+  });
+
+  it('should not expose sensor.set-state for actuators (read_only false)', async () => {
+    const devices = [
+      {
+        selector: 'virtual-ph-sensor',
+        name: 'Virtual pH Sensor',
+        room: { selector: 'salon', name: 'Salon' },
+        features: [
+          {
+            id: 10,
+            selector: 'virtual-ph-sensor-ph',
+            name: 'pH',
+            category: 'level-sensor',
+            type: 'decimal',
+            read_only: true,
+          },
+        ],
+      },
+      {
+        selector: 'actuator-valve',
+        name: 'Pool Valve',
+        room: { selector: 'salon', name: 'Salon' },
+        features: [
+          {
+            id: 17,
+            selector: 'actuator-valve-switch',
+            name: 'Valve',
+            category: 'switch',
+            type: 'binary',
+            read_only: false,
+          },
+        ],
+      },
+    ];
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves([{ id: 'room-1', name: 'Salon', selector: 'salon' }]) },
+        user: { get: stub().resolves([]) },
+        house: { get: stub().resolves([]) },
+        calendar: { get: stub().resolves([]) },
+        area: { get: stub().resolves([]) },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves(devices),
+          setValue: stub().resolves(),
+          saveState: stub().resolves(),
+          saveStringState: stub().resolves(),
+        },
+      },
+      levenshtein: { distance: stub().returns(0) },
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    const sensorSetStateTool = tools.find((tool) => tool.intent === 'sensor.set-state');
+
+    expect(sensorSetStateTool).to.not.equal(undefined);
+    expect(sensorSetStateTool.config.inputSchema.device.options).to.deep.equal(['Virtual pH Sensor']);
+  });
+
+  it('should expose sensor.set-state for read-only virtual sensors', async () => {
+    const writableTextDevice = {
+      selector: 'virtual-plate-sensor',
+      name: 'License Plate Sensor',
+      room: { selector: 'salon', name: 'Salon' },
+      features: [
+        {
+          id: 16,
+          selector: 'virtual-plate-sensor-text',
+          name: 'Plate',
+          category: 'text',
+          type: 'text',
+          read_only: true,
+        },
+      ],
+    };
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves([{ id: 'room-1', name: 'Salon', selector: 'salon' }]) },
+        user: { get: stub().resolves([]) },
+        house: { get: stub().resolves([]) },
+        calendar: { get: stub().resolves([]) },
+        area: { get: stub().resolves([]) },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves([writableTextDevice]),
+          setValue: stub().resolves(),
+          saveState: stub().resolves(),
+          saveStringState: stub().resolves(),
+        },
+      },
+      levenshtein: { distance: stub().returns(0) },
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    const sensorSetStateTool = tools.find((tool) => tool.intent === 'sensor.set-state');
+
+    expect(sensorSetStateTool).to.not.equal(undefined);
+
+    await sensorSetStateTool.cb({
+      device: 'License Plate Sensor',
+      value: 'AB-123-CD',
+    });
+
+    expect(mcpHandler.gladys.device.saveStringState.callCount).to.eq(1);
   });
 });

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -13,6 +13,7 @@ const {
   isSensorFeature,
   isSwitchableFeature,
   isHistoryFeature,
+  isWritableSensorFeature,
 } = require('../../../../services/mcp/lib/selectFeature');
 const { findBySimilarity } = require('../../../../services/mcp/lib/findBySimilarity');
 const { SCENE_CREATE_TOOL_DESCRIPTION } = require('../../../../services/mcp/lib/sceneSchemas');
@@ -116,6 +117,7 @@ describe('build schemas', () => {
       isSensorFeature,
       isSwitchableFeature,
       isHistoryFeature,
+      isWritableSensorFeature,
       gladys: {
         room: {
           getAll: stub().resolves(rooms),
@@ -264,6 +266,7 @@ describe('build schemas', () => {
       isSensorFeature,
       isSwitchableFeature,
       isHistoryFeature,
+      isWritableSensorFeature,
       gladys: {
         room: {
           getAll: stub().resolves(rooms),
@@ -376,6 +379,7 @@ describe('build schemas', () => {
       isSensorFeature,
       isSwitchableFeature,
       isHistoryFeature,
+      isWritableSensorFeature,
       formatValue: stub().callsFake((feature) => ({
         value: feature.last_value,
         unit: feature.unit,
@@ -819,6 +823,7 @@ describe('build schemas', () => {
       isSensorFeature,
       isSwitchableFeature,
       isHistoryFeature,
+      isWritableSensorFeature,
       formatValue: stub().callsFake((feature) => ({
         value: feature.last_value,
         unit: feature.unit,
@@ -892,6 +897,7 @@ describe('build schemas', () => {
       isSensorFeature,
       isSwitchableFeature,
       isHistoryFeature,
+      isWritableSensorFeature,
       formatValue: stub().callsFake((feature) => ({
         value: feature.last_value,
         unit: feature.unit,
@@ -1003,6 +1009,7 @@ describe('build schemas', () => {
       isSensorFeature,
       isSwitchableFeature,
       isHistoryFeature,
+      isWritableSensorFeature,
       formatValue: stub().callsFake((feature) => ({
         value: feature.last_value,
         unit: feature.unit,
@@ -1093,6 +1100,7 @@ describe('build schemas', () => {
       isSensorFeature,
       isSwitchableFeature,
       isHistoryFeature,
+      isWritableSensorFeature,
       formatValue: stub().callsFake((feature) => ({ value: feature.last_value })),
       findBySimilarity,
       gladys: {
@@ -1134,6 +1142,7 @@ describe('build schemas', () => {
       isSensorFeature,
       isSwitchableFeature,
       isHistoryFeature,
+      isWritableSensorFeature,
       formatValue: stub().returns({ value: 1 }),
       findBySimilarity,
       toon: stub().callsFake((value) => JSON.stringify(value)),
@@ -1199,5 +1208,291 @@ describe('build schemas', () => {
       lookupStub.restore();
       nock.cleanAll();
     }
+  });
+
+  it('should expose sensor.set-state for writable virtual sensors', async () => {
+    const writableSensorDevice = {
+      selector: 'virtual-ph-sensor',
+      name: 'Virtual pH Sensor',
+      room: { selector: 'salon', name: 'Salon' },
+      features: [
+        {
+          id: 10,
+          selector: 'virtual-ph-sensor-ph',
+          name: 'pH',
+          category: 'level-sensor',
+          type: 'decimal',
+          read_only: false,
+          last_value: 7.2,
+        },
+      ],
+    };
+    const writableTextDevice = {
+      selector: 'virtual-plate-sensor',
+      name: 'License Plate Sensor',
+      room: { selector: 'salon', name: 'Salon' },
+      features: [
+        {
+          id: 11,
+          selector: 'virtual-plate-sensor-text',
+          name: 'Plate',
+          category: 'text',
+          type: 'text',
+          read_only: false,
+        },
+      ],
+    };
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves([{ id: 'room-1', name: 'Salon', selector: 'salon' }]) },
+        user: { get: stub().resolves([]) },
+        house: { get: stub().resolves([]) },
+        calendar: { get: stub().resolves([]) },
+        area: { get: stub().resolves([]) },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves([writableSensorDevice, writableTextDevice]),
+          setValue: stub().resolves(),
+          saveState: stub().resolves(),
+          saveStringState: stub().resolves(),
+        },
+      },
+      levenshtein: { distance: stub().returns(0) },
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    const sensorSetStateTool = tools.find((tool) => tool.intent === 'sensor.set-state');
+
+    expect(sensorSetStateTool).to.not.equal(undefined);
+    expect(sensorSetStateTool.config.title).to.eq('Set sensor state');
+
+    const numericResult = await sensorSetStateTool.cb({
+      device: 'Virtual pH Sensor',
+      value: 7.4,
+    });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[2]).to.eq(7.4);
+    expect(mcpHandler.gladys.device.saveStringState.callCount).to.eq(0);
+    expect(numericResult.content[0].text).to.eq('sensor.set-state: set Virtual pH Sensor / pH to 7.4');
+
+    mcpHandler.gladys.device.setValue.resetHistory();
+
+    const textResult = await sensorSetStateTool.cb({
+      device: 'License Plate Sensor',
+      value: 'AB-123-CD',
+    });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[2]).to.eq('AB-123-CD');
+    expect(mcpHandler.gladys.device.saveStringState.callCount).to.eq(1);
+    expect(mcpHandler.gladys.device.saveStringState.firstCall.args[2]).to.eq('AB-123-CD');
+    expect(textResult.content[0].text).to.eq('sensor.set-state: set License Plate Sensor / Plate to AB-123-CD');
+  });
+
+  it('should save sensor state locally when setValue is unavailable', async () => {
+    const writableSensorDevice = {
+      selector: 'virtual-sensor',
+      name: 'Virtual Sensor',
+      room: { selector: 'salon', name: 'Salon' },
+      features: [
+        {
+          id: 12,
+          selector: 'virtual-sensor-value',
+          name: 'Value',
+          category: 'temperature-sensor',
+          type: 'decimal',
+          read_only: false,
+        },
+      ],
+    };
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves([{ id: 'room-1', name: 'Salon', selector: 'salon' }]) },
+        user: { get: stub().resolves([]) },
+        house: { get: stub().resolves([]) },
+        calendar: { get: stub().resolves([]) },
+        area: { get: stub().resolves([]) },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves([writableSensorDevice]),
+          setValue: stub().rejects(new Error('setValue unavailable')),
+          saveState: stub().resolves(),
+          saveStringState: stub().resolves(),
+        },
+      },
+      levenshtein: { distance: stub().returns(0) },
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    const sensorSetStateTool = tools.find((tool) => tool.intent === 'sensor.set-state');
+
+    await sensorSetStateTool.cb({
+      device: 'Virtual Sensor',
+      value: 21.5,
+    });
+
+    expect(mcpHandler.gladys.device.saveState.callCount).to.eq(1);
+    expect(mcpHandler.gladys.device.saveState.firstCall.args[1]).to.eq(21.5);
+  });
+
+  it('should validate sensor.set-state inputs and support explicit feature selection', async () => {
+    const writableSensorDevice = {
+      selector: 'virtual-multi-sensor',
+      name: 'Virtual Multi Sensor',
+      room: { selector: 'salon', name: 'Salon' },
+      features: [
+        {
+          id: 13,
+          selector: 'virtual-multi-sensor-ph',
+          name: 'pH',
+          category: 'level-sensor',
+          type: 'decimal',
+          read_only: false,
+        },
+        {
+          id: 14,
+          selector: 'virtual-multi-sensor-temp',
+          name: 'Temperature',
+          category: 'temperature-sensor',
+          type: 'decimal',
+          read_only: false,
+        },
+      ],
+    };
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves([{ id: 'room-1', name: 'Salon', selector: 'salon' }]) },
+        user: { get: stub().resolves([]) },
+        house: { get: stub().resolves([]) },
+        calendar: { get: stub().resolves([]) },
+        area: { get: stub().resolves([]) },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves([writableSensorDevice]),
+          setValue: stub().resolves(),
+          saveState: stub().resolves(),
+          saveStringState: stub().resolves(),
+        },
+      },
+      levenshtein: { distance: stub().returns(0) },
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    const sensorSetStateTool = tools.find((tool) => tool.intent === 'sensor.set-state');
+
+    let missingFeatureError = null;
+    try {
+      await sensorSetStateTool.cb({
+        device: 'Virtual Multi Sensor',
+        value: 7.1,
+      });
+    } catch (e) {
+      missingFeatureError = e;
+    }
+    expect(missingFeatureError).to.be.an('error');
+    expect(missingFeatureError.message).to.contain(
+      'feature is required when device has multiple writable sensor features',
+    );
+
+    let invalidValueError = null;
+    try {
+      await sensorSetStateTool.cb({
+        device: 'Virtual Multi Sensor',
+        feature: 'pH',
+        value: Number.NaN,
+      });
+    } catch (e) {
+      invalidValueError = e;
+    }
+    expect(invalidValueError).to.be.an('error');
+    expect(invalidValueError.message).to.contain('value must be a number or string');
+
+    const explicitFeatureResult = await sensorSetStateTool.cb({
+      device: 'Virtual Multi Sensor',
+      feature: 'Temperature',
+      value: 24.5,
+    });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[1].name).to.eq('Temperature');
+    expect(explicitFeatureResult.content[0].text).to.eq(
+      'sensor.set-state: set Virtual Multi Sensor / Temperature to 24.5',
+    );
+  });
+
+  it('should save string sensor state locally when setValue is unavailable', async () => {
+    const writableTextDevice = {
+      selector: 'virtual-plate-sensor',
+      name: 'License Plate Sensor',
+      room: { selector: 'salon', name: 'Salon' },
+      features: [
+        {
+          id: 15,
+          selector: 'virtual-plate-sensor-text',
+          name: 'Plate',
+          category: 'text',
+          type: 'text',
+          read_only: false,
+        },
+      ],
+    };
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves([{ id: 'room-1', name: 'Salon', selector: 'salon' }]) },
+        user: { get: stub().resolves([]) },
+        house: { get: stub().resolves([]) },
+        calendar: { get: stub().resolves([]) },
+        area: { get: stub().resolves([]) },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves([writableTextDevice]),
+          setValue: stub().rejects(new Error('setValue unavailable')),
+          saveState: stub().resolves(),
+          saveStringState: stub().resolves(),
+        },
+      },
+      levenshtein: { distance: stub().returns(0) },
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    const sensorSetStateTool = tools.find((tool) => tool.intent === 'sensor.set-state');
+
+    await sensorSetStateTool.cb({
+      device: 'License Plate Sensor',
+      value: 'EF-456-GH',
+    });
+
+    expect(mcpHandler.gladys.device.saveStringState.callCount).to.eq(1);
+    expect(mcpHandler.gladys.device.saveStringState.firstCall.args[2]).to.eq('EF-456-GH');
   });
 });

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -1524,7 +1524,20 @@ describe('build schemas', () => {
       invalidValueError = e;
     }
     expect(invalidValueError).to.be.an('error');
-    expect(invalidValueError.message).to.contain('value must be a number or string');
+    expect(invalidValueError.message).to.contain('value must be a number for numeric sensors');
+
+    let nonNumericStringError = null;
+    try {
+      await sensorSetStateTool.cb({
+        device: 'Virtual Multi Sensor',
+        feature: 'pH',
+        value: 'abc',
+      });
+    } catch (e) {
+      nonNumericStringError = e;
+    }
+    expect(nonNumericStringError).to.be.an('error');
+    expect(nonNumericStringError.message).to.contain('value must be a number for numeric sensors');
 
     const explicitFeatureResult = await sensorSetStateTool.cb({
       device: 'Virtual Multi Sensor',
@@ -1590,6 +1603,82 @@ describe('build schemas', () => {
 
     expect(mcpHandler.gladys.device.saveStringState.callCount).to.eq(1);
     expect(mcpHandler.gladys.device.saveStringState.firstCall.args[2]).to.eq('EF-456-GH');
+  });
+
+  it('should reject feature names that belong to another device', async () => {
+    const phSensorDevice = {
+      selector: 'virtual-ph-sensor',
+      name: 'Virtual pH Sensor',
+      room: { selector: 'salon', name: 'Salon' },
+      features: [
+        {
+          id: 20,
+          selector: 'virtual-ph-sensor-ph',
+          name: 'pH',
+          category: 'level-sensor',
+          type: 'decimal',
+          read_only: true,
+        },
+      ],
+    };
+    const plateSensorDevice = {
+      selector: 'virtual-plate-sensor',
+      name: 'License Plate Sensor',
+      room: { selector: 'salon', name: 'Salon' },
+      features: [
+        {
+          id: 21,
+          selector: 'virtual-plate-sensor-text',
+          name: 'Plate',
+          category: 'text',
+          type: 'text',
+          read_only: true,
+        },
+      ],
+    };
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves([{ id: 'room-1', name: 'Salon', selector: 'salon' }]) },
+        user: { get: stub().resolves([]) },
+        house: { get: stub().resolves([]) },
+        calendar: { get: stub().resolves([]) },
+        area: { get: stub().resolves([]) },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves([phSensorDevice, plateSensorDevice]),
+          setValue: stub().resolves(),
+          saveState: stub().resolves(),
+          saveStringState: stub().resolves(),
+        },
+      },
+      levenshtein: { distance: stub().returns(4) },
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    const sensorSetStateTool = tools.find((tool) => tool.intent === 'sensor.set-state');
+
+    let crossDeviceFeatureError = null;
+    try {
+      await sensorSetStateTool.cb({
+        device: 'Virtual pH Sensor',
+        feature: 'Plate',
+        value: 7.2,
+      });
+    } catch (e) {
+      crossDeviceFeatureError = e;
+    }
+
+    expect(crossDeviceFeatureError).to.be.an('error');
+    expect(crossDeviceFeatureError.message).to.contain('feature "Plate" is not available on device Virtual pH Sensor');
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(0);
   });
 
   it('should not expose sensor.set-state for actuators (read_only false)', async () => {

--- a/server/test/services/mcp/lib/createServer.test.js
+++ b/server/test/services/mcp/lib/createServer.test.js
@@ -70,7 +70,7 @@ describe('Create server', () => {
 
     expect(mcpServerInstance.registerTool.callCount).to.eq(1);
     expect(mcpServerInstance.registerTool.firstCall.args).to.deep.equal([
-      'device_turn-on-off',
+      'device_turn_on_off',
       { description: 'Turn on/off device' },
       tools[0].cb,
     ]);
@@ -142,7 +142,7 @@ describe('Create server', () => {
 
     expect(mcpServerInstance.registerTool.callCount).to.eq(1);
     expect(mcpServerInstance.registerTool.firstCall.args).to.deep.equal([
-      'device_turn-on-off',
+      'device_turn_on_off',
       { description: 'Turn on/off device' },
       tools[0].cb,
     ]);


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

AI: Add sensor.set-state tool ( https://community.gladysassistant.com/t/lire-une-valeur-avec-une-camera-puis-lia-lecrit-dans-un-capteur-virtuel/10276 ) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated AI behavior so requests to save/store values into virtual sensors correctly use the virtual sensor state tool, with proper handling for writable text features.
  * Virtual sensor MCP schema and tooling now reflect writable access (`write` + `read`) and expose `sensor.set-state` only when writable virtual sensors are available.

* **Bug Fixes**
  * Normalized MCP tool registration naming for consistent tool identifiers.

* **Tests**
  * Expanded automated coverage for writable virtual sensor resources, `sensor.set-state` behavior, input validation, feature selection, and numeric vs text persistence fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->