### PR TITLE
Fix Philips Hue control bug after first pairing

### DIFF
--- a/server/services/philips-hue/lib/light/index.js
+++ b/server/services/philips-hue/lib/light/index.js
@@ -8,7 +8,9 @@ const { poll } = require('./light.poll');
 const { getLights } = require('./light.getLights');
 const { getScenes } = require('./light.getScenes');
 const { setValue } = require('./light.setValue');
+const { postCreate } = require('./light.postCreate');
 const { syncWithBridge } = require('./light.syncWithBridge');
+const { syncBridgeBySerialNumber } = require('./light.syncBridgeBySerialNumber');
 
 // we rate-limit the number of request per seconds to poll lights
 const pollLimiter = new Bottleneck({
@@ -49,6 +51,8 @@ PhilipsHueLightHandler.prototype.poll = pollLimiter.wrap(poll);
 PhilipsHueLightHandler.prototype.getLights = getLights;
 PhilipsHueLightHandler.prototype.getScenes = getScenes;
 PhilipsHueLightHandler.prototype.setValue = setValueLimiter.wrap(setValue);
+PhilipsHueLightHandler.prototype.postCreate = postCreate;
 PhilipsHueLightHandler.prototype.syncWithBridge = syncWithBridge;
+PhilipsHueLightHandler.prototype.syncBridgeBySerialNumber = syncBridgeBySerialNumber;
 
 module.exports = PhilipsHueLightHandler;

--- a/server/services/philips-hue/lib/light/light.postCreate.js
+++ b/server/services/philips-hue/lib/light/light.postCreate.js
@@ -1,0 +1,25 @@
+const logger = require('../../../../utils/logger');
+const { parseExternalId } = require('../utils/parseExternalId');
+const { BRIDGE_MODEL, LIGHT_EXTERNAL_ID_BASE } = require('../utils/consts');
+
+/**
+ * @description Philips Hue device post creation action: sync bridge cache when a light is added.
+ * @param {object} device - The created device.
+ * @example
+ * postCreate(device);
+ */
+async function postCreate(device) {
+  if (device.model === BRIDGE_MODEL) {
+    return;
+  }
+  if (!device.external_id || !device.external_id.startsWith(`${LIGHT_EXTERNAL_ID_BASE}:`)) {
+    return;
+  }
+  const { bridgeSerialNumber } = parseExternalId(device.external_id);
+  logger.debug(`Philips Hue: postCreate sync for light ${device.external_id}`);
+  await this.syncBridgeBySerialNumber(bridgeSerialNumber);
+}
+
+module.exports = {
+  postCreate,
+};

--- a/server/services/philips-hue/lib/light/light.setValue.js
+++ b/server/services/philips-hue/lib/light/light.setValue.js
@@ -35,7 +35,16 @@ async function setValue(device, deviceFeature, value) {
       logger.debug(`Philips Hue : Feature type = "${deviceFeature.type}" not handled`);
       break;
   }
-  await hueApi.lights.setLightState(lightId, state);
+  try {
+    await hueApi.lights.setLightState(lightId, state);
+  } catch (e) {
+    if (!e.message || !e.message.includes('was not found on this bridge')) {
+      throw e;
+    }
+    logger.debug(`Philips Hue: Light ${lightId} not found in cache, syncing with bridge ${bridgeSerialNumber}`);
+    await this.syncBridgeBySerialNumber(bridgeSerialNumber);
+    await hueApi.lights.setLightState(lightId, state);
+  }
 }
 
 module.exports = {

--- a/server/services/philips-hue/lib/light/light.setValue.js
+++ b/server/services/philips-hue/lib/light/light.setValue.js
@@ -33,7 +33,7 @@ async function setValue(device, deviceFeature, value) {
       break;
     default:
       logger.debug(`Philips Hue : Feature type = "${deviceFeature.type}" not handled`);
-      break;
+      return;
   }
   try {
     await hueApi.lights.setLightState(lightId, state);

--- a/server/services/philips-hue/lib/light/light.syncBridgeBySerialNumber.js
+++ b/server/services/philips-hue/lib/light/light.syncBridgeBySerialNumber.js
@@ -1,0 +1,22 @@
+const { NotFoundError } = require('../../../../utils/coreErrors');
+const logger = require('../../../../utils/logger');
+
+/**
+ * @description Re-sync with a specific bridge.
+ * @param {string} bridgeSerialNumber - Serial number of the bridge to sync.
+ * @returns {Promise} Resolve when sync is finished.
+ * @example
+ * syncBridgeBySerialNumber('001788FFFE000000');
+ */
+async function syncBridgeBySerialNumber(bridgeSerialNumber) {
+  const hueApi = this.hueApisBySerialNumber.get(bridgeSerialNumber);
+  if (!hueApi) {
+    throw new NotFoundError(`HUE_API_NOT_FOUND`);
+  }
+  logger.info(`Philips Hue: Syncing with bridge ${bridgeSerialNumber}`);
+  await hueApi.syncWithBridge();
+}
+
+module.exports = {
+  syncBridgeBySerialNumber,
+};

--- a/server/services/philips-hue/lib/light/light.syncWithBridge.js
+++ b/server/services/philips-hue/lib/light/light.syncWithBridge.js
@@ -1,5 +1,4 @@
 const Promise = require('bluebird');
-const { NotFoundError } = require('../../../../utils/coreErrors');
 const logger = require('../../../../utils/logger');
 
 const { getDeviceParam } = require('../../../../utils/device');
@@ -16,12 +15,7 @@ async function syncWithBridge() {
   logger.info(`Philips Hue: syncWithBridge`);
   await Promise.map(this.connnectedBridges, async (device) => {
     const serialNumber = getDeviceParam(device, BRIDGE_SERIAL_NUMBER);
-    const hueApi = this.hueApisBySerialNumber.get(serialNumber);
-    if (!hueApi) {
-      throw new NotFoundError(`HUE_API_NOT_FOUND`);
-    }
-    logger.info(`Philips Hue: Syncing with bridge ${serialNumber}`);
-    await hueApi.syncWithBridge();
+    await this.syncBridgeBySerialNumber(serialNumber);
   });
 }
 

--- a/server/test/services/philips-hue/light/light.postCreate.test.js
+++ b/server/test/services/philips-hue/light/light.postCreate.test.js
@@ -1,0 +1,73 @@
+const { assert, fake } = require('sinon');
+const EventEmitter = require('events');
+const proxyquire = require('proxyquire').noCallThru();
+const { MockedPhilipsHueClient, hueApi } = require('../mocks.test');
+
+const PhilipsHueService = proxyquire('../../../../services/philips-hue/index', {
+  'node-hue-api': MockedPhilipsHueClient,
+});
+
+const StateManager = require('../../../../lib/state');
+const ServiceManager = require('../../../../lib/service');
+const DeviceManager = require('../../../../lib/device');
+const Job = require('../../../../lib/job');
+
+const event = new EventEmitter();
+const stateManager = new StateManager(event);
+const job = new Job(event);
+const serviceManager = new ServiceManager({}, stateManager);
+const brain = {
+  addNamedEntity: fake.returns(null),
+};
+const deviceManager = new DeviceManager(event, {}, stateManager, serviceManager, {}, {}, job, brain);
+
+const gladys = {
+  device: deviceManager,
+};
+
+describe('PhilipsHueService', () => {
+  afterEach(() => {
+    hueApi.syncWithBridge.resetHistory();
+  });
+
+  it('should sync bridge when a light is created', async () => {
+    const philipsHueService = PhilipsHueService(gladys, 'a810b8db-6d04-4697-bed3-c4b72c996279');
+    await philipsHueService.device.getBridges();
+    await philipsHueService.device.configureBridge('192.168.1.10');
+
+    await philipsHueService.device.postCreate({
+      model: 'LCT015',
+      external_id: 'philips-hue-light:1234:5',
+    });
+
+    assert.calledOnce(hueApi.syncWithBridge);
+  });
+
+  it('should not sync bridge when a bridge is created', async () => {
+    const philipsHueService = PhilipsHueService(gladys, 'a810b8db-6d04-4697-bed3-c4b72c996279');
+    await philipsHueService.device.getBridges();
+    await philipsHueService.device.configureBridge('192.168.1.10');
+    hueApi.syncWithBridge.resetHistory();
+
+    await philipsHueService.device.postCreate({
+      model: 'philips-hue-bridge',
+      external_id: 'philips-hue:bridge:1234',
+    });
+
+    assert.notCalled(hueApi.syncWithBridge);
+  });
+
+  it('should not sync bridge when external id is not a light', async () => {
+    const philipsHueService = PhilipsHueService(gladys, 'a810b8db-6d04-4697-bed3-c4b72c996279');
+    await philipsHueService.device.getBridges();
+    await philipsHueService.device.configureBridge('192.168.1.10');
+    hueApi.syncWithBridge.resetHistory();
+
+    await philipsHueService.device.postCreate({
+      model: 'LCT015',
+      external_id: 'unknown-format:1234:5',
+    });
+
+    assert.notCalled(hueApi.syncWithBridge);
+  });
+});

--- a/server/test/services/philips-hue/light/light.setValue.test.js
+++ b/server/test/services/philips-hue/light/light.setValue.test.js
@@ -251,7 +251,7 @@ describe('PhilipsHueService', () => {
       1,
     );
 
-    assert.calledOnce(setLightStateStub);
+    assert.notCalled(setLightStateStub);
   });
   it('should rethrow error when setLightState fails for another reason', async () => {
     const philipsHueService = PhilipsHueService(gladys, 'a810b8db-6d04-4697-bed3-c4b72c996279');

--- a/server/test/services/philips-hue/light/light.setValue.test.js
+++ b/server/test/services/philips-hue/light/light.setValue.test.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const EventEmitter = require('events');
 const proxyquire = require('proxyquire').noCallThru();
-const { MockedPhilipsHueClient, fakes } = require('../mocks.test');
+const { MockedPhilipsHueClient, fakes, hueApi } = require('../mocks.test');
 
 const { fake, assert } = sinon;
 
@@ -192,6 +192,95 @@ describe('PhilipsHueService', () => {
       expect.fail();
     } catch (e) {
       expect(e.message).eq('HUE_API_NOT_FOUND');
+    }
+  });
+  it('should sync bridge and retry when light is not found in cache', async () => {
+    const philipsHueService = PhilipsHueService(gladys, 'a810b8db-6d04-4697-bed3-c4b72c996279');
+    await philipsHueService.device.init();
+
+    const bridgeHueApi = philipsHueService.device.hueApisBySerialNumber.get('1234');
+    const lightNotFoundError = new Error('Light with id:5 was not found on this bridge');
+    const setLightStateStub = sinon.stub();
+    setLightStateStub.onFirstCall().rejects(lightNotFoundError);
+    setLightStateStub.onSecondCall().resolves(null);
+    bridgeHueApi.lights.setLightState = setLightStateStub;
+    hueApi.syncWithBridge.resetHistory();
+
+    await philipsHueService.device.setValue(
+      {
+        external_id: 'light:1234:5',
+        features: [
+          {
+            category: 'light',
+            type: 'binary',
+          },
+        ],
+      },
+      {
+        category: 'light',
+        type: 'binary',
+      },
+      1,
+    );
+
+    assert.calledTwice(setLightStateStub);
+    assert.calledOnce(hueApi.syncWithBridge);
+  });
+  it('should not call setLightState when feature type is not handled', async () => {
+    const philipsHueService = PhilipsHueService(gladys, 'a810b8db-6d04-4697-bed3-c4b72c996279');
+    await philipsHueService.device.init();
+
+    const bridgeHueApi = philipsHueService.device.hueApisBySerialNumber.get('1234');
+    const setLightStateStub = sinon.stub().resolves(null);
+    bridgeHueApi.lights.setLightState = setLightStateStub;
+
+    await philipsHueService.device.setValue(
+      {
+        external_id: 'light:1234:1',
+        features: [
+          {
+            category: 'light',
+            type: 'unknown',
+          },
+        ],
+      },
+      {
+        category: 'light',
+        type: 'unknown',
+      },
+      1,
+    );
+
+    assert.calledOnce(setLightStateStub);
+  });
+  it('should rethrow error when setLightState fails for another reason', async () => {
+    const philipsHueService = PhilipsHueService(gladys, 'a810b8db-6d04-4697-bed3-c4b72c996279');
+    await philipsHueService.device.init();
+
+    const bridgeHueApi = philipsHueService.device.hueApisBySerialNumber.get('1234');
+    const bridgeError = new Error('Bridge unreachable');
+    bridgeHueApi.lights.setLightState = sinon.stub().rejects(bridgeError);
+
+    try {
+      await philipsHueService.device.setValue(
+        {
+          external_id: 'light:1234:5',
+          features: [
+            {
+              category: 'light',
+              type: 'binary',
+            },
+          ],
+        },
+        {
+          category: 'light',
+          type: 'binary',
+        },
+        1,
+      );
+      expect.fail();
+    } catch (e) {
+      expect(e.message).eq('Bridge unreachable');
     }
   });
 });


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

When pairing a Philips Hue light, it was not controllable unless Gladys was restarted. 
It's now fixed!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic Philips Hue bridge resynchronization when a new light is created (using the bridge serial number).
* **Bug Fixes**
  * Improved light updates to safely handle unknown feature types by stopping further state updates.
  * If updating a light fails because it wasn’t found on the bridge, the system resyncs and retries once; other errors still surface normally.
* **Tests**
  * Added/expanded tests covering light creation sync behavior, resync-driven retry on “not found,” and correct handling of unknown feature types and rethrowing unexpected failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->