### PR TITLE
Zigbee2mqtt: Display credentials in UI

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -993,6 +993,13 @@
               "unknownDongle": "Nicht definiert",
               "tcpPort": "TCP-Port"
             },
+            "externalMqtt": {
+              "title": "Verbindung für externe Tools",
+              "description": "Schreibgeschützte Anmeldedaten, um externe Tools (z. B. Node-RED) mit dem von Gladys verwalteten MQTT-Broker zu verbinden. Wenn das Tool auf einem anderen Rechner läuft, ersetzen Sie \"localhost\" in der URL durch die IP-Adresse Ihres Gladys-Rechners.",
+              "credentialsPending": "Anmeldedaten sind nach der ersten Aktivierung des Dienstes verfügbar.",
+              "brokerNotRunning": "Der MQTT-Broker läuft noch nicht. Diese Anmeldedaten funktionieren, sobald der Dienst gestartet ist.",
+              "copied": "Kopiert"
+            },
             "containerErrors": {
               "EZSP_PROTOCOL_VERSION": "Warnung: Die Firmware Ihres Ember-Koordinators ist veraltet. Version 7.4.x oder höher ist erforderlich. Bitte folgen Sie der <a href=\"https://www.zigbee2mqtt.io/guide/adapters/emberznet.html#firmware-flashing\" target=\"_blank\" rel=\"noopener noreferrer\">Firmware-Aktualisierungsanleitung</a>, um sie zu aktualisieren. Wählen Sie andernfalls den Dongle (legacy ezsp) in der Konfiguration aus.",
               "unknownErrorPrefix": "Zigbee2MQTT-Containerfehler: "

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -888,6 +888,13 @@
               "unknownDongle": "Not defined",
               "tcpPort": "TCP Port"
             },
+            "externalMqtt": {
+              "title": "External tools connection",
+              "description": "Read-only credentials to connect external tools (e.g. Node-RED) to the MQTT broker managed by Gladys. If the tool runs on another machine, replace \"localhost\" in the URL with the IP address of your Gladys machine.",
+              "credentialsPending": "Credentials will be available after the service is activated for the first time.",
+              "brokerNotRunning": "The MQTT broker is not running yet. These credentials will work once the service is started.",
+              "copied": "Copied"
+            },
             "containerErrors": {
               "EZSP_PROTOCOL_VERSION": "Warning: Your Ember coordinator firmware is outdated. Firmware version 7.4.x or higher is required. Please follow the <a href=\"https://www.zigbee2mqtt.io/guide/adapters/emberznet.html#firmware-flashing\" target=\"_blank\" rel=\"noopener noreferrer\">firmware flashing guide</a> to update it. Otherwise, select the dongle (legacy ezsp) in the configuration.",
               "unknownErrorPrefix": "Zigbee2MQTT container error: "

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -1126,6 +1126,13 @@
               "unknownDongle": "Non défini",
               "tcpPort": "Port TCP"
             },
+            "externalMqtt": {
+              "title": "Connexion pour outils externes",
+              "description": "Identifiants en lecture seule pour connecter des outils externes (ex. Node-RED) au broker MQTT géré par Gladys. Si l'outil est sur une autre machine, remplacez \"localhost\" dans l'URL par l'adresse IP de votre machine Gladys.",
+              "credentialsPending": "Les identifiants seront disponibles après la première activation du service.",
+              "brokerNotRunning": "Le broker MQTT n'est pas encore démarré. Ces identifiants seront utilisables une fois le service lancé.",
+              "copied": "Copié"
+            },
             "containerErrors": {
               "EZSP_PROTOCOL_VERSION": "Attention : Le firmware de votre coordinateur Ember est obsolète. La version 7.4.x ou supérieure est requise. Vous pouvez suivre ce <a href=\"https://www.zigbee2mqtt.io/guide/adapters/emberznet.html#firmware-flashing\" target=\"_blank\" rel=\"noopener noreferrer\">guide</a> pour le mettre à jour. Dans le cas contraire, sélectionner le dongle (legacy ezsp) dans la configuration.",
               "unknownErrorPrefix": "Erreur du conteneur Zigbee2MQTT : "

--- a/front/src/routes/integration/all/zigbee2mqtt/setup-page/SetupPanel.jsx
+++ b/front/src/routes/integration/all/zigbee2mqtt/setup-page/SetupPanel.jsx
@@ -59,6 +59,8 @@ class SetupPanel extends Component {
         setupMode = SETUP_MODES.REMOTE;
       }
       this.setState({ setupMode, configuration });
+    } else if (configuration !== this.props.configuration) {
+      this.setState({ configuration });
     }
   }
 

--- a/front/src/routes/integration/all/zigbee2mqtt/setup-page/SetupTab.jsx
+++ b/front/src/routes/integration/all/zigbee2mqtt/setup-page/SetupTab.jsx
@@ -8,6 +8,7 @@ import { MQTT_MODE } from './constants';
 import SetupPanel from './SetupPanel';
 import EnableStatus from './status/EnableStatus';
 import RunningStatus from './status/RunningStatus';
+import MqttExternalCredentials from './local/MqttExternalCredentials';
 
 class SetupTab extends Component {
   showConfirmReset = () => {
@@ -49,6 +50,7 @@ class SetupTab extends Component {
       resetZigbee2mqttStatus === RequestStatus.Getting;
     const disabled = loading || saving;
     const isLocalMode = configuration.mqttMode === MQTT_MODE.LOCAL;
+    const { mqttRunning = false } = props.zigbee2mqttStatus || {};
 
     return (
       <div class="card" data-cy="z2m-setup-wizard">
@@ -114,6 +116,12 @@ class SetupTab extends Component {
                 <li class="list-group-item" data-cy="z2m-running-status">
                   <RunningStatus {...props} disabled={disabled} />
                 </li>
+
+                {isLocalMode && success && (
+                  <li class="list-group-item" data-cy="z2m-mqtt-external-section">
+                    <MqttExternalCredentials configuration={configuration} mqttRunning={mqttRunning} />
+                  </li>
+                )}
 
                 {isLocalMode && (
                   <li class="list-group-item" data-cy="z2m-reset-section">

--- a/front/src/routes/integration/all/zigbee2mqtt/setup-page/index.js
+++ b/front/src/routes/integration/all/zigbee2mqtt/setup-page/index.js
@@ -101,6 +101,9 @@ class Zigbee2mqttSetupPage extends Component {
       this.setState({
         toggleZigee2mqttStatus: RequestStatus.Success
       });
+      if (enable) {
+        await this.loadZ2MConfig();
+      }
     } catch (e) {
       console.error(e);
       this.setState({

--- a/front/src/routes/integration/all/zigbee2mqtt/setup-page/local/MqttExternalCredentials.jsx
+++ b/front/src/routes/integration/all/zigbee2mqtt/setup-page/local/MqttExternalCredentials.jsx
@@ -1,0 +1,158 @@
+import { Component } from 'preact';
+import { Text } from 'preact-i18n';
+import cx from 'classnames';
+
+const DEFAULT_MQTT_URL = 'mqtt://localhost:1884';
+const DEFAULT_MQTT_USERNAME = 'gladys';
+
+class MqttExternalCredentials extends Component {
+  showPasswordTimer = null;
+
+  togglePassword = () => {
+    const { showPassword } = this.state;
+
+    if (this.showPasswordTimer) {
+      clearTimeout(this.showPasswordTimer);
+      this.showPasswordTimer = null;
+    }
+
+    this.setState({ showPassword: !showPassword });
+
+    if (!showPassword) {
+      this.showPasswordTimer = setTimeout(() => this.setState({ showPassword: false }), 5000);
+    }
+  };
+
+  copyValue = async value => {
+    if (typeof navigator !== 'undefined' && navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(value);
+      this.setState({ copiedField: value });
+      if (this.copyTimer) {
+        clearTimeout(this.copyTimer);
+      }
+      this.copyTimer = setTimeout(() => this.setState({ copiedField: null }), 2000);
+    }
+  };
+
+  componentWillUnmount() {
+    if (this.showPasswordTimer) {
+      clearTimeout(this.showPasswordTimer);
+      this.showPasswordTimer = null;
+    }
+    if (this.copyTimer) {
+      clearTimeout(this.copyTimer);
+      this.copyTimer = null;
+    }
+  }
+
+  renderCredentialRow = (labelId, value, dataCy, { secret = false, showPassword = false } = {}) => {
+    const canCopy = typeof window !== 'undefined' && window.isSecureContext;
+
+    return (
+      <tr>
+        <td class="pr-4 text-muted align-top">
+          <Text id={labelId} />
+        </td>
+        <td>
+          <div class="d-flex align-items-center flex-wrap" style="gap: 0.5rem;">
+            {secret ? (
+              <code data-cy={dataCy}>{showPassword ? value : '••••••••••••••••••••'}</code>
+            ) : (
+              <code data-cy={dataCy}>{value}</code>
+            )}
+            {secret && (
+              <button type="button" class="btn btn-sm btn-outline-secondary py-0 px-2" onClick={this.togglePassword}>
+                <i
+                  class={cx('fe', {
+                    'fe-eye': !showPassword,
+                    'fe-eye-off': showPassword
+                  })}
+                />
+              </button>
+            )}
+            {canCopy && (
+              <button
+                type="button"
+                class="btn btn-sm btn-outline-secondary py-0 px-2"
+                onClick={() => this.copyValue(value)}
+                data-cy="z2m-setup-local-mqtt-copy-button"
+              >
+                <i class="fe fe-copy" />
+              </button>
+            )}
+            {canCopy && this.state.copiedField === value && (
+              <small class="text-success">
+                <Text id="integration.zigbee2mqtt.setup.modes.local.externalMqtt.copied" />
+              </small>
+            )}
+          </div>
+        </td>
+      </tr>
+    );
+  };
+
+  render({ configuration = {}, mqttRunning }, { showPassword }) {
+    const { mqttUrl, mqttUsername, mqttPassword } = configuration;
+    const hasMqttCredentials = Boolean(mqttPassword);
+
+    if (!hasMqttCredentials) {
+      return (
+        <div data-cy="z2m-mqtt-external-credentials-pending">
+          <div class="form-label">
+            <Text id="integration.zigbee2mqtt.setup.modes.local.externalMqtt.title" />
+          </div>
+          <small class="text-muted">
+            <Text id="integration.zigbee2mqtt.setup.modes.local.externalMqtt.credentialsPending" />
+          </small>
+        </div>
+      );
+    }
+
+    const brokerUrl = mqttUrl || DEFAULT_MQTT_URL;
+    const username = mqttUsername || DEFAULT_MQTT_USERNAME;
+
+    return (
+      <div data-cy="z2m-mqtt-external-credentials">
+        <div class="form-label">
+          <Text id="integration.zigbee2mqtt.setup.modes.local.externalMqtt.title" />
+        </div>
+        <small class="form-text text-muted mb-3">
+          <Text id="integration.zigbee2mqtt.setup.modes.local.externalMqtt.description" />
+        </small>
+        {!mqttRunning && (
+          <div class="alert alert-warning py-2 mb-3">
+            <small>
+              <Text id="integration.zigbee2mqtt.setup.modes.local.externalMqtt.brokerNotRunning" />
+            </small>
+          </div>
+        )}
+        <div class="card bg-light border">
+          <div class="card-body py-3">
+            <table class="mb-0">
+              <tbody>
+                {this.renderCredentialRow(
+                  'integration.mqtt.setup.urlLabel',
+                  brokerUrl,
+                  'z2m-setup-local-mqtt-url-summary'
+                )}
+                {this.renderCredentialRow(
+                  'integration.mqtt.setup.userLabel',
+                  username,
+                  'z2m-setup-local-mqtt-username-summary'
+                )}
+                {this.renderCredentialRow(
+                  'integration.mqtt.setup.passwordLabel',
+                  mqttPassword,
+                  'z2m-setup-local-mqtt-password-summary',
+                  { secret: true, showPassword }
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default MqttExternalCredentials;


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

Zigbee2mqtt: Display credentials in UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new MQTT credentials section for Zigbee2MQTT setup, showing connection details for external tools.
  * Users can now reveal or hide the password, and copy available fields with a temporary “copied” confirmation.
  * Added translated text for this new section in English, French, and German.

* **Bug Fixes**
  * Improved setup refresh behavior so updated configuration is reloaded when Zigbee2MQTT is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->