### PR TITLE
feat(energy): support contrats Enercoop (Nuit & Week-end, 2 Saisons)

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -733,8 +733,20 @@
       "contractTypes": {
         "base": "Basis",
         "peak-off-peak": "Haupt-/Nebenzeiten",
-        "edf-tempo": "EDF Tempo"
+        "edf-tempo": "EDF Tempo",
+        "enercoop-nuit-weekend": "Enercoop Nacht & Wochenende",
+        "enercoop-2-saisons": "Enercoop 2 Jahreszeiten"
       },
+      "rateType": "Tarifart",
+      "rateTypes": {
+        "peak": "Hauptzeit",
+        "off_peak": "Nebenzeit"
+      },
+      "enercoopContractHelp": "Enercoop-Verträge benötigen zwei Tarife: einen für Haupt- und einen für Nebenzeiten. Erstellen Sie zwei Einträge mit demselben Vertragsnamen. Zeitfenster, Wochenenden, Feiertage und Jahreszeiten werden automatisch berechnet.",
+      "schoolVacationZoneDescription": "Schulferienzone (optional). Nutzt die offizielle API des Bildungsministeriums. Schulferien beeinflussen die Enercoop-Tarife nicht, können aber für die Verbrauchsverfolgung nützlich sein.",
+      "schoolVacationZoneNone": "Nicht konfiguriert",
+      "schoolVacationZoneSuccess": "Schulferienzone gespeichert.",
+      "schoolVacationZoneError": "Fehler beim Speichern der Schulferienzone.",
       "priceTypes": {
         "consumption": "Verbrauch",
         "subscription": "Abonnement"

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -1888,8 +1888,20 @@
       "contractTypes": {
         "base": "base",
         "peak-off-peak": "peak/off-peak hours",
-        "edf-tempo": "EDF Tempo"
+        "edf-tempo": "EDF Tempo",
+        "enercoop-nuit-weekend": "Enercoop Night & Weekend",
+        "enercoop-2-saisons": "Enercoop 2 Seasons"
       },
+      "rateType": "Rate type",
+      "rateTypes": {
+        "peak": "peak hours",
+        "off_peak": "off-peak hours"
+      },
+      "enercoopContractHelp": "Enercoop contracts require two prices: one for peak hours and one for off-peak hours. Create two entries with the same contract name. Time slots, weekends, public holidays and seasons are calculated automatically.",
+      "schoolVacationZoneDescription": "School vacation zone (optional). Uses the official Ministry of Education API. School vacations do not affect Enercoop tariffs, but this information can be useful for consumption tracking.",
+      "schoolVacationZoneNone": "Not configured",
+      "schoolVacationZoneSuccess": "School vacation zone saved.",
+      "schoolVacationZoneError": "Error saving school vacation zone.",
       "priceTypes": {
         "consumption": "consumption",
         "subscription": "subscription"

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -631,8 +631,20 @@
       "contractTypes": {
         "base": "base",
         "peak-off-peak": "heures pleines/creuses",
-        "edf-tempo": "EDF Tempo"
+        "edf-tempo": "EDF Tempo",
+        "enercoop-nuit-weekend": "Enercoop Nuit & Week-end",
+        "enercoop-2-saisons": "Enercoop 2 Saisons"
       },
+      "rateType": "Type de tarif",
+      "rateTypes": {
+        "peak": "heures pleines",
+        "off_peak": "heures creuses"
+      },
+      "enercoopContractHelp": "Les contrats Enercoop nécessitent deux tarifs : un pour les heures pleines et un pour les heures creuses. Créez deux entrées avec le même nom de contrat. Les créneaux horaires, week-ends, jours fériés et saisons sont calculés automatiquement.",
+      "schoolVacationZoneDescription": "Zone de vacances scolaires (optionnel). Utilise l'API officielle du Ministère de l'Éducation. Les vacances scolaires n'affectent pas les tarifs Enercoop, mais cette information peut être utile pour le suivi de consommation.",
+      "schoolVacationZoneNone": "Non configurée",
+      "schoolVacationZoneSuccess": "Zone de vacances scolaires enregistrée.",
+      "schoolVacationZoneError": "Erreur lors de l'enregistrement de la zone de vacances scolaires.",
       "priceTypes": {
         "consumption": "consommation",
         "subscription": "abonnement"

--- a/front/src/routes/integration/all/energy-monitoring/EnergyMonitoring.jsx
+++ b/front/src/routes/integration/all/energy-monitoring/EnergyMonitoring.jsx
@@ -1290,80 +1290,82 @@ class EnergyMonitoringPage extends Component {
                   </div>
                 </div>
                 {!this.isEnercoopContract(state.newPrice.contract) && (
-                <div class="row">
-                  <div class="col-12">
-                    <div class="form-group">
-                      <label>
-                        <Text id="integration.energyMonitoring.hourSlots" />
-                      </label>
-                      <div class="mb-2 d-flex justify-content-between align-items-center">
-                        <div class="small text-muted">
-                          <Text id="integration.energyMonitoring.selectHoursHelp" />
-                        </div>
-                        <div>
-                          <button
-                            type="button"
-                            class="btn btn-sm btn-outline-secondary mr-2"
-                            onClick={() =>
-                              this.setState({ wizardHourSlots: new Set(Array.from({ length: 24 }, (_, i) => i + 16)) })
-                            }
-                          >
-                            <Text id="integration.energyMonitoring.daytime820" />
-                          </button>
-                          <button
-                            type="button"
-                            class="btn btn-sm btn-outline-secondary"
-                            onClick={() => this.setState({ wizardHourSlots: new Set() })}
-                          >
-                            <Text id="integration.energyMonitoring.clear" />
-                          </button>
-                        </div>
-                      </div>
-                      <div class="row">
-                        {Array.from({ length: 48 }, (_, slot) => (
-                          <div class="col-3 col-sm-2 mb-2" key={slot}>
+                  <div class="row">
+                    <div class="col-12">
+                      <div class="form-group">
+                        <label>
+                          <Text id="integration.energyMonitoring.hourSlots" />
+                        </label>
+                        <div class="mb-2 d-flex justify-content-between align-items-center">
+                          <div class="small text-muted">
+                            <Text id="integration.energyMonitoring.selectHoursHelp" />
+                          </div>
+                          <div>
                             <button
                               type="button"
-                              class={cx(
-                                'btn btn-sm btn-block text-center py-2 text-nowrap',
-                                state.wizardHourSlots.has(slot) ? 'btn-primary' : 'btn-outline-secondary'
-                              )}
+                              class="btn btn-sm btn-outline-secondary mr-2"
                               onClick={() =>
-                                this.setState(({ wizardHourSlots }) => {
-                                  const next = new Set(wizardHourSlots);
-                                  if (next.has(slot)) next.delete(slot);
-                                  else next.add(slot);
-                                  return { wizardHourSlots: next };
+                                this.setState({
+                                  wizardHourSlots: new Set(Array.from({ length: 24 }, (_, i) => i + 16))
                                 })
                               }
                             >
-                              {(() => {
-                                const hour = Math.floor(slot / 2);
-                                const m = slot % 2 === 1 ? '30' : '00';
-                                const hh = hour < 10 ? `0${hour}` : `${hour}`;
-                                return <span class="text-monospace font-weight-bold">{`${hh}:${m}`}</span>;
-                              })()}
+                              <Text id="integration.energyMonitoring.daytime820" />
+                            </button>
+                            <button
+                              type="button"
+                              class="btn btn-sm btn-outline-secondary"
+                              onClick={() => this.setState({ wizardHourSlots: new Set() })}
+                            >
+                              <Text id="integration.energyMonitoring.clear" />
                             </button>
                           </div>
-                        ))}
-                      </div>
-                      <div class="small text-muted mt-2">
-                        <Text id="integration.energyMonitoring.selected" />{' '}
-                        {(() => {
-                          const arr = Array.from(state.wizardHourSlots).sort((a, b) => a - b);
-                          if (!arr.length) return <Text id="integration.energyMonitoring.none" />;
-                          const toLabel = slot => {
-                            const hour = Math.floor(slot / 2);
-                            const m = slot % 2 === 1 ? '30' : '00';
-                            const hh = hour < 10 ? `0${hour}` : `${hour}`;
-                            return `${hh}:${m}`;
-                          };
-                          return arr.map(toLabel).join(', ');
-                        })()}
+                        </div>
+                        <div class="row">
+                          {Array.from({ length: 48 }, (_, slot) => (
+                            <div class="col-3 col-sm-2 mb-2" key={slot}>
+                              <button
+                                type="button"
+                                class={cx(
+                                  'btn btn-sm btn-block text-center py-2 text-nowrap',
+                                  state.wizardHourSlots.has(slot) ? 'btn-primary' : 'btn-outline-secondary'
+                                )}
+                                onClick={() =>
+                                  this.setState(({ wizardHourSlots }) => {
+                                    const next = new Set(wizardHourSlots);
+                                    if (next.has(slot)) next.delete(slot);
+                                    else next.add(slot);
+                                    return { wizardHourSlots: next };
+                                  })
+                                }
+                              >
+                                {(() => {
+                                  const hour = Math.floor(slot / 2);
+                                  const m = slot % 2 === 1 ? '30' : '00';
+                                  const hh = hour < 10 ? `0${hour}` : `${hour}`;
+                                  return <span class="text-monospace font-weight-bold">{`${hh}:${m}`}</span>;
+                                })()}
+                              </button>
+                            </div>
+                          ))}
+                        </div>
+                        <div class="small text-muted mt-2">
+                          <Text id="integration.energyMonitoring.selected" />{' '}
+                          {(() => {
+                            const arr = Array.from(state.wizardHourSlots).sort((a, b) => a - b);
+                            if (!arr.length) return <Text id="integration.energyMonitoring.none" />;
+                            const toLabel = slot => {
+                              const hour = Math.floor(slot / 2);
+                              const m = slot % 2 === 1 ? '30' : '00';
+                              const hh = hour < 10 ? `0${hour}` : `${hour}`;
+                              return `${hh}:${m}`;
+                            };
+                            return arr.map(toLabel).join(', ');
+                          })()}
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
                 )}
                 <div class="row">
                   <div class="col-12 col-md-6">

--- a/front/src/routes/integration/all/energy-monitoring/EnergyMonitoring.jsx
+++ b/front/src/routes/integration/all/energy-monitoring/EnergyMonitoring.jsx
@@ -18,6 +18,8 @@ const DEVICE_FEATURE_CATEGORIES_TO_DISPLAY = [
   DEVICE_FEATURE_CATEGORIES.TELEINFORMATION
 ];
 
+const ENERCOOP_CONTRACT_TYPES = ['enercoop-nuit-weekend', 'enercoop-2-saisons'];
+
 const DEVICE_FEATURE_TYPES_TO_DISPLAY = [
   DEVICE_FEATURE_TYPES.ENERGY_SENSOR.DAILY_CONSUMPTION,
   DEVICE_FEATURE_TYPES.ENERGY_SENSOR.DAILY_CONSUMPTION_COST,
@@ -55,6 +57,10 @@ class EnergyMonitoringPage extends Component {
     settingsError: null,
     consumptionSettingsSuccess: null,
     consumptionSettingsError: null,
+    schoolVacationZone: '',
+    savingSchoolVacationZone: false,
+    schoolVacationZoneSuccess: null,
+    schoolVacationZoneError: null,
     // UI state for collapsible price items
     expandedPriceIds: new Set(),
     // UI state for collapsible contract groups (collapsed by default)
@@ -75,6 +81,7 @@ class EnergyMonitoringPage extends Component {
       end_date: '',
       electric_meter_device_id: '',
       day_type: 'any',
+      rate_type: 'peak',
       price: '',
       hour_slots: '',
       subscribed_power: ''
@@ -173,6 +180,9 @@ class EnergyMonitoringPage extends Component {
     if (this.isPricesRoute()) {
       this.loadPrices();
     }
+    if (this.isSettingsRoute()) {
+      this.loadSchoolVacationZone();
+    }
   }
 
   componentDidUpdate() {
@@ -182,6 +192,12 @@ class EnergyMonitoringPage extends Component {
       this.loadPrices();
     }
     this.wasPricesRouteLastUpdate = wasPricesRoute;
+
+    const isSettingsRoute = this.isSettingsRoute();
+    if (isSettingsRoute && !this.wasSettingsRouteLastUpdate) {
+      this.loadSchoolVacationZone();
+    }
+    this.wasSettingsRouteLastUpdate = isSettingsRoute;
   }
 
   // ----- ROUTE HELPERS -----
@@ -204,6 +220,31 @@ class EnergyMonitoringPage extends Component {
     const path = (typeof window !== 'undefined' && window.location && window.location.pathname) || '';
     return path.startsWith('/dashboard/integration/device/energy-monitoring') && path.includes('/settings');
   }
+
+  isEnercoopContract = contract => ENERCOOP_CONTRACT_TYPES.includes(contract);
+
+  loadSchoolVacationZone = async () => {
+    try {
+      const result = await this.props.httpClient.get('/api/v1/variable/ENERGY_SCHOOL_VACATION_ZONE');
+      this.setState({ schoolVacationZone: result.value || '' });
+    } catch (e) {
+      this.setState({ schoolVacationZone: '' });
+    }
+  };
+
+  saveSchoolVacationZone = async () => {
+    try {
+      this.setState({ savingSchoolVacationZone: true, schoolVacationZoneError: null, schoolVacationZoneSuccess: null });
+      await this.props.httpClient.post('/api/v1/variable/ENERGY_SCHOOL_VACATION_ZONE', {
+        value: this.state.schoolVacationZone || ''
+      });
+      this.setState({ schoolVacationZoneSuccess: 'ok' });
+    } catch (e) {
+      this.setState({ schoolVacationZoneError: e });
+    } finally {
+      this.setState({ savingSchoolVacationZone: false });
+    }
+  };
 
   isImportPricesRoute() {
     const path = (typeof window !== 'undefined' && window.location && window.location.pathname) || '';
@@ -257,6 +298,7 @@ class EnergyMonitoringPage extends Component {
           end_date: p.end_date || '',
           electric_meter_device_id: p.electric_meter_device_id || '',
           day_type: p.day_type || 'any',
+          rate_type: p.rate_type || 'peak',
           price: p.price != null && p.price !== '' ? p.price / 10000 : '',
           hour_slots: p.hour_slots || '',
           subscribed_power: p.subscribed_power || ''
@@ -322,6 +364,14 @@ class EnergyMonitoringPage extends Component {
       // Convert empty end_date to null
       if (payload.end_date === '' || payload.end_date === 'Invalid date') {
         payload.end_date = null;
+      }
+      if (payload.day_type === 'any') {
+        payload.day_type = null;
+      }
+      if (!this.isEnercoopContract(payload.contract)) {
+        delete payload.rate_type;
+      } else {
+        payload.hour_slots = null;
       }
       // Scale price to integer with 4 decimals (x10000) before saving
       if (payload.price !== undefined && payload.price !== null && payload.price !== '') {
@@ -720,6 +770,8 @@ class EnergyMonitoringPage extends Component {
     // Peak hours are typically during the day (e.g., 08:00-12:00, 18:00-22:00)
     // Off-peak hours typically include night hours (00:00-06:00)
     const isPeakPrice = p => {
+      if (p.rate_type === 'peak') return true;
+      if (p.rate_type === 'off_peak') return false;
       if (!p.hour_slots || String(p.hour_slots).trim().length === 0) {
         // No hour slots = base contract, not peak/off-peak
         return null;
@@ -1038,6 +1090,12 @@ class EnergyMonitoringPage extends Component {
                         <option value="edf-tempo">
                           <Text id="integration.energyMonitoring.contractTypes.edf-tempo" />
                         </option>
+                        <option value="enercoop-nuit-weekend">
+                          <Text id="integration.energyMonitoring.contractTypes.enercoop-nuit-weekend" />
+                        </option>
+                        <option value="enercoop-2-saisons">
+                          <Text id="integration.energyMonitoring.contractTypes.enercoop-2-saisons" />
+                        </option>
                       </select>
                     </div>
                   </div>
@@ -1082,6 +1140,11 @@ class EnergyMonitoringPage extends Component {
                     </div>
                   </div>
                 </div>
+                {this.isEnercoopContract(state.newPrice.contract) && (
+                  <div class="alert alert-info mt-3">
+                    <Text id="integration.energyMonitoring.enercoopContractHelp" />
+                  </div>
+                )}
               </div>
             )}
             {state.wizardStep === 1 && (
@@ -1131,6 +1194,7 @@ class EnergyMonitoringPage extends Component {
                         class="form-control"
                         value={state.newPrice.day_type}
                         onChange={e => updateNewPrice({ day_type: e.target.value })}
+                        disabled={this.isEnercoopContract(state.newPrice.contract)}
                       >
                         <option value="any">
                           <Text id="integration.energyMonitoring.dayTypeOptions.any" />
@@ -1187,6 +1251,29 @@ class EnergyMonitoringPage extends Component {
                 <h5 class="mb-3">
                   <Text id="integration.energyMonitoring.priceAndTimeSlots" />
                 </h5>
+                {this.isEnercoopContract(state.newPrice.contract) && (
+                  <div class="row">
+                    <div class="col-md-4">
+                      <div class="form-group">
+                        <label>
+                          <Text id="integration.energyMonitoring.rateType" />
+                        </label>
+                        <select
+                          class="form-control"
+                          value={state.newPrice.rate_type || 'peak'}
+                          onChange={e => updateNewPrice({ rate_type: e.target.value })}
+                        >
+                          <option value="peak">
+                            <Text id="integration.energyMonitoring.rateTypes.peak" />
+                          </option>
+                          <option value="off_peak">
+                            <Text id="integration.energyMonitoring.rateTypes.off_peak" />
+                          </option>
+                        </select>
+                      </div>
+                    </div>
+                  </div>
+                )}
                 <div class="row">
                   <div class="col-12 col-md-6">
                     <div class="form-group">
@@ -1202,6 +1289,7 @@ class EnergyMonitoringPage extends Component {
                     </div>
                   </div>
                 </div>
+                {!this.isEnercoopContract(state.newPrice.contract) && (
                 <div class="row">
                   <div class="col-12">
                     <div class="form-group">
@@ -1276,6 +1364,7 @@ class EnergyMonitoringPage extends Component {
                     </div>
                   </div>
                 </div>
+                )}
                 <div class="row">
                   <div class="col-12 col-md-6">
                     <div class="form-group">
@@ -1442,6 +1531,47 @@ class EnergyMonitoringPage extends Component {
                 />
               </div>
             )}
+            <div class="mb-4">
+              <p class="text-muted">
+                <Text id="integration.energyMonitoring.schoolVacationZoneDescription" />
+              </p>
+              <div class="row">
+                <div class="col-md-4">
+                  <select
+                    class="form-control"
+                    value={state.schoolVacationZone}
+                    onChange={e => this.setState({ schoolVacationZone: e.target.value })}
+                  >
+                    <option value="">
+                      <Text id="integration.energyMonitoring.schoolVacationZoneNone" />
+                    </option>
+                    <option value="Zone A">Zone A</option>
+                    <option value="Zone B">Zone B</option>
+                    <option value="Zone C">Zone C</option>
+                    <option value="Corse">Corse</option>
+                  </select>
+                </div>
+                <div class="col-md-4">
+                  <button
+                    class="btn btn-primary"
+                    disabled={state.savingSchoolVacationZone}
+                    onClick={this.saveSchoolVacationZone}
+                  >
+                    <Text id="global.save" defaultMessage="Save" />
+                  </button>
+                </div>
+              </div>
+              {state.schoolVacationZoneError && (
+                <div class="alert alert-danger mt-2" role="alert">
+                  <Text id="integration.energyMonitoring.schoolVacationZoneError" />
+                </div>
+              )}
+              {state.schoolVacationZoneSuccess && (
+                <div class="alert alert-success mt-2" role="alert">
+                  <Text id="integration.energyMonitoring.schoolVacationZoneSuccess" />
+                </div>
+              )}
+            </div>
             <div class="mb-4">
               <p class="text-muted">
                 <Text

--- a/server/lib/french-calendar/french-calendar.buildPublicHolidaysSet.js
+++ b/server/lib/french-calendar/french-calendar.buildPublicHolidaysSet.js
@@ -1,0 +1,57 @@
+const axios = require('axios');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+const { LRUCache } = require('lru-cache');
+const logger = require('../../utils/logger');
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const publicHolidaysCache = new LRUCache({
+  max: 20,
+  ttl: 1000 * 60 * 60 * 24 * 7,
+});
+
+/**
+ * @description Build a set of French public holiday dates (YYYY-MM-DD) between two dates.
+ * Uses the official calendrier.api.gouv.fr open API.
+ * @param {string} startDate - Start date (YYYY-MM-DD).
+ * @param {string} endDate - End date (YYYY-MM-DD).
+ * @returns {Promise<Set<string>>} Set of public holiday dates.
+ */
+async function buildPublicHolidaysSet(startDate, endDate) {
+  const startYear = dayjs(startDate).year();
+  const endYear = dayjs(endDate).year();
+  const holidaysSet = new Set();
+
+  const years = [];
+  for (let year = startYear; year <= endYear; year += 1) {
+    years.push(year);
+  }
+
+  await Promise.all(
+    years.map(async (year) => {
+      let yearHolidays = publicHolidaysCache.get(year);
+      if (!yearHolidays) {
+        try {
+          const response = await axios.get(`https://calendrier.api.gouv.fr/jours-feries/metropole/${year}.json`, {
+            timeout: 10000,
+          });
+          yearHolidays = Object.keys(response.data);
+          publicHolidaysCache.set(year, yearHolidays);
+        } catch (error) {
+          logger.warn(`Failed to fetch French public holidays for ${year}: ${error.message}`);
+          yearHolidays = [];
+        }
+      }
+      yearHolidays.forEach((date) => holidaysSet.add(date));
+    }),
+  );
+
+  return holidaysSet;
+}
+
+module.exports = {
+  buildPublicHolidaysSet,
+};

--- a/server/lib/french-calendar/french-calendar.buildPublicHolidaysSet.js
+++ b/server/lib/french-calendar/french-calendar.buildPublicHolidaysSet.js
@@ -19,6 +19,8 @@ const publicHolidaysCache = new LRUCache({
  * @param {string} startDate - Start date (YYYY-MM-DD).
  * @param {string} endDate - End date (YYYY-MM-DD).
  * @returns {Promise<Set<string>>} Set of public holiday dates.
+ * @example
+ * await buildPublicHolidaysSet('2025-01-01', '2025-12-31');
  */
 async function buildPublicHolidaysSet(startDate, endDate) {
   const startYear = dayjs(startDate).year();

--- a/server/lib/french-calendar/french-calendar.buildSchoolVacationsSet.js
+++ b/server/lib/french-calendar/french-calendar.buildSchoolVacationsSet.js
@@ -1,0 +1,69 @@
+const axios = require('axios');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+const { LRUCache } = require('lru-cache');
+const logger = require('../../utils/logger');
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const schoolVacationsCache = new LRUCache({
+  max: 50,
+  ttl: 1000 * 60 * 60 * 24 * 7,
+});
+
+const SCHOOL_VACATION_ZONES = ['Zone A', 'Zone B', 'Zone C', 'Corse'];
+
+/**
+ * @description Build a set of French school vacation dates (YYYY-MM-DD) for a zone.
+ * Uses the official education.gouv.fr open data API.
+ * @param {string} startDate - Start date (YYYY-MM-DD).
+ * @param {string} endDate - End date (YYYY-MM-DD).
+ * @param {string} zone - School vacation zone (e.g. "Zone A").
+ * @returns {Promise<Set<string>>} Set of school vacation dates.
+ */
+async function buildSchoolVacationsSet(startDate, endDate, zone) {
+  if (!zone || !SCHOOL_VACATION_ZONES.includes(zone)) {
+    return new Set();
+  }
+
+  const cacheKey = `${zone}:${startDate}:${endDate}`;
+  const cached = schoolVacationsCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const vacationsSet = new Set();
+
+  try {
+    const where = `zones = "${zone}" AND end_date >= "${startDate}" AND start_date <= "${endDate}"`;
+    const url = `https://data.education.gouv.fr/api/explore/v2.1/catalog/datasets/fr-en-calendrier-scolaire/records?where=${encodeURIComponent(
+      where,
+    )}&limit=100`;
+
+    const response = await axios.get(url, { timeout: 10000 });
+    const results = response.data.results || [];
+
+    results.forEach((period) => {
+      let current = dayjs(period.start_date).tz('Europe/Paris').startOf('day');
+      const end = dayjs(period.end_date).tz('Europe/Paris').startOf('day');
+
+      while (current.isBefore(end) || current.isSame(end, 'day')) {
+        vacationsSet.add(current.format('YYYY-MM-DD'));
+        current = current.add(1, 'day');
+      }
+    });
+
+    schoolVacationsCache.set(cacheKey, vacationsSet);
+  } catch (error) {
+    logger.warn(`Failed to fetch French school vacations for ${zone}: ${error.message}`);
+  }
+
+  return vacationsSet;
+}
+
+module.exports = {
+  buildSchoolVacationsSet,
+  SCHOOL_VACATION_ZONES,
+};

--- a/server/lib/french-calendar/french-calendar.buildSchoolVacationsSet.js
+++ b/server/lib/french-calendar/french-calendar.buildSchoolVacationsSet.js
@@ -22,6 +22,8 @@ const SCHOOL_VACATION_ZONES = ['Zone A', 'Zone B', 'Zone C', 'Corse'];
  * @param {string} endDate - End date (YYYY-MM-DD).
  * @param {string} zone - School vacation zone (e.g. "Zone A").
  * @returns {Promise<Set<string>>} Set of school vacation dates.
+ * @example
+ * await buildSchoolVacationsSet('2025-01-01', '2025-12-31', 'Zone A');
  */
 async function buildSchoolVacationsSet(startDate, endDate, zone) {
   if (!zone || !SCHOOL_VACATION_ZONES.includes(zone)) {

--- a/server/lib/french-calendar/french-calendar.buildSchoolVacationsSet.js
+++ b/server/lib/french-calendar/french-calendar.buildSchoolVacationsSet.js
@@ -46,8 +46,12 @@ async function buildSchoolVacationsSet(startDate, endDate, zone) {
     const results = response.data.results || [];
 
     results.forEach((period) => {
-      let current = dayjs(period.start_date).tz('Europe/Paris').startOf('day');
-      const end = dayjs(period.end_date).tz('Europe/Paris').startOf('day');
+      let current = dayjs(period.start_date)
+        .tz('Europe/Paris')
+        .startOf('day');
+      const end = dayjs(period.end_date)
+        .tz('Europe/Paris')
+        .startOf('day');
 
       while (current.isBefore(end) || current.isSame(end, 'day')) {
         vacationsSet.add(current.format('YYYY-MM-DD'));

--- a/server/lib/french-calendar/french-calendar.getEnercoopSeason.js
+++ b/server/lib/french-calendar/french-calendar.getEnercoopSeason.js
@@ -1,0 +1,20 @@
+const dayjs = require('dayjs');
+const timezone = require('dayjs/plugin/timezone');
+
+dayjs.extend(timezone);
+
+/**
+ * @description Get the Enercoop season for a date.
+ * Summer runs from April to October, winter from November to March.
+ * @param {Date} date - The date to evaluate.
+ * @param {string} systemTimezone - The system timezone.
+ * @returns {'summer'|'winter'} The Enercoop season.
+ */
+function getEnercoopSeason(date, systemTimezone) {
+  const month = dayjs(date).tz(systemTimezone).month() + 1;
+  return month >= 4 && month <= 10 ? 'summer' : 'winter';
+}
+
+module.exports = {
+  getEnercoopSeason,
+};

--- a/server/lib/french-calendar/french-calendar.getEnercoopSeason.js
+++ b/server/lib/french-calendar/french-calendar.getEnercoopSeason.js
@@ -11,7 +11,10 @@ dayjs.extend(timezone);
  * @returns {'summer'|'winter'} The Enercoop season.
  */
 function getEnercoopSeason(date, systemTimezone) {
-  const month = dayjs(date).tz(systemTimezone).month() + 1;
+  const month =
+    dayjs(date)
+      .tz(systemTimezone)
+      .month() + 1;
   return month >= 4 && month <= 10 ? 'summer' : 'winter';
 }
 

--- a/server/lib/french-calendar/french-calendar.getEnercoopSeason.js
+++ b/server/lib/french-calendar/french-calendar.getEnercoopSeason.js
@@ -9,6 +9,8 @@ dayjs.extend(timezone);
  * @param {Date} date - The date to evaluate.
  * @param {string} systemTimezone - The system timezone.
  * @returns {'summer'|'winter'} The Enercoop season.
+ * @example
+ * getEnercoopSeason(new Date('2025-07-15'), 'Europe/Paris');
  */
 function getEnercoopSeason(date, systemTimezone) {
   const month =

--- a/server/lib/french-calendar/index.js
+++ b/server/lib/french-calendar/index.js
@@ -1,9 +1,6 @@
 const { getEnercoopSeason } = require('./french-calendar.getEnercoopSeason');
 const { buildPublicHolidaysSet } = require('./french-calendar.buildPublicHolidaysSet');
-const {
-  buildSchoolVacationsSet,
-  SCHOOL_VACATION_ZONES,
-} = require('./french-calendar.buildSchoolVacationsSet');
+const { buildSchoolVacationsSet, SCHOOL_VACATION_ZONES } = require('./french-calendar.buildSchoolVacationsSet');
 
 module.exports = {
   getEnercoopSeason,

--- a/server/lib/french-calendar/index.js
+++ b/server/lib/french-calendar/index.js
@@ -1,0 +1,13 @@
+const { getEnercoopSeason } = require('./french-calendar.getEnercoopSeason');
+const { buildPublicHolidaysSet } = require('./french-calendar.buildPublicHolidaysSet');
+const {
+  buildSchoolVacationsSet,
+  SCHOOL_VACATION_ZONES,
+} = require('./french-calendar.buildSchoolVacationsSet');
+
+module.exports = {
+  getEnercoopSeason,
+  buildPublicHolidaysSet,
+  buildSchoolVacationsSet,
+  SCHOOL_VACATION_ZONES,
+};

--- a/server/migrations/20260703120000-add-energy-price-rate-type.js
+++ b/server/migrations/20260703120000-add-energy-price-rate-type.js
@@ -5,7 +5,5 @@ module.exports = {
       allowNull: true,
     });
   },
-  down: async (queryInterface) => {
-    await queryInterface.removeColumn('t_energy_price', 'rate_type');
-  },
+  down: async () => {},
 };

--- a/server/migrations/20260703120000-add-energy-price-rate-type.js
+++ b/server/migrations/20260703120000-add-energy-price-rate-type.js
@@ -1,0 +1,11 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('t_energy_price', 'rate_type', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn('t_energy_price', 'rate_type');
+  },
+};

--- a/server/models/energy_price.js
+++ b/server/models/energy_price.js
@@ -2,6 +2,7 @@ const {
   ENERGY_CONTRACT_TYPES_LIST,
   ENERGY_PRICE_TYPES_LIST,
   ENERGY_PRICE_DAY_TYPES_LIST,
+  ENERGY_RATE_TYPES_LIST,
 } = require('../utils/constants');
 const { slugify } = require('../utils/slugify');
 
@@ -66,6 +67,10 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: true,
         type: DataTypes.ENUM(...ENERGY_PRICE_DAY_TYPES_LIST),
       },
+      rate_type: {
+        allowNull: true,
+        type: DataTypes.ENUM(...ENERGY_RATE_TYPES_LIST),
+      },
       selector: {
         allowNull: false,
         unique: true,
@@ -88,6 +93,7 @@ module.exports = (sequelize, DataTypes) => {
         item.hour_slots,
         item.subscribed_power,
         item.day_type,
+        item.rate_type,
       ].join('-');
       item.selector = slugify(base, true);
     }

--- a/server/services/energy-monitoring/contracts/contracts.buildPublicHolidaysMap.js
+++ b/server/services/energy-monitoring/contracts/contracts.buildPublicHolidaysMap.js
@@ -12,6 +12,8 @@ dayjs.extend(timezone);
  * @description Build a set of French public holiday dates for cost calculation.
  * @param {string} startDate - Start date (YYYY-MM-DD).
  * @returns {Promise<Set<string>>} Set of public holiday dates.
+ * @example
+ * await buildPublicHolidaysMap('2025-01-01');
  */
 async function buildPublicHolidaysMap(startDate) {
   const today = dayjs()
@@ -32,6 +34,8 @@ async function buildPublicHolidaysMap(startDate) {
  * @description Check if any energy prices require French public holiday data.
  * @param {Array} energyPrices - Energy price rows.
  * @returns {boolean} True if public holidays are needed.
+ * @example
+ * needsPublicHolidays([{ contract: 'enercoop-nuit-weekend' }]);
  */
 function needsPublicHolidays(energyPrices) {
   return energyPrices.some(

--- a/server/services/energy-monitoring/contracts/contracts.buildPublicHolidaysMap.js
+++ b/server/services/energy-monitoring/contracts/contracts.buildPublicHolidaysMap.js
@@ -14,8 +14,12 @@ dayjs.extend(timezone);
  * @returns {Promise<Set<string>>} Set of public holiday dates.
  */
 async function buildPublicHolidaysMap(startDate) {
-  const today = dayjs().tz('Europe/Paris').format('YYYY-MM-DD');
-  const fromDate = dayjs(startDate).tz('Europe/Paris').format('YYYY-MM-DD');
+  const today = dayjs()
+    .tz('Europe/Paris')
+    .format('YYYY-MM-DD');
+  const fromDate = dayjs(startDate)
+    .tz('Europe/Paris')
+    .format('YYYY-MM-DD');
 
   logger.info(`Building French public holidays set from ${fromDate} to ${today}`);
   const publicHolidaysSet = await buildPublicHolidaysSet(fromDate, today);

--- a/server/services/energy-monitoring/contracts/contracts.buildPublicHolidaysMap.js
+++ b/server/services/energy-monitoring/contracts/contracts.buildPublicHolidaysMap.js
@@ -1,0 +1,43 @@
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+const { buildPublicHolidaysSet } = require('../../../lib/french-calendar');
+const { ENERGY_CONTRACT_TYPES } = require('../../../utils/constants');
+const logger = require('../../../utils/logger');
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+/**
+ * @description Build a set of French public holiday dates for cost calculation.
+ * @param {string} startDate - Start date (YYYY-MM-DD).
+ * @returns {Promise<Set<string>>} Set of public holiday dates.
+ */
+async function buildPublicHolidaysMap(startDate) {
+  const today = dayjs().tz('Europe/Paris').format('YYYY-MM-DD');
+  const fromDate = dayjs(startDate).tz('Europe/Paris').format('YYYY-MM-DD');
+
+  logger.info(`Building French public holidays set from ${fromDate} to ${today}`);
+  const publicHolidaysSet = await buildPublicHolidaysSet(fromDate, today);
+  logger.info(`Found ${publicHolidaysSet.size} French public holidays in range`);
+
+  return publicHolidaysSet;
+}
+
+/**
+ * @description Check if any energy prices require French public holiday data.
+ * @param {Array} energyPrices - Energy price rows.
+ * @returns {boolean} True if public holidays are needed.
+ */
+function needsPublicHolidays(energyPrices) {
+  return energyPrices.some(
+    (p) =>
+      p.contract === ENERGY_CONTRACT_TYPES.ENERCOOP_NUIT_WEEKEND ||
+      p.contract === ENERGY_CONTRACT_TYPES.ENERCOOP_2_SAISONS,
+  );
+}
+
+module.exports = {
+  buildPublicHolidaysMap,
+  needsPublicHolidays,
+};

--- a/server/services/energy-monitoring/contracts/contracts.calculateCost.js
+++ b/server/services/energy-monitoring/contracts/contracts.calculateCost.js
@@ -6,6 +6,12 @@ dayjs.extend(timezone);
 const { ENERGY_CONTRACT_TYPES } = require('../../../utils/constants');
 const { NotFoundError } = require('../../../utils/coreErrors');
 const logger = require('../../../utils/logger');
+const {
+  getEnercoopConsumptionContext,
+  isEnercoopNuitWeekendOffPeak,
+  isEnercoop2SaisonsOffPeak,
+  findEnercoopRatePrice,
+} = require('./contracts.enercoopUtils');
 
 /**
  * @description Convert a Date to an HH:MM slot label at 30-minute granularity.
@@ -99,6 +105,44 @@ module.exports = {
       `Found price: ${price.price / 10000}${
         price.currency
       }/kWh for time slot ${label} on day ${tempoDayDayType}, cost: ${cost}`,
+    );
+    return cost;
+  },
+  [ENERGY_CONTRACT_TYPES.ENERCOOP_NUIT_WEEKEND]: async (
+    energyPricesAtConsumptionDate,
+    consumptionDate,
+    consumptionValue,
+    systemTimezone,
+    { publicHolidaysSet },
+  ) => {
+    const context = getEnercoopConsumptionContext(consumptionDate, systemTimezone, { publicHolidaysSet });
+    const isOffPeak = isEnercoopNuitWeekendOffPeak(context);
+    const price = findEnercoopRatePrice(energyPricesAtConsumptionDate, isOffPeak);
+    if (!price) {
+      throw new NotFoundError(`No ${isOffPeak ? 'off-peak' : 'peak'} price found for Enercoop Nuit & Week-end contract`);
+    }
+    const cost = (price.price / 10000) * consumptionValue;
+    logger.debug(
+      `Enercoop Nuit & Week-end: ${isOffPeak ? 'off-peak' : 'peak'} at ${context.slotLabel} on ${context.dateStr}, cost: ${cost}`,
+    );
+    return cost;
+  },
+  [ENERGY_CONTRACT_TYPES.ENERCOOP_2_SAISONS]: async (
+    energyPricesAtConsumptionDate,
+    consumptionDate,
+    consumptionValue,
+    systemTimezone,
+    { publicHolidaysSet },
+  ) => {
+    const context = getEnercoopConsumptionContext(consumptionDate, systemTimezone, { publicHolidaysSet });
+    const isOffPeak = isEnercoop2SaisonsOffPeak(context);
+    const price = findEnercoopRatePrice(energyPricesAtConsumptionDate, isOffPeak);
+    if (!price) {
+      throw new NotFoundError(`No ${isOffPeak ? 'off-peak' : 'peak'} price found for Enercoop 2 Saisons contract`);
+    }
+    const cost = (price.price / 10000) * consumptionValue;
+    logger.debug(
+      `Enercoop 2 Saisons (${context.season}): ${isOffPeak ? 'off-peak' : 'peak'} at ${context.slotLabel} on ${context.dateStr}, cost: ${cost}`,
     );
     return cost;
   },

--- a/server/services/energy-monitoring/contracts/contracts.calculateCost.js
+++ b/server/services/energy-monitoring/contracts/contracts.calculateCost.js
@@ -119,11 +119,15 @@ module.exports = {
     const isOffPeak = isEnercoopNuitWeekendOffPeak(context);
     const price = findEnercoopRatePrice(energyPricesAtConsumptionDate, isOffPeak);
     if (!price) {
-      throw new NotFoundError(`No ${isOffPeak ? 'off-peak' : 'peak'} price found for Enercoop Nuit & Week-end contract`);
+      throw new NotFoundError(
+        `No ${isOffPeak ? 'off-peak' : 'peak'} price found for Enercoop Nuit & Week-end contract`,
+      );
     }
     const cost = (price.price / 10000) * consumptionValue;
     logger.debug(
-      `Enercoop Nuit & Week-end: ${isOffPeak ? 'off-peak' : 'peak'} at ${context.slotLabel} on ${context.dateStr}, cost: ${cost}`,
+      `Enercoop Nuit & Week-end: ${isOffPeak ? 'off-peak' : 'peak'} at ${context.slotLabel} on ${
+        context.dateStr
+      }, cost: ${cost}`,
     );
     return cost;
   },
@@ -142,7 +146,9 @@ module.exports = {
     }
     const cost = (price.price / 10000) * consumptionValue;
     logger.debug(
-      `Enercoop 2 Saisons (${context.season}): ${isOffPeak ? 'off-peak' : 'peak'} at ${context.slotLabel} on ${context.dateStr}, cost: ${cost}`,
+      `Enercoop 2 Saisons (${context.season}): ${isOffPeak ? 'off-peak' : 'peak'} at ${context.slotLabel} on ${
+        context.dateStr
+      }, cost: ${cost}`,
     );
     return cost;
   },

--- a/server/services/energy-monitoring/contracts/contracts.enercoopUtils.js
+++ b/server/services/energy-monitoring/contracts/contracts.enercoopUtils.js
@@ -9,6 +9,8 @@ dayjs.extend(timezone);
  * @param {Date} date - The date of the consumption sample.
  * @param {string} systemTimezone - The timezone of the system.
  * @returns {string} The label formatted as HH:MM (minutes are 00 or 30).
+ * @example
+ * formatDateToSlotLabel(new Date('2025-09-11T17:14:57+02:00'), 'Europe/Paris');
  */
 function formatDateToSlotLabel(date, systemTimezone) {
   const dayjsDate = dayjs(date).tz(systemTimezone);
@@ -23,6 +25,8 @@ function formatDateToSlotLabel(date, systemTimezone) {
  * @param {number} startHour - Start hour (0-23).
  * @param {number} endHour - End hour (0-24), exclusive.
  * @returns {Set<string>} Set of slot labels.
+ * @example
+ * generateSlotLabelsBetweenHours(23, 24);
  */
 function generateSlotLabelsBetweenHours(startHour, endHour) {
   const slots = new Set();
@@ -51,6 +55,8 @@ const SUMMER_WEEKDAY_OFF_PEAK_SLOTS = generateSlotLabelsBetweenHours(11, 17);
  * @param {object} options - Calendar options.
  * @param {Set<string>} options.publicHolidaysSet - Public holiday dates.
  * @returns {object} Consumption context.
+ * @example
+ * getEnercoopConsumptionContext(new Date(), 'Europe/Paris', { publicHolidaysSet: new Set() });
  */
 function getEnercoopConsumptionContext(consumptionDate, systemTimezone, { publicHolidaysSet }) {
   const localDate = dayjs(consumptionDate).tz(systemTimezone);
@@ -71,6 +77,8 @@ function getEnercoopConsumptionContext(consumptionDate, systemTimezone, { public
  * @description Check if consumption is off-peak for Enercoop Nuit & Week-end contract.
  * @param {object} context - Consumption context from getEnercoopConsumptionContext.
  * @returns {boolean} True if off-peak.
+ * @example
+ * isEnercoopNuitWeekendOffPeak({ isWeekend: true, isPublicHoliday: false, slotLabel: '10:00' });
  */
 function isEnercoopNuitWeekendOffPeak(context) {
   if (context.isPublicHoliday || context.isWeekend) {
@@ -83,6 +91,8 @@ function isEnercoopNuitWeekendOffPeak(context) {
  * @description Check if consumption is off-peak for Enercoop 2 Saisons contract.
  * @param {object} context - Consumption context from getEnercoopConsumptionContext.
  * @returns {boolean} True if off-peak.
+ * @example
+ * isEnercoop2SaisonsOffPeak({ season: 'summer', isWeekend: false, isPublicHoliday: false, slotLabel: '12:00' });
  */
 function isEnercoop2SaisonsOffPeak(context) {
   if (context.isPublicHoliday || context.isWeekend) {
@@ -99,6 +109,8 @@ function isEnercoop2SaisonsOffPeak(context) {
  * @param {Array} energyPricesAtConsumptionDate - Price rows for the date.
  * @param {boolean} isOffPeak - Whether off-peak rate applies.
  * @returns {object|undefined} Matching price row.
+ * @example
+ * findEnercoopRatePrice([{ rate_type: 'peak', price: 1500 }], false);
  */
 function findEnercoopRatePrice(energyPricesAtConsumptionDate, isOffPeak) {
   const rateType = isOffPeak ? 'off_peak' : 'peak';

--- a/server/services/energy-monitoring/contracts/contracts.enercoopUtils.js
+++ b/server/services/energy-monitoring/contracts/contracts.enercoopUtils.js
@@ -1,0 +1,118 @@
+const dayjs = require('dayjs');
+const timezone = require('dayjs/plugin/timezone');
+const { getEnercoopSeason } = require('../../../lib/french-calendar');
+
+dayjs.extend(timezone);
+
+/**
+ * @description Convert a Date to an HH:MM slot label at 30-minute granularity.
+ * @param {Date} date - The date of the consumption sample.
+ * @param {string} systemTimezone - The timezone of the system.
+ * @returns {string} The label formatted as HH:MM (minutes are 00 or 30).
+ */
+function formatDateToSlotLabel(date, systemTimezone) {
+  const dayjsDate = dayjs(date).tz(systemTimezone);
+  const hour = dayjsDate.hour();
+  const minutes = dayjsDate.minute() >= 30 ? '30' : '00';
+  const hh = hour < 10 ? `0${hour}` : `${hour}`;
+  return `${hh}:${minutes}`;
+}
+
+/**
+ * @description Generate 30-minute slot labels between two hours (inclusive start, exclusive end).
+ * @param {number} startHour - Start hour (0-23).
+ * @param {number} endHour - End hour (0-24), exclusive.
+ * @returns {Set<string>} Set of slot labels.
+ */
+function generateSlotLabelsBetweenHours(startHour, endHour) {
+  const slots = new Set();
+  for (let hour = startHour; hour < endHour; hour += 1) {
+    const hh = hour < 10 ? `0${hour}` : `${hour}`;
+    slots.add(`${hh}:00`);
+    slots.add(`${hh}:30`);
+  }
+  return slots;
+}
+
+const NUIT_WEEKEND_OFF_PEAK_SLOTS = generateSlotLabelsBetweenHours(23, 24);
+generateSlotLabelsBetweenHours(0, 6).forEach((slot) => NUIT_WEEKEND_OFF_PEAK_SLOTS.add(slot));
+
+const WINTER_WEEKDAY_OFF_PEAK_SLOTS = new Set([
+  ...generateSlotLabelsBetweenHours(0, 7),
+  ...generateSlotLabelsBetweenHours(13, 16),
+]);
+
+const SUMMER_WEEKDAY_OFF_PEAK_SLOTS = generateSlotLabelsBetweenHours(11, 17);
+
+/**
+ * @description Get consumption context for Enercoop tariff rules.
+ * @param {Date} consumptionDate - Consumption date.
+ * @param {string} systemTimezone - System timezone.
+ * @param {object} options - Calendar options.
+ * @param {Set<string>} options.publicHolidaysSet - Public holiday dates.
+ * @returns {object} Consumption context.
+ */
+function getEnercoopConsumptionContext(consumptionDate, systemTimezone, { publicHolidaysSet }) {
+  const localDate = dayjs(consumptionDate).tz(systemTimezone);
+  const dateStr = localDate.format('YYYY-MM-DD');
+  const dayOfWeek = localDate.day();
+  const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
+
+  return {
+    slotLabel: formatDateToSlotLabel(consumptionDate, systemTimezone),
+    dateStr,
+    isWeekend,
+    isPublicHoliday: publicHolidaysSet.has(dateStr),
+    season: getEnercoopSeason(consumptionDate, systemTimezone),
+  };
+}
+
+/**
+ * @description Check if consumption is off-peak for Enercoop Nuit & Week-end contract.
+ * @param {object} context - Consumption context from getEnercoopConsumptionContext.
+ * @returns {boolean} True if off-peak.
+ */
+function isEnercoopNuitWeekendOffPeak(context) {
+  if (context.isPublicHoliday || context.isWeekend) {
+    return true;
+  }
+  return NUIT_WEEKEND_OFF_PEAK_SLOTS.has(context.slotLabel);
+}
+
+/**
+ * @description Check if consumption is off-peak for Enercoop 2 Saisons contract.
+ * @param {object} context - Consumption context from getEnercoopConsumptionContext.
+ * @returns {boolean} True if off-peak.
+ */
+function isEnercoop2SaisonsOffPeak(context) {
+  if (context.isPublicHoliday || context.isWeekend) {
+    return true;
+  }
+  if (context.season === 'summer') {
+    return SUMMER_WEEKDAY_OFF_PEAK_SLOTS.has(context.slotLabel);
+  }
+  return WINTER_WEEKDAY_OFF_PEAK_SLOTS.has(context.slotLabel);
+}
+
+/**
+ * @description Find peak or off-peak price row for Enercoop contracts.
+ * @param {Array} energyPricesAtConsumptionDate - Price rows for the date.
+ * @param {boolean} isOffPeak - Whether off-peak rate applies.
+ * @returns {object|undefined} Matching price row.
+ */
+function findEnercoopRatePrice(energyPricesAtConsumptionDate, isOffPeak) {
+  const rateType = isOffPeak ? 'off_peak' : 'peak';
+  return energyPricesAtConsumptionDate.find((p) => p.rate_type === rateType);
+}
+
+module.exports = {
+  formatDateToSlotLabel,
+  generateSlotLabelsBetweenHours,
+  getEnercoopConsumptionContext,
+  isEnercoopNuitWeekendOffPeak,
+  isEnercoop2SaisonsOffPeak,
+  findEnercoopRatePrice,
+  NUIT_WEEKEND_OFF_PEAK_SLOTS,
+  WINTER_WEEKDAY_OFF_PEAK_SLOTS,
+  SUMMER_WEEKDAY_OFF_PEAK_SLOTS,
+};

--- a/server/services/energy-monitoring/lib/energy-monitoring.calculateCostFrom.js
+++ b/server/services/energy-monitoring/lib/energy-monitoring.calculateCostFrom.js
@@ -18,6 +18,7 @@ const {
 const { convertEnergyUnit } = require('../../../utils/units');
 const contracts = require('../contracts/contracts.calculateCost');
 const { buildEdfTempoDayMap } = require('../contracts/contracts.buildEdfTempoDayMap');
+const { buildPublicHolidaysMap, needsPublicHolidays } = require('../contracts/contracts.buildPublicHolidaysMap');
 
 const isNullOrEmpty = (value) => value === null || value === undefined || value === '';
 
@@ -37,6 +38,7 @@ async function calculateCostFrom(startAt, jobId) {
   });
   logger.info(`Found ${energyDevices.length} energy devices`);
   let edfTempoHistoricalMap = null;
+  let publicHolidaysSet = null;
   await Promise.each(energyDevices, async (energyDevice, index) => {
     try {
       const energyConsumptionFeatures = [];
@@ -133,6 +135,13 @@ async function calculateCostFrom(startAt, jobId) {
             .format('YYYY-MM-DD');
           edfTempoHistoricalMap = await buildEdfTempoDayMap(this.gladys, startDateAsDayString);
         }
+        if (needsPublicHolidays(energyPrices) && !publicHolidaysSet) {
+          logger.info(
+            `Device ${electricMeterFeature.device_id} has Enercoop prices, loading French public holidays`,
+          );
+          const startDateAsDayString = dayjs.tz(startAt, systemTimezone).format('YYYY-MM-DD');
+          publicHolidaysSet = await buildPublicHolidaysMap(startDateAsDayString);
+        }
         logger.debug(`Found ${energyPrices.length} energy prices for device ${electricMeterFeature.device_id}`);
         // We get all the states of the consumption feature in the time range
         const deviceFeatureStates = await this.gladys.device.getDeviceFeatureStates(
@@ -183,7 +192,7 @@ async function calculateCostFrom(startAt, jobId) {
             createdAtRemoved30Minutes,
             valueInKwh,
             systemTimezone,
-            { edfTempoHistoricalMap },
+            { edfTempoHistoricalMap, publicHolidaysSet: publicHolidaysSet || new Set() },
           );
           deviceFeatureCostStatesToInsert.push({
             value: cost,

--- a/server/services/energy-monitoring/lib/energy-monitoring.calculateCostFrom.js
+++ b/server/services/energy-monitoring/lib/energy-monitoring.calculateCostFrom.js
@@ -136,9 +136,7 @@ async function calculateCostFrom(startAt, jobId) {
           edfTempoHistoricalMap = await buildEdfTempoDayMap(this.gladys, startDateAsDayString);
         }
         if (needsPublicHolidays(energyPrices) && !publicHolidaysSet) {
-          logger.info(
-            `Device ${electricMeterFeature.device_id} has Enercoop prices, loading French public holidays`,
-          );
+          logger.info(`Device ${electricMeterFeature.device_id} has Enercoop prices, loading French public holidays`);
           const startDateAsDayString = dayjs.tz(startAt, systemTimezone).format('YYYY-MM-DD');
           publicHolidaysSet = await buildPublicHolidaysMap(startDateAsDayString);
         }

--- a/server/test/lib/french-calendar/french-calendar.buildPublicHolidaysSet.test.js
+++ b/server/test/lib/french-calendar/french-calendar.buildPublicHolidaysSet.test.js
@@ -1,0 +1,92 @@
+/* eslint-disable require-jsdoc */
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
+const { LRUCache } = require('lru-cache');
+
+describe('French calendar - buildPublicHolidaysSet', () => {
+  let buildPublicHolidaysSet;
+  let axiosGetStub;
+  let loggerStub;
+  let cacheInstance;
+
+  beforeEach(() => {
+    axiosGetStub = sinon.stub();
+    loggerStub = {
+      warn: sinon.stub(),
+    };
+
+    function LRUCacheWrapper(options) {
+      const instance = new LRUCache(options);
+      cacheInstance = instance;
+      return instance;
+    }
+
+    buildPublicHolidaysSet = proxyquire('../../../lib/french-calendar/french-calendar.buildPublicHolidaysSet', {
+      axios: { get: axiosGetStub },
+      '../../utils/logger': loggerStub,
+      'lru-cache': { LRUCache: LRUCacheWrapper },
+    }).buildPublicHolidaysSet;
+  });
+
+  afterEach(() => {
+    if (cacheInstance) {
+      cacheInstance.clear();
+    }
+  });
+
+  it('should fetch public holidays for each year in range', async () => {
+    axiosGetStub.callsFake((url) => {
+      if (url.includes('/2025.json')) {
+        return Promise.resolve({ data: { '2025-01-01': "Jour de l'an", '2025-05-01': 'Fête du travail' } });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    const result = await buildPublicHolidaysSet('2025-01-01', '2025-12-31');
+
+    expect(result).to.be.instanceOf(Set);
+    expect(result.has('2025-01-01')).to.equal(true);
+    expect(result.has('2025-05-01')).to.equal(true);
+    expect(axiosGetStub.calledOnce).to.equal(true);
+  });
+
+  it('should fetch holidays for multiple years', async () => {
+    axiosGetStub.callsFake((url) => {
+      if (url.includes('/2024.json')) {
+        return Promise.resolve({ data: { '2024-12-25': 'Noël' } });
+      }
+      if (url.includes('/2025.json')) {
+        return Promise.resolve({ data: { '2025-01-01': "Jour de l'an" } });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    const result = await buildPublicHolidaysSet('2024-12-01', '2025-01-31');
+
+    expect(result.has('2024-12-25')).to.equal(true);
+    expect(result.has('2025-01-01')).to.equal(true);
+    expect(axiosGetStub.callCount).to.equal(2);
+  });
+
+  it('should use cache on second call for same year', async () => {
+    axiosGetStub.resolves({ data: { '2025-07-14': 'Fête nationale' } });
+
+    await buildPublicHolidaysSet('2025-01-01', '2025-12-31');
+    axiosGetStub.resetHistory();
+    const result = await buildPublicHolidaysSet('2025-06-01', '2025-12-31');
+
+    expect(axiosGetStub.called).to.equal(false);
+    expect(result.has('2025-07-14')).to.equal(true);
+  });
+
+  it('should return empty set and log warning when API fails', async () => {
+    axiosGetStub.rejects(new Error('Network error'));
+
+    const result = await buildPublicHolidaysSet('2025-01-01', '2025-12-31');
+
+    expect(result).to.be.instanceOf(Set);
+    expect(result.size).to.equal(0);
+    expect(loggerStub.warn.calledOnce).to.equal(true);
+  });
+});

--- a/server/test/lib/french-calendar/french-calendar.buildSchoolVacationsSet.test.js
+++ b/server/test/lib/french-calendar/french-calendar.buildSchoolVacationsSet.test.js
@@ -1,0 +1,100 @@
+/* eslint-disable require-jsdoc */
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
+const { LRUCache } = require('lru-cache');
+
+describe('French calendar - buildSchoolVacationsSet', () => {
+  let buildSchoolVacationsSet;
+  let axiosGetStub;
+  let loggerStub;
+  let cacheInstance;
+
+  beforeEach(() => {
+    axiosGetStub = sinon.stub();
+    loggerStub = {
+      warn: sinon.stub(),
+    };
+
+    function LRUCacheWrapper(options) {
+      const instance = new LRUCache(options);
+      cacheInstance = instance;
+      return instance;
+    }
+
+    ({ buildSchoolVacationsSet } = proxyquire('../../../lib/french-calendar/french-calendar.buildSchoolVacationsSet', {
+      axios: { get: axiosGetStub },
+      '../../utils/logger': loggerStub,
+      'lru-cache': { LRUCache: LRUCacheWrapper },
+    }));
+  });
+
+  afterEach(() => {
+    if (cacheInstance) {
+      cacheInstance.clear();
+    }
+  });
+
+  it('should return empty set for invalid zone', async () => {
+    const result = await buildSchoolVacationsSet('2025-01-01', '2025-12-31', 'Invalid Zone');
+
+    expect(result).to.be.instanceOf(Set);
+    expect(result.size).to.equal(0);
+    expect(axiosGetStub.called).to.equal(false);
+  });
+
+  it('should return empty set when zone is not provided', async () => {
+    const result = await buildSchoolVacationsSet('2025-01-01', '2025-12-31', null);
+
+    expect(result.size).to.equal(0);
+    expect(axiosGetStub.called).to.equal(false);
+  });
+
+  it('should fetch school vacation dates for a valid zone', async () => {
+    axiosGetStub.resolves({
+      data: {
+        results: [
+          {
+            start_date: '2025-02-21T23:00:00+00:00',
+            end_date: '2025-03-08T23:00:00+00:00',
+          },
+        ],
+      },
+    });
+
+    const result = await buildSchoolVacationsSet('2025-01-01', '2025-12-31', 'Zone A');
+
+    expect(axiosGetStub.calledOnce).to.equal(true);
+    expect(result.size).to.be.greaterThan(0);
+    expect(result.has('2025-02-22')).to.equal(true);
+  });
+
+  it('should use cache on second call with same parameters', async () => {
+    axiosGetStub.resolves({
+      data: {
+        results: [
+          {
+            start_date: '2025-04-18T22:00:00+00:00',
+            end_date: '2025-05-04T22:00:00+00:00',
+          },
+        ],
+      },
+    });
+
+    await buildSchoolVacationsSet('2025-01-01', '2025-12-31', 'Zone B');
+    axiosGetStub.resetHistory();
+    const result = await buildSchoolVacationsSet('2025-01-01', '2025-12-31', 'Zone B');
+
+    expect(axiosGetStub.called).to.equal(false);
+    expect(result.size).to.be.greaterThan(0);
+  });
+
+  it('should return empty set and log warning when API fails', async () => {
+    axiosGetStub.rejects(new Error('API unavailable'));
+
+    const result = await buildSchoolVacationsSet('2025-01-01', '2025-12-31', 'Zone C');
+
+    expect(result.size).to.equal(0);
+    expect(loggerStub.warn.calledOnce).to.equal(true);
+  });
+});

--- a/server/test/lib/french-calendar/french-calendar.getEnercoopSeason.test.js
+++ b/server/test/lib/french-calendar/french-calendar.getEnercoopSeason.test.js
@@ -1,0 +1,16 @@
+const { expect } = require('chai');
+const { getEnercoopSeason } = require('../../../lib/french-calendar/french-calendar.getEnercoopSeason');
+
+describe('French calendar - getEnercoopSeason', () => {
+  it('should return summer between April and October', () => {
+    expect(getEnercoopSeason(new Date('2025-04-01T12:00:00+02:00'), 'Europe/Paris')).to.equal('summer');
+    expect(getEnercoopSeason(new Date('2025-07-15T12:00:00+02:00'), 'Europe/Paris')).to.equal('summer');
+    expect(getEnercoopSeason(new Date('2025-10-31T12:00:00+01:00'), 'Europe/Paris')).to.equal('summer');
+  });
+
+  it('should return winter between November and March', () => {
+    expect(getEnercoopSeason(new Date('2025-01-15T12:00:00+01:00'), 'Europe/Paris')).to.equal('winter');
+    expect(getEnercoopSeason(new Date('2025-03-31T12:00:00+02:00'), 'Europe/Paris')).to.equal('winter');
+    expect(getEnercoopSeason(new Date('2025-11-01T12:00:00+01:00'), 'Europe/Paris')).to.equal('winter');
+  });
+});

--- a/server/test/services/energy-monitoring/contracts/contracts.buildPublicHolidaysMap.test.js
+++ b/server/test/services/energy-monitoring/contracts/contracts.buildPublicHolidaysMap.test.js
@@ -1,0 +1,62 @@
+/* eslint-disable require-jsdoc */
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
+const { ENERGY_CONTRACT_TYPES } = require('../../../../utils/constants');
+
+describe('Contracts.buildPublicHolidaysMap', () => {
+  let buildPublicHolidaysMap;
+  let needsPublicHolidays;
+  let buildPublicHolidaysSetStub;
+  let loggerStub;
+
+  beforeEach(() => {
+    buildPublicHolidaysSetStub = sinon.stub();
+    loggerStub = {
+      info: sinon.stub(),
+    };
+
+    ({ buildPublicHolidaysMap, needsPublicHolidays } = proxyquire(
+      '../../../../services/energy-monitoring/contracts/contracts.buildPublicHolidaysMap',
+      {
+        '../../../lib/french-calendar': {
+          buildPublicHolidaysSet: buildPublicHolidaysSetStub,
+        },
+        '../../../utils/logger': loggerStub,
+      },
+    ));
+  });
+
+  it('should build public holidays set from start date to today', async () => {
+    const holidaysSet = new Set(['2025-05-01', '2025-07-14']);
+    buildPublicHolidaysSetStub.resolves(holidaysSet);
+
+    const result = await buildPublicHolidaysMap('2025-01-01');
+
+    expect(buildPublicHolidaysSetStub.calledOnce).to.equal(true);
+    expect(result).to.equal(holidaysSet);
+    expect(loggerStub.info.callCount).to.equal(2);
+    expect(loggerStub.info.firstCall.args[0]).to.include('Building French public holidays set');
+    expect(loggerStub.info.secondCall.args[0]).to.include('Found 2 French public holidays');
+  });
+
+  describe('needsPublicHolidays', () => {
+    it('should return true for Enercoop Nuit & Week-end contract', () => {
+      const result = needsPublicHolidays([{ contract: ENERGY_CONTRACT_TYPES.ENERCOOP_NUIT_WEEKEND }]);
+      expect(result).to.equal(true);
+    });
+
+    it('should return true for Enercoop 2 Saisons contract', () => {
+      const result = needsPublicHolidays([{ contract: ENERGY_CONTRACT_TYPES.ENERCOOP_2_SAISONS }]);
+      expect(result).to.equal(true);
+    });
+
+    it('should return false for other contract types', () => {
+      const result = needsPublicHolidays([
+        { contract: ENERGY_CONTRACT_TYPES.BASE },
+        { contract: ENERGY_CONTRACT_TYPES.PEAK_OFF_PEAK },
+      ]);
+      expect(result).to.equal(false);
+    });
+  });
+});

--- a/server/test/services/energy-monitoring/contracts/contracts.calculateCost.test.js
+++ b/server/test/services/energy-monitoring/contracts/contracts.calculateCost.test.js
@@ -213,4 +213,75 @@ describe('Contracts.calculateCost', () => {
       expect(cost).to.equal(1.5); // 0.1500 * 10 = 1.5 EUR (BLUE day peak price)
     });
   });
+
+  describe('ENERCOOP_NUIT_WEEKEND contract', () => {
+    const publicHolidaysSet = new Set(['2025-05-01']);
+    const energyPrices = [
+      { price: 1000, currency: 'EUR', rate_type: 'off_peak' },
+      { price: 1500, currency: 'EUR', rate_type: 'peak' },
+    ];
+
+    it('should use off-peak price at night on weekdays', async () => {
+      const cost = await contractsCalculateCost[ENERGY_CONTRACT_TYPES.ENERCOOP_NUIT_WEEKEND](
+        energyPrices,
+        new Date('2025-03-10T22:30:00.000Z'),
+        10,
+        'Europe/Paris',
+        { publicHolidaysSet },
+      );
+      expect(cost).to.equal(1.0);
+    });
+
+    it('should use peak price during daytime on weekdays', async () => {
+      const cost = await contractsCalculateCost[ENERGY_CONTRACT_TYPES.ENERCOOP_NUIT_WEEKEND](
+        energyPrices,
+        new Date('2025-03-10T10:00:00.000Z'),
+        10,
+        'Europe/Paris',
+        { publicHolidaysSet },
+      );
+      expect(cost).to.equal(1.5);
+    });
+
+    it('should use off-peak price on public holidays', async () => {
+      const cost = await contractsCalculateCost[ENERGY_CONTRACT_TYPES.ENERCOOP_NUIT_WEEKEND](
+        energyPrices,
+        new Date('2025-05-01T14:00:00.000Z'),
+        10,
+        'Europe/Paris',
+        { publicHolidaysSet },
+      );
+      expect(cost).to.equal(1.0);
+    });
+  });
+
+  describe('ENERCOOP_2_SAISONS contract', () => {
+    const publicHolidaysSet = new Set();
+    const energyPrices = [
+      { price: 900, currency: 'EUR', rate_type: 'off_peak' },
+      { price: 1400, currency: 'EUR', rate_type: 'peak' },
+    ];
+
+    it('should use summer off-peak slots in July', async () => {
+      const cost = await contractsCalculateCost[ENERGY_CONTRACT_TYPES.ENERCOOP_2_SAISONS](
+        energyPrices,
+        new Date('2025-07-15T12:00:00.000Z'),
+        10,
+        'Europe/Paris',
+        { publicHolidaysSet },
+      );
+      expect(cost).to.be.closeTo(0.9, 0.0001);
+    });
+
+    it('should use winter off-peak slots in March', async () => {
+      const cost = await contractsCalculateCost[ENERGY_CONTRACT_TYPES.ENERCOOP_2_SAISONS](
+        energyPrices,
+        new Date('2025-03-10T14:00:00.000Z'),
+        10,
+        'Europe/Paris',
+        { publicHolidaysSet },
+      );
+      expect(cost).to.be.closeTo(0.9, 0.0001);
+    });
+  });
 });

--- a/server/test/services/energy-monitoring/contracts/contracts.calculateCost.test.js
+++ b/server/test/services/energy-monitoring/contracts/contracts.calculateCost.test.js
@@ -253,6 +253,18 @@ describe('Contracts.calculateCost', () => {
       );
       expect(cost).to.equal(1.0);
     });
+
+    it('should throw NotFoundError when no matching rate price is found', async () => {
+      const promise = contractsCalculateCost[ENERGY_CONTRACT_TYPES.ENERCOOP_NUIT_WEEKEND](
+        [{ price: 1500, currency: 'EUR', rate_type: 'peak' }],
+        new Date('2025-03-10T22:30:00.000Z'),
+        10,
+        'Europe/Paris',
+        { publicHolidaysSet },
+      );
+
+      return assert.isRejected(promise, 'No off-peak price found for Enercoop Nuit & Week-end contract');
+    });
   });
 
   describe('ENERCOOP_2_SAISONS contract', () => {
@@ -282,6 +294,18 @@ describe('Contracts.calculateCost', () => {
         { publicHolidaysSet },
       );
       expect(cost).to.be.closeTo(0.9, 0.0001);
+    });
+
+    it('should throw NotFoundError when no matching rate price is found', async () => {
+      const promise = contractsCalculateCost[ENERGY_CONTRACT_TYPES.ENERCOOP_2_SAISONS](
+        [{ price: 1400, currency: 'EUR', rate_type: 'peak' }],
+        new Date('2025-07-15T12:00:00.000Z'),
+        10,
+        'Europe/Paris',
+        { publicHolidaysSet },
+      );
+
+      return assert.isRejected(promise, 'No off-peak price found for Enercoop 2 Saisons contract');
     });
   });
 });

--- a/server/test/services/energy-monitoring/contracts/contracts.enercoopUtils.test.js
+++ b/server/test/services/energy-monitoring/contracts/contracts.enercoopUtils.test.js
@@ -10,59 +10,45 @@ describe('Enercoop utils', () => {
 
   describe('Enercoop Nuit & Week-end', () => {
     it('should be off-peak at night on weekdays', () => {
-      const context = getEnercoopConsumptionContext(
-        new Date('2025-03-10T22:30:00.000Z'),
-        'Europe/Paris',
-        { publicHolidaysSet },
-      );
+      const context = getEnercoopConsumptionContext(new Date('2025-03-10T22:30:00.000Z'), 'Europe/Paris', {
+        publicHolidaysSet,
+      });
       expect(isEnercoopNuitWeekendOffPeak(context)).to.equal(true);
     });
 
     it('should be peak during daytime on weekdays', () => {
-      const context = getEnercoopConsumptionContext(
-        new Date('2025-03-10T10:00:00.000Z'),
-        'Europe/Paris',
-        { publicHolidaysSet },
-      );
+      const context = getEnercoopConsumptionContext(new Date('2025-03-10T10:00:00.000Z'), 'Europe/Paris', {
+        publicHolidaysSet,
+      });
       expect(isEnercoopNuitWeekendOffPeak(context)).to.equal(false);
     });
 
     it('should be off-peak all day on weekends', () => {
-      const context = getEnercoopConsumptionContext(
-        new Date('2025-03-15T14:00:00.000Z'),
-        'Europe/Paris',
-        { publicHolidaysSet },
-      );
+      const context = getEnercoopConsumptionContext(new Date('2025-03-15T14:00:00.000Z'), 'Europe/Paris', {
+        publicHolidaysSet,
+      });
       expect(isEnercoopNuitWeekendOffPeak(context)).to.equal(true);
     });
 
     it('should be off-peak all day on public holidays', () => {
-      const context = getEnercoopConsumptionContext(
-        new Date('2025-05-01T14:00:00.000Z'),
-        'Europe/Paris',
-        { publicHolidaysSet },
-      );
+      const context = getEnercoopConsumptionContext(new Date('2025-05-01T14:00:00.000Z'), 'Europe/Paris', {
+        publicHolidaysSet,
+      });
       expect(isEnercoopNuitWeekendOffPeak(context)).to.equal(true);
     });
   });
 
   describe('Enercoop 2 Saisons', () => {
     it('should use winter weekday slots in March', () => {
-      const morningContext = getEnercoopConsumptionContext(
-        new Date('2025-03-10T05:00:00.000Z'),
-        'Europe/Paris',
-        { publicHolidaysSet },
-      );
-      const afternoonContext = getEnercoopConsumptionContext(
-        new Date('2025-03-10T14:00:00.000Z'),
-        'Europe/Paris',
-        { publicHolidaysSet },
-      );
-      const peakContext = getEnercoopConsumptionContext(
-        new Date('2025-03-10T10:00:00.000Z'),
-        'Europe/Paris',
-        { publicHolidaysSet },
-      );
+      const morningContext = getEnercoopConsumptionContext(new Date('2025-03-10T05:00:00.000Z'), 'Europe/Paris', {
+        publicHolidaysSet,
+      });
+      const afternoonContext = getEnercoopConsumptionContext(new Date('2025-03-10T14:00:00.000Z'), 'Europe/Paris', {
+        publicHolidaysSet,
+      });
+      const peakContext = getEnercoopConsumptionContext(new Date('2025-03-10T10:00:00.000Z'), 'Europe/Paris', {
+        publicHolidaysSet,
+      });
 
       expect(isEnercoop2SaisonsOffPeak(morningContext)).to.equal(true);
       expect(isEnercoop2SaisonsOffPeak(afternoonContext)).to.equal(true);
@@ -70,27 +56,21 @@ describe('Enercoop utils', () => {
     });
 
     it('should use summer weekday slots in July', () => {
-      const offPeakContext = getEnercoopConsumptionContext(
-        new Date('2025-07-15T12:00:00.000Z'),
-        'Europe/Paris',
-        { publicHolidaysSet },
-      );
-      const peakContext = getEnercoopConsumptionContext(
-        new Date('2025-07-15T08:00:00.000Z'),
-        'Europe/Paris',
-        { publicHolidaysSet },
-      );
+      const offPeakContext = getEnercoopConsumptionContext(new Date('2025-07-15T12:00:00.000Z'), 'Europe/Paris', {
+        publicHolidaysSet,
+      });
+      const peakContext = getEnercoopConsumptionContext(new Date('2025-07-15T08:00:00.000Z'), 'Europe/Paris', {
+        publicHolidaysSet,
+      });
 
       expect(isEnercoop2SaisonsOffPeak(offPeakContext)).to.equal(true);
       expect(isEnercoop2SaisonsOffPeak(peakContext)).to.equal(false);
     });
 
     it('should be off-peak all day on weekends', () => {
-      const context = getEnercoopConsumptionContext(
-        new Date('2025-07-19T10:00:00.000Z'),
-        'Europe/Paris',
-        { publicHolidaysSet },
-      );
+      const context = getEnercoopConsumptionContext(new Date('2025-07-19T10:00:00.000Z'), 'Europe/Paris', {
+        publicHolidaysSet,
+      });
       expect(isEnercoop2SaisonsOffPeak(context)).to.equal(true);
     });
   });

--- a/server/test/services/energy-monitoring/contracts/contracts.enercoopUtils.test.js
+++ b/server/test/services/energy-monitoring/contracts/contracts.enercoopUtils.test.js
@@ -1,0 +1,97 @@
+const { expect } = require('chai');
+const {
+  isEnercoopNuitWeekendOffPeak,
+  isEnercoop2SaisonsOffPeak,
+  getEnercoopConsumptionContext,
+} = require('../../../../services/energy-monitoring/contracts/contracts.enercoopUtils');
+
+describe('Enercoop utils', () => {
+  const publicHolidaysSet = new Set(['2025-05-01']);
+
+  describe('Enercoop Nuit & Week-end', () => {
+    it('should be off-peak at night on weekdays', () => {
+      const context = getEnercoopConsumptionContext(
+        new Date('2025-03-10T22:30:00.000Z'),
+        'Europe/Paris',
+        { publicHolidaysSet },
+      );
+      expect(isEnercoopNuitWeekendOffPeak(context)).to.equal(true);
+    });
+
+    it('should be peak during daytime on weekdays', () => {
+      const context = getEnercoopConsumptionContext(
+        new Date('2025-03-10T10:00:00.000Z'),
+        'Europe/Paris',
+        { publicHolidaysSet },
+      );
+      expect(isEnercoopNuitWeekendOffPeak(context)).to.equal(false);
+    });
+
+    it('should be off-peak all day on weekends', () => {
+      const context = getEnercoopConsumptionContext(
+        new Date('2025-03-15T14:00:00.000Z'),
+        'Europe/Paris',
+        { publicHolidaysSet },
+      );
+      expect(isEnercoopNuitWeekendOffPeak(context)).to.equal(true);
+    });
+
+    it('should be off-peak all day on public holidays', () => {
+      const context = getEnercoopConsumptionContext(
+        new Date('2025-05-01T14:00:00.000Z'),
+        'Europe/Paris',
+        { publicHolidaysSet },
+      );
+      expect(isEnercoopNuitWeekendOffPeak(context)).to.equal(true);
+    });
+  });
+
+  describe('Enercoop 2 Saisons', () => {
+    it('should use winter weekday slots in March', () => {
+      const morningContext = getEnercoopConsumptionContext(
+        new Date('2025-03-10T05:00:00.000Z'),
+        'Europe/Paris',
+        { publicHolidaysSet },
+      );
+      const afternoonContext = getEnercoopConsumptionContext(
+        new Date('2025-03-10T14:00:00.000Z'),
+        'Europe/Paris',
+        { publicHolidaysSet },
+      );
+      const peakContext = getEnercoopConsumptionContext(
+        new Date('2025-03-10T10:00:00.000Z'),
+        'Europe/Paris',
+        { publicHolidaysSet },
+      );
+
+      expect(isEnercoop2SaisonsOffPeak(morningContext)).to.equal(true);
+      expect(isEnercoop2SaisonsOffPeak(afternoonContext)).to.equal(true);
+      expect(isEnercoop2SaisonsOffPeak(peakContext)).to.equal(false);
+    });
+
+    it('should use summer weekday slots in July', () => {
+      const offPeakContext = getEnercoopConsumptionContext(
+        new Date('2025-07-15T12:00:00.000Z'),
+        'Europe/Paris',
+        { publicHolidaysSet },
+      );
+      const peakContext = getEnercoopConsumptionContext(
+        new Date('2025-07-15T08:00:00.000Z'),
+        'Europe/Paris',
+        { publicHolidaysSet },
+      );
+
+      expect(isEnercoop2SaisonsOffPeak(offPeakContext)).to.equal(true);
+      expect(isEnercoop2SaisonsOffPeak(peakContext)).to.equal(false);
+    });
+
+    it('should be off-peak all day on weekends', () => {
+      const context = getEnercoopConsumptionContext(
+        new Date('2025-07-19T10:00:00.000Z'),
+        'Europe/Paris',
+        { publicHolidaysSet },
+      );
+      expect(isEnercoop2SaisonsOffPeak(context)).to.equal(true);
+    });
+  });
+});

--- a/server/test/services/energy-monitoring/energy-monitoring.calculateCostFrom.test.js
+++ b/server/test/services/energy-monitoring/energy-monitoring.calculateCostFrom.test.js
@@ -4,6 +4,7 @@ const EventEmitter = require('events');
 const dayjs = require('dayjs');
 const utc = require('dayjs/plugin/utc');
 const timezone = require('dayjs/plugin/timezone');
+const nock = require('nock');
 const historicalTempoData = require('./data/tempo_mock');
 
 dayjs.extend(utc);
@@ -394,6 +395,51 @@ describe('EnergyMonitoring.calculateCostFrom', () => {
     expect(deviceFeatureState[3]).to.have.property('value', 10 * 0.1447);
     expect(deviceFeatureState[4]).to.have.property('value', 10 * 0.1552);
     expect(deviceFeatureState[5]).to.have.property('value', 10 * 0.1288);
+  });
+  it('should calculate cost from a specific date for an Enercoop nuit & week-end contract', async () => {
+    nock('https://calendrier.api.gouv.fr')
+      .get('/jours-feries/metropole/2025.json')
+      .reply(200, { '2025-05-01': 'Fête du travail' });
+    nock('https://calendrier.api.gouv.fr')
+      .get('/jours-feries/metropole/2026.json')
+      .reply(200, {});
+
+    await energyPrice.create({
+      electric_meter_device_id: electricalMeterDevice.id,
+      contract: ENERGY_CONTRACT_TYPES.ENERCOOP_NUIT_WEEKEND,
+      price_type: ENERGY_PRICE_TYPES.CONSUMPTION,
+      currency: 'euro',
+      start_date: '2025-01-01',
+      price: 1000,
+      rate_type: 'off_peak',
+    });
+    await energyPrice.create({
+      electric_meter_device_id: electricalMeterDevice.id,
+      contract: ENERGY_CONTRACT_TYPES.ENERCOOP_NUIT_WEEKEND,
+      price_type: ENERGY_PRICE_TYPES.CONSUMPTION,
+      currency: 'euro',
+      start_date: '2025-01-01',
+      price: 1800,
+      rate_type: 'peak',
+    });
+    await db.duckDbBatchInsertState('17488546-e1b8-4cb9-bd75-e20526a94a99', [
+      {
+        value: 10,
+        created_at: dayjs.tz('2025-03-10T23:30:00.000Z', 'Europe/Paris').toDate(),
+      },
+    ]);
+    const energyMonitoring = new EnergyMonitoring(gladys, '43732e67-6669-4a95-83d6-38c50b835387');
+    const date = new Date('2025-03-01T00:00:00.000Z');
+    await energyMonitoring.calculateCostFrom(date);
+    const deviceFeatureState = await device.getDeviceFeatureStates(
+      'power-plug-consumption-cost',
+      dayjs.tz('2025-01-01T00:00:00.000Z', 'Europe/Paris').toDate(),
+      dayjs.tz('2025-12-01T00:00:00.000Z', 'Europe/Paris').toDate(),
+    );
+    expect(deviceFeatureState).to.have.lengthOf(1);
+    expect(deviceFeatureState[0]).to.have.property('value', 10 * 0.1);
+
+    nock.cleanAll();
   });
   it('should calculate cost from a specific date for a base contract on a daily consumption', async () => {
     // We create a new device with consumption & consumption cost

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -287,6 +287,7 @@ const SYSTEM_VARIABLE_NAMES = {
   AI_WEEKLY_DIGEST_HOUR: 'AI_WEEKLY_DIGEST_HOUR',
   DUCKDB_MIGRATED: 'DUCKDB_MIGRATED',
   GLADYS_VERSION: 'GLADYS_VERSION',
+  ENERGY_SCHOOL_VACATION_ZONE: 'ENERGY_SCHOOL_VACATION_ZONE',
 };
 
 const EVENTS = {
@@ -1652,6 +1653,15 @@ const ENERGY_CONTRACT_TYPES = {
   PEAK_OFF_PEAK: 'peak-off-peak',
   // EDF Tempo
   EDF_TEMPO: 'edf-tempo',
+  // Enercoop Flexibilité Nuit & Week-end (23h-6h + week-end + jours fériés)
+  ENERCOOP_NUIT_WEEKEND: 'enercoop-nuit-weekend',
+  // Enercoop Flexibilité 2 Saisons (créneaux variables été/hiver + week-end + jours fériés)
+  ENERCOOP_2_SAISONS: 'enercoop-2-saisons',
+};
+
+const ENERGY_RATE_TYPES = {
+  PEAK: 'peak',
+  OFF_PEAK: 'off_peak',
 };
 
 const ENERGY_PRICE_TYPES = {
@@ -1699,6 +1709,7 @@ const JOB_STATUS_LIST = createList(JOB_STATUS);
 const JOB_ERROR_TYPES_LIST = createList(JOB_ERROR_TYPES);
 const ALARM_MODES_LIST = createList(ALARM_MODES);
 const ENERGY_CONTRACT_TYPES_LIST = createList(ENERGY_CONTRACT_TYPES);
+const ENERGY_RATE_TYPES_LIST = createList(ENERGY_RATE_TYPES);
 const ENERGY_PRICE_TYPES_LIST = createList(ENERGY_PRICE_TYPES);
 const ENERGY_PRICE_DAY_TYPES_LIST = createList(ENERGY_PRICE_DAY_TYPES);
 
@@ -1794,6 +1805,8 @@ module.exports.OPENING_SENSOR_STATE = OPENING_SENSOR_STATE;
 
 module.exports.ENERGY_CONTRACT_TYPES = ENERGY_CONTRACT_TYPES;
 module.exports.ENERGY_CONTRACT_TYPES_LIST = ENERGY_CONTRACT_TYPES_LIST;
+module.exports.ENERGY_RATE_TYPES = ENERGY_RATE_TYPES;
+module.exports.ENERGY_RATE_TYPES_LIST = ENERGY_RATE_TYPES_LIST;
 module.exports.ENERGY_PRICE_TYPES = ENERGY_PRICE_TYPES;
 module.exports.ENERGY_PRICE_TYPES_LIST = ENERGY_PRICE_TYPES_LIST;
 module.exports.ENERGY_PRICE_DAY_TYPES = ENERGY_PRICE_DAY_TYPES;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Contexte

Un utilisateur souhaite ajouter un contrat Enercoop dans Gladys. Les offres **Flexibilité Nuit & Week-end** et **Flexibilité 2 Saisons** nécessitent des notions absentes du moteur de tarification existant : gestion week-end/semaine, jours fériés et saisons.

## Recherche sur les contrats Enercoop

| Offre | Heures creuses |
|-------|----------------|
| **Nuit & Week-end** | 23h–6h en semaine + tout le week-end + jours fériés |
| **2 Saisons** | Hiver (nov–mars) : 0h–7h et 13h–16h en semaine + WE/fériés ; Été (avr–oct) : 11h–17h en semaine + WE/fériés |

> Les **vacances scolaires** ne modifient pas les tarifs Enercoop (confirmé par la FAQ Enercoop). L'infrastructure est toutefois préparée via l'API officielle du Ministère de l'Éducation pour un usage futur (suivi de consommation).

## APIs gouvernementales utilisées

- **Jours fériés** : [calendrier.api.gouv.fr](https://calendrier.api.gouv.fr) (API ouverte, licence ouverte)
- **Vacances scolaires** : [data.education.gouv.fr](https://data.education.gouv.fr/explore/dataset/fr-en-calendrier-scolaire/) (optionnel, zone configurable dans les paramètres)

## Changements

### Backend
- Nouveaux types de contrat : `enercoop-nuit-weekend`, `enercoop-2-saisons`
- Bibliothèque `server/lib/french-calendar/` pour jours fériés et vacances scolaires
- Calcul automatique des créneaux HC selon les règles Enercoop
- Nouveau champ `rate_type` (`peak` / `off_peak`) sur `t_energy_price`
- Chargement des jours fériés lors du calcul de coût (comme EDF Tempo)

### Frontend
- Nouveaux types de contrat dans l'assistant de création de tarifs
- Sélection peak/off-peak pour les contrats Enercoop (2 tarifs requis par contrat)
- Configuration optionnelle de la zone de vacances scolaires dans les paramètres
- Traductions FR/EN/DE

## Configuration utilisateur

Pour un contrat Enercoop, créer **deux tarifs** avec le même nom de contrat :
1. Un tarif `heures creuses` (off_peak)
2. Un tarif `heures pleines` (peak)

Les créneaux horaires, week-ends, jours fériés et saisons sont calculés automatiquement.

## Tests

- Tests unitaires pour la détection de saison Enercoop
- Tests unitaires pour les règles HC (nuit, week-end, fériés, saisons)
- Tests du calculateur de coût pour les deux types de contrat
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f27c6-2f8f-7680-81a4-0cc119b5a441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f27c6-2f8f-7680-81a4-0cc119b5a441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

