### PR TITLE
feat(energy-monitoring): gestion nuit & week-end pour contrats Enercoop

### DIFF
--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -1867,7 +1867,10 @@
         "any": "any",
         "red": "red",
         "white": "white",
-        "blue": "blue"
+        "blue": "blue",
+        "weekday": "weekday",
+        "weekend": "weekend",
+        "holiday": "public holidays"
       },
       "electricMeter": "Electric Meter",
       "leaveEndDateEmpty": "Leave the end date empty for an open period.",
@@ -1876,6 +1879,8 @@
       "hourSlots": "Time Slots",
       "selectHoursHelp": "Select the hours when this price applies.",
       "daytime820": "Daytime 8-20",
+      "night2306": "Night 11pm-6am",
+      "allDay": "All day",
       "clear": "Clear",
       "selected": "Selected:",
       "none": "none",
@@ -1888,6 +1893,7 @@
       "contractTypes": {
         "base": "base",
         "peak-off-peak": "peak/off-peak hours",
+        "night-weekend": "night & weekend",
         "edf-tempo": "EDF Tempo"
       },
       "priceTypes": {

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -610,7 +610,10 @@
         "any": "tous",
         "red": "rouge",
         "white": "blanc",
-        "blue": "bleu"
+        "blue": "bleu",
+        "weekday": "semaine",
+        "weekend": "week-end",
+        "holiday": "jours fériés"
       },
       "electricMeter": "Compteur électrique",
       "leaveEndDateEmpty": "Laissez la date de fin vide pour une période ouverte.",
@@ -619,6 +622,8 @@
       "hourSlots": "Créneaux horaires",
       "selectHoursHelp": "Sélectionnez les heures auxquelles ce prix s'applique.",
       "daytime820": "Journée 8-20",
+      "night2306": "Nuit 23h-6h",
+      "allDay": "Toute la journée",
       "clear": "Effacer",
       "selected": "Sélectionné :",
       "none": "aucun",
@@ -631,6 +636,7 @@
       "contractTypes": {
         "base": "base",
         "peak-off-peak": "heures pleines/creuses",
+        "night-weekend": "nuit & week-end",
         "edf-tempo": "EDF Tempo"
       },
       "priceTypes": {

--- a/front/src/routes/integration/all/energy-monitoring/EnergyMonitoring.jsx
+++ b/front/src/routes/integration/all/energy-monitoring/EnergyMonitoring.jsx
@@ -132,6 +132,27 @@ class EnergyMonitoringPage extends Component {
     return arr.map(this.slotIndexToLabel).join(',');
   };
 
+  isCalendarContract = contract => contract === 'night-weekend' || contract === 'peak-off-peak';
+
+  isTempoContract = contract => contract === 'edf-tempo';
+
+  getNightHourSlots = () => new Set([46, 47, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+
+  getAllHourSlots = () => new Set(Array.from({ length: 48 }, (_, slot) => slot));
+
+  handleContractChange = contract => {
+    this.setState(({ newPrice }) => {
+      const updates = { contract };
+      if (contract === 'night-weekend' && (newPrice.day_type === 'any' || !newPrice.day_type)) {
+        updates.day_type = 'weekday';
+      }
+      if (contract === 'edf-tempo' && ['weekday', 'weekend', 'holiday'].includes(newPrice.day_type)) {
+        updates.day_type = 'any';
+      }
+      return { newPrice: { ...newPrice, ...updates } };
+    });
+  };
+
   calculateFromBeginning = async () => {
     try {
       this.setState({ calculatingFromBeginning: true, settingsError: null, settingsSuccess: null });
@@ -318,6 +339,8 @@ class EnergyMonitoringPage extends Component {
       // Save hour slots from wizardHourSlots as comma-separated HH:MM string
       if (this.state.wizardHourSlots && this.state.wizardHourSlots.size > 0) {
         payload.hour_slots = this.formatSetToHourSlots(this.state.wizardHourSlots);
+      } else if (['weekend', 'holiday'].includes(payload.day_type)) {
+        payload.hour_slots = '';
       }
       // Convert empty end_date to null
       if (payload.end_date === '' || payload.end_date === 'Invalid date') {
@@ -720,6 +743,9 @@ class EnergyMonitoringPage extends Component {
     // Peak hours are typically during the day (e.g., 08:00-12:00, 18:00-22:00)
     // Off-peak hours typically include night hours (00:00-06:00)
     const isPeakPrice = p => {
+      if (p.day_type === 'weekend' || p.day_type === 'holiday') {
+        return false;
+      }
       if (!p.hour_slots || String(p.hour_slots).trim().length === 0) {
         // No hour slots = base contract, not peak/off-peak
         return null;
@@ -758,6 +784,12 @@ class EnergyMonitoringPage extends Component {
           return '#868e96'; // gray
         case 'red':
           return '#fa5252'; // red
+        case 'weekday':
+          return '#228be6';
+        case 'weekend':
+          return '#7950f2';
+        case 'holiday':
+          return '#e64980';
         default:
           return null;
       }
@@ -789,7 +821,7 @@ class EnergyMonitoringPage extends Component {
 
     // Sort prices within a group: by day_type, then by peak/off-peak
     const sortPricesInGroup = prices => {
-      const dayTypeOrder = { blue: 0, white: 1, red: 2, any: 3 };
+      const dayTypeOrder = { blue: 0, white: 1, red: 2, weekday: 3, weekend: 4, holiday: 5, any: 6 };
       return [...prices].sort((a, b) => {
         // First sort by day_type
         const dayA = dayTypeOrder[a.day_type] !== undefined ? dayTypeOrder[a.day_type] : 99;
@@ -1027,13 +1059,16 @@ class EnergyMonitoringPage extends Component {
                       <select
                         class="form-control"
                         value={state.newPrice.contract}
-                        onChange={e => updateNewPrice({ contract: e.target.value })}
+                        onChange={e => this.handleContractChange(e.target.value)}
                       >
                         <option value="base">
                           <Text id="integration.energyMonitoring.contractTypes.base" />
                         </option>
                         <option value="peak-off-peak">
                           <Text id="integration.energyMonitoring.contractTypes.peak-off-peak" />
+                        </option>
+                        <option value="night-weekend">
+                          <Text id="integration.energyMonitoring.contractTypes.night-weekend" />
                         </option>
                         <option value="edf-tempo">
                           <Text id="integration.energyMonitoring.contractTypes.edf-tempo" />
@@ -1132,18 +1167,45 @@ class EnergyMonitoringPage extends Component {
                         value={state.newPrice.day_type}
                         onChange={e => updateNewPrice({ day_type: e.target.value })}
                       >
-                        <option value="any">
-                          <Text id="integration.energyMonitoring.dayTypeOptions.any" />
-                        </option>
-                        <option value="red">
-                          <Text id="integration.energyMonitoring.dayTypeOptions.red" />
-                        </option>
-                        <option value="white">
-                          <Text id="integration.energyMonitoring.dayTypeOptions.white" />
-                        </option>
-                        <option value="blue">
-                          <Text id="integration.energyMonitoring.dayTypeOptions.blue" />
-                        </option>
+                        {!this.isTempoContract(state.newPrice.contract) && !this.isCalendarContract(state.newPrice.contract) && (
+                          <option value="any">
+                            <Text id="integration.energyMonitoring.dayTypeOptions.any" />
+                          </option>
+                        )}
+                        {this.isTempoContract(state.newPrice.contract) && (
+                          <>
+                            <option value="any">
+                              <Text id="integration.energyMonitoring.dayTypeOptions.any" />
+                            </option>
+                            <option value="red">
+                              <Text id="integration.energyMonitoring.dayTypeOptions.red" />
+                            </option>
+                            <option value="white">
+                              <Text id="integration.energyMonitoring.dayTypeOptions.white" />
+                            </option>
+                            <option value="blue">
+                              <Text id="integration.energyMonitoring.dayTypeOptions.blue" />
+                            </option>
+                          </>
+                        )}
+                        {this.isCalendarContract(state.newPrice.contract) && (
+                          <>
+                            <option value="weekday">
+                              <Text id="integration.energyMonitoring.dayTypeOptions.weekday" />
+                            </option>
+                            <option value="weekend">
+                              <Text id="integration.energyMonitoring.dayTypeOptions.weekend" />
+                            </option>
+                            <option value="holiday">
+                              <Text id="integration.energyMonitoring.dayTypeOptions.holiday" />
+                            </option>
+                            {state.newPrice.contract === 'peak-off-peak' && (
+                              <option value="any">
+                                <Text id="integration.energyMonitoring.dayTypeOptions.any" />
+                              </option>
+                            )}
+                          </>
+                        )}
                       </select>
                     </div>
                   </div>
@@ -1213,6 +1275,26 @@ class EnergyMonitoringPage extends Component {
                           <Text id="integration.energyMonitoring.selectHoursHelp" />
                         </div>
                         <div>
+                          {this.isCalendarContract(state.newPrice.contract) && (
+                            <>
+                              <button
+                                type="button"
+                                class="btn btn-sm btn-outline-secondary mr-2"
+                                onClick={() => this.setState({ wizardHourSlots: this.getNightHourSlots() })}
+                              >
+                                <Text id="integration.energyMonitoring.night2306" />
+                              </button>
+                              {(state.newPrice.day_type === 'weekend' || state.newPrice.day_type === 'holiday') && (
+                                <button
+                                  type="button"
+                                  class="btn btn-sm btn-outline-secondary mr-2"
+                                  onClick={() => this.setState({ wizardHourSlots: this.getAllHourSlots() })}
+                                >
+                                  <Text id="integration.energyMonitoring.allDay" />
+                                </button>
+                              )}
+                            </>
+                          )}
                           <button
                             type="button"
                             class="btn btn-sm btn-outline-secondary mr-2"

--- a/front/src/routes/integration/all/energy-monitoring/ImportPrices.jsx
+++ b/front/src/routes/integration/all/energy-monitoring/ImportPrices.jsx
@@ -10,7 +10,7 @@ import {
   DEVICE_FEATURE_UNITS
 } from '../../../../../../server/utils/constants';
 
-const KNOWN_CONTRACT_TYPES = ['peak-off-peak', 'tempo', 'base'];
+const KNOWN_CONTRACT_TYPES = ['night-weekend', 'peak-off-peak', 'tempo', 'base'];
 
 class ImportPricesPage extends Component {
   state = {

--- a/server/services/energy-monitoring/contracts/contracts.calculateCost.js
+++ b/server/services/energy-monitoring/contracts/contracts.calculateCost.js
@@ -3,9 +3,22 @@ const timezone = require('dayjs/plugin/timezone');
 
 dayjs.extend(timezone);
 
-const { ENERGY_CONTRACT_TYPES } = require('../../../utils/constants');
+const { ENERGY_CONTRACT_TYPES, ENERGY_PRICE_DAY_TYPES } = require('../../../utils/constants');
 const { NotFoundError } = require('../../../utils/coreErrors');
 const logger = require('../../../utils/logger');
+const { getConsumptionCalendarDayType } = require('./contracts.getConsumptionCalendarDayType');
+
+const TEMPO_DAY_TYPES = new Set([
+  ENERGY_PRICE_DAY_TYPES.RED,
+  ENERGY_PRICE_DAY_TYPES.BLUE,
+  ENERGY_PRICE_DAY_TYPES.WHITE,
+]);
+
+const CALENDAR_DAY_TYPES = new Set([
+  ENERGY_PRICE_DAY_TYPES.WEEKDAY,
+  ENERGY_PRICE_DAY_TYPES.WEEKEND,
+  ENERGY_PRICE_DAY_TYPES.HOLIDAY,
+]);
 
 /**
  * @description Convert a Date to an HH:MM slot label at 30-minute granularity.
@@ -20,6 +33,98 @@ function formatDateToSlotLabel(date, systemTimezone) {
   const minutes = dayjsDate.minute() >= 30 ? '30' : '00';
   const hh = hour < 10 ? `0${hour}` : `${hour}`;
   return `${hh}:${minutes}`;
+}
+
+/**
+ * @description Check if a price row applies to the current calendar day type.
+ * @param {object} price - The energy price row.
+ * @param {string} calendarDayType - The resolved calendar day type.
+ * @returns {boolean} True when the price applies to this day.
+ */
+function priceMatchesCalendarDayType(price, calendarDayType) {
+  const { day_type: dayType } = price;
+  if (!dayType || dayType === 'any') {
+    return true;
+  }
+  if (TEMPO_DAY_TYPES.has(dayType)) {
+    return true;
+  }
+  return dayType === calendarDayType;
+}
+
+/**
+ * @description Check if hour slots match, with all-day support for weekend/holiday rows.
+ * @param {object} price - The energy price row.
+ * @param {string} label - The HH:MM slot label.
+ * @returns {boolean} True when the price applies to this time slot.
+ */
+function priceMatchesHourSlot(price, label) {
+  const hourSlots = (price.hour_slots || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (hourSlots.length === 0) {
+    const { day_type: dayType } = price;
+    return dayType === ENERGY_PRICE_DAY_TYPES.WEEKEND || dayType === ENERGY_PRICE_DAY_TYPES.HOLIDAY;
+  }
+
+  return hourSlots.includes(label);
+}
+
+/**
+ * @description Determine if calendar day filtering should be applied.
+ * @param {string} contract - The contract type.
+ * @param {Array} energyPricesAtConsumptionDate - The price rows for the consumption date.
+ * @returns {boolean} True when day-of-week filtering is required.
+ */
+function usesCalendarDayFiltering(contract, energyPricesAtConsumptionDate) {
+  if (contract === ENERGY_CONTRACT_TYPES.NIGHT_WEEKEND) {
+    return true;
+  }
+  if (contract === ENERGY_CONTRACT_TYPES.PEAK_OFF_PEAK) {
+    return energyPricesAtConsumptionDate.some((price) => CALENDAR_DAY_TYPES.has(price.day_type));
+  }
+  return false;
+}
+
+/**
+ * @description Calculate cost for peak/off-peak contracts, optionally filtered by calendar day type.
+ * @param {Array} energyPricesAtConsumptionDate - The price rows for the consumption date.
+ * @param {Date} consumptionDate - The date of the consumption sample.
+ * @param {number} consumptionValue - The consumption value in kWh.
+ * @param {string} systemTimezone - The timezone of the system.
+ * @param {string} contract - The contract type.
+ * @returns {number} The calculated cost.
+ */
+function calculatePeakOffPeakCost(
+  energyPricesAtConsumptionDate,
+  consumptionDate,
+  consumptionValue,
+  systemTimezone,
+  contract,
+) {
+  const label = formatDateToSlotLabel(consumptionDate, systemTimezone);
+  let pricesToSearch = energyPricesAtConsumptionDate;
+
+  if (usesCalendarDayFiltering(contract, energyPricesAtConsumptionDate)) {
+    const calendarDayType = getConsumptionCalendarDayType(consumptionDate, systemTimezone);
+    pricesToSearch = energyPricesAtConsumptionDate.filter((price) =>
+      priceMatchesCalendarDayType(price, calendarDayType),
+    );
+
+    if (pricesToSearch.length === 0) {
+      throw new NotFoundError(`No price found for calendar day type ${calendarDayType}`);
+    }
+  }
+
+  const price = pricesToSearch.find((p) => priceMatchesHourSlot(p, label));
+  if (!price) {
+    throw new NotFoundError(`No price found for time slot ${label}`);
+  }
+
+  const cost = (price.price / 10000) * consumptionValue;
+  return cost;
 }
 
 module.exports = {
@@ -38,22 +143,27 @@ module.exports = {
     consumptionValue,
     systemTimezone,
   ) => {
-    // Compute the HH:MM slot label
-    const label = formatDateToSlotLabel(consumptionDate, systemTimezone);
-    // Find the price for this time slot
-    const price = energyPricesAtConsumptionDate.find((p) => {
-      const hourSlots = (p.hour_slots || '')
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean);
-      return hourSlots.includes(label);
-    });
-    if (!price) {
-      throw new NotFoundError(`No price found for time slot ${label}`);
-    }
-    // Price are stored as integer with 4 decimals
-    const cost = (price.price / 10000) * consumptionValue;
-    return cost;
+    return calculatePeakOffPeakCost(
+      energyPricesAtConsumptionDate,
+      consumptionDate,
+      consumptionValue,
+      systemTimezone,
+      ENERGY_CONTRACT_TYPES.PEAK_OFF_PEAK,
+    );
+  },
+  [ENERGY_CONTRACT_TYPES.NIGHT_WEEKEND]: async (
+    energyPricesAtConsumptionDate,
+    consumptionDate,
+    consumptionValue,
+    systemTimezone,
+  ) => {
+    return calculatePeakOffPeakCost(
+      energyPricesAtConsumptionDate,
+      consumptionDate,
+      consumptionValue,
+      systemTimezone,
+      ENERGY_CONTRACT_TYPES.NIGHT_WEEKEND,
+    );
   },
   [ENERGY_CONTRACT_TYPES.EDF_TEMPO]: async (
     energyPricesAtConsumptionDate,

--- a/server/services/energy-monitoring/contracts/contracts.getConsumptionCalendarDayType.js
+++ b/server/services/energy-monitoring/contracts/contracts.getConsumptionCalendarDayType.js
@@ -1,0 +1,33 @@
+const dayjs = require('dayjs');
+const timezone = require('dayjs/plugin/timezone');
+
+dayjs.extend(timezone);
+
+const { ENERGY_PRICE_DAY_TYPES } = require('../../../utils/constants');
+const { isFrenchPublicHoliday } = require('./contracts.isFrenchPublicHoliday');
+
+/**
+ * @description Resolve the calendar day type for energy pricing (weekday, weekend, or holiday).
+ * @param {Date} consumptionDate - The date of the consumption sample.
+ * @param {string} systemTimezone - The timezone of the system.
+ * @returns {string} One of ENERGY_PRICE_DAY_TYPES.WEEKDAY, WEEKEND, or HOLIDAY.
+ */
+function getConsumptionCalendarDayType(consumptionDate, systemTimezone) {
+  const date = dayjs(consumptionDate).tz(systemTimezone);
+  const dateString = date.format('YYYY-MM-DD');
+
+  if (isFrenchPublicHoliday(dateString)) {
+    return ENERGY_PRICE_DAY_TYPES.HOLIDAY;
+  }
+
+  const dayOfWeek = date.day();
+  if (dayOfWeek === 0 || dayOfWeek === 6) {
+    return ENERGY_PRICE_DAY_TYPES.WEEKEND;
+  }
+
+  return ENERGY_PRICE_DAY_TYPES.WEEKDAY;
+}
+
+module.exports = {
+  getConsumptionCalendarDayType,
+};

--- a/server/services/energy-monitoring/contracts/contracts.isFrenchPublicHoliday.js
+++ b/server/services/energy-monitoring/contracts/contracts.isFrenchPublicHoliday.js
@@ -1,0 +1,69 @@
+const dayjs = require('dayjs');
+
+/**
+ * @description Compute Easter Sunday for a given year (Gregorian calendar).
+ * @param {number} year - The year.
+ * @returns {dayjs.Dayjs} Easter Sunday date.
+ */
+function getEasterSunday(year) {
+  const a = year % 19;
+  const b = Math.floor(year / 100);
+  const c = year % 100;
+  const d = Math.floor(b / 4);
+  const e = b % 4;
+  const f = Math.floor((b + 8) / 25);
+  const g = Math.floor((b - f + 1) / 3);
+  const h = (19 * a + b - d - g + 15) % 30;
+  const i = Math.floor(c / 4);
+  const k = c % 4;
+  const l = (32 + 2 * e + 2 * i - h - k) % 7;
+  const m = Math.floor((a + 11 * h + 22 * l) / 451);
+  const month = Math.floor((h + l - 7 * m + 114) / 31);
+  const day = ((h + l - 7 * m + 114) % 31) + 1;
+  return dayjs(`${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`);
+}
+
+/**
+ * @description Build the set of French national public holidays for a given year.
+ * @param {number} year - The year.
+ * @returns {Set<string>} Set of dates formatted as YYYY-MM-DD.
+ */
+function getFrenchPublicHolidaysForYear(year) {
+  const easterSunday = getEasterSunday(year);
+  const holidays = [
+    dayjs(`${year}-01-01`),
+    easterSunday.add(1, 'day'),
+    dayjs(`${year}-05-01`),
+    dayjs(`${year}-05-08`),
+    easterSunday.add(39, 'day'),
+    easterSunday.add(50, 'day'),
+    dayjs(`${year}-07-14`),
+    dayjs(`${year}-08-15`),
+    dayjs(`${year}-11-01`),
+    dayjs(`${year}-11-11`),
+    dayjs(`${year}-12-25`),
+  ];
+
+  return new Set(holidays.map((date) => date.format('YYYY-MM-DD')));
+}
+
+const holidaysCache = new Map();
+
+/**
+ * @description Check if a date is a French national public holiday.
+ * @param {string} dateString - The date formatted as YYYY-MM-DD.
+ * @returns {boolean} True when the date is a French public holiday.
+ */
+function isFrenchPublicHoliday(dateString) {
+  const year = Number(dateString.split('-')[0]);
+  if (!holidaysCache.has(year)) {
+    holidaysCache.set(year, getFrenchPublicHolidaysForYear(year));
+  }
+  return holidaysCache.get(year).has(dateString);
+}
+
+module.exports = {
+  getEasterSunday,
+  getFrenchPublicHolidaysForYear,
+  isFrenchPublicHoliday,
+};

--- a/server/test/services/energy-monitoring/contracts/contracts.calculateCost.test.js
+++ b/server/test/services/energy-monitoring/contracts/contracts.calculateCost.test.js
@@ -121,6 +121,141 @@ describe('Contracts.calculateCost', () => {
 
       expect(cost).to.equal(1.5); // 0.1500 * 10 = 1.5 EUR (peak price)
     });
+
+    it('should filter by calendar day type when day_type is set', async () => {
+      const energyPricesAtConsumptionDate = [
+        {
+          price: 1000,
+          currency: 'EUR',
+          day_type: 'weekend',
+          hour_slots: '',
+        },
+        {
+          price: 1500,
+          currency: 'EUR',
+          day_type: 'weekday',
+          hour_slots: '08:00,08:30,09:00,16:00,16:30,17:00',
+        },
+        {
+          price: 1000,
+          currency: 'EUR',
+          day_type: 'weekday',
+          hour_slots: '00:00,00:30,01:00,22:00,22:30,23:00,23:30',
+        },
+      ];
+      const consumptionDate = new Date('2023-10-14T14:30:00.000Z'); // Saturday 16:30 Paris
+      const consumptionValue = 10;
+      const systemTimezone = 'Europe/Paris';
+
+      const cost = await contractsCalculateCost[ENERGY_CONTRACT_TYPES.PEAK_OFF_PEAK](
+        energyPricesAtConsumptionDate,
+        consumptionDate,
+        consumptionValue,
+        systemTimezone,
+      );
+
+      expect(cost).to.equal(1.0);
+    });
+  });
+
+  describe('NIGHT_WEEKEND contract', () => {
+    it('should apply off-peak price on weekday nights (23h-6h)', async () => {
+      const offPeakNightSlots =
+        '23:00,23:30,00:00,00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30';
+      const peakWeekdaySlots =
+        '06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30';
+
+      const energyPricesAtConsumptionDate = [
+        {
+          price: 1636,
+          currency: 'EUR',
+          day_type: 'weekday',
+          hour_slots: offPeakNightSlots,
+        },
+        {
+          price: 2929,
+          currency: 'EUR',
+          day_type: 'weekday',
+          hour_slots: peakWeekdaySlots,
+        },
+        {
+          price: 1636,
+          currency: 'EUR',
+          day_type: 'weekend',
+          hour_slots: '',
+        },
+        {
+          price: 1636,
+          currency: 'EUR',
+          day_type: 'holiday',
+          hour_slots: '',
+        },
+      ];
+
+      const consumptionDate = new Date('2024-03-12T22:30:00.000Z'); // Wednesday 23:30 Paris
+      const cost = await contractsCalculateCost[ENERGY_CONTRACT_TYPES.NIGHT_WEEKEND](
+        energyPricesAtConsumptionDate,
+        consumptionDate,
+        10,
+        'Europe/Paris',
+      );
+
+      expect(cost).to.be.closeTo(1.636, 0.001);
+    });
+
+    it('should apply off-peak price all day on weekends', async () => {
+      const energyPricesAtConsumptionDate = [
+        {
+          price: 1636,
+          currency: 'EUR',
+          day_type: 'weekend',
+          hour_slots: '',
+        },
+        {
+          price: 2929,
+          currency: 'EUR',
+          day_type: 'weekday',
+          hour_slots: '06:00,06:30,07:00',
+        },
+      ];
+
+      const consumptionDate = new Date('2024-03-16T10:00:00.000Z'); // Saturday 11:00 Paris
+      const cost = await contractsCalculateCost[ENERGY_CONTRACT_TYPES.NIGHT_WEEKEND](
+        energyPricesAtConsumptionDate,
+        consumptionDate,
+        5,
+        'Europe/Paris',
+      );
+
+      expect(cost).to.be.closeTo(0.818, 0.001);
+    });
+
+    it('should apply off-peak price all day on public holidays', async () => {
+      const energyPricesAtConsumptionDate = [
+        {
+          price: 1636,
+          currency: 'EUR',
+          day_type: 'holiday',
+          hour_slots: '',
+        },
+        {
+          price: 2929,
+          currency: 'EUR',
+          day_type: 'weekday',
+          hour_slots: '10:00,10:30,11:00',
+        },
+      ];
+
+      const consumptionDate = new Date('2024-05-01T08:30:00.000Z'); // May 1st 10:30 Paris
+      const cost = await contractsCalculateCost[ENERGY_CONTRACT_TYPES.NIGHT_WEEKEND](
+        energyPricesAtConsumptionDate,
+        consumptionDate,
+        4,
+        'Europe/Paris',
+      );
+
+      expect(cost).to.be.closeTo(0.6544, 0.001);
+    });
   });
 
   describe('EDF_TEMPO contract', () => {

--- a/server/test/services/energy-monitoring/contracts/contracts.calendarDayTypes.test.js
+++ b/server/test/services/energy-monitoring/contracts/contracts.calendarDayTypes.test.js
@@ -1,0 +1,44 @@
+const { expect } = require('chai');
+const {
+  getFrenchPublicHolidaysForYear,
+  isFrenchPublicHoliday,
+} = require('../../../../services/energy-monitoring/contracts/contracts.isFrenchPublicHoliday');
+const {
+  getConsumptionCalendarDayType,
+} = require('../../../../services/energy-monitoring/contracts/contracts.getConsumptionCalendarDayType');
+const { ENERGY_PRICE_DAY_TYPES } = require('../../../../utils/constants');
+
+describe('contracts.isFrenchPublicHoliday', () => {
+  it('should include fixed French national holidays', () => {
+    const holidays2024 = getFrenchPublicHolidaysForYear(2024);
+    expect(holidays2024.has('2024-01-01')).to.equal(true);
+    expect(holidays2024.has('2024-05-01')).to.equal(true);
+    expect(holidays2024.has('2024-07-14')).to.equal(true);
+    expect(holidays2024.has('2024-12-25')).to.equal(true);
+  });
+
+  it('should include Easter Monday for 2024', () => {
+    expect(isFrenchPublicHoliday('2024-04-01')).to.equal(true);
+  });
+
+  it('should return false for regular weekdays', () => {
+    expect(isFrenchPublicHoliday('2024-03-12')).to.equal(false);
+  });
+});
+
+describe('contracts.getConsumptionCalendarDayType', () => {
+  it('should return weekday for a regular Tuesday', () => {
+    const dayType = getConsumptionCalendarDayType(new Date('2024-03-12T10:00:00.000Z'), 'Europe/Paris');
+    expect(dayType).to.equal(ENERGY_PRICE_DAY_TYPES.WEEKDAY);
+  });
+
+  it('should return weekend for a Saturday', () => {
+    const dayType = getConsumptionCalendarDayType(new Date('2024-03-16T10:00:00.000Z'), 'Europe/Paris');
+    expect(dayType).to.equal(ENERGY_PRICE_DAY_TYPES.WEEKEND);
+  });
+
+  it('should return holiday for a public holiday', () => {
+    const dayType = getConsumptionCalendarDayType(new Date('2024-05-01T10:00:00.000Z'), 'Europe/Paris');
+    expect(dayType).to.equal(ENERGY_PRICE_DAY_TYPES.HOLIDAY);
+  });
+});

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -1650,6 +1650,8 @@ const ENERGY_CONTRACT_TYPES = {
   BASE: 'base',
   // Generic peak off peak contract
   PEAK_OFF_PEAK: 'peak-off-peak',
+  // Night and weekend contract (e.g. Enercoop Flexibilité Nuit & Week-end)
+  NIGHT_WEEKEND: 'night-weekend',
   // EDF Tempo
   EDF_TEMPO: 'edf-tempo',
 };
@@ -1663,6 +1665,9 @@ const ENERGY_PRICE_DAY_TYPES = {
   RED: 'red',
   BLUE: 'blue',
   WHITE: 'white',
+  WEEKDAY: 'weekday',
+  WEEKEND: 'weekend',
+  HOLIDAY: 'holiday',
 };
 
 const createList = (obj) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Ajoute la gestion des tarifs **nuit & week-end** dans le suivi énergétique, pour les contrats comme l'offre Enercoop Flexibilité Nuit & Week-end ([discussion communauté](https://community.gladysassistant.com/t/contrat-enercoop/10307)).

Jusqu'ici, Gladys ne gérait que les heures pleines/creuses avec les mêmes créneaux tous les jours. Ce PR introduit la distinction entre **semaine**, **week-end** et **jours fériés nationaux français**.

### Changements

**Backend**
- Nouveau type de contrat `night-weekend`
- Nouveaux types de jour : `weekday`, `weekend`, `holiday`
- Calcul des jours fériés français (sans API externe)
- Extension du contrat `peak-off-peak` : filtrage optionnel par type de jour si configuré
- Créneaux vides sur week-end / jours fériés = tarif toute la journée

**Frontend**
- Nouveau type de contrat dans l'assistant de tarifs
- Sélecteur de type de jour adapté au contrat
- Raccourcis « Nuit 23h-6h » et « Toute la journée »
- Traductions FR/EN

### Configuration Enercoop (exemple)

Pour l'offre Flexibilité Nuit & Week-end, créer 4 lignes de prix consommation :

| Type de jour | Créneaux | Tarif |
|---|---|---|
| Semaine | 23h-6h | HC (heures creuses) |
| Semaine | 6h-23h | HP (heures pleines) |
| Week-end | (vide = toute la journée) | HC |
| Jours fériés | (vide = toute la journée) | HC |

### Tests

- 18 tests passent sur la logique de calcul et le calendrier
- Rétrocompatibilité des contrats HP/HC et Tempo existants

### Notes

- Les jours fériés sont calculés localement (jours fériés nationaux français uniquement, hors exceptions régionales comme l'Alsace-Moselle)
- L'import automatique depuis le dépôt `energy-contracts` pour Enercoop pourra être ajouté dans un PR séparé sur ce dépôt
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1ec7-2238-7157-af6d-072b7d8be6ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1ec7-2238-7157-af6d-072b7d8be6ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

