### PR TITLE
Scene: Select default values for askAi, send message & send camera image actions

### DIFF
--- a/front/src/routes/scene/edit-scene/actions/AskAI.jsx
+++ b/front/src/routes/scene/edit-scene/actions/AskAI.jsx
@@ -27,7 +27,11 @@ class AskAI extends Component {
       }));
 
       await this.setState({ userOptions, cameraOptions });
-      this.refreshSelectedOptions(this.props);
+      if (!this.props.action.user && userOptions.length > 0) {
+        this.props.updateActionProperty(this.props.path, 'user', userOptions[0].value);
+      } else {
+        this.refreshSelectedOptions(this.props);
+      }
       return userOptions;
     } catch (e) {
       console.error(e);

--- a/front/src/routes/scene/edit-scene/actions/AskAI.jsx
+++ b/front/src/routes/scene/edit-scene/actions/AskAI.jsx
@@ -28,8 +28,9 @@ class AskAI extends Component {
 
       let selectedUserOption = '';
       let selectedCameraOption = '';
+      const actionUpdates = [];
       if (!this.props.action.user && userOptions.length > 0) {
-        this.props.updateActionProperty(this.props.path, 'user', userOptions[0].value);
+        actionUpdates.push(['user', userOptions[0].value]);
         selectedUserOption = userOptions[0];
       } else if (this.props.action.user) {
         selectedUserOption = userOptions.find(option => option.value === this.props.action.user) || '';
@@ -37,7 +38,9 @@ class AskAI extends Component {
       if (this.props.action.camera) {
         selectedCameraOption = cameraOptions.find(option => option.value === this.props.action.camera) || '';
       }
-      this.setState({ userOptions, cameraOptions, selectedUserOption, selectedCameraOption });
+      this.setState({ userOptions, cameraOptions, selectedUserOption, selectedCameraOption }, () => {
+        actionUpdates.forEach(([key, value]) => this.props.updateActionProperty(this.props.path, key, value));
+      });
       return userOptions;
     } catch (e) {
       console.error(e);

--- a/front/src/routes/scene/edit-scene/actions/AskAI.jsx
+++ b/front/src/routes/scene/edit-scene/actions/AskAI.jsx
@@ -26,12 +26,18 @@ class AskAI extends Component {
         value: camera.selector
       }));
 
-      await this.setState({ userOptions, cameraOptions });
+      let selectedUserOption = '';
+      let selectedCameraOption = '';
       if (!this.props.action.user && userOptions.length > 0) {
         this.props.updateActionProperty(this.props.path, 'user', userOptions[0].value);
-      } else {
-        this.refreshSelectedOptions(this.props);
+        selectedUserOption = userOptions[0];
+      } else if (this.props.action.user) {
+        selectedUserOption = userOptions.find(option => option.value === this.props.action.user) || '';
       }
+      if (this.props.action.camera) {
+        selectedCameraOption = cameraOptions.find(option => option.value === this.props.action.camera) || '';
+      }
+      this.setState({ userOptions, cameraOptions, selectedUserOption, selectedCameraOption });
       return userOptions;
     } catch (e) {
       console.error(e);

--- a/front/src/routes/scene/edit-scene/actions/SendMessageCameraParams.jsx
+++ b/front/src/routes/scene/edit-scene/actions/SendMessageCameraParams.jsx
@@ -23,19 +23,21 @@ class SendMessageCameraParams extends Component {
         value: camera.selector
       }));
 
-      await this.setState({ userOptions, cameraOptions });
-      let updated = false;
+      let selectedUserOption = '';
+      let selectedCameraOption = '';
       if (!this.props.action.user && userOptions.length > 0) {
         this.props.updateActionProperty(this.props.path, 'user', userOptions[0].value);
-        updated = true;
+        selectedUserOption = userOptions[0];
+      } else if (this.props.action.user) {
+        selectedUserOption = userOptions.find(option => option.value === this.props.action.user) || '';
       }
       if (!this.props.action.camera && cameraOptions.length > 0) {
         this.props.updateActionProperty(this.props.path, 'camera', cameraOptions[0].value);
-        updated = true;
+        selectedCameraOption = cameraOptions[0];
+      } else if (this.props.action.camera) {
+        selectedCameraOption = cameraOptions.find(option => option.value === this.props.action.camera) || '';
       }
-      if (!updated) {
-        this.refreshSelectedOptions(this.props);
-      }
+      this.setState({ userOptions, cameraOptions, selectedUserOption, selectedCameraOption });
       return userOptions;
     } catch (e) {
       console.error(e);

--- a/front/src/routes/scene/edit-scene/actions/SendMessageCameraParams.jsx
+++ b/front/src/routes/scene/edit-scene/actions/SendMessageCameraParams.jsx
@@ -25,19 +25,22 @@ class SendMessageCameraParams extends Component {
 
       let selectedUserOption = '';
       let selectedCameraOption = '';
+      const actionUpdates = [];
       if (!this.props.action.user && userOptions.length > 0) {
-        this.props.updateActionProperty(this.props.path, 'user', userOptions[0].value);
+        actionUpdates.push(['user', userOptions[0].value]);
         selectedUserOption = userOptions[0];
       } else if (this.props.action.user) {
         selectedUserOption = userOptions.find(option => option.value === this.props.action.user) || '';
       }
       if (!this.props.action.camera && cameraOptions.length > 0) {
-        this.props.updateActionProperty(this.props.path, 'camera', cameraOptions[0].value);
+        actionUpdates.push(['camera', cameraOptions[0].value]);
         selectedCameraOption = cameraOptions[0];
       } else if (this.props.action.camera) {
         selectedCameraOption = cameraOptions.find(option => option.value === this.props.action.camera) || '';
       }
-      this.setState({ userOptions, cameraOptions, selectedUserOption, selectedCameraOption });
+      this.setState({ userOptions, cameraOptions, selectedUserOption, selectedCameraOption }, () => {
+        actionUpdates.forEach(([key, value]) => this.props.updateActionProperty(this.props.path, key, value));
+      });
       return userOptions;
     } catch (e) {
       console.error(e);

--- a/front/src/routes/scene/edit-scene/actions/SendMessageCameraParams.jsx
+++ b/front/src/routes/scene/edit-scene/actions/SendMessageCameraParams.jsx
@@ -24,7 +24,18 @@ class SendMessageCameraParams extends Component {
       }));
 
       await this.setState({ userOptions, cameraOptions });
-      this.refreshSelectedOptions(this.props);
+      let updated = false;
+      if (!this.props.action.user && userOptions.length > 0) {
+        this.props.updateActionProperty(this.props.path, 'user', userOptions[0].value);
+        updated = true;
+      }
+      if (!this.props.action.camera && cameraOptions.length > 0) {
+        this.props.updateActionProperty(this.props.path, 'camera', cameraOptions[0].value);
+        updated = true;
+      }
+      if (!updated) {
+        this.refreshSelectedOptions(this.props);
+      }
       return userOptions;
     } catch (e) {
       console.error(e);

--- a/front/src/routes/scene/edit-scene/actions/SendMessageParams.jsx
+++ b/front/src/routes/scene/edit-scene/actions/SendMessageParams.jsx
@@ -16,12 +16,14 @@ class SendMessageParams extends Component {
           value: user.selector
         });
       });
-      await this.setState({ userOptions });
+      let selectedOption = '';
       if (!this.props.action.user && userOptions.length > 0) {
         this.props.updateActionProperty(this.props.path, 'user', userOptions[0].value);
-      } else {
-        this.refreshSelectedOptions(this.props);
+        selectedOption = userOptions[0];
+      } else if (this.props.action.user) {
+        selectedOption = userOptions.find(option => option.value === this.props.action.user) || '';
       }
+      this.setState({ userOptions, selectedOption });
       return userOptions;
     } catch (e) {
       console.error(e);

--- a/front/src/routes/scene/edit-scene/actions/SendMessageParams.jsx
+++ b/front/src/routes/scene/edit-scene/actions/SendMessageParams.jsx
@@ -17,13 +17,16 @@ class SendMessageParams extends Component {
         });
       });
       let selectedOption = '';
+      const actionUpdates = [];
       if (!this.props.action.user && userOptions.length > 0) {
-        this.props.updateActionProperty(this.props.path, 'user', userOptions[0].value);
+        actionUpdates.push(['user', userOptions[0].value]);
         selectedOption = userOptions[0];
       } else if (this.props.action.user) {
         selectedOption = userOptions.find(option => option.value === this.props.action.user) || '';
       }
-      this.setState({ userOptions, selectedOption });
+      this.setState({ userOptions, selectedOption }, () => {
+        actionUpdates.forEach(([key, value]) => this.props.updateActionProperty(this.props.path, key, value));
+      });
       return userOptions;
     } catch (e) {
       console.error(e);

--- a/front/src/routes/scene/edit-scene/actions/SendMessageParams.jsx
+++ b/front/src/routes/scene/edit-scene/actions/SendMessageParams.jsx
@@ -17,7 +17,11 @@ class SendMessageParams extends Component {
         });
       });
       await this.setState({ userOptions });
-      this.refreshSelectedOptions(this.props);
+      if (!this.props.action.user && userOptions.length > 0) {
+        this.props.updateActionProperty(this.props.path, 'user', userOptions[0].value);
+      } else {
+        this.refreshSelectedOptions(this.props);
+      }
       return userOptions;
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

Scene: Select default values for askAi, send message & send camera image actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scene action forms now correctly derive and display selected user/camera options on load, auto-selecting the first available user (and camera when applicable) when no prior selection exists.
  * Message actions with camera parameters now prefill both user and camera selections based on the available options.
  * If a saved selection no longer matches any available option, the form clears the selection to avoid showing stale values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->