### PR TITLE
AI : Fix device-turn-on-off schema

### DIFF
--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -517,15 +517,19 @@ async function getAllTools(userId) {
           };
         }
 
-        let selectedDevices = switchableDevices;
-
-        if (room && room !== '') {
-          const { selector } = this.findBySimilarity(rooms, room);
-          selectedDevices = selectedDevices.filter((d) => (d.room?.selector || noRoom.selector) === selector);
+        if (device && (room || deviceCategory)) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `device.turn-${actionValue}: mixed targeting. Provide device name only, or both room and device_category without device.`,
+              },
+            ],
+          };
         }
 
         if (device) {
-          const selectedDevice = this.findBySimilarity(selectedDevices, device);
+          const selectedDevice = this.findBySimilarity(switchableDevices, device);
           if (selectedDevice?.name) {
             await Promise.all(
               selectedDevice.features.map((f) => {
@@ -537,35 +541,45 @@ async function getAllTools(userId) {
               content: [{ type: 'text', text: `device.turn-${actionValue} command sent for ${selectedDevice.name}` }],
             };
           }
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `device.turn-${actionValue} command not sent, no device found matching "${device}"`,
+              },
+            ],
+          };
         }
 
-        if (room && deviceCategory) {
-          selectedDevices = selectedDevices.filter((d) => d.features.some((f) => f.category === deviceCategory));
+        let selectedDevices = switchableDevices;
+        const { selector } = this.findBySimilarity(rooms, room);
+        selectedDevices = selectedDevices.filter((d) => (d.room?.selector || noRoom.selector) === selector);
+        selectedDevices = selectedDevices.filter((d) => d.features.some((f) => f.category === deviceCategory));
 
-          if (selectedDevices.length > 0) {
-            await Promise.all(
-              selectedDevices.map((d) => {
-                return Promise.all(
-                  d.features.map((f) => {
-                    if (f.category === deviceCategory) {
-                      return this.gladys.device.setValue(d, f, actionValue === 'on' ? 1 : 0);
-                    }
+        if (selectedDevices.length > 0) {
+          await Promise.all(
+            selectedDevices.map((d) => {
+              return Promise.all(
+                d.features.map((f) => {
+                  if (f.category === deviceCategory) {
+                    return this.gladys.device.setValue(d, f, actionValue === 'on' ? 1 : 0);
+                  }
 
-                    return null;
-                  }),
-                );
-              }),
-            );
+                  return null;
+                }),
+              );
+            }),
+          );
 
-            return {
-              content: [
-                {
-                  type: 'text',
-                  text: `device.turn-${actionValue} command sent for devices in room ${room} with category ${deviceCategory}`,
-                },
-              ],
-            };
-          }
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `device.turn-${actionValue} command sent for devices in room ${room} with category ${deviceCategory}`,
+              },
+            ],
+          };
         }
 
         return {

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -485,25 +485,38 @@ async function getAllTools(userId) {
       config: {
         title: 'Turn on/off devices',
         description:
-          'Turn on/off specific device selected either by the name if we know it else by it room and it device type.',
+          'Turn a device on or off. Requires either `device` (exact device name from the enum), or both `room` and `device_category` together. Never call with only `action`. For requests covering multiple rooms (for example "all lights"), call once per room with room and device_category, or use device_get_state with device_type light then turn off each device by name.',
+        requireDeviceTargeting: true,
         inputSchema: {
           action: z.enum(['on', 'off']).describe('Action to perform on the device.'),
           device: z
             .enum([...new Set(switchableDevices.map(({ name }) => name))])
-            .describe('Device name to turn on/off.')
+            .describe('Exact device name. Required unless both room and device_category are provided.')
             .optional(),
           room: z
             .enum(rooms.map(({ name }) => name))
-            .describe("Device's room if specified, required if device_category is specified.")
+            .describe('Room name. Required together with device_category when device is not specified.')
             .optional(),
           device_category: z
             .enum(availableSwitchableFeatureCategories)
-            .describe('Type of device to turn on/off only if user has not specified device name.')
+            .describe('Device type (light or switch). Required together with room when device is not specified.')
             .optional(),
         },
       },
       cb: async ({ action, device, room, device_category: deviceCategory }) => {
         const actionValue = action;
+
+        if (!device && !(room && deviceCategory)) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `device.turn-${actionValue}: missing target. Provide device name, or both room and device_category. Never call with only action.`,
+              },
+            ],
+          };
+        }
+
         let selectedDevices = switchableDevices;
 
         if (room && room !== '') {

--- a/server/services/mcp/lib/mcpToolsToChatApiFormat.js
+++ b/server/services/mcp/lib/mcpToolsToChatApiFormat.js
@@ -12,6 +12,27 @@ function toolNameFromIntent(intent) {
 }
 
 /**
+ * @description Require either a device name or both room and device_category in tool parameters.
+ * @param {object} parameters - JSON Schema parameters object.
+ * @returns {object} Parameters with anyOf targeting constraints.
+ * @example
+ * applyDeviceTargetingSchema({ type: 'object', properties: { action: {} }, required: ['action'] });
+ */
+function applyDeviceTargetingSchema(parameters) {
+  const baseRequired = parameters.required ?? [];
+  const requiredWithAction = baseRequired.includes('action') ? baseRequired : ['action', ...baseRequired];
+
+  return {
+    ...parameters,
+    required: requiredWithAction,
+    anyOf: [
+      { required: [...requiredWithAction, 'device'] },
+      { required: [...requiredWithAction, 'room', 'device_category'] },
+    ],
+  };
+}
+
+/**
  * @description Build OpenAI-compatible tool definitions from MCP tool schemas.
  * Uses the same Zod inputSchema as the MCP server (rooms, devices, intervals, etc.)
  * so the model receives the actual enum values from the home.
@@ -22,8 +43,12 @@ function toolNameFromIntent(intent) {
  */
 function mcpToolsToChatApiFormat(mcpTools) {
   return mcpTools.map(({ intent, config }) => {
-    const parameters = z.object(config.inputSchema).toJSONSchema();
+    let parameters = z.object(config.inputSchema).toJSONSchema();
     delete parameters.$schema;
+
+    if (config.requireDeviceTargeting) {
+      parameters = applyDeviceTargetingSchema(parameters);
+    }
 
     return {
       type: 'function',
@@ -39,4 +64,5 @@ function mcpToolsToChatApiFormat(mcpTools) {
 module.exports = {
   mcpToolsToChatApiFormat,
   toolNameFromIntent,
+  applyDeviceTargetingSchema,
 };

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -825,7 +825,20 @@ describe('build schemas', () => {
       device: 'non-existent-device',
     });
     expect(mcpHandler.gladys.device.setValue.callCount).to.eq(0);
-    expect(noDeviceResult.content[0].text).to.eq('device.turn-on command not sent, no device found');
+    expect(noDeviceResult.content[0].text).to.eq(
+      'device.turn-on command not sent, no device found matching "non-existent-device"',
+    );
+
+    const mixedTargetingResult = await tools[4].cb({
+      action: 'off',
+      device: 'Room switch',
+      room: 'salon',
+      device_category: 'light',
+    });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(0);
+    expect(mixedTargetingResult.content[0].text).to.eq(
+      'device.turn-off: mixed targeting. Provide device name only, or both room and device_category without device.',
+    );
 
     // Test device.get-history
     const getHistoryResult = await tools[5].cb({
@@ -1199,6 +1212,71 @@ describe('build schemas', () => {
       }),
     ).to.deep.equal([{ path: 'actions.2', message: 'invalid 2' }]);
     expect(flattenUnionIssues({ path: ['actions'] })).to.deep.equal([]);
+  });
+
+  it('should reject mixed device turn-on-off targeting instead of widening to room category', async () => {
+    const rooms = [
+      { id: 'room-1', name: 'Salon', selector: 'salon' },
+      { id: 'room-2', name: 'Chambre', selector: 'chambre' },
+    ];
+    const devices = [
+      {
+        selector: 'device-light-1',
+        name: 'Living Room Light',
+        room: { selector: 'salon', name: 'Salon' },
+        features: [{ id: 1, selector: 'f-light', name: 'On/Off', category: 'light', type: 'binary' }],
+      },
+      {
+        selector: 'device-switch-1',
+        name: 'Room switch',
+        room: { selector: 'chambre', name: 'Chambre' },
+        features: [{ id: 2, selector: 'f-switch', name: 'On/Off', category: 'switch', type: 'binary' }],
+      },
+    ];
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isShutterFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      formatValue: stub().returns({ value: 1 }),
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves(rooms) },
+        user: { get: stub().resolves([]) },
+        house: { get: stub().resolves([]) },
+        calendar: { get: stub().resolves([]) },
+        area: { get: stub().resolves([]) },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves(devices),
+          getBySelector: stub().resolves(devices[0]),
+          setValue: stub().resolves(),
+          getDeviceFeaturesAggregates: stub().resolves({ values: [] }),
+          camera: { getImagesInRoom: stub().resolves([]) },
+        },
+        event: { emit: fake() },
+      },
+      levenshtein: { distance: stub().returns(0) },
+      toon: stub().returns('ok'),
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    const turnOnOffTool = tools.find((tool) => tool.intent === 'device.turn-on-off');
+
+    const result = await turnOnOffTool.cb({
+      action: 'off',
+      device: 'Room switch',
+      room: 'salon',
+      device_category: 'light',
+    });
+
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(0);
+    expect(result.content[0].text).to.eq(
+      'device.turn-off: mixed targeting. Provide device name only, or both room and device_category without device.',
+    );
   });
 
   it('should cover filtered-out feature branches in device state and turn-on-off tools', async () => {

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -18,6 +18,7 @@ const {
 } = require('../../../../services/mcp/lib/selectFeature');
 const { findBySimilarity } = require('../../../../services/mcp/lib/findBySimilarity');
 const { SCENE_CREATE_TOOL_DESCRIPTION } = require('../../../../services/mcp/lib/sceneSchemas');
+const { mcpToolsToChatApiFormat } = require('../../../../services/mcp/lib/mcpToolsToChatApiFormat');
 
 describe('build schemas', () => {
   it('should build home structure resources schema', async () => {
@@ -774,6 +775,19 @@ describe('build schemas', () => {
     // Tool: device.turn-on-off by device
     expect(tools[4].intent).to.eq('device.turn-on-off');
     expect(tools[4].config.title).to.eq('Turn on/off devices');
+    expect(tools[4].config.requireDeviceTargeting).to.eq(true);
+
+    const turnOnOffApiTool = mcpToolsToChatApiFormat(tools).find((tool) => tool.function.name === 'device_turn_on_off');
+    expect(turnOnOffApiTool.function.parameters.anyOf).to.deep.equal([
+      { required: ['action', 'device'] },
+      { required: ['action', 'room', 'device_category'] },
+    ]);
+
+    const missingTargetResult = await tools[4].cb({ action: 'off' });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(0);
+    expect(missingTargetResult.content[0].text).to.eq(
+      'device.turn-off: missing target. Provide device name, or both room and device_category. Never call with only action.',
+    );
 
     const turnOnResult = await tools[4].cb({ action: 'on', device: 'Living Room Light' });
     expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);

--- a/server/test/services/mcp/lib/mcpToolsToChatApiFormat.test.js
+++ b/server/test/services/mcp/lib/mcpToolsToChatApiFormat.test.js
@@ -1,0 +1,32 @@
+const { expect } = require('chai');
+const {
+  applyDeviceTargetingSchema,
+  toolNameFromIntent,
+} = require('../../../../services/mcp/lib/mcpToolsToChatApiFormat');
+
+describe('mcpToolsToChatApiFormat', () => {
+  it('should convert intent names to chat API function names', () => {
+    expect(toolNameFromIntent('device.turn-on-off')).to.equal('device_turn_on_off');
+  });
+});
+
+describe('applyDeviceTargetingSchema', () => {
+  it('should keep action in required and add anyOf branches', () => {
+    const parameters = applyDeviceTargetingSchema({
+      type: 'object',
+      properties: {
+        action: { type: 'string' },
+        device: { type: 'string' },
+        room: { type: 'string' },
+        device_category: { type: 'string' },
+      },
+      required: ['action'],
+    });
+
+    expect(parameters.required).to.deep.equal(['action']);
+    expect(parameters.anyOf).to.deep.equal([
+      { required: ['action', 'device'] },
+      { required: ['action', 'room', 'device_category'] },
+    ]);
+  });
+});


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

AI : Fix device-turn-on-off schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device control requests now require explicit targeting: either a specific device, or a room plus a device category.
  * Tool definitions provided to clients now include schema rules that mirror this targeting contract for stronger client-side validation.

* **Bug Fixes**
  * Added clear errors for action-only requests (“missing target”), mixed targeting inputs (“mixed targeting”), and non-existent device lookups (“no device found matching …”).
  * Ensures invalid targeting inputs do not trigger device commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->