### PR TITLE
AI: Debug file should contain last 50 messages

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -2237,7 +2237,7 @@
       },
       "debugContext": {
         "title": "KI-Debug",
-        "description": "Erweiterte Funktion: lädt den JSON-Kontext herunter, der an die KI gesendet wird (System-Prompt, die letzten 10 Nachrichten der Unterhaltung und verfügbare Tools). Nützlich zum Reproduzieren und Diagnostizieren von Benutzerproblemen.",
+        "description": "Erweiterte Funktion: lädt den JSON-Kontext herunter, der an die KI gesendet wird (System-Prompt, die letzten 50 Nachrichten der Unterhaltung und verfügbare Tools). Nützlich zum Reproduzieren und Diagnostizieren von Benutzerproblemen.",
         "downloadButton": "JSON-Kontext für Debug herunterladen",
         "error": "Debug-Kontext konnte nicht erstellt werden. Stelle sicher, dass der MCP-Dienst läuft."
       },

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -2237,7 +2237,7 @@
       },
       "debugContext": {
         "title": "AI debug",
-        "description": "Advanced feature: download the JSON context sent to the AI (system prompt, last 10 conversation messages, and available tools). Useful for reproducing and diagnosing user issues.",
+        "description": "Advanced feature: download the JSON context sent to the AI (system prompt, last 50 conversation messages, and available tools). Useful for reproducing and diagnosing user issues.",
         "downloadButton": "Download JSON context for debug",
         "error": "Unable to generate debug context. Make sure the MCP service is running."
       },

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -2237,7 +2237,7 @@
       },
       "debugContext": {
         "title": "Debug IA",
-        "description": "Fonctionnalité avancée : télécharge le contexte JSON transmis à l'IA (prompt système, 10 derniers messages de la conversation et outils disponibles). Utile pour reproduire et diagnostiquer les problèmes rencontrés par les utilisateurs.",
+        "description": "Fonctionnalité avancée : télécharge le contexte JSON transmis à l'IA (prompt système, 50 derniers messages de la conversation et outils disponibles). Utile pour reproduire et diagnostiquer les problèmes rencontrés par les utilisateurs.",
         "downloadButton": "Télécharger le contexte JSON pour debug",
         "error": "Impossible de générer le contexte de debug. Vérifiez que le service MCP est démarré."
       },

--- a/server/lib/gateway/gateway.getAiChatDebugContext.js
+++ b/server/lib/gateway/gateway.getAiChatDebugContext.js
@@ -6,7 +6,7 @@ const { mcpToolsToChatApiFormat } = require('../../services/mcp/lib/mcpToolsToCh
 const { buildSystemPromptWithCurrentTime } = require('./gateway.forwardMessageToAiChat');
 
 const DEFAULT_TIMEZONE = 'Europe/Paris';
-const DEBUG_MESSAGE_LIMIT = 10;
+const DEBUG_MESSAGE_LIMIT = 50;
 
 /**
  * @description Return MCP handler from service manager.
@@ -68,7 +68,7 @@ function dbMessageToApiMessage(message, userId) {
 /**
  * @public
  * @description Build the AI chat request payload for debug/replay purposes.
- * Includes the system prompt, the last 10 conversation messages, and available MCP tools.
+ * Includes the system prompt, the last 50 conversation messages, and available MCP tools.
  * @param {string} userId - Gladys user id.
  * @returns {Promise<object>} OpenAI-compatible chat request body.
  * @example

--- a/server/test/lib/gateway/gateway.getAiChatDebugContext.test.js
+++ b/server/test/lib/gateway/gateway.getAiChatDebugContext.test.js
@@ -115,7 +115,7 @@ describe('gateway.getAiChatDebugContext', () => {
     expect(payload._debug.messageCount).to.equal(2);
 
     assert.calledOnce(messageFindAll);
-    expect(messageFindAll.firstCall.args[0].limit).to.equal(10);
+    expect(messageFindAll.firstCall.args[0].limit).to.equal(50);
   });
 
   it('should throw when MCP service is not running', async () => {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

AI: Debug file should contain last 50 messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The AI debug context download now includes the last 50 conversation messages instead of 10.
  * The downloaded JSON still includes the system prompt and available tools.

* **Documentation**
  * Updated the AI debug description text in English, German, and French to match the new 50-message context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->