### PR TITLE
AI : Add new "device_set_shutter" tool

### DIFF
--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -1,5 +1,5 @@
 const z = require('zod/v4');
-const { SYSTEM_VARIABLE_NAMES, DEVICE_FEATURE_CATEGORIES } = require('../../../utils/constants');
+const { SYSTEM_VARIABLE_NAMES, DEVICE_FEATURE_CATEGORIES, COVER_STATE } = require('../../../utils/constants');
 const {
   createSceneCreateInputSchema,
   formatSceneCreateZodIssue,
@@ -140,6 +140,37 @@ async function getAllResources() {
     homeSchema[device.room?.selector || noRoom.selector].devices[device.selector] = d;
   });
 
+  const shutterDevices = allDevices
+    .filter((device) => {
+      return device.features.some((feature) => this.isShutterFeature(feature));
+    })
+    .map((device) => ({
+      ...device,
+      features: device.features.filter((feature) => this.isShutterFeature(feature)),
+    }));
+
+  shutterDevices.forEach((device) => {
+    const d = {
+      name: device.name,
+      selector: device.selector,
+      features: device.features.map((feature) => ({
+        name: feature.name,
+        selector: feature.selector,
+        category: feature.category,
+        type: feature.type,
+        access: ['write', 'read'],
+      })),
+    };
+
+    if (homeSchema[device.room?.selector || noRoom.selector].devices[device.selector]?.name) {
+      homeSchema[device.room?.selector || noRoom.selector].devices[device.selector].features.push(...d.features);
+
+      return;
+    }
+
+    homeSchema[device.room?.selector || noRoom.selector].devices[device.selector] = d;
+  });
+
   return [
     {
       name: 'home',
@@ -211,6 +242,24 @@ async function getAllTools(userId) {
   const availableSwitchableFeatureCategories = [
     ...new Set(
       switchableDevices
+        .map((device) => {
+          return device.features.map((feature) => feature.category);
+        })
+        .flat(),
+    ),
+  ];
+  const shutterDevices = allDevices
+    .filter((device) => {
+      return device.features.some((feature) => this.isShutterFeature(feature));
+    })
+    .map((device) => ({
+      ...device,
+      name: device.name,
+      features: device.features.filter((feature) => this.isShutterFeature(feature)),
+    }));
+  const availableShutterFeatureCategories = [
+    ...new Set(
+      shutterDevices
         .map((device) => {
           return device.features.map((feature) => feature.category);
         })
@@ -371,7 +420,13 @@ async function getAllTools(userId) {
             .optional()
             .describe('Room to get information from, leave empty to select multiple rooms.'),
           device_type: z
-            .enum([...new Set([...availableSensorFeatureCategories, ...availableSwitchableFeatureCategories])])
+            .enum([
+              ...new Set([
+                ...availableSensorFeatureCategories,
+                ...availableSwitchableFeatureCategories,
+                ...availableShutterFeatureCategories,
+              ]),
+            ])
             .optional()
             .describe('Type of device to query, leave empty to retrieve all devices.'),
         },
@@ -379,7 +434,7 @@ async function getAllTools(userId) {
       cb: async ({ room, device_type: deviceType }) => {
         const states = [];
 
-        let selectedDevices = [...sensorDevices, ...switchableDevices];
+        let selectedDevices = [...sensorDevices, ...switchableDevices, ...shutterDevices];
 
         if (room && room !== '') {
           const { selector } = this.findBySimilarity(rooms, room);
@@ -612,6 +667,120 @@ async function getAllTools(userId) {
       },
     },
   ];
+
+  if (shutterDevices.length > 0) {
+    tools.push({
+      intent: 'device.set-shutter',
+      config: {
+        title: 'Control shutters and curtains',
+        description:
+          'Open, close, stop or set the position of shutters and curtains. Use action for open/close/stop commands, or position (0-100) to set a percentage. Select the device by name, or by room and device category.',
+        inputSchema: {
+          action: z
+            .enum(['open', 'close', 'stop'])
+            .optional()
+            .describe('Action to perform on the shutter or curtain.'),
+          position: z
+            .number()
+            .min(0)
+            .max(100)
+            .optional()
+            .describe('Target position as a percentage from 0 (fully closed) to 100 (fully open).'),
+          device: z
+            .enum([...new Set(shutterDevices.map(({ name }) => name))])
+            .describe('Device name to control.')
+            .optional(),
+          room: z
+            .enum(rooms.map(({ name }) => name))
+            .describe("Device's room if specified, required if device_category is specified.")
+            .optional(),
+          device_category: z
+            .enum(availableShutterFeatureCategories)
+            .describe('Type of device to control only if user has not specified device name.')
+            .optional(),
+        },
+      },
+      cb: async ({ action, position, device, room, device_category: deviceCategory }) => {
+        if (!action && position === undefined) {
+          return {
+            content: [{ type: 'text', text: 'device.set-shutter: action or position is required' }],
+          };
+        }
+
+        const actionToState = {
+          open: COVER_STATE.OPEN,
+          close: COVER_STATE.CLOSE,
+          stop: COVER_STATE.STOP,
+        };
+
+        let selectedDevices = shutterDevices;
+
+        if (room && room !== '') {
+          const { selector } = this.findBySimilarity(rooms, room);
+          selectedDevices = selectedDevices.filter((d) => (d.room?.selector || noRoom.selector) === selector);
+        }
+
+        if (device) {
+          const selectedDevice = this.findBySimilarity(selectedDevices, device);
+          if (selectedDevice?.name) {
+            selectedDevices = [selectedDevice];
+          } else {
+            return {
+              content: [{ type: 'text', text: 'device.set-shutter: no device found' }],
+            };
+          }
+        } else if (room && deviceCategory) {
+          selectedDevices = selectedDevices.filter((d) => d.features.some((f) => f.category === deviceCategory));
+        }
+
+        if (selectedDevices.length === 0) {
+          return {
+            content: [{ type: 'text', text: 'device.set-shutter: no device found' }],
+          };
+        }
+
+        await Promise.all(
+          selectedDevices.map((d) => {
+            const commands = [];
+
+            if (position !== undefined) {
+              const positionFeature = d.features.find((f) => f.type === 'position');
+              if (positionFeature) {
+                commands.push(this.gladys.device.setValue(d, positionFeature, position));
+              }
+            }
+
+            if (action) {
+              const stateFeature = d.features.find((f) => f.type === 'state');
+              if (stateFeature) {
+                commands.push(this.gladys.device.setValue(d, stateFeature, actionToState[action]));
+              }
+            }
+
+            return Promise.all(commands);
+          }),
+        );
+
+        const deviceNames = selectedDevices.map((d) => d.name).join(', ');
+        const commandParts = [];
+        if (action) {
+          commandParts.push(action);
+        }
+        if (position !== undefined) {
+          commandParts.push(`position ${position}%`);
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `device.set-shutter: ${commandParts.join(' and ')} command sent for ${deviceNames}`,
+            },
+          ],
+        };
+      },
+    });
+  }
 
   if (writableSensorDevices.length > 0) {
     tools.push({

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -739,42 +739,81 @@ async function getAllTools(userId) {
           };
         }
 
-        await Promise.all(
-          selectedDevices.map((d) => {
-            const commands = [];
+        const requestedPosition = position !== undefined;
+        const requestedAction = Boolean(action);
+        const dispatchResults = [];
 
-            if (position !== undefined) {
+        await Promise.all(
+          selectedDevices.map(async (d) => {
+            const sent = [];
+            const missing = [];
+
+            if (requestedPosition) {
               const positionFeature = d.features.find((f) => f.type === 'position');
               if (positionFeature) {
-                commands.push(this.gladys.device.setValue(d, positionFeature, position));
+                await this.gladys.device.setValue(d, positionFeature, position);
+                sent.push(`position ${position}%`);
+              } else {
+                missing.push('position');
               }
             }
 
-            if (action) {
+            if (requestedAction) {
               const stateFeature = d.features.find((f) => f.type === 'state');
               if (stateFeature) {
-                commands.push(this.gladys.device.setValue(d, stateFeature, actionToState[action]));
+                await this.gladys.device.setValue(d, stateFeature, actionToState[action]);
+                sent.push(action);
+              } else {
+                missing.push('state');
               }
             }
 
-            return Promise.all(commands);
+            dispatchResults.push({ device: d.name, sent, missing });
           }),
         );
 
-        const deviceNames = selectedDevices.map((d) => d.name).join(', ');
-        const commandParts = [];
-        if (action) {
-          commandParts.push(action);
+        const successfulDevices = dispatchResults.filter((result) => result.sent.length > 0);
+        const devicesWithMissingFeatures = dispatchResults.filter((result) => result.missing.length > 0);
+
+        if (successfulDevices.length === 0) {
+          const missingByDevice = devicesWithMissingFeatures
+            .map((result) => `${result.device} (missing ${result.missing.join(' and ')} feature)`)
+            .join('; ');
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `device.set-shutter: no command sent, no matching feature on ${missingByDevice}`,
+              },
+            ],
+          };
         }
-        if (position !== undefined) {
-          commandParts.push(`position ${position}%`);
+
+        const successMessage = successfulDevices
+          .map((result) => `${result.sent.join(' and ')} command sent for ${result.device}`)
+          .join('; ');
+
+        if (devicesWithMissingFeatures.length > 0) {
+          const partialFailures = devicesWithMissingFeatures
+            .map((result) => `${result.device} (missing ${result.missing.join(' and ')} feature)`)
+            .join('; ');
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `device.set-shutter: ${successMessage}; could not dispatch for ${partialFailures}`,
+              },
+            ],
+          };
         }
 
         return {
           content: [
             {
               type: 'text',
-              text: `device.set-shutter: ${commandParts.join(' and ')} command sent for ${deviceNames}`,
+              text: `device.set-shutter: ${successMessage}`,
             },
           ],
         };

--- a/server/services/mcp/lib/formatValue.js
+++ b/server/services/mcp/lib/formatValue.js
@@ -1,3 +1,11 @@
+const { COVER_STATE } = require('../../../utils/constants');
+
+const coverStateLabels = {
+  [COVER_STATE.OPEN]: 'open',
+  [COVER_STATE.CLOSE]: 'closed',
+  [COVER_STATE.STOP]: 'stopped',
+};
+
 /**
  * @description Format feature value for llm.
  * @param {object} feature - Feature to format.
@@ -17,6 +25,12 @@ function formatValue(feature) {
     case 'air-conditioning':
       return {
         value: feature.last_value === 0 ? 'off' : 'on',
+        unit: null,
+      };
+    case 'shutter:state':
+    case 'curtain:state':
+      return {
+        value: coverStateLabels[feature.last_value] ?? feature.last_value,
         unit: null,
       };
     default:

--- a/server/services/mcp/lib/index.js
+++ b/server/services/mcp/lib/index.js
@@ -3,7 +3,13 @@ const { stopServer } = require('./stopServer');
 const { getAllResources, getAllTools } = require('./buildSchemas');
 const { formatValue } = require('./formatValue');
 const { proxy } = require('./mcp.proxy');
-const { isSensorFeature, isSwitchableFeature, isHistoryFeature, isWritableSensorFeature } = require('./selectFeature');
+const {
+  isSensorFeature,
+  isSwitchableFeature,
+  isShutterFeature,
+  isHistoryFeature,
+  isWritableSensorFeature,
+} = require('./selectFeature');
 const { findBySimilarity } = require('./findBySimilarity');
 const { eventFunctionWrapper } = require('../../../utils/functionsWrapper');
 
@@ -35,6 +41,7 @@ MCPHandler.prototype.getAllResources = getAllResources;
 MCPHandler.prototype.getAllTools = getAllTools;
 MCPHandler.prototype.isSensorFeature = isSensorFeature;
 MCPHandler.prototype.isSwitchableFeature = isSwitchableFeature;
+MCPHandler.prototype.isShutterFeature = isShutterFeature;
 MCPHandler.prototype.isHistoryFeature = isHistoryFeature;
 MCPHandler.prototype.isWritableSensorFeature = isWritableSensorFeature;
 MCPHandler.prototype.findBySimilarity = findBySimilarity;

--- a/server/services/mcp/lib/selectFeature.js
+++ b/server/services/mcp/lib/selectFeature.js
@@ -44,6 +44,17 @@ const isSwitchableFeature = (deviceFeature) => {
   );
 };
 
+const shutterFeatures = [
+  `${DEVICE_FEATURE_CATEGORIES.SHUTTER}:${DEVICE_FEATURE_TYPES.SHUTTER.STATE}`,
+  `${DEVICE_FEATURE_CATEGORIES.SHUTTER}:${DEVICE_FEATURE_TYPES.SHUTTER.POSITION}`,
+  `${DEVICE_FEATURE_CATEGORIES.CURTAIN}:${DEVICE_FEATURE_TYPES.CURTAIN.STATE}`,
+  `${DEVICE_FEATURE_CATEGORIES.CURTAIN}:${DEVICE_FEATURE_TYPES.CURTAIN.POSITION}`,
+];
+
+const isShutterFeature = (deviceFeature) => {
+  return shutterFeatures.some((types) => `${deviceFeature.category}:${deviceFeature.type}`.startsWith(types));
+};
+
 const historyFeatures = [
   DEVICE_FEATURE_CATEGORIES.AIRQUALITY_SENSOR,
   DEVICE_FEATURE_CATEGORIES.CO_SENSOR,
@@ -95,6 +106,7 @@ const isWritableSensorFeature = (deviceFeature, device) => {
 module.exports = {
   isSensorFeature,
   isSwitchableFeature,
+  isShutterFeature,
   isHistoryFeature,
   isWritableSensorFeature,
 };

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -2218,7 +2218,85 @@ describe('build schemas', () => {
     });
     expect(mcpHandler.gladys.device.setValue.callCount).to.eq(2);
     expect(combinedResult.content[0].text).to.eq(
-      'device.set-shutter: open and position 75% command sent for Salon Shutter',
+      'device.set-shutter: position 75% and open command sent for Salon Shutter',
+    );
+  });
+
+  it('should report when device.set-shutter cannot dispatch a matching feature', async () => {
+    const rooms = [{ id: 'room-1', name: 'Salon', selector: 'salon' }];
+    const stateOnlyShutter = {
+      selector: 'device-shutter-state-only',
+      name: 'State Only Shutter',
+      room: { selector: 'salon', name: 'Salon' },
+      features: [{ id: 1, selector: 'f-state', name: 'State', category: 'shutter', type: 'state' }],
+    };
+    const positionOnlyShutter = {
+      selector: 'device-shutter-position-only',
+      name: 'Position Only Shutter',
+      room: { selector: 'salon', name: 'Salon' },
+      features: [{ id: 2, selector: 'f-position', name: 'Position', category: 'shutter', type: 'position' }],
+    };
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isShutterFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      formatValue: stub().returns({ value: 0 }),
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves(rooms) },
+        user: { get: stub().resolves([]) },
+        house: { get: stub().resolves([]) },
+        calendar: { get: stub().resolves([]) },
+        area: { get: stub().resolves([]) },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves([stateOnlyShutter, positionOnlyShutter]),
+          setValue: stub().resolves(),
+          getDeviceFeaturesAggregates: stub().resolves({ values: [] }),
+          camera: { getImagesInRoom: stub().resolves([]) },
+        },
+        event: { emit: fake() },
+      },
+      levenshtein: { distance: stub().returns(10) },
+      toon: stub().returns('ok'),
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    const setShutterTool = tools.find((tool) => tool.intent === 'device.set-shutter');
+
+    const missingPositionResult = await setShutterTool.cb({
+      position: 50,
+      device: 'State Only Shutter',
+    });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(0);
+    expect(missingPositionResult.content[0].text).to.eq(
+      'device.set-shutter: no command sent, no matching feature on State Only Shutter (missing position feature)',
+    );
+
+    const missingStateResult = await setShutterTool.cb({
+      action: 'open',
+      device: 'Position Only Shutter',
+    });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(0);
+    expect(missingStateResult.content[0].text).to.eq(
+      'device.set-shutter: no command sent, no matching feature on Position Only Shutter (missing state feature)',
+    );
+
+    mcpHandler.gladys.device.setValue.resetHistory();
+
+    const partialResult = await setShutterTool.cb({
+      action: 'open',
+      position: 50,
+      device: 'State Only Shutter',
+    });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);
+    expect(partialResult.content[0].text).to.eq(
+      'device.set-shutter: open command sent for State Only Shutter; could not dispatch for State Only Shutter (missing position feature)',
     );
   });
 });

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 const { stub, fake } = require('sinon');
 const nock = require('nock');
 const dns = require('dns');
-const { SYSTEM_VARIABLE_NAMES } = require('../../../../utils/constants');
+const { SYSTEM_VARIABLE_NAMES, COVER_STATE } = require('../../../../utils/constants');
 const {
   getAllResources,
   getAllTools,
@@ -12,6 +12,7 @@ const {
 const {
   isSensorFeature,
   isSwitchableFeature,
+  isShutterFeature,
   isHistoryFeature,
   isWritableSensorFeature,
 } = require('../../../../services/mcp/lib/selectFeature');
@@ -116,6 +117,7 @@ describe('build schemas', () => {
       getAllResources,
       isSensorFeature,
       isSwitchableFeature,
+      isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
       gladys: {
@@ -256,6 +258,7 @@ describe('build schemas', () => {
       getAllResources,
       isSensorFeature,
       isSwitchableFeature,
+      isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
       gladys: {
@@ -363,6 +366,7 @@ describe('build schemas', () => {
       getAllResources,
       isSensorFeature,
       isSwitchableFeature,
+      isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
       gladys: {
@@ -476,6 +480,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
       formatValue: stub().callsFake((feature) => ({
@@ -920,6 +925,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
       formatValue: stub().callsFake((feature) => ({
@@ -994,6 +1000,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
       formatValue: stub().callsFake((feature) => ({
@@ -1106,6 +1113,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
       formatValue: stub().callsFake((feature) => ({
@@ -1197,6 +1205,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
       formatValue: stub().callsFake((feature) => ({ value: feature.last_value })),
@@ -1239,6 +1248,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
       formatValue: stub().returns({ value: 1 }),
@@ -1348,6 +1358,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
       findBySimilarity,
@@ -1419,6 +1430,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
       findBySimilarity,
@@ -1482,6 +1494,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
       findBySimilarity,
@@ -1580,6 +1593,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
       findBySimilarity,
@@ -1651,6 +1665,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
       findBySimilarity,
@@ -1729,6 +1744,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
       findBySimilarity,
@@ -1779,6 +1795,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
       findBySimilarity,
@@ -1845,6 +1862,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
       findBySimilarity,
@@ -1895,6 +1913,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
       findBySimilarity,
@@ -1926,5 +1945,280 @@ describe('build schemas', () => {
     });
 
     expect(mcpHandler.gladys.device.saveStringState.callCount).to.eq(1);
+  });
+
+  it('should expose shutters in home schema and device.set-shutter tool', async () => {
+    const rooms = [{ id: 'room-1', name: 'Salon', selector: 'salon' }];
+    const shutterDevice = {
+      selector: 'device-shutter-1',
+      name: 'Living Room Shutter',
+      room: { selector: 'salon', name: 'Salon' },
+      features: [
+        {
+          id: 1,
+          selector: 'device-shutter-1-state',
+          name: 'State',
+          category: 'shutter',
+          type: 'state',
+          last_value: COVER_STATE.CLOSE,
+        },
+        {
+          id: 2,
+          selector: 'device-shutter-1-position',
+          name: 'Position',
+          category: 'shutter',
+          type: 'position',
+          last_value: 0,
+          unit: 'percent',
+        },
+      ],
+    };
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllResources,
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isShutterFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      formatValue: stub().callsFake((feature) => ({
+        value: feature.last_value,
+        unit: feature.unit,
+      })),
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves(rooms) },
+        user: { get: stub().resolves([]) },
+        house: { get: stub().resolves([]) },
+        calendar: { get: stub().resolves([]) },
+        area: { get: stub().resolves([]) },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves([shutterDevice]),
+          getBySelector: stub().resolves(shutterDevice),
+          setValue: stub().resolves(),
+          getDeviceFeaturesAggregates: stub().resolves({ values: [] }),
+          camera: { getImagesInRoom: stub().resolves([]) },
+        },
+        event: { emit: fake() },
+      },
+      levenshtein: { distance: stub().returns(0) },
+      toon: stub().returns('toonmockdata'),
+    };
+
+    const resources = await mcpHandler.getAllResources();
+    const homeSchema = JSON.parse((await resources[0].cb({ href: 'schema://home' })).contents[0].text);
+
+    expect(homeSchema.salon.devices['device-shutter-1']).to.deep.equal({
+      name: 'Living Room Shutter',
+      selector: 'device-shutter-1',
+      features: [
+        {
+          name: 'State',
+          selector: 'device-shutter-1-state',
+          category: 'shutter',
+          type: 'state',
+          access: ['write', 'read'],
+        },
+        {
+          name: 'Position',
+          selector: 'device-shutter-1-position',
+          category: 'shutter',
+          type: 'position',
+          access: ['write', 'read'],
+        },
+      ],
+    });
+
+    const tools = await mcpHandler.getAllTools();
+    const setShutterTool = tools.find((tool) => tool.intent === 'device.set-shutter');
+    const getStateTool = tools.find((tool) => tool.intent === 'device.get-state');
+
+    expect(setShutterTool).to.not.equal(undefined);
+
+    const openResult = await setShutterTool.cb({ action: 'open', device: 'Living Room Shutter' });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[1].type).to.eq('state');
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[2]).to.eq(COVER_STATE.OPEN);
+    expect(openResult.content[0].text).to.eq('device.set-shutter: open command sent for Living Room Shutter');
+
+    mcpHandler.gladys.device.setValue.resetHistory();
+
+    const positionResult = await setShutterTool.cb({ position: 50, device: 'Living Room Shutter' });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[1].type).to.eq('position');
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[2]).to.eq(50);
+    expect(positionResult.content[0].text).to.eq(
+      'device.set-shutter: position 50% command sent for Living Room Shutter',
+    );
+
+    const stateResult = await getStateTool.cb({ room: 'salon', device_type: 'shutter' });
+    expect(stateResult.content[0].text).to.eq('toonmockdata');
+  });
+
+  it('should merge shutter features into an existing device in home schema', async () => {
+    const rooms = [{ id: 'room-1', name: 'Salon', selector: 'salon' }];
+    const combinedDevice = {
+      selector: 'device-combined-shutter',
+      name: 'Smart Shutter',
+      room: { selector: 'salon' },
+      features: [
+        {
+          id: 1,
+          selector: 'device-combined-shutter-temp',
+          name: 'Temperature',
+          category: 'temperature-sensor',
+          type: 'decimal',
+        },
+        {
+          id: 2,
+          selector: 'device-combined-shutter-state',
+          name: 'State',
+          category: 'shutter',
+          type: 'state',
+        },
+      ],
+    };
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllResources,
+      isSensorFeature,
+      isSwitchableFeature,
+      isShutterFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      gladys: {
+        room: { getAll: stub().resolves(rooms) },
+        device: { get: stub().resolves([combinedDevice]) },
+      },
+    };
+
+    const resources = await mcpHandler.getAllResources();
+    const homeSchema = JSON.parse((await resources[0].cb({ href: 'schema://home' })).contents[0].text);
+
+    expect(homeSchema.salon.devices['device-combined-shutter'].features).to.deep.equal([
+      {
+        name: 'Temperature',
+        selector: 'device-combined-shutter-temp',
+        category: 'temperature-sensor',
+        type: 'decimal',
+        access: ['read'],
+      },
+      {
+        name: 'State',
+        selector: 'device-combined-shutter-state',
+        category: 'shutter',
+        type: 'state',
+        access: ['write', 'read'],
+      },
+    ]);
+  });
+
+  it('should cover device.set-shutter error and filtering branches', async () => {
+    const rooms = [
+      { id: 'room-1', name: 'Salon', selector: 'salon' },
+      { id: 'room-2', name: 'Chambre', selector: 'chambre' },
+    ];
+    const shutterDevices = [
+      {
+        selector: 'device-shutter-salon',
+        name: 'Salon Shutter',
+        room: { selector: 'salon', name: 'Salon' },
+        features: [
+          { id: 1, selector: 'f-state', name: 'State', category: 'shutter', type: 'state' },
+          { id: 2, selector: 'f-position', name: 'Position', category: 'shutter', type: 'position' },
+        ],
+      },
+      {
+        selector: 'device-curtain-chambre',
+        name: 'Bedroom Curtain',
+        room: { selector: 'chambre', name: 'Chambre' },
+        features: [
+          { id: 3, selector: 'c-state', name: 'State', category: 'curtain', type: 'state' },
+          { id: 4, selector: 'c-position', name: 'Position', category: 'curtain', type: 'position' },
+        ],
+      },
+    ];
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isShutterFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      formatValue: stub().returns({ value: 0 }),
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves(rooms) },
+        user: { get: stub().resolves([]) },
+        house: { get: stub().resolves([]) },
+        calendar: { get: stub().resolves([]) },
+        area: { get: stub().resolves([]) },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves(shutterDevices),
+          getBySelector: stub().resolves(shutterDevices[0]),
+          setValue: stub().resolves(),
+          getDeviceFeaturesAggregates: stub().resolves({ values: [] }),
+          camera: { getImagesInRoom: stub().resolves([]) },
+        },
+        event: { emit: fake() },
+      },
+      levenshtein: { distance: stub().returns(10) },
+      toon: stub().returns('ok'),
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    const setShutterTool = tools.find((tool) => tool.intent === 'device.set-shutter');
+
+    const missingArgsResult = await setShutterTool.cb({});
+    expect(missingArgsResult.content[0].text).to.eq('device.set-shutter: action or position is required');
+
+    const unknownDeviceResult = await setShutterTool.cb({ action: 'open', device: 'Unknown Shutter' });
+    expect(unknownDeviceResult.content[0].text).to.eq('device.set-shutter: no device found');
+
+    const noDeviceInRoomResult = await setShutterTool.cb({
+      action: 'close',
+      room: 'chambre',
+      device_category: 'shutter',
+    });
+    expect(noDeviceInRoomResult.content[0].text).to.eq('device.set-shutter: no device found');
+
+    mcpHandler.gladys.device.setValue.resetHistory();
+
+    const roomCategoryResult = await setShutterTool.cb({
+      action: 'stop',
+      room: 'chambre',
+      device_category: 'curtain',
+    });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[0].name).to.eq('Bedroom Curtain');
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[2]).to.eq(COVER_STATE.STOP);
+    expect(roomCategoryResult.content[0].text).to.eq('device.set-shutter: stop command sent for Bedroom Curtain');
+
+    mcpHandler.gladys.device.setValue.resetHistory();
+
+    const roomResult = await setShutterTool.cb({ action: 'close', room: 'salon' });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[0].name).to.eq('Salon Shutter');
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[2]).to.eq(COVER_STATE.CLOSE);
+    expect(roomResult.content[0].text).to.eq('device.set-shutter: close command sent for Salon Shutter');
+
+    mcpHandler.gladys.device.setValue.resetHistory();
+
+    const combinedResult = await setShutterTool.cb({
+      action: 'open',
+      position: 75,
+      device: 'Salon Shutter',
+    });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(2);
+    expect(combinedResult.content[0].text).to.eq(
+      'device.set-shutter: open and position 75% command sent for Salon Shutter',
+    );
   });
 });

--- a/server/test/services/mcp/lib/formatValue.test.js
+++ b/server/test/services/mcp/lib/formatValue.test.js
@@ -1,4 +1,5 @@
 const { expect } = require('chai');
+const { COVER_STATE } = require('../../../../utils/constants');
 const { formatValue } = require('../../../../services/mcp/lib/formatValue');
 
 describe('formatValue', () => {
@@ -28,6 +29,52 @@ describe('formatValue', () => {
 
     expect(result).to.deep.equal({
       value: 'off',
+      unit: null,
+    });
+  });
+
+  it('should format shutter:state values', () => {
+    expect(formatValue({ category: 'shutter', type: 'state', last_value: COVER_STATE.OPEN })).to.deep.equal({
+      value: 'open',
+      unit: null,
+    });
+    expect(formatValue({ category: 'shutter', type: 'state', last_value: COVER_STATE.CLOSE })).to.deep.equal({
+      value: 'closed',
+      unit: null,
+    });
+    expect(formatValue({ category: 'shutter', type: 'state', last_value: COVER_STATE.STOP })).to.deep.equal({
+      value: 'stopped',
+      unit: null,
+    });
+  });
+
+  it('should format opening-sensor:binary with value 1 as "closed"', () => {
+    const result = formatValue({
+      category: 'opening-sensor',
+      type: 'binary',
+      last_value: 1,
+    });
+
+    expect(result).to.deep.equal({
+      value: 'closed',
+      unit: null,
+    });
+  });
+
+  it('should format switch:binary values', () => {
+    expect(formatValue({ category: 'switch', type: 'binary', last_value: 1 })).to.deep.equal({
+      value: 'on',
+      unit: null,
+    });
+  });
+
+  it('should format curtain:state values and fallback for unknown state', () => {
+    expect(formatValue({ category: 'curtain', type: 'state', last_value: COVER_STATE.OPEN })).to.deep.equal({
+      value: 'open',
+      unit: null,
+    });
+    expect(formatValue({ category: 'shutter', type: 'state', last_value: 42 })).to.deep.equal({
+      value: 42,
       unit: null,
     });
   });


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

AI : Add new "device_set_shutter" tool

https://community.gladysassistant.com/t/ia-gladys-et-alexa-avec-mes-volets-roulants/10299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shutter and curtain support to available device schemas and status displays.
  * Introduced a new `device.set-shutter` control to open, close, stop, and/or set shutter position (0–100), with smart scoping by device, room, and category.
  * Extended device state and tool availability so shutters are discovered and controllable alongside other device types.
* **Bug Fixes**
  * Improved cover state formatting for shutter/curtain status (open, closed, stopped), with safe fallback for unknown values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->