### PR TITLE
MQTT : Add copy button for credentials/url

### DIFF
--- a/front/src/routes/integration/all/mqtt/setup-page/SetupForm.jsx
+++ b/front/src/routes/integration/all/mqtt/setup-page/SetupForm.jsx
@@ -34,10 +34,10 @@ class SetupForm extends Component {
     }
   };
 
-  copyValue = async value => {
+  copyValue = async (fieldId, value) => {
     if (typeof navigator !== 'undefined' && navigator.clipboard && navigator.clipboard.writeText) {
       await navigator.clipboard.writeText(value);
-      this.setState({ copiedField: value });
+      this.setState({ copiedField: fieldId });
       if (this.copyTimer) {
         clearTimeout(this.copyTimer);
       }
@@ -56,7 +56,7 @@ class SetupForm extends Component {
     }
   }
 
-  renderCopyButton = (value, dataCy) => {
+  renderCopyButton = (fieldId, value, dataCy) => {
     const canCopy = typeof window !== 'undefined' && window.isSecureContext;
 
     if (!canCopy || !value) {
@@ -65,22 +65,27 @@ class SetupForm extends Component {
 
     return (
       <span class="input-group-append">
-        <button type="button" class="btn btn-outline-secondary" onClick={() => this.copyValue(value)} data-cy={dataCy}>
+        <button
+          type="button"
+          class="btn btn-outline-secondary"
+          onClick={() => this.copyValue(fieldId, value)}
+          data-cy={dataCy}
+        >
           <i class="fe fe-copy" />
         </button>
       </span>
     );
   };
 
-  renderCopiedFeedback = value => {
+  renderCopiedFeedback = fieldId => {
     const canCopy = typeof window !== 'undefined' && window.isSecureContext;
 
-    if (!canCopy || this.state.copiedField !== value) {
+    if (!canCopy || this.state.copiedField !== fieldId) {
       return null;
     }
 
     return (
-      <small class="text-success">
+      <small class="text-success d-block mt-1">
         <Text id="integration.mqtt.feature.copied" />
       </small>
     );
@@ -106,9 +111,9 @@ class SetupForm extends Component {
                 disabled={props.useEmbeddedBroker || gladysNotAvailable}
               />
             </Localizer>
-            {this.renderCopyButton(props.mqttUrl, 'mqtt-setup-url-copy-button')}
+            {this.renderCopyButton('mqttUrl', props.mqttUrl, 'mqtt-setup-url-copy-button')}
           </div>
-          {this.renderCopiedFeedback(props.mqttUrl)}
+          {this.renderCopiedFeedback('mqttUrl')}
         </div>
 
         <div class="form-group">
@@ -128,9 +133,9 @@ class SetupForm extends Component {
                 disabled={gladysNotAvailable}
               />
             </Localizer>
-            {this.renderCopyButton(props.mqttUsername, 'mqtt-setup-username-copy-button')}
+            {this.renderCopyButton('mqttUsername', props.mqttUsername, 'mqtt-setup-username-copy-button')}
           </div>
-          {this.renderCopiedFeedback(props.mqttUsername)}
+          {this.renderCopiedFeedback('mqttUsername')}
         </div>
 
         <div class="form-group">
@@ -165,14 +170,14 @@ class SetupForm extends Component {
               <button
                 type="button"
                 class="btn btn-outline-secondary"
-                onClick={() => this.copyValue(props.mqttPassword)}
+                onClick={() => this.copyValue('mqttPassword', props.mqttPassword)}
                 data-cy="mqtt-setup-password-copy-button"
               >
                 <i class="fe fe-copy" />
               </button>
             )}
-            {this.renderCopiedFeedback(props.mqttPassword)}
           </div>
+          {this.renderCopiedFeedback('mqttPassword')}
         </div>
 
         <div class="form-group">

--- a/front/src/routes/integration/all/mqtt/setup-page/SetupForm.jsx
+++ b/front/src/routes/integration/all/mqtt/setup-page/SetupForm.jsx
@@ -5,6 +5,7 @@ import cx from 'classnames';
 
 class SetupForm extends Component {
   showPasswordTimer = null;
+  copyTimer = null;
 
   updateUrl = e => {
     this.props.updateConfiguration({ mqttUrl: e.target.value });
@@ -33,12 +34,57 @@ class SetupForm extends Component {
     }
   };
 
+  copyValue = async value => {
+    if (typeof navigator !== 'undefined' && navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(value);
+      this.setState({ copiedField: value });
+      if (this.copyTimer) {
+        clearTimeout(this.copyTimer);
+      }
+      this.copyTimer = setTimeout(() => this.setState({ copiedField: null }), 2000);
+    }
+  };
+
   componentWillUnmount() {
     if (this.showPasswordTimer) {
       clearTimeout(this.showPasswordTimer);
       this.showPasswordTimer = null;
     }
+    if (this.copyTimer) {
+      clearTimeout(this.copyTimer);
+      this.copyTimer = null;
+    }
   }
+
+  renderCopyButton = (value, dataCy) => {
+    const canCopy = typeof window !== 'undefined' && window.isSecureContext;
+
+    if (!canCopy || !value) {
+      return null;
+    }
+
+    return (
+      <span class="input-group-append">
+        <button type="button" class="btn btn-outline-secondary" onClick={() => this.copyValue(value)} data-cy={dataCy}>
+          <i class="fe fe-copy" />
+        </button>
+      </span>
+    );
+  };
+
+  renderCopiedFeedback = value => {
+    const canCopy = typeof window !== 'undefined' && window.isSecureContext;
+
+    if (!canCopy || this.state.copiedField !== value) {
+      return null;
+    }
+
+    return (
+      <small class="text-success">
+        <Text id="integration.mqtt.feature.copied" />
+      </small>
+    );
+  };
 
   render(props, { showPassword }) {
     const gladysNotAvailable = props.mqttConnectionError === RequestStatus.NetworkError;
@@ -48,63 +94,84 @@ class SetupForm extends Component {
           <label for="mqttUrl" class="form-label">
             <Text id={`integration.mqtt.setup.urlLabel`} />
           </label>
-          <Localizer>
-            <input
-              id="mqttUrl"
-              name="mqttUrl"
-              placeholder={<Text id="integration.mqtt.setup.urlPlaceholder" />}
-              value={props.mqttUrl}
-              class="form-control"
-              onInput={this.updateUrl}
-              disabled={props.useEmbeddedBroker || gladysNotAvailable}
-            />
-          </Localizer>
+          <div class="input-group">
+            <Localizer>
+              <input
+                id="mqttUrl"
+                name="mqttUrl"
+                placeholder={<Text id="integration.mqtt.setup.urlPlaceholder" />}
+                value={props.mqttUrl}
+                class="form-control"
+                onInput={this.updateUrl}
+                disabled={props.useEmbeddedBroker || gladysNotAvailable}
+              />
+            </Localizer>
+            {this.renderCopyButton(props.mqttUrl, 'mqtt-setup-url-copy-button')}
+          </div>
+          {this.renderCopiedFeedback(props.mqttUrl)}
         </div>
 
         <div class="form-group">
           <label for="mqttUsername" class="form-label">
             <Text id={`integration.mqtt.setup.userLabel`} />
           </label>
-          <Localizer>
-            <input
-              id="mqttUsername"
-              name="mqttUsername"
-              placeholder={<Text id="integration.mqtt.setup.userPlaceholder" />}
-              value={props.mqttUsername}
-              class="form-control"
-              onInput={this.updateUsername}
-              autocomplete="off"
-              disabled={gladysNotAvailable}
-            />
-          </Localizer>
+          <div class="input-group">
+            <Localizer>
+              <input
+                id="mqttUsername"
+                name="mqttUsername"
+                placeholder={<Text id="integration.mqtt.setup.userPlaceholder" />}
+                value={props.mqttUsername}
+                class="form-control"
+                onInput={this.updateUsername}
+                autocomplete="off"
+                disabled={gladysNotAvailable}
+              />
+            </Localizer>
+            {this.renderCopyButton(props.mqttUsername, 'mqtt-setup-username-copy-button')}
+          </div>
+          {this.renderCopiedFeedback(props.mqttUsername)}
         </div>
 
         <div class="form-group">
           <label for="mqttPassword" class="form-label">
             <Text id={`integration.mqtt.setup.passwordLabel`} />
           </label>
-          <div class="input-icon mb-3">
-            <Localizer>
-              <input
-                id="mqttPassword"
-                name="mqttPassword"
-                type={showPassword ? 'text' : 'password'}
-                placeholder={<Text id="integration.mqtt.setup.passwordPlaceholder" />}
-                value={props.mqttPassword}
-                class="form-control"
-                onInput={this.updatePassword}
-                autocomplete="off"
-                disabled={gladysNotAvailable}
-              />
-            </Localizer>
-            <span class="input-icon-addon cursor-pointer" onClick={this.togglePassword}>
-              <i
-                class={cx('fe', {
-                  'fe-eye': !showPassword,
-                  'fe-eye-off': showPassword
-                })}
-              />
-            </span>
+          <div class="d-flex align-items-start flex-wrap" style="gap: 0.5rem;">
+            <div class="input-icon mb-0 flex-grow-1" style="min-width: 0;">
+              <Localizer>
+                <input
+                  id="mqttPassword"
+                  name="mqttPassword"
+                  type={showPassword ? 'text' : 'password'}
+                  placeholder={<Text id="integration.mqtt.setup.passwordPlaceholder" />}
+                  value={props.mqttPassword}
+                  class="form-control"
+                  onInput={this.updatePassword}
+                  autocomplete="off"
+                  disabled={gladysNotAvailable}
+                />
+              </Localizer>
+              <span class="input-icon-addon cursor-pointer" onClick={this.togglePassword}>
+                <i
+                  class={cx('fe', {
+                    'fe-eye': !showPassword,
+                    'fe-eye-off': showPassword
+                  })}
+                />
+              </span>
+            </div>
+            {typeof window !== 'undefined' && window.isSecureContext && props.mqttPassword && (
+              <button
+                type="button"
+                class="btn btn-outline-secondary"
+                onClick={() => this.copyValue(props.mqttPassword)}
+                data-cy="mqtt-setup-password-copy-button"
+              >
+                <i class="fe fe-copy" />
+              </button>
+            )}
+            {this.renderCopiedFeedback(props.mqttPassword)}
           </div>
         </div>
 


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.

### Description of change

MQTT : Add copy button for credentials/url

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one-click copy buttons for MQTT connection details (server URL, username, and password when provided).
  * Displays a brief “copied” confirmation after successfully copying a field.

* **Bug Fixes**
  * Copy actions are now available only in secure browser contexts and only for fields that contain a value, avoiding confusing or unusable options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->