### PR TITLE
feat(scene): variables pour identifier ce qui a déclenché la scène

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -2742,6 +2742,20 @@
       },
       "askAi": {
         "answer": "AI Antwort"
+      },
+      "trigger": {
+        "device": {
+          "name": "Name des auslösenden Geräts"
+        },
+        "deviceFeature": {
+          "name": "Name der auslösenden Gerätefunktion",
+          "last_value": "Aktueller Wert des Auslösers",
+          "previous_value": "Vorheriger Wert des Auslösers"
+        },
+        "mqtt": {
+          "topic": "Empfangenes MQTT-Topic",
+          "message": "Empfangene MQTT-Nachricht"
+        }
       }
     },
     "triggers": {

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -2742,6 +2742,20 @@
       },
       "askAi": {
         "answer": "AI answer"
+      },
+      "trigger": {
+        "device": {
+          "name": "Triggering device name"
+        },
+        "deviceFeature": {
+          "name": "Triggering device feature name",
+          "last_value": "Triggering device current value",
+          "previous_value": "Triggering device previous value"
+        },
+        "mqtt": {
+          "topic": "Received MQTT topic",
+          "message": "Received MQTT message"
+        }
       }
     },
     "triggers": {

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -2742,6 +2742,20 @@
       },
       "askAi": {
         "answer": "Réponse de l'IA"
+      },
+      "trigger": {
+        "device": {
+          "name": "Nom de l'appareil déclencheur"
+        },
+        "deviceFeature": {
+          "name": "Nom de la fonctionnalité déclencheuse",
+          "last_value": "Valeur actuelle du déclencheur",
+          "previous_value": "Valeur précédente du déclencheur"
+        },
+        "mqtt": {
+          "topic": "Topic MQTT reçu",
+          "message": "Message MQTT reçu"
+        }
       }
     },
     "triggers": {

--- a/front/src/routes/scene/edit-scene/TriggerCard.jsx
+++ b/front/src/routes/scene/edit-scene/TriggerCard.jsx
@@ -79,6 +79,7 @@ const TriggerCard = ({ children, ...props }) => (
           updateTriggerProperty={props.updateTriggerProperty}
           index={props.index}
           trigger={props.trigger}
+          setVariablesTrigger={props.setVariablesTrigger}
         />
       )}
       {props.trigger.type === EVENTS.TIME.CHANGED && (
@@ -172,6 +173,7 @@ const TriggerCard = ({ children, ...props }) => (
           updateTriggerProperty={props.updateTriggerProperty}
           index={props.index}
           trigger={props.trigger}
+          setVariablesTrigger={props.setVariablesTrigger}
         />
       )}
     </div>

--- a/front/src/routes/scene/edit-scene/triggers/DeviceFeatureState.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/DeviceFeatureState.jsx
@@ -1,6 +1,7 @@
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Text, Localizer } from 'preact-i18n';
+import get from 'get-value';
 
 import { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } from '../../../../../../server/utils/constants';
 
@@ -15,8 +16,57 @@ import FanModeDeviceState from './device-states/FanModeDeviceState';
 import FanLabeledDeviceState from './device-states/FanLabeledDeviceState';
 import LevelSensorDeviceState from './device-states/LevelSensorDeviceState';
 import LevelMatterSensorDeviceState from './device-states/LevelMatterSensorDeviceState';
+import withIntlAsProp from '../../../../utils/withIntlAsProp';
 
 class TurnOnLight extends Component {
+  setVariables = () => {
+    const DEVICE_NAME_VARIABLE = get(this.props.intl.dictionary, 'editScene.variables.trigger.device.name');
+    const DEVICE_FEATURE_NAME_VARIABLE = get(
+      this.props.intl.dictionary,
+      'editScene.variables.trigger.deviceFeature.name'
+    );
+    const LAST_VALUE_VARIABLE = get(this.props.intl.dictionary, 'editScene.variables.trigger.deviceFeature.last_value');
+    const PREVIOUS_VALUE_VARIABLE = get(
+      this.props.intl.dictionary,
+      'editScene.variables.trigger.deviceFeature.previous_value'
+    );
+
+    this.props.setVariablesTrigger(this.props.index, [
+      {
+        name: 'device.name',
+        type: 'trigger',
+        ready: true,
+        label: DEVICE_NAME_VARIABLE,
+        data: {}
+      },
+      {
+        name: 'deviceFeature.name',
+        type: 'trigger',
+        ready: true,
+        label: DEVICE_FEATURE_NAME_VARIABLE,
+        data: {}
+      },
+      {
+        name: 'deviceFeature.last_value',
+        type: 'trigger',
+        ready: true,
+        label: LAST_VALUE_VARIABLE,
+        data: {}
+      },
+      {
+        name: 'deviceFeature.previous_value',
+        type: 'trigger',
+        ready: true,
+        label: PREVIOUS_VALUE_VARIABLE,
+        data: {}
+      }
+    ]);
+  };
+
+  componentDidMount() {
+    this.setVariables();
+  }
+
   onDeviceFeatureChange = deviceFeature => {
     this.setState({ selectedDeviceFeature: deviceFeature });
     if (deviceFeature) {
@@ -170,4 +220,4 @@ class TurnOnLight extends Component {
   }
 }
 
-export default connect('httpClient', {})(TurnOnLight);
+export default connect('httpClient', {})(withIntlAsProp(TurnOnLight));

--- a/front/src/routes/scene/edit-scene/triggers/MQTTReceivedTrigger.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/MQTTReceivedTrigger.jsx
@@ -1,8 +1,36 @@
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Text, Localizer } from 'preact-i18n';
+import get from 'get-value';
+import withIntlAsProp from '../../../../utils/withIntlAsProp';
 
 class MQTTReceived extends Component {
+  setVariables = () => {
+    const TOPIC_VARIABLE = get(this.props.intl.dictionary, 'editScene.variables.trigger.mqtt.topic');
+    const MESSAGE_VARIABLE = get(this.props.intl.dictionary, 'editScene.variables.trigger.mqtt.message');
+
+    this.props.setVariablesTrigger(this.props.index, [
+      {
+        name: 'topic',
+        type: 'trigger',
+        ready: true,
+        label: TOPIC_VARIABLE,
+        data: {}
+      },
+      {
+        name: 'message',
+        type: 'trigger',
+        ready: true,
+        label: MESSAGE_VARIABLE,
+        data: {}
+      }
+    ]);
+  };
+
+  componentDidMount() {
+    this.setVariables();
+  }
+
   updateTopicName = e => {
     this.props.updateTriggerProperty(this.props.index, 'topic', e.target.value);
   };
@@ -53,4 +81,4 @@ class MQTTReceived extends Component {
   }
 }
 
-export default connect('httpClient,user', {})(MQTTReceived);
+export default connect('httpClient,user', {})(withIntlAsProp(MQTTReceived));

--- a/server/lib/scene/scene.buildTriggerEventScope.js
+++ b/server/lib/scene/scene.buildTriggerEventScope.js
@@ -7,6 +7,8 @@ const { EVENTS } = require('../../utils/constants');
  * @param {object} event - The raw trigger event.
  * @param {object} stateManager - The Gladys state manager.
  * @returns {object} The enriched trigger event.
+ * @example
+ * buildTriggerEventScope({ type: 'device.new-state', device_feature: 'door-sensor' }, stateManager);
  */
 function buildTriggerEventScope(event, stateManager) {
   const triggerEvent = cloneDeep(event);

--- a/server/lib/scene/scene.buildTriggerEventScope.js
+++ b/server/lib/scene/scene.buildTriggerEventScope.js
@@ -1,0 +1,78 @@
+const cloneDeep = require('lodash.clonedeep');
+
+const { EVENTS } = require('../../utils/constants');
+
+/**
+ * @description Enrich a trigger event with human-readable data for use in scene variables.
+ * @param {object} event - The raw trigger event.
+ * @param {object} stateManager - The Gladys state manager.
+ * @returns {object} The enriched trigger event.
+ */
+function buildTriggerEventScope(event, stateManager) {
+  const triggerEvent = cloneDeep(event);
+
+  switch (event.type) {
+    case EVENTS.DEVICE.NEW_STATE: {
+      const deviceFeature = stateManager.get('deviceFeature', event.device_feature);
+      if (deviceFeature) {
+        triggerEvent.deviceFeature = cloneDeep({
+          selector: deviceFeature.selector,
+          name: deviceFeature.name,
+          category: deviceFeature.category,
+          type: deviceFeature.type,
+          unit: deviceFeature.unit,
+          last_value: event.last_value,
+          previous_value: event.previous_value,
+          last_value_changed: event.last_value_changed,
+        });
+        const device = stateManager.get('deviceById', deviceFeature.device_id);
+        if (device) {
+          triggerEvent.device = cloneDeep({
+            selector: device.selector,
+            name: device.name,
+          });
+        }
+      }
+      break;
+    }
+    case EVENTS.USER_PRESENCE.BACK_HOME:
+    case EVENTS.USER_PRESENCE.LEFT_HOME: {
+      const user = stateManager.get('user', event.user);
+      if (user) {
+        triggerEvent.user = cloneDeep({
+          selector: user.selector,
+          firstname: user.firstname,
+          lastname: user.lastname,
+        });
+      }
+      const house = stateManager.get('house', event.house);
+      if (house) {
+        triggerEvent.house = cloneDeep({
+          selector: house.selector,
+          name: house.name,
+        });
+      }
+      break;
+    }
+    case EVENTS.AREA.USER_ENTERED:
+    case EVENTS.AREA.USER_LEFT: {
+      const user = stateManager.get('user', event.user);
+      if (user) {
+        triggerEvent.user = cloneDeep({
+          selector: user.selector,
+          firstname: user.firstname,
+          lastname: user.lastname,
+        });
+      }
+      break;
+    }
+    default:
+      break;
+  }
+
+  return triggerEvent;
+}
+
+module.exports = {
+  buildTriggerEventScope,
+};

--- a/server/lib/scene/scene.checkTrigger.js
+++ b/server/lib/scene/scene.checkTrigger.js
@@ -1,4 +1,5 @@
 const { triggersFunc } = require('./scene.triggers');
+const { buildTriggerEventScope } = require('./scene.buildTriggerEventScope');
 const logger = require('../../utils/logger');
 
 /**
@@ -36,7 +37,7 @@ function checkTrigger(event) {
           // if yes, we execute the scene
           if (conditionVerified) {
             this.execute(sceneSelector, {
-              triggerEvent: event,
+              triggerEvent: buildTriggerEventScope(event, this.stateManager),
             });
           }
         }

--- a/server/test/lib/scene/scene.buildTriggerEventScope.test.js
+++ b/server/test/lib/scene/scene.buildTriggerEventScope.test.js
@@ -69,6 +69,70 @@ describe('scene.buildTriggerEventScope', () => {
     expect(triggerEvent).to.not.have.property('device');
     expect(triggerEvent.device_feature).to.equal('unknown-sensor');
   });
+
+  it('should enrich user presence event with user and house info', () => {
+    stateManager.setState('user', 'john', {
+      selector: 'john',
+      firstname: 'John',
+      lastname: 'Doe',
+    });
+    stateManager.setState('house', 'main-house', {
+      selector: 'main-house',
+      name: 'Home',
+    });
+
+    const event = {
+      type: EVENTS.USER_PRESENCE.BACK_HOME,
+      user: 'john',
+      house: 'main-house',
+    };
+
+    const triggerEvent = buildTriggerEventScope(event, stateManager);
+
+    expect(triggerEvent.user).to.deep.equal({
+      selector: 'john',
+      firstname: 'John',
+      lastname: 'Doe',
+    });
+    expect(triggerEvent.house).to.deep.equal({
+      selector: 'main-house',
+      name: 'Home',
+    });
+  });
+
+  it('should enrich area event with user info', () => {
+    stateManager.setState('user', 'john', {
+      selector: 'john',
+      firstname: 'John',
+      lastname: 'Doe',
+    });
+
+    const event = {
+      type: EVENTS.AREA.USER_ENTERED,
+      user: 'john',
+      area: 'kitchen',
+    };
+
+    const triggerEvent = buildTriggerEventScope(event, stateManager);
+
+    expect(triggerEvent.user).to.deep.equal({
+      selector: 'john',
+      firstname: 'John',
+      lastname: 'Doe',
+    });
+  });
+
+  it('should return event unchanged for unsupported trigger types', () => {
+    const event = {
+      type: EVENTS.MQTT.RECEIVED,
+      topic: 'gladys/test',
+      message: 'hello',
+    };
+
+    const triggerEvent = buildTriggerEventScope(event, stateManager);
+
+    expect(triggerEvent).to.deep.equal(event);
+  });
 });
 
 describe('scene triggerEvent in actions', () => {

--- a/server/test/lib/scene/scene.buildTriggerEventScope.test.js
+++ b/server/test/lib/scene/scene.buildTriggerEventScope.test.js
@@ -1,0 +1,215 @@
+const { expect } = require('chai');
+const EventEmitter = require('events');
+
+const { EVENTS, ACTIONS } = require('../../../utils/constants');
+const { buildTriggerEventScope } = require('../../../lib/scene/scene.buildTriggerEventScope');
+const SceneManager = require('../../../lib/scene');
+const StateManager = require('../../../lib/state');
+const executeActionsFactory = require('../../../lib/scene/scene.executeActions');
+const actionsFunc = require('../../../lib/scene/scene.actions');
+
+describe('scene.buildTriggerEventScope', () => {
+  let stateManager;
+
+  beforeEach(() => {
+    stateManager = new StateManager(new EventEmitter());
+  });
+
+  it('should enrich device.new-state event with device and deviceFeature info', () => {
+    stateManager.setState('deviceFeature', 'door-sensor', {
+      selector: 'door-sensor',
+      name: 'Front door',
+      category: 'opening-sensor',
+      type: 'binary',
+      unit: null,
+      device_id: 'device-1',
+    });
+    stateManager.setState('deviceById', 'device-1', {
+      selector: 'my-door',
+      name: 'Door sensor',
+    });
+
+    const event = {
+      type: EVENTS.DEVICE.NEW_STATE,
+      device_feature: 'door-sensor',
+      previous_value: 0,
+      last_value: 1,
+      last_value_changed: new Date('2024-01-01'),
+    };
+
+    const triggerEvent = buildTriggerEventScope(event, stateManager);
+
+    expect(triggerEvent).to.have.property('deviceFeature');
+    expect(triggerEvent.deviceFeature).to.deep.include({
+      selector: 'door-sensor',
+      name: 'Front door',
+      category: 'opening-sensor',
+      type: 'binary',
+      last_value: 1,
+      previous_value: 0,
+    });
+    expect(triggerEvent.device).to.deep.equal({
+      selector: 'my-door',
+      name: 'Door sensor',
+    });
+  });
+
+  it('should return event unchanged when device feature is unknown', () => {
+    const event = {
+      type: EVENTS.DEVICE.NEW_STATE,
+      device_feature: 'unknown-sensor',
+      previous_value: 0,
+      last_value: 1,
+    };
+
+    const triggerEvent = buildTriggerEventScope(event, stateManager);
+
+    expect(triggerEvent).to.not.have.property('deviceFeature');
+    expect(triggerEvent).to.not.have.property('device');
+    expect(triggerEvent.device_feature).to.equal('unknown-sensor');
+  });
+});
+
+describe('scene triggerEvent in actions', () => {
+  const { executeActions } = executeActionsFactory(actionsFunc);
+
+  it('should inject triggerEvent variables in send message action', async () => {
+    const stateManager = new StateManager(new EventEmitter());
+    stateManager.setState('deviceFeature', 'door-sensor', {
+      selector: 'door-sensor',
+      name: 'Front door',
+      category: 'opening-sensor',
+      type: 'binary',
+      device_id: 'device-1',
+    });
+    stateManager.setState('deviceById', 'device-1', {
+      selector: 'my-door',
+      name: 'Door sensor',
+    });
+
+    const message = {
+      sendToUser: require('sinon').fake.resolves(null),
+    };
+
+    const scope = {
+      triggerEvent: buildTriggerEventScope(
+        {
+          type: EVENTS.DEVICE.NEW_STATE,
+          device_feature: 'door-sensor',
+          previous_value: 0,
+          last_value: 1,
+        },
+        stateManager,
+      ),
+    };
+
+    await executeActions(
+      { stateManager, message, event: new EventEmitter() },
+      [
+        [
+          {
+            type: ACTIONS.MESSAGE.SEND,
+            user: 'pepper',
+            text: 'Alert: {{triggerEvent.device.name}} - {{triggerEvent.deviceFeature.name}} is now {{triggerEvent.deviceFeature.last_value}}',
+          },
+        ],
+      ],
+      scope,
+    );
+
+    require('sinon').assert.calledWith(
+      message.sendToUser,
+      'pepper',
+      'Alert: Door sensor - Front door is now 1',
+    );
+  });
+});
+
+describe('scene.checkTrigger triggerEvent', () => {
+  let sceneManager;
+  const event = new EventEmitter();
+  const device = {
+    setValue: require('sinon').fake.resolves(null),
+  };
+  const brain = {};
+
+  beforeEach(() => {
+    const stateManager = new StateManager(event);
+    stateManager.setState('deviceFeature', 'door-sensor', {
+      selector: 'door-sensor',
+      name: 'Front door',
+      category: 'opening-sensor',
+      type: 'binary',
+      device_id: 'device-1',
+      last_value: 0,
+    });
+    stateManager.setState('deviceById', 'device-1', {
+      selector: 'my-door',
+      name: 'Door sensor',
+    });
+
+    const message = {
+      sendToUser: require('sinon').fake.resolves(null),
+    };
+
+    sceneManager = new SceneManager(
+      stateManager,
+      event,
+      device,
+      message,
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      brain,
+    );
+  });
+
+  it('should pass enriched triggerEvent when scene is triggered by device state', async () => {
+    await sceneManager.addScene({
+      selector: 'door-scene',
+      active: true,
+      actions: [
+        [
+          {
+            type: ACTIONS.MESSAGE.SEND,
+            user: 'pepper',
+            text: 'Opened: {{triggerEvent.deviceFeature.name}}',
+          },
+        ],
+      ],
+      triggers: [
+        {
+          type: EVENTS.DEVICE.NEW_STATE,
+          device_feature: 'door-sensor',
+          value: 1,
+          operator: '=',
+        },
+      ],
+    });
+
+    sceneManager.checkTrigger({
+      type: EVENTS.DEVICE.NEW_STATE,
+      device_feature: 'door-sensor',
+      previous_value: 0,
+      last_value: 1,
+    });
+
+    await new Promise((resolve, reject) => {
+      sceneManager.queue.start(() => {
+        try {
+          require('sinon').assert.calledWith(
+            sceneManager.message.sendToUser,
+            'pepper',
+            'Opened: Front door',
+          );
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  });
+});

--- a/server/test/lib/scene/scene.buildTriggerEventScope.test.js
+++ b/server/test/lib/scene/scene.buildTriggerEventScope.test.js
@@ -1,4 +1,5 @@
 const { expect } = require('chai');
+const { fake, assert } = require('sinon');
 const EventEmitter = require('events');
 
 const { EVENTS, ACTIONS } = require('../../../utils/constants');
@@ -88,7 +89,7 @@ describe('scene triggerEvent in actions', () => {
     });
 
     const message = {
-      sendToUser: require('sinon').fake.resolves(null),
+      sendToUser: fake.resolves(null),
     };
 
     const scope = {
@@ -110,18 +111,15 @@ describe('scene triggerEvent in actions', () => {
           {
             type: ACTIONS.MESSAGE.SEND,
             user: 'pepper',
-            text: 'Alert: {{triggerEvent.device.name}} - {{triggerEvent.deviceFeature.name}} is now {{triggerEvent.deviceFeature.last_value}}',
+            text:
+              'Alert: {{triggerEvent.device.name}} - {{triggerEvent.deviceFeature.name}} is now {{triggerEvent.deviceFeature.last_value}}',
           },
         ],
       ],
       scope,
     );
 
-    require('sinon').assert.calledWith(
-      message.sendToUser,
-      'pepper',
-      'Alert: Door sensor - Front door is now 1',
-    );
+    assert.calledWith(message.sendToUser, 'pepper', 'Alert: Door sensor - Front door is now 1');
   });
 });
 
@@ -129,7 +127,7 @@ describe('scene.checkTrigger triggerEvent', () => {
   let sceneManager;
   const event = new EventEmitter();
   const device = {
-    setValue: require('sinon').fake.resolves(null),
+    setValue: fake.resolves(null),
   };
   const brain = {};
 
@@ -149,22 +147,10 @@ describe('scene.checkTrigger triggerEvent', () => {
     });
 
     const message = {
-      sendToUser: require('sinon').fake.resolves(null),
+      sendToUser: fake.resolves(null),
     };
 
-    sceneManager = new SceneManager(
-      stateManager,
-      event,
-      device,
-      message,
-      {},
-      {},
-      {},
-      {},
-      {},
-      {},
-      brain,
-    );
+    sceneManager = new SceneManager(stateManager, event, device, message, {}, {}, {}, {}, {}, {}, brain);
   });
 
   it('should pass enriched triggerEvent when scene is triggered by device state', async () => {
@@ -200,11 +186,7 @@ describe('scene.checkTrigger triggerEvent', () => {
     await new Promise((resolve, reject) => {
       sceneManager.queue.start(() => {
         try {
-          require('sinon').assert.calledWith(
-            sceneManager.message.sendToUser,
-            'pepper',
-            'Opened: Front door',
-          );
+          assert.calledWith(sceneManager.message.sendToUser, 'pepper', 'Opened: Front door');
           resolve();
         } catch (e) {
           reject(e);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Implémente la demande de la communauté : [Avoir la possibilité de récupérer qui a déclenché la scène](https://community.gladysassistant.com/t/avoir-la-possibilite-de-recuperer-qui-a-declencher-la-scene/8534).

Lorsqu'une scène est déclenchée par un événement (changement d'état d'appareil, message MQTT, etc.), les informations du déclencheur sont désormais enrichies et exposées dans le scope de la scène via la variable `triggerEvent`.

### Utilisation

Dans une action de scène (message, SMS, notification, etc.), il est possible d'utiliser des variables comme :

- `{{triggerEvent.device.name}}` — nom de l'appareil qui a déclenché la scène
- `{{triggerEvent.deviceFeature.name}}` — nom de la fonctionnalité déclencheuse
- `{{triggerEvent.deviceFeature.last_value}}` — valeur actuelle
- `{{triggerEvent.deviceFeature.previous_value}}` — valeur précédente
- `{{triggerEvent.topic}}` / `{{triggerEvent.message}}` — pour les déclencheurs MQTT

Ces variables sont proposées automatiquement dans l'éditeur de scène (comme pour les événements calendrier) lorsqu'un déclencheur « Changement d'état d'appareil » ou « Message MQTT » est configuré.

### Exemple concret

Scène avec plusieurs capteurs de porte en déclencheurs → envoi d'un message :

> Alerte : la porte **{{triggerEvent.deviceFeature.name}}** ({{triggerEvent.device.name}}) est passée à {{triggerEvent.deviceFeature.last_value}}

### Changements techniques

- **Serveur** : nouveau module `scene.buildTriggerEventScope.js` qui enrichit l'événement déclencheur avec les métadonnées appareil/fonctionnalité
- **Front** : variables de déclencheur exposées dans l'éditeur pour les triggers device et MQTT
- **i18n** : libellés ajoutés en fr, en et de

### Check-list

- [x] Tests écrits (`server/test/lib/scene/scene.buildTriggerEventScope.test.js`)
- [x] Tests passants sur les nouveaux cas
- [x] `compare-translations` passant

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f28c0-dd0c-74f6-9ffd-cacc1917e36f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f28c0-dd0c-74f6-9ffd-cacc1917e36f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

