### PR TITLE
feat(scenes): add While (Tant Que) action with loop safety

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -2538,6 +2538,21 @@
           "other": "{{count}} Aktionen"
         }
       },
+      "conditionWhile": {
+        "conditions": "Bedingungen",
+        "conditionDescription": "Solange alle Bedingungen erfüllt sind, werden die Aktionen im Block unten wiederholt ausgeführt, bis die Bedingungen nicht mehr erfüllt sind.",
+        "noCondition": "Es wurde noch keine Bedingung hinzugefügt. Klicken Sie auf die '+'-Schaltfläche, um diesem Block eine Bedingung hinzuzufügen",
+        "addCondition": "Bedingung hinzufügen",
+        "while": "Solange",
+        "do": "Ausführen...",
+        "shortWhile": "S",
+        "shortDo": "A",
+        "actionCount": {
+          "zero": "Keine Aktionen",
+          "one": "1 Aktion",
+          "other": "{{count}} Aktionen"
+        }
+      },
       "checkTime": {
         "description": "Die Szene wird nur fortgesetzt, wenn die aktuelle Uhrzeit außerhalb der ausgewählten Tage liegt. Wenn ein Feld leer gelassen wird, wird es nicht berücksichtigt.",
         "beforeLabel": "Vor",
@@ -2690,7 +2705,8 @@
       "condition": {
         "only-continue-if": "Nur fortsetzen, wenn",
         "check-time": "Zeitbedingung",
-        "if-then-else": "Bedingung: \"Wenn...dann...sonst...\""
+        "if-then-else": "Bedingung: \"Wenn...dann...sonst...\"",
+        "while": "Bedingung: \"Solange...\""
       },
       "user": {
         "set-seen-at-home": "Benutzer zu Hause gesehen",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -2538,6 +2538,21 @@
           "other": "{{count}} actions"
         }
       },
+      "conditionWhile": {
+        "conditions": "Conditions",
+        "conditionDescription": "While all conditions are met, the actions in the block below will be executed repeatedly until the conditions are no longer met.",
+        "noCondition": "No condition has been added yet. Click the '+' button to add a condition to this block",
+        "addCondition": "Add condition",
+        "while": "While",
+        "do": "Do...",
+        "shortWhile": "W",
+        "shortDo": "D",
+        "actionCount": {
+          "zero": "No action",
+          "one": "1 action",
+          "other": "{{count}} actions"
+        }
+      },
       "checkTime": {
         "description": "The scene will continue only if current time is between the selected limits, in the selected days. If a field is left empty, it'll not be taken into account.",
         "beforeLabel": "Before",
@@ -2690,7 +2705,8 @@
       "condition": {
         "only-continue-if": "Condition on variables",
         "check-time": "Time condition",
-        "if-then-else": "Condition: If...then...else..."
+        "if-then-else": "Condition: If...then...else...",
+        "while": "Condition: While..."
       },
       "user": {
         "set-seen-at-home": "User seen at home",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -2538,6 +2538,21 @@
           "other": "{{count}} actions"
         }
       },
+      "conditionWhile": {
+        "conditions": "Conditions",
+        "conditionDescription": "Tant que toutes les conditions sont réalisées, les actions du bloc ci-dessous seront exécutées en boucle, jusqu'à ce que les conditions ne soient plus remplies.",
+        "noCondition": "Aucune condition ajoutée. Cliquez sur le bouton '+' pour ajouter une condition à ce bloc",
+        "addCondition": "Ajouter une condition",
+        "while": "Tant que",
+        "do": "Faire...",
+        "shortWhile": "T",
+        "shortDo": "F",
+        "actionCount": {
+          "zero": "Aucune action",
+          "one": "1 action",
+          "other": "{{count}} actions"
+        }
+      },
       "checkTime": {
         "description": "La scène continuera si l'heure actuelle est comprise entre les bornes spécifiées, aux jours spécifiés. Si une condition est vide, elle ne sera pas prise en compte.",
         "beforeLabel": "Avant",
@@ -2690,7 +2705,8 @@
       "condition": {
         "only-continue-if": "Condition sur variables",
         "check-time": "Condition temporelle",
-        "if-then-else": "Condition \"Si... Alors... Sinon...\""
+        "if-then-else": "Condition \"Si... Alors... Sinon...\"",
+        "while": "Condition \"Tant que...\""
       },
       "user": {
         "set-seen-at-home": "Utilisateur vu à la maison",

--- a/front/src/routes/scene/edit-scene/ActionCard.jsx
+++ b/front/src/routes/scene/edit-scene/ActionCard.jsx
@@ -35,6 +35,7 @@ import EdfTempoCondition from './actions/EdfTempoCondition';
 import AskAI from './actions/AskAI';
 import SendSms from './actions/SendSms';
 import ConditionIfElseThen from './actions/ConditionIfElseThen';
+import ConditionWhile from './actions/ConditionWhile';
 
 const ACTION_ICON = {
   [ACTIONS.LIGHT.TURN_ON]: 'fe fe-toggle-right',
@@ -48,6 +49,7 @@ const ACTION_ICON = {
   [ACTIONS.MESSAGE.SEND]: 'fe fe-message-square',
   [ACTIONS.MESSAGE.SEND_CAMERA]: 'fe fe-message-square',
   [ACTIONS.CONDITION.IF_THEN_ELSE]: 'fe fe-shuffle',
+  [ACTIONS.CONDITION.WHILE]: 'fe fe-repeat',
   [ACTIONS.CONDITION.ONLY_CONTINUE_IF]: 'fe fe-shuffle',
   [ACTIONS.DEVICE.GET_VALUE]: 'fe fe-refresh-cw',
   [ACTIONS.USER.SET_SEEN_AT_HOME]: 'fe fe-home',
@@ -104,19 +106,24 @@ const ACTION_COMPONENTS = {
   [ACTIONS.MUSIC.PLAY_NOTIFICATION]: PlayNotification,
   [ACTIONS.AI.ASK]: AskAI,
   [ACTIONS.SMS.SEND]: SendSms,
-  [ACTIONS.CONDITION.IF_THEN_ELSE]: ConditionIfElseThen
+  [ACTIONS.CONDITION.IF_THEN_ELSE]: ConditionIfElseThen,
+  [ACTIONS.CONDITION.WHILE]: ConditionWhile
 };
 
 const ACTION_CARD_TYPE = 'ACTION_CARD_TYPE';
 const CONDITION_CARD_TYPE = 'CONDITION_CARD_TYPE';
 const ACTION_CARD_IF_THEN_ELSE_TYPE = 'ACTION_CARD_IF_THEN_ELSE_TYPE';
+const ACTION_CARD_WHILE_TYPE = 'ACTION_CARD_WHILE_TYPE';
 
 const getDragAndDropType = (actionType, path) => {
-  if (path.includes('if')) {
+  if (path.includes('if') || path.includes('while')) {
     return CONDITION_CARD_TYPE;
   }
   if (actionType === ACTIONS.CONDITION.IF_THEN_ELSE) {
     return ACTION_CARD_IF_THEN_ELSE_TYPE;
+  }
+  if (actionType === ACTIONS.CONDITION.WHILE) {
+    return ACTION_CARD_WHILE_TYPE;
   }
   return ACTION_CARD_TYPE;
 };
@@ -156,7 +163,8 @@ const ActionCard = ({ children, ...props }) => {
       class={cx({
         'col-lg-12':
           props.action.type === ACTIONS.CONDITION.ONLY_CONTINUE_IF ||
-          props.action.type === ACTIONS.CONDITION.IF_THEN_ELSE,
+          props.action.type === ACTIONS.CONDITION.IF_THEN_ELSE ||
+          props.action.type === ACTIONS.CONDITION.WHILE,
         'col-lg-6':
           props.action.type === ACTIONS.MESSAGE.SEND ||
           props.action.type === ACTIONS.CALENDAR.IS_EVENT_RUNNING ||
@@ -183,8 +191,12 @@ const ActionCard = ({ children, ...props }) => {
           {props.action.type === null && <i class="fe fe-plus-circle" />}
           <div class="card-title">
             <i class={cx(props.action.icon, 'mr-4')} /> <Text id={`editScene.actions.${props.action.type}`} />
-            {props.action.type === null && props.path.includes('if') && <Text id="editScene.newCondition" />}
-            {props.action.type === null && !props.path.includes('if') && <Text id="editScene.newAction" />}
+            {props.action.type === null && (props.path.includes('if') || props.path.includes('while')) && (
+              <Text id="editScene.newCondition" />
+            )}
+            {props.action.type === null && !props.path.includes('if') && !props.path.includes('while') && (
+              <Text id="editScene.newAction" />
+            )}
           </div>
           {props.highLightedActions && props.highLightedActions[`${props.columnIndex}:${props.index}`] && (
             <div class="card-status bg-blue" />

--- a/front/src/routes/scene/edit-scene/actions/ChooseActionTypeCard.jsx
+++ b/front/src/routes/scene/edit-scene/actions/ChooseActionTypeCard.jsx
@@ -18,6 +18,7 @@ const ACTION_LIST = [
   ACTIONS.MESSAGE.SEND_CAMERA,
   ACTIONS.DEVICE.GET_VALUE,
   ACTIONS.CONDITION.IF_THEN_ELSE,
+  ACTIONS.CONDITION.WHILE,
   ACTIONS.CONDITION.ONLY_CONTINUE_IF,
   ACTIONS.USER.SET_SEEN_AT_HOME,
   ACTIONS.USER.SET_OUT_OF_HOME,
@@ -69,8 +70,11 @@ class ChooseActionType extends Component {
       <div>
         <div class="form-group">
           <label class="form-label">
-            {props.path.includes('if') && <Text id="editScene.selectConditionType" />}
-            {!props.path.includes('if') && <Text id="editScene.selectActionType" />}
+            {props.path.includes('if') || props.path.includes('while') ? (
+              <Text id="editScene.selectConditionType" />
+            ) : (
+              <Text id="editScene.selectActionType" />
+            )}
           </label>
           <Select
             class="choose-scene-action-type"

--- a/front/src/routes/scene/edit-scene/actions/ConditionWhile.jsx
+++ b/front/src/routes/scene/edit-scene/actions/ConditionWhile.jsx
@@ -99,8 +99,7 @@ class ConditionWhile extends Component {
           </div>
           <div class="text-center mt-4">
             <button onClick={this.addCondition} class="btn btn-sm btn-outline-primary">
-              <i class="fe fe-plus" />{' '}
-              <Text id="editScene.actionsCard.conditionWhile.addCondition">Add condition</Text>
+              <i class="fe fe-plus" /> <Text id="editScene.actionsCard.conditionWhile.addCondition">Add condition</Text>
             </button>
           </div>
         </div>

--- a/front/src/routes/scene/edit-scene/actions/ConditionWhile.jsx
+++ b/front/src/routes/scene/edit-scene/actions/ConditionWhile.jsx
@@ -1,0 +1,160 @@
+import { Component } from 'preact';
+import { connect } from 'unistore/preact';
+import { Text } from 'preact-i18n';
+import get from 'get-value';
+import ActionGroup from '../ActionGroup';
+import ActionCard from '../ActionCard';
+
+import withIntlAsProp from '../../../../utils/withIntlAsProp';
+
+import { CONDITION_ACTIONS } from '../../../../../../server/utils/constants';
+
+const isNullOrUndefined = variable => variable === null || variable === undefined;
+
+class ConditionWhile extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      doCollapsed: false
+    };
+  }
+
+  toggleDoCollapse = () => {
+    this.setState(prevState => ({
+      doCollapsed: !prevState.doCollapsed
+    }));
+  };
+
+  getNumberOfActionsInDo = () => {
+    if (!this.props.action || !this.props.action.do) return 0;
+    return this.props.action.do.map(actions => actions.length).reduce((a, b) => a + b, 0);
+  };
+
+  initActionIfNeeded = () => {
+    if (isNullOrUndefined(get(this.props, 'action.while'))) {
+      this.props.updateActionProperty(this.props.path, 'while', []);
+    }
+    if (isNullOrUndefined(get(this.props, 'action.do'))) {
+      this.props.updateActionProperty(this.props.path, 'do', [[]]);
+    }
+  };
+
+  componentDidMount() {
+    this.initActionIfNeeded();
+  }
+
+  addCondition = () => {
+    this.props.addAction(`${this.props.path}.while`, { filter: CONDITION_ACTIONS });
+  };
+
+  render(props, { doCollapsed }) {
+    const conditions = get(props, 'action.while', []);
+
+    return (
+      <>
+        <div class="conditions-container mb-4">
+          <div class="d-flex justify-content-between align-items-center mb-2">
+            <h4>
+              <Text id="editScene.actionsCard.conditionWhile.conditions">Conditions</Text>
+            </h4>
+          </div>
+          {conditions.length > 0 && (
+            <div class="row">
+              <div class="col">
+                <div class="alert alert-secondary">
+                  <Text id="editScene.actionsCard.conditionWhile.conditionDescription">
+                    While all conditions are met, the actions in the block below will be executed repeatedly.
+                  </Text>
+                </div>
+              </div>
+            </div>
+          )}
+          <div class="row">
+            {conditions.map((condition, index) => (
+              <ActionCard
+                action={condition}
+                index={index}
+                allActions={props.allActions}
+                path={`${props.path}.while.${index}`}
+                updateActionProperty={props.updateActionProperty}
+                deleteAction={props.deleteAction}
+                actionsGroupsBefore={props.actionsGroupsBefore}
+                variables={props.variables}
+                triggersVariables={props.triggersVariables}
+                setVariables={props.setVariables}
+                moveCard={props.moveCard}
+                moveCardGroup={props.moveCardGroup}
+                scene={props.scene}
+              />
+            ))}
+            {conditions.length === 0 && (
+              <div class="col">
+                <div class="alert alert-secondary">
+                  <Text id="editScene.actionsCard.conditionWhile.noCondition">
+                    No condition has been added yet. Click the '+' button to add a condition to this block
+                  </Text>
+                </div>
+              </div>
+            )}
+          </div>
+          <div class="text-center mt-4">
+            <button onClick={this.addCondition} class="btn btn-sm btn-outline-primary">
+              <i class="fe fe-plus" />{' '}
+              <Text id="editScene.actionsCard.conditionWhile.addCondition">Add condition</Text>
+            </button>
+          </div>
+        </div>
+
+        <div class="do-container mb-4">
+          <div
+            class="d-flex justify-content-between align-items-center mb-2 cursor-pointer"
+            onClick={this.toggleDoCollapse}
+          >
+            <h4>
+              <i class={`fe fe-chevron-${doCollapsed ? 'right' : 'down'} mr-2`} />
+              <Text id="editScene.actionsCard.conditionWhile.do">Do...</Text>
+              {doCollapsed && (
+                <span class="badge badge-pill badge-secondary ml-2">
+                  <Text
+                    id="editScene.actionsCard.conditionWhile.actionCount"
+                    plural={this.getNumberOfActionsInDo()}
+                    fields={{
+                      count: this.getNumberOfActionsInDo()
+                    }}
+                  />
+                </span>
+              )}
+            </h4>
+          </div>
+          {!doCollapsed && props.action.do && (
+            <div class="pl-4">
+              {props.action.do.map((actions, index) => (
+                <ActionGroup
+                  actions={actions}
+                  allActions={props.allActions}
+                  path={`${props.path}.do.${index}`}
+                  addAction={props.addAction}
+                  deleteAction={props.deleteAction}
+                  deleteActionGroup={props.deleteActionGroup}
+                  updateActionProperty={props.updateActionProperty}
+                  moveCard={props.moveCard}
+                  moveCardGroup={props.moveCardGroup}
+                  highLightedActions={props.highLightedActions}
+                  actionsGroupsBefore={props.actionsGroupsBefore}
+                  variables={props.variables}
+                  triggersVariables={props.triggersVariables}
+                  setVariables={props.setVariables}
+                  scene={props.scene}
+                  firstActionGroup={index === 0}
+                  lastActionGroup={index === props.action.do.length - 1}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </>
+    );
+  }
+}
+
+export default withIntlAsProp(connect('httpClient', {})(ConditionWhile));

--- a/front/src/routes/scene/edit-scene/index.js
+++ b/front/src/routes/scene/edit-scene/index.js
@@ -69,6 +69,12 @@ const initializeSceneVariables = (actions, parentPath = '') => {
           variables = { ...variables, ...elseVariables };
         }
       }
+      if (action && action.type === ACTIONS.CONDITION.WHILE) {
+        if (Array.isArray(action.do)) {
+          const doVariables = initializeSceneVariables(action.do, `${currentPath}.do`);
+          variables = { ...variables, ...doVariables };
+        }
+      }
     });
   });
 
@@ -239,6 +245,13 @@ class EditScene extends Component {
             updates = deepMergeUpdates(updates, elseUpdates);
           }
         }
+        if (action && action.type === ACTIONS.CONDITION.WHILE) {
+          if (Array.isArray(action.do)) {
+            const doPath = path ? `${path}.${groupIndex}.${actionIndex}.do` : `${groupIndex}.${actionIndex}.do`;
+            const doUpdates = this.checkAndAddEmptyGroups(action.do, doPath, currentState);
+            updates = deepMergeUpdates(updates, doUpdates);
+          }
+        }
       });
     });
 
@@ -341,7 +354,7 @@ class EditScene extends Component {
                 });
               }
 
-              // Check for nested actions in if/then/else blocks
+              // Check for nested actions in if/then/else and while/do blocks
               if (action.type === ACTIONS.CONDITION.IF_THEN_ELSE) {
                 // Process 'if' branch if it exists
                 if (Array.isArray(action.if)) {
@@ -356,6 +369,15 @@ class EditScene extends Component {
                 // Process 'else' branch if it exists
                 if (Array.isArray(action.else)) {
                   processActions(action.else);
+                }
+              }
+              if (action.type === ACTIONS.CONDITION.WHILE) {
+                if (Array.isArray(action.while)) {
+                  processActions([action.while]);
+                }
+
+                if (Array.isArray(action.do)) {
+                  processActions(action.do);
                 }
               }
             });
@@ -451,8 +473,8 @@ class EditScene extends Component {
 
       // Build the nested structure up to the second-to-last segment
       pathSegments.forEach((segment, index) => {
-        // Special handling for 'then' and 'else' segments
-        if (segment === 'then' || segment === 'else') {
+        // Special handling for 'then', 'else' and 'do' segments
+        if (segment === 'then' || segment === 'else' || segment === 'do') {
           actionsPath[segment] = {};
           actionsPath = actionsPath[segment];
           return;
@@ -464,7 +486,7 @@ class EditScene extends Component {
         } else if (index < pathSegments.length - 1) {
           // Not the last segment - continue building the path
           const nextSegment = pathSegments[index + 1];
-          if (nextSegment === 'then' || nextSegment === 'else') {
+          if (nextSegment === 'then' || nextSegment === 'else' || nextSegment === 'do') {
             // If next segment is then/else, current segment needs numeric index
             actionsPath[parseInt(segment, 10)] = {};
             actionsPath = actionsPath[parseInt(segment, 10)];
@@ -524,7 +546,7 @@ class EditScene extends Component {
 
       // Check if we need to remove an empty action group
       // Only if we are not in a "if" action
-      if (!path.includes('if')) {
+      if (!path.includes('if') && !path.includes('while')) {
         const parentPath = path
           .split('.')
           .slice(0, -1)
@@ -538,7 +560,7 @@ class EditScene extends Component {
         // Navigate to the correct action group based on the path
         for (let i = 0; i < parentSegments.length; i++) {
           const segment = parentSegments[i];
-          if (segment === 'then' || segment === 'else') {
+          if (segment === 'then' || segment === 'else' || segment === 'do') {
             actionGroup = actionGroup[segment];
           } else {
             actionGroup = actionGroup[parseInt(segment, 10)];
@@ -573,7 +595,7 @@ class EditScene extends Component {
           // Navigate to the container
           for (let i = 0; i < parentSegments.length - 1; i++) {
             const segment = parentSegments[i];
-            if (segment === 'then' || segment === 'else') {
+            if (segment === 'then' || segment === 'else' || segment === 'do') {
               container = container[segment];
             } else {
               container = container[parseInt(segment, 10)];
@@ -592,7 +614,7 @@ class EditScene extends Component {
             // Build the path to the container
             for (let i = 0; i < parentSegments.length - 1; i++) {
               const segment = parentSegments[i];
-              if (segment === 'then' || segment === 'else') {
+              if (segment === 'then' || segment === 'else' || segment === 'do') {
                 currentNested[segment] = {};
                 currentNested = currentNested[segment];
               } else {
@@ -1075,7 +1097,7 @@ class EditScene extends Component {
     const currentLevel = parentPath.split('.').length;
 
     // Add the current level if not already in the list
-    if (!parentPath.endsWith('then') && !parentPath.endsWith('else')) {
+    if (!parentPath.endsWith('then') && !parentPath.endsWith('else') && !parentPath.endsWith('do')) {
       const groupType = `ACTION_GROUP_TYPE_LEVEL_${currentLevel}`;
       if (!types.includes(groupType)) {
         types.push(groupType);
@@ -1108,6 +1130,12 @@ class EditScene extends Component {
             if (Array.isArray(action.else)) {
               const elseTypes = this.generateActionGroupTypes(action.else, `${actionPath}.else`);
               types = [...types, ...elseTypes];
+            }
+          }
+          if (action && action.type === ACTIONS.CONDITION.WHILE) {
+            if (Array.isArray(action.do)) {
+              const doTypes = this.generateActionGroupTypes(action.do, `${actionPath}.do`);
+              types = [...types, ...doTypes];
             }
           }
         });

--- a/front/src/routes/scene/edit-scene/sceneUtils.js
+++ b/front/src/routes/scene/edit-scene/sceneUtils.js
@@ -17,7 +17,7 @@ const isVariableAvailableAtThisPath = (variableSourcePath, targetPath) => {
 
   while (sourceIndex < sourceSegments.length && targetIndex < targetSegments.length) {
     // If we encounter special segments, we need to compare within the same branch
-    if (sourceSegments[sourceIndex] === 'then' || sourceSegments[sourceIndex] === 'else') {
+    if (sourceSegments[sourceIndex] === 'then' || sourceSegments[sourceIndex] === 'else' || sourceSegments[sourceIndex] === 'do') {
       // If target doesn't match the same branch, paths are not comparable
       if (sourceSegments[sourceIndex] !== targetSegments[targetIndex]) {
         return false;
@@ -51,11 +51,17 @@ const convertPathToText = (path, dictionary) => {
       if (segment === 'if') {
         return get(dictionary, 'editScene.actionsCard.conditionIfThenElse.shortIf');
       }
+      if (segment === 'while') {
+        return get(dictionary, 'editScene.actionsCard.conditionWhile.shortWhile');
+      }
       if (segment === 'then') {
         return get(dictionary, 'editScene.actionsCard.conditionIfThenElse.shortThen');
       }
       if (segment === 'else') {
         return get(dictionary, 'editScene.actionsCard.conditionIfThenElse.shortElse');
+      }
+      if (segment === 'do') {
+        return get(dictionary, 'editScene.actionsCard.conditionWhile.shortDo');
       }
       return `${Number(segment) + 1}`;
     })

--- a/front/src/routes/scene/edit-scene/sceneUtils.js
+++ b/front/src/routes/scene/edit-scene/sceneUtils.js
@@ -17,7 +17,11 @@ const isVariableAvailableAtThisPath = (variableSourcePath, targetPath) => {
 
   while (sourceIndex < sourceSegments.length && targetIndex < targetSegments.length) {
     // If we encounter special segments, we need to compare within the same branch
-    if (sourceSegments[sourceIndex] === 'then' || sourceSegments[sourceIndex] === 'else' || sourceSegments[sourceIndex] === 'do') {
+    if (
+      sourceSegments[sourceIndex] === 'then' ||
+      sourceSegments[sourceIndex] === 'else' ||
+      sourceSegments[sourceIndex] === 'do'
+    ) {
       // If target doesn't match the same branch, paths are not comparable
       if (sourceSegments[sourceIndex] !== targetSegments[targetIndex]) {
         return false;

--- a/server/lib/scene/scene.actions.js
+++ b/server/lib/scene/scene.actions.js
@@ -20,7 +20,14 @@ const dayjs = require('dayjs');
 const utc = require('dayjs/plugin/utc');
 const timezone = require('dayjs/plugin/timezone');
 
-const { ACTIONS, DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES, ALARM_MODES, SCENE_WHILE_MAX_ITERATIONS, SCENE_WHILE_ITERATION_DELAY_MS } = require('../../utils/constants');
+const {
+  ACTIONS,
+  DEVICE_FEATURE_CATEGORIES,
+  DEVICE_FEATURE_TYPES,
+  ALARM_MODES,
+  SCENE_WHILE_MAX_ITERATIONS,
+  SCENE_WHILE_ITERATION_DELAY_MS,
+} = require('../../utils/constants');
 const { getDeviceFeature } = require('../../utils/device');
 const { AbortScene } = require('../../utils/coreErrors');
 const { compare } = require('../../utils/compare');
@@ -673,6 +680,8 @@ const actionsFunc = {
       action.iteration_delay_ms !== undefined ? action.iteration_delay_ms : SCENE_WHILE_ITERATION_DELAY_MS;
 
     let iteration = 0;
+    /* eslint-disable no-await-in-loop */
+    // Sequential iterations are intentional: conditions must be re-evaluated between each loop
     while (iteration < maxIterations) {
       let conditionsVerified;
       try {
@@ -696,6 +705,7 @@ const actionsFunc = {
       // Yield to the event loop between iterations to avoid blocking Gladys
       await Promise.delay(iterationDelayMs);
     }
+    /* eslint-enable no-await-in-loop */
 
     if (iteration >= maxIterations) {
       logger.warn(`While action at path ${path} reached max iterations (${maxIterations})`);

--- a/server/lib/scene/scene.actions.js
+++ b/server/lib/scene/scene.actions.js
@@ -20,7 +20,7 @@ const dayjs = require('dayjs');
 const utc = require('dayjs/plugin/utc');
 const timezone = require('dayjs/plugin/timezone');
 
-const { ACTIONS, DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES, ALARM_MODES } = require('../../utils/constants');
+const { ACTIONS, DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES, ALARM_MODES, SCENE_WHILE_MAX_ITERATIONS, SCENE_WHILE_ITERATION_DELAY_MS } = require('../../utils/constants');
 const { getDeviceFeature } = require('../../utils/device');
 const { AbortScene } = require('../../utils/coreErrors');
 const { compare } = require('../../utils/compare');
@@ -663,6 +663,42 @@ const actionsFunc = {
       await executeActions(self, thenActions, scope, `${path}.then`);
     } else {
       await executeActions(self, elseActions, scope, `${path}.else`);
+    }
+  },
+  [ACTIONS.CONDITION.WHILE]: async (self, action, scope, path) => {
+    const { while: whileActions, do: doActions } = action;
+    const { executeActions } = executeActionsFactory(actionsFunc);
+    const maxIterations = action.max_iterations || SCENE_WHILE_MAX_ITERATIONS;
+    const iterationDelayMs =
+      action.iteration_delay_ms !== undefined ? action.iteration_delay_ms : SCENE_WHILE_ITERATION_DELAY_MS;
+
+    let iteration = 0;
+    while (iteration < maxIterations) {
+      let conditionsVerified;
+      try {
+        await executeActions(self, [whileActions], scope, `${path}.while`, { throwUnknownError: true });
+        conditionsVerified = true;
+      } catch (e) {
+        if (e instanceof AbortScene) {
+          conditionsVerified = false;
+        } else {
+          throw e;
+        }
+      }
+
+      if (!conditionsVerified) {
+        break;
+      }
+
+      await executeActions(self, doActions, scope, `${path}.do`);
+      iteration += 1;
+
+      // Yield to the event loop between iterations to avoid blocking Gladys
+      await Promise.delay(iterationDelayMs);
+    }
+
+    if (iteration >= maxIterations) {
+      logger.warn(`While action at path ${path} reached max iterations (${maxIterations})`);
     }
   },
 };

--- a/server/models/scene.js
+++ b/server/models/scene.js
@@ -77,6 +77,16 @@ const actionSchema = Joi.object()
     if: Joi.array().items(Joi.link('#action')),
     then: Joi.array().items(Joi.array().items(Joi.link('#action'))),
     else: Joi.array().items(Joi.array().items(Joi.link('#action'))),
+    while: Joi.array().items(Joi.link('#action')),
+    do: Joi.array().items(Joi.array().items(Joi.link('#action'))),
+    max_iterations: Joi.number()
+      .integer()
+      .min(1)
+      .max(10000),
+    iteration_delay_ms: Joi.number()
+      .integer()
+      .min(0)
+      .max(60000),
   })
   .id('action');
 

--- a/server/services/mcp/lib/sceneSchemas.js
+++ b/server/services/mcp/lib/sceneSchemas.js
@@ -305,6 +305,22 @@ function createSceneCreateInputSchema(
         then: z.array(z.array(sceneActionSchema)),
         else: z.array(z.array(sceneActionSchema)),
       }),
+      actionSchemaByType(ACTIONS.CONDITION.WHILE, {
+        while: z.array(sceneActionSchema).min(1),
+        do: z.array(z.array(sceneActionSchema)),
+        max_iterations: z
+          .number()
+          .int()
+          .min(1)
+          .max(10000)
+          .optional(),
+        iteration_delay_ms: z
+          .number()
+          .int()
+          .min(0)
+          .max(60000)
+          .optional(),
+      }),
     ]),
   );
 

--- a/server/test/lib/scene/actions/scene.action.conditionWhile.test.js
+++ b/server/test/lib/scene/actions/scene.action.conditionWhile.test.js
@@ -1,0 +1,221 @@
+const { fake, assert } = require('sinon');
+const EventEmitter = require('events');
+
+const { ACTIONS } = require('../../../../utils/constants');
+const actionsFunc = require('../../../../lib/scene/scene.actions');
+const executeActionsFactory = require('../../../../lib/scene/scene.executeActions');
+
+const StateManager = require('../../../../lib/state');
+
+describe('scene.conditionWhile', () => {
+  let event;
+  let stateManager;
+  const { executeActions } = executeActionsFactory(actionsFunc);
+
+  beforeEach(() => {
+    event = new EventEmitter();
+    stateManager = new StateManager(event);
+  });
+
+  it('should not execute do block when condition is false', async () => {
+    stateManager.setState('deviceFeature', 'my-device-feature', {
+      category: 'light',
+      type: 'binary',
+      last_value: 15,
+    });
+    const message = {
+      sendToUser: fake.resolves(null),
+    };
+    const scope = {};
+    await executeActions(
+      { stateManager, event, message },
+      [
+        [
+          {
+            type: ACTIONS.DEVICE.GET_VALUE,
+            device_feature: 'my-device-feature',
+          },
+        ],
+        [
+          {
+            type: ACTIONS.CONDITION.WHILE,
+            while: [
+              {
+                type: ACTIONS.CONDITION.ONLY_CONTINUE_IF,
+                conditions: [
+                  {
+                    variable: '0.0.last_value',
+                    operator: '=',
+                    value: 20,
+                  },
+                ],
+              },
+            ],
+            do: [
+              [
+                {
+                  type: ACTIONS.MESSAGE.SEND,
+                  user: 'pepper',
+                  text: 'Do executed',
+                },
+              ],
+            ],
+            max_iterations: 5,
+            iteration_delay_ms: 0,
+          },
+        ],
+      ],
+      scope,
+    );
+    assert.notCalled(message.sendToUser);
+  });
+
+  it('should execute do block repeatedly while condition is true', async () => {
+    stateManager.setState('deviceFeature', 'my-device-feature', {
+      category: 'light',
+      type: 'binary',
+      last_value: 15,
+    });
+    const message = {
+      sendToUser: fake.resolves(null),
+    };
+    const scope = {};
+    await executeActions(
+      { stateManager, event, message },
+      [
+        [
+          {
+            type: ACTIONS.DEVICE.GET_VALUE,
+            device_feature: 'my-device-feature',
+          },
+        ],
+        [
+          {
+            type: ACTIONS.CONDITION.WHILE,
+            while: [
+              {
+                type: ACTIONS.CONDITION.ONLY_CONTINUE_IF,
+                conditions: [
+                  {
+                    variable: '0.0.last_value',
+                    operator: '=',
+                    value: 15,
+                  },
+                ],
+              },
+            ],
+            do: [
+              [
+                {
+                  type: ACTIONS.MESSAGE.SEND,
+                  user: 'pepper',
+                  text: 'Do executed',
+                },
+              ],
+            ],
+            max_iterations: 3,
+            iteration_delay_ms: 0,
+          },
+        ],
+      ],
+      scope,
+    );
+    assert.callCount(message.sendToUser, 3);
+  });
+
+  it('should execute get-value in do branch with correct path', async () => {
+    stateManager.setState('deviceFeature', 'my-device-feature', {
+      category: 'light',
+      type: 'binary',
+      last_value: 15,
+    });
+    const message = {
+      sendToUser: fake.resolves(null),
+    };
+    const scope = {};
+    await executeActions(
+      { stateManager, event, message },
+      [
+        [
+          {
+            type: ACTIONS.DEVICE.GET_VALUE,
+            device_feature: 'my-device-feature',
+          },
+        ],
+        [
+          {
+            type: ACTIONS.CONDITION.WHILE,
+            while: [
+              {
+                type: ACTIONS.CONDITION.ONLY_CONTINUE_IF,
+                conditions: [
+                  {
+                    variable: '0.0.last_value',
+                    operator: '=',
+                    value: 15,
+                  },
+                ],
+              },
+            ],
+            do: [
+              [
+                {
+                  type: ACTIONS.DEVICE.GET_VALUE,
+                  device_feature: 'my-device-feature',
+                },
+                {
+                  type: ACTIONS.MESSAGE.SEND,
+                  user: 'pepper',
+                  text: 'Do executed, last value = {{1.0.do.0.0.last_value}}',
+                },
+              ],
+            ],
+            max_iterations: 1,
+            iteration_delay_ms: 0,
+          },
+        ],
+      ],
+      scope,
+    );
+    assert.calledWith(message.sendToUser, 'pepper', 'Do executed, last value = 15');
+  });
+
+  it('should throw error when a real error happens in while condition', async () => {
+    const message = {
+      sendToUser: fake.resolves(null),
+    };
+    const house = {
+      getBySelector: fake.rejects(new Error('HOUSE_NOT_FOUND')),
+    };
+    const scope = {};
+    await executeActions(
+      { stateManager, event, message, house },
+      [
+        [
+          {
+            type: ACTIONS.CONDITION.WHILE,
+            while: [
+              {
+                type: ACTIONS.ALARM.CHECK_ALARM_MODE,
+                house: 'unknown-house',
+              },
+            ],
+            do: [
+              [
+                {
+                  type: ACTIONS.MESSAGE.SEND,
+                  user: 'pepper',
+                  text: 'Do executed',
+                },
+              ],
+            ],
+            max_iterations: 5,
+            iteration_delay_ms: 0,
+          },
+        ],
+      ],
+      scope,
+    );
+    assert.notCalled(message.sendToUser);
+  });
+});

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -531,6 +531,7 @@ const ACTIONS = {
     ONLY_CONTINUE_IF: 'condition.only-continue-if',
     CHECK_TIME: 'condition.check-time',
     IF_THEN_ELSE: 'condition.if-then-else',
+    WHILE: 'condition.while',
   },
   USER: {
     SET_SEEN_AT_HOME: 'user.set-seen-at-home',
@@ -575,6 +576,9 @@ const CONDITION_ACTIONS = [
   ACTIONS.HOUSE.IS_EMPTY,
   ACTIONS.HOUSE.IS_NOT_EMPTY,
 ];
+
+const SCENE_WHILE_MAX_ITERATIONS = 1000;
+const SCENE_WHILE_ITERATION_DELAY_MS = 50;
 
 const INTENTS = {
   LIGHT: {
@@ -1725,6 +1729,8 @@ module.exports.STATES = STATES;
 module.exports.CONDITIONS = CONDITIONS;
 module.exports.ACTIONS = ACTIONS;
 module.exports.CONDITION_ACTIONS = CONDITION_ACTIONS;
+module.exports.SCENE_WHILE_MAX_ITERATIONS = SCENE_WHILE_MAX_ITERATIONS;
+module.exports.SCENE_WHILE_ITERATION_DELAY_MS = SCENE_WHILE_ITERATION_DELAY_MS;
 module.exports.INTENTS = INTENTS;
 module.exports.DEVICE_FEATURE_CATEGORIES = DEVICE_FEATURE_CATEGORIES;
 module.exports.DEVICE_FEATURE_TYPES = DEVICE_FEATURE_TYPES;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Add a new scene action **« Tant Que »** (`condition.while`) that repeatedly executes a nested block of actions while its conditions remain true — similar to the existing « Si... Alors... Sinon... » action.

### Changes

**Server**
- New action type `condition.while` with `while` (conditions) and `do` (nested actions) blocks
- Loop execution reuses the same condition evaluation pattern as if-then-else (`AbortScene` = condition false)
- **Infinite loop protection**: max 1000 iterations by default (`max_iterations` optional field, 1–10000)
- **Event loop breathing**: 50ms delay between iterations by default (`iteration_delay_ms` optional, 0–60000ms) via `Promise.delay`
- Joi + MCP schema validation

**Front**
- New `ConditionWhile` editor component (conditions + collapsible « Faire... » block)
- Integrated in action picker, drag-and-drop, variable paths, and nested group management

**i18n**
- EN / FR / DE translations

**Tests**
- 4 unit tests covering: no execution when false, repeated execution, max iterations cap, nested variable paths, error propagation

### Example JSON

```json
{
  "type": "condition.while",
  "while": [
    { "type": "condition.only-continue-if", "conditions": [{ "variable": "0.0.last_value", "operator": "=", "value": 1 }] }
  ],
  "do": [
    [{ "type": "delay", "value": 1, "unit": "seconds" }],
    [{ "type": "device.set-value", "device_feature": "...", "value": 0 }]
  ]
}
```

### Checklist

- [x] Server tests pass (`scene.conditionWhile`)
- [x] i18n files in sync (`compare-translations`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f27cb-8654-78b4-b12d-65344b1bef04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f27cb-8654-78b4-b12d-65344b1bef04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

