### PR TITLE
AI Weekly digest should be displayed as background job + add random wait time to prevent server saturation

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -3074,7 +3074,8 @@
       "energy-monitoring-cost-calculation-beginning": "Energiekostenberechnung (von Anfang an)",
       "energy-monitoring-consumption-from-index-thirty-minutes": "Energieverbrauchsberechnung aus Index (30 Minuten)",
       "energy-monitoring-consumption-from-index-beginning": "Energieverbrauchsberechnung aus Index (von Anfang an)",
-      "service-enedis-sync": "Enedis-Datensynchronisation"
+      "service-enedis-sync": "Enedis-Datensynchronisation",
+      "ai-weekly-digest": "KI-Wochenzusammenfassung"
     },
     "jobErrors": {
       "purged-when-restarted": "Gladys Assistant wurde neu gestartet, während diese Aufgabe noch lief. Daher wurde sie gelöscht. Das bedeutet nicht, dass die Aufgabe fehlgeschlagen ist – es handelt sich um normales Verhalten."

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -3074,7 +3074,8 @@
       "energy-monitoring-cost-calculation-beginning": "Energy cost calculation (from beginning)",
       "energy-monitoring-consumption-from-index-thirty-minutes": "Energy consumption calculation from index (30 minutes)",
       "energy-monitoring-consumption-from-index-beginning": "Energy consumption calculation from index (from beginning)",
-      "service-enedis-sync": "Enedis data synchronization"
+      "service-enedis-sync": "Enedis data synchronization",
+      "ai-weekly-digest": "AI weekly digest"
     },
     "jobErrors": {
       "purged-when-restarted": "Gladys Assistant restarted while this job was still running, so it was purged. It doesn't mean the job has failed, it's a normal behavior."

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -3074,7 +3074,8 @@
       "energy-monitoring-cost-calculation-beginning": "Calcul du coût énergétique (depuis le début)",
       "energy-monitoring-consumption-from-index-thirty-minutes": "Calcul de la consommation énergétique depuis l'index (30 minutes)",
       "energy-monitoring-consumption-from-index-beginning": "Calcul de la consommation énergétique depuis l'index (depuis le début)",
-      "service-enedis-sync": "Synchronisation des données Enedis"
+      "service-enedis-sync": "Synchronisation des données Enedis",
+      "ai-weekly-digest": "Résumé hebdomadaire IA"
     },
     "jobErrors": {
       "purged-when-restarted": "Gladys Assistant a redémarré alors que cette tâche était en cours. Cela ne veut pas dire que cette tâche a échouée, c'est un comportement normal."

--- a/server/lib/gateway/gateway.scheduleWeeklyDigest.js
+++ b/server/lib/gateway/gateway.scheduleWeeklyDigest.js
@@ -2,6 +2,18 @@ const logger = require('../../utils/logger');
 const { SYSTEM_VARIABLE_NAMES } = require('../../utils/constants');
 const { isSystemVariableEnabled } = require('./gateway.sendWeeklyDigest');
 
+const WEEKLY_DIGEST_MAX_RANDOM_DELAY_MS = 60 * 1000;
+
+/**
+ * @description Return a random delay between 0 and 60 seconds (inclusive).
+ * @returns {number} Delay in milliseconds.
+ * @example
+ * getWeeklyDigestRandomDelayMs();
+ */
+function getWeeklyDigestRandomDelayMs() {
+  return Math.floor(Math.random() * (WEEKLY_DIGEST_MAX_RANDOM_DELAY_MS + 1));
+}
+
 /**
  * @description Schedule the weekly digest job based on system variables.
  * @returns {Promise<null>} Resolves when scheduled or cancelled.
@@ -33,6 +45,14 @@ async function scheduleWeeklyDigest() {
     };
 
     this.weeklyDigestSchedule = this.scheduler.scheduleJob(rule, async () => {
+      const randomDelayMs = getWeeklyDigestRandomDelayMs();
+      if (randomDelayMs > 0) {
+        logger.info(`Weekly digest will start in ${Math.round(randomDelayMs / 1000)} seconds`);
+        await new Promise((resolve) => {
+          setTimeout(resolve, randomDelayMs);
+        });
+      }
+
       try {
         await this.sendWeeklyDigest();
       } catch (e) {
@@ -49,4 +69,6 @@ async function scheduleWeeklyDigest() {
 
 module.exports = {
   scheduleWeeklyDigest,
+  getWeeklyDigestRandomDelayMs,
+  WEEKLY_DIGEST_MAX_RANDOM_DELAY_MS,
 };

--- a/server/lib/gateway/index.js
+++ b/server/lib/gateway/index.js
@@ -93,6 +93,7 @@ const Gateway = function Gateway(
     logger,
   });
   this.backup = this.job.wrapper(JOB_TYPES.GLADYS_GATEWAY_BACKUP, this.backup.bind(this));
+  this.sendWeeklyDigest = this.job.wrapper(JOB_TYPES.AI_WEEKLY_DIGEST, this.sendWeeklyDigest.bind(this));
 
   this.event.on(EVENTS.GATEWAY.CREATE_BACKUP, eventFunctionWrapper(this.backup.bind(this)));
   this.event.on(EVENTS.GATEWAY.CHECK_IF_BACKUP_NEEDED, eventFunctionWrapper(this.checkIfBackupNeeded.bind(this)));

--- a/server/test/lib/gateway/gateway.scheduleWeeklyDigest.test.js
+++ b/server/test/lib/gateway/gateway.scheduleWeeklyDigest.test.js
@@ -1,15 +1,23 @@
 const { expect } = require('chai');
-const { fake, assert } = require('sinon');
+const { fake, assert, stub, useFakeTimers } = require('sinon');
 
 const { SYSTEM_VARIABLE_NAMES } = require('../../../utils/constants');
-const { scheduleWeeklyDigest } = require('../../../lib/gateway/gateway.scheduleWeeklyDigest');
+const {
+  scheduleWeeklyDigest,
+  getWeeklyDigestRandomDelayMs,
+  WEEKLY_DIGEST_MAX_RANDOM_DELAY_MS,
+} = require('../../../lib/gateway/gateway.scheduleWeeklyDigest');
 
 describe('gateway.scheduleWeeklyDigest', () => {
   let gateway;
   let cancel;
+  let clock;
+  let randomStub;
 
   beforeEach(() => {
     cancel = fake();
+    clock = useFakeTimers();
+    randomStub = stub(Math, 'random').returns(0);
     gateway = {
       weeklyDigestSchedule: null,
       variable: {
@@ -34,6 +42,11 @@ describe('gateway.scheduleWeeklyDigest', () => {
       },
       sendWeeklyDigest: fake.resolves({ sent: 0 }),
     };
+  });
+
+  afterEach(() => {
+    randomStub.restore();
+    clock.restore();
   });
 
   it('should cancel existing schedule when disabled', async () => {
@@ -97,5 +110,31 @@ describe('gateway.scheduleWeeklyDigest', () => {
 
     assert.calledOnce(cancel);
     assert.calledOnce(gateway.scheduler.scheduleJob);
+  });
+
+  it('should wait a random delay before sending the weekly digest', async () => {
+    randomStub.returns(0.5);
+
+    await scheduleWeeklyDigest.call(gateway);
+
+    const scheduledCallback = gateway.scheduler.scheduleJob.firstCall.args[1];
+    const callbackPromise = scheduledCallback();
+
+    assert.notCalled(gateway.sendWeeklyDigest);
+
+    await clock.tickAsync(30500);
+    await callbackPromise;
+
+    assert.calledOnce(gateway.sendWeeklyDigest);
+  });
+});
+
+describe('getWeeklyDigestRandomDelayMs', () => {
+  it('should return a value between 0 and 60 seconds', () => {
+    for (let i = 0; i < 100; i += 1) {
+      const delayMs = getWeeklyDigestRandomDelayMs();
+      expect(delayMs).to.be.at.least(0);
+      expect(delayMs).to.be.at.most(WEEKLY_DIGEST_MAX_RANDOM_DELAY_MS);
+    }
   });
 });

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -1614,6 +1614,7 @@ const JOB_TYPES = {
   ENERGY_MONITORING_CONSUMPTION_FROM_INDEX_THIRTY_MINUTES: 'energy-monitoring-consumption-from-index-thirty-minutes',
   ENERGY_MONITORING_CONSUMPTION_FROM_INDEX_BEGINNING: 'energy-monitoring-consumption-from-index-beginning',
   SERVICE_ENEDIS_SYNC: 'service-enedis-sync',
+  AI_WEEKLY_DIGEST: 'ai-weekly-digest',
 };
 
 const JOB_STATUS = {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

AI Weekly digest should be displayed as background job + add random wait time to prevent server saturation

https://community.gladysassistant.com/t/bilan-hebdomadaire-non-recu/10294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced weekly AI digest as a schedulable background job with randomized execution delays (0–60 seconds) to optimize resource distribution and prevent simultaneous processing.

* **Documentation**
  * Added multilingual translations for the new weekly digest job type in German, English, and French.

* **Tests**
  * Expanded test coverage to verify randomized delay calculations and scheduled job execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->