### PR TITLE
Scenes: filtres et multi-sélection pour le choix des appareils (#8566)

### DIFF
--- a/front/src/components/device/SelectDeviceFeature.css
+++ b/front/src/components/device/SelectDeviceFeature.css
@@ -1,0 +1,15 @@
+.select-device-feature-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.select-device-feature-filter {
+  flex: 1 1 10rem;
+  min-width: 10rem;
+}
+
+.select-device-feature-filter .react-select-container {
+  font-size: 0.875rem;
+}

--- a/front/src/components/device/SelectDeviceFeature.jsx
+++ b/front/src/components/device/SelectDeviceFeature.jsx
@@ -1,30 +1,34 @@
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
+import { Text } from 'preact-i18n';
 import Select from 'react-select';
+import get from 'get-value';
 
 import { getDeviceFeatureName } from '../../utils/device';
 import withIntlAsProp from '../../utils/withIntlAsProp';
+import './SelectDeviceFeature.css';
+
+const sortByLabel = (a, b) => a.label.localeCompare(b.label);
 
 class SelectDeviceFeature extends Component {
+  getFeatureTypeLabel = (category, type) => {
+    const label = get(this.props.intl.dictionary, `deviceFeatureCategory.${category}.${type}`);
+    if (label) {
+      return label;
+    }
+    return `${category} / ${type}`;
+  };
+
   getOptions = async () => {
     try {
       const rooms = await this.props.httpClient.get('/api/v1/room', { expand: 'devices' });
-      const deviceOptions = [];
 
       const deviceDictionnary = {};
       const deviceFeaturesDictionnary = {};
+      const allFeatures = [];
+      const roomOptions = [];
 
-      const sortByLabel = (a, b) => {
-        if (a.label < b.label) {
-          return -1;
-        }
-        if (a.label > b.label) {
-          return 1;
-        }
-        return 0;
-      };
-
-      const pushDeviceFeatures = (devices, targetFeatures) => {
+      const pushDeviceFeatures = (devices, roomId = null, roomName = null) => {
         devices.forEach(device => {
           device.features.forEach(feature => {
             deviceFeaturesDictionnary[feature.selector] = feature;
@@ -34,24 +38,19 @@ class SelectDeviceFeature extends Component {
               return;
             }
 
-            targetFeatures.push({
-              value: feature.selector,
-              label: getDeviceFeatureName(this.props.intl.dictionary, device, feature)
+            allFeatures.push({
+              feature,
+              device,
+              roomId,
+              roomName
             });
           });
         });
       };
 
       rooms.forEach(room => {
-        const roomDeviceFeatures = [];
-        pushDeviceFeatures(room.devices, roomDeviceFeatures);
-        if (roomDeviceFeatures.length > 0) {
-          roomDeviceFeatures.sort(sortByLabel);
-          deviceOptions.push({
-            label: room.name,
-            options: roomDeviceFeatures
-          });
-        }
+        roomOptions.push({ value: room.id, label: room.name });
+        pushDeviceFeatures(room.devices, room.id, room.name);
       });
 
       let devicesWithoutRoom = [];
@@ -62,23 +61,81 @@ class SelectDeviceFeature extends Component {
         console.error('Could not load devices without room', e);
       }
 
-      const noRoomDeviceFeatures = [];
-      pushDeviceFeatures(devicesWithoutRoom, noRoomDeviceFeatures);
-      if (noRoomDeviceFeatures.length > 0) {
-        noRoomDeviceFeatures.sort(sortByLabel);
-        deviceOptions.push({
-          label: this.props.intl.dictionary.device.noRoom,
-          options: noRoomDeviceFeatures
-        });
-      }
+      pushDeviceFeatures(devicesWithoutRoom, 'no-room', this.props.intl.dictionary.device.noRoom);
 
-      await this.setState({ deviceOptions, deviceFeaturesDictionnary, deviceDictionnary });
+      const featureTypeOptions = [];
+      const seenFeatureTypes = new Set();
+      allFeatures.forEach(({ feature }) => {
+        const featureTypeKey = `${feature.category}:${feature.type}`;
+        if (!seenFeatureTypes.has(featureTypeKey)) {
+          seenFeatureTypes.add(featureTypeKey);
+          featureTypeOptions.push({
+            value: featureTypeKey,
+            label: this.getFeatureTypeLabel(feature.category, feature.type)
+          });
+        }
+      });
+      featureTypeOptions.sort(sortByLabel);
+      roomOptions.sort(sortByLabel);
+
+      await this.setState({
+        allFeatures,
+        roomOptions,
+        featureTypeOptions,
+        deviceFeaturesDictionnary,
+        deviceDictionnary
+      });
       await this.refreshSelectedOptions(this.props);
-      return deviceOptions;
     } catch (e) {
       console.error(e);
     }
   };
+
+  getFilteredDeviceOptions = () => {
+    const { allFeatures, filterRoom, filterType } = this.state;
+    if (!allFeatures) {
+      return [];
+    }
+
+    let filteredFeatures = allFeatures;
+    if (filterRoom) {
+      filteredFeatures = filteredFeatures.filter(({ roomId }) => roomId === filterRoom);
+    }
+    if (filterType) {
+      filteredFeatures = filteredFeatures.filter(({ feature }) => `${feature.category}:${feature.type}` === filterType);
+    }
+
+    const featureOptions = filteredFeatures.map(({ feature, device }) => ({
+      value: feature.selector,
+      label: getDeviceFeatureName(this.props.intl.dictionary, device, feature)
+    }));
+    featureOptions.sort(sortByLabel);
+
+    if (filterRoom || filterType) {
+      return featureOptions;
+    }
+
+    const groupedOptions = {};
+    filteredFeatures.forEach(({ feature, device, roomName }) => {
+      const groupLabel = roomName || this.props.intl.dictionary.device.noRoom;
+      if (!groupedOptions[groupLabel]) {
+        groupedOptions[groupLabel] = [];
+      }
+      groupedOptions[groupLabel].push({
+        value: feature.selector,
+        label: getDeviceFeatureName(this.props.intl.dictionary, device, feature)
+      });
+    });
+
+    return Object.keys(groupedOptions)
+      .sort()
+      .map(label => {
+        const options = groupedOptions[label];
+        options.sort(sortByLabel);
+        return { label, options };
+      });
+  };
+
   handleChange = selectedOption => {
     const { deviceFeaturesDictionnary, deviceDictionnary } = this.state;
     if (selectedOption && selectedOption.value) {
@@ -90,40 +147,91 @@ class SelectDeviceFeature extends Component {
       this.props.onDeviceFeatureChange(null);
     }
   };
-  refreshSelectedOptions = async nextProps => {
-    let selectedOption = '';
-    const { selectedOption: originalSelected } = this.state;
-    if (nextProps.value && this.state.deviceOptions) {
-      let deviceOption;
-      let i = 0;
-      while (i < this.state.deviceOptions.length && deviceOption === undefined) {
-        deviceOption = this.state.deviceOptions[i].options.find(option => option.value === nextProps.value);
-        i++;
-      }
 
-      if (deviceOption) {
-        selectedOption = deviceOption;
-      }
+  handleMultiChange = selectedOptions => {
+    const { deviceFeaturesDictionnary, deviceDictionnary } = this.state;
+
+    if (!selectedOptions || selectedOptions.length === 0) {
+      this.setState({ selectedOption: null, selectedOptions: [] });
+      this.props.onDeviceFeatureChange(null);
+      return;
     }
 
-    await this.setState({ selectedOption });
+    const firstOption = selectedOptions[0];
+    const additionalOptions = selectedOptions.slice(1);
 
-    if (originalSelected !== selectedOption) {
+    this.props.onDeviceFeatureChange(
+      deviceFeaturesDictionnary[firstOption.value],
+      deviceDictionnary[firstOption.value]
+    );
+
+    if (additionalOptions.length > 0 && this.props.onAdditionalDeviceFeaturesSelected) {
+      this.props.onAdditionalDeviceFeaturesSelected(
+        additionalOptions.map(option => ({
+          deviceFeature: deviceFeaturesDictionnary[option.value],
+          device: deviceDictionnary[option.value]
+        }))
+      );
+    }
+
+    this.setState({ selectedOption: firstOption, selectedOptions: [firstOption] });
+  };
+
+  handleRoomFilterChange = selectedOption => {
+    this.setState({ filterRoom: selectedOption ? selectedOption.value : null });
+  };
+
+  handleTypeFilterChange = selectedOption => {
+    this.setState({ filterType: selectedOption ? selectedOption.value : null });
+  };
+
+  refreshSelectedOptions = async nextProps => {
+    const deviceOptions = this.getFilteredDeviceOptions();
+    let selectedOption = null;
+    const { selectedOption: originalSelected } = this.state;
+
+    if (nextProps.value && this.state.deviceFeaturesDictionnary[nextProps.value]) {
+      const feature = this.state.deviceFeaturesDictionnary[nextProps.value];
+      const device = this.state.deviceDictionnary[nextProps.value];
+      selectedOption = {
+        value: nextProps.value,
+        label: getDeviceFeatureName(this.props.intl.dictionary, device, feature)
+      };
+    }
+
+    const selectedOptions = selectedOption ? [selectedOption] : [];
+
+    await this.setState({
+      selectedOption,
+      selectedOptions,
+      deviceOptions
+    });
+
+    if (!this.props.isMulti && originalSelected !== selectedOption && nextProps.value !== this.props.value) {
       if (selectedOption) {
         this.props.onDeviceFeatureChange(
           this.state.deviceFeaturesDictionnary[selectedOption.value],
           this.state.deviceDictionnary[selectedOption.value]
         );
-      } else {
+      } else if (nextProps.value === null || nextProps.value === undefined) {
         this.props.onDeviceFeatureChange(null, null);
       }
     }
   };
+
   constructor(props) {
     super(props);
     this.state = {
+      allFeatures: null,
+      roomOptions: [],
+      featureTypeOptions: [],
       deviceOptions: null,
-      selectedOption: ''
+      deviceFeaturesDictionnary: {},
+      deviceDictionnary: {},
+      filterRoom: null,
+      filterType: null,
+      selectedOption: null,
+      selectedOptions: []
     };
   }
 
@@ -135,21 +243,76 @@ class SelectDeviceFeature extends Component {
     this.refreshSelectedOptions(nextProps);
   }
 
-  render(props, { selectedOption, deviceOptions }) {
+  componentDidUpdate(prevProps, prevState) {
+    if (
+      prevState.filterRoom !== this.state.filterRoom ||
+      prevState.filterType !== this.state.filterType ||
+      prevState.allFeatures !== this.state.allFeatures
+    ) {
+      this.refreshSelectedOptions(this.props);
+    }
+  }
+
+  render(props, state) {
+    const { withFilters, isMulti } = props;
+    const {
+      deviceOptions,
+      roomOptions,
+      featureTypeOptions,
+      filterRoom,
+      filterType,
+      selectedOption,
+      selectedOptions
+    } = state;
+
     if (!deviceOptions) {
       return null;
     }
+
+    const roomFilterValue = filterRoom ? roomOptions.find(option => option.value === filterRoom) : null;
+    const typeFilterValue = filterType ? featureTypeOptions.find(option => option.value === filterType) : null;
+
     return (
-      <Select
-        class="select-device-feature"
-        defaultValue={''}
-        value={selectedOption}
-        onChange={this.handleChange}
-        options={deviceOptions}
-        styles={{ menu: base => ({ ...base, zIndex: 2 }) }}
-        className="react-select-container"
-        classNamePrefix="react-select"
-      />
+      <div>
+        {withFilters && (
+          <div class="select-device-feature-filters">
+            <div class="select-device-feature-filter">
+              <Select
+                isClearable
+                placeholder={<Text id="selectDeviceFeature.filterByRoom" />}
+                value={roomFilterValue}
+                onChange={this.handleRoomFilterChange}
+                options={roomOptions}
+                className="react-select-container"
+                classNamePrefix="react-select"
+              />
+            </div>
+            <div class="select-device-feature-filter">
+              <Select
+                isClearable
+                placeholder={<Text id="selectDeviceFeature.filterByType" />}
+                value={typeFilterValue}
+                onChange={this.handleTypeFilterChange}
+                options={featureTypeOptions}
+                className="react-select-container"
+                classNamePrefix="react-select"
+              />
+            </div>
+          </div>
+        )}
+        <Select
+          class="select-device-feature"
+          defaultValue={isMulti ? [] : ''}
+          isMulti={isMulti}
+          closeMenuOnSelect={!isMulti}
+          value={isMulti ? selectedOptions : selectedOption}
+          onChange={isMulti ? this.handleMultiChange : this.handleChange}
+          options={deviceOptions}
+          styles={{ menu: base => ({ ...base, zIndex: 2 }) }}
+          className="react-select-container"
+          classNamePrefix="react-select"
+        />
+      </div>
     );
   }
 }

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -68,6 +68,10 @@
     "noFeatures": "Keine Funktionen",
     "tooMuchStatesToDelete": "Dieses Gerät hat {{count}} Zustände in der Datenbank. Um zu verhindern, dass deine Gladys-Instanz langsam wird, während sie gelöscht werden, haben wir begonnen, diese Zustände langsam im Hintergrund zu löschen. Du kannst zurückkommen, um dieses Gerät zu löschen, wenn es keine Zustände mehr hat. Um den Löschvorgang zu überwachen, <a href=\"/dashboard/settings/jobs\">klicke hier</a>."
   },
+  "selectDeviceFeature": {
+    "filterByRoom": "Nach Raum filtern",
+    "filterByType": "Nach Funktionstyp filtern"
+  },
   "login": {
     "title": "Gladys Assistant",
     "welcome": "Willkommen",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -68,6 +68,10 @@
     "noFeatures": "No features",
     "tooMuchStatesToDelete": "This device has {{count}} states in database. To prevent your Gladys instance to be slow while deleting them, we've started a delete of those states slowly in background. You can come back to delete this device later when the device will not have any states anymore. To follow the delete job, <a href=\"/dashboard/settings/jobs\">click here</a>."
   },
+  "selectDeviceFeature": {
+    "filterByRoom": "Filter by room",
+    "filterByType": "Filter by feature type"
+  },
   "login": {
     "title": "Gladys Assistant",
     "welcome": "Welcome",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -68,6 +68,10 @@
     "noFeatures": "Aucune fonctionnalité",
     "tooMuchStatesToDelete": "Cet appareil a {{count}} états dans la base de données et ne peut être supprimé immédiatement. Gladys a lancé une suppression lente en arrière-plan de tous les états de cet appareil afin d'éviter qu'elle ne soit bloquée pendant la suppression de ceux-ci. Cette suppression peut durer quelques minutes /heures ( selon la rapidité de votre disque). Vous pouvez suivre la progression de la suppression <a href=\"/dashboard/settings/jobs\"> ici</a>. Lorsque ce processus sera terminé, nous vous invitons à revenir sur cet onglet pour effectuer la suppression définitive de cet appareil."
   },
+  "selectDeviceFeature": {
+    "filterByRoom": "Filtrer par pièce",
+    "filterByType": "Filtrer par type de fonctionnalité"
+  },
   "login": {
     "title": "Gladys Assistant",
     "welcome": "Bienvenue",

--- a/front/src/routes/scene/edit-scene/EditScenePage.jsx
+++ b/front/src/routes/scene/edit-scene/EditScenePage.jsx
@@ -124,6 +124,7 @@ const EditScenePage = ({ children, ...props }) => (
               <TriggerGroup
                 triggers={props.scene.triggers}
                 addTrigger={props.addTrigger}
+                addTriggersAfter={props.addTriggersAfter}
                 deleteTrigger={props.deleteTrigger}
                 updateTriggerProperty={props.updateTriggerProperty}
                 saving={props.saving}

--- a/front/src/routes/scene/edit-scene/TriggerCard.jsx
+++ b/front/src/routes/scene/edit-scene/TriggerCard.jsx
@@ -77,6 +77,7 @@ const TriggerCard = ({ children, ...props }) => (
       {props.trigger.type === EVENTS.DEVICE.NEW_STATE && (
         <DeviceFeatureState
           updateTriggerProperty={props.updateTriggerProperty}
+          addTriggersAfter={props.addTriggersAfter}
           index={props.index}
           trigger={props.trigger}
         />

--- a/front/src/routes/scene/edit-scene/TriggerGroup.jsx
+++ b/front/src/routes/scene/edit-scene/TriggerGroup.jsx
@@ -47,6 +47,7 @@ const TriggerGroup = ({ children, ...props }) => (
                       deleteTrigger={props.deleteTrigger}
                       index={index}
                       updateTriggerProperty={props.updateTriggerProperty}
+                      addTriggersAfter={props.addTriggersAfter}
                       variables={props.variables}
                       setVariablesTrigger={props.setVariablesTrigger}
                     />

--- a/front/src/routes/scene/edit-scene/actions/DeviceGetValueParams.jsx
+++ b/front/src/routes/scene/edit-scene/actions/DeviceGetValueParams.jsx
@@ -9,6 +9,19 @@ import withIntlAsProp from '../../../../utils/withIntlAsProp';
 import { DeviceFeatureTypesString } from '../../../../utils/consts';
 
 class DeviceGetValue extends Component {
+  onAdditionalDeviceFeaturesSelected = additionalSelections => {
+    if (!this.props.addAction || additionalSelections.length === 0) {
+      return;
+    }
+
+    additionalSelections.forEach(({ deviceFeature }) => {
+      this.props.addAction(this.props.path, {
+        type: this.props.action.type,
+        device_feature: deviceFeature.selector
+      });
+    });
+  };
+
   onDeviceFeatureChange = (deviceFeature, device) => {
     if (deviceFeature) {
       this.props.updateActionProperty(this.props.path, 'device_feature', deviceFeature.selector);
@@ -65,7 +78,13 @@ class DeviceGetValue extends Component {
               <Text id="global.requiredField" />
             </span>
           </label>
-          <SelectDeviceFeature value={action.device_feature} onDeviceFeatureChange={this.onDeviceFeatureChange} />
+          <SelectDeviceFeature
+            value={action.device_feature}
+            onDeviceFeatureChange={this.onDeviceFeatureChange}
+            withFilters
+            isMulti
+            onAdditionalDeviceFeaturesSelected={this.onAdditionalDeviceFeaturesSelected}
+          />
         </div>
       </div>
     );

--- a/front/src/routes/scene/edit-scene/index.js
+++ b/front/src/routes/scene/edit-scene/index.js
@@ -726,6 +726,24 @@ class EditScene extends Component {
       return newState;
     });
   };
+  addTriggersAfter = (index, triggersConfig) => {
+    if (!triggersConfig || triggersConfig.length === 0) {
+      return;
+    }
+    this.setState(prevState => {
+      const newState = update(prevState, {
+        scene: {
+          triggers: {
+            $splice: [[index + 1, 0, ...triggersConfig]]
+          }
+        },
+        triggersVariables: {
+          $splice: [[index + 1, 0, ...triggersConfig.map(() => [])]]
+        }
+      });
+      return newState;
+    });
+  };
   deleteTrigger = index => {
     this.setState(prevState => {
       const newState = update(prevState, {
@@ -1160,6 +1178,7 @@ class EditScene extends Component {
               deleteActionGroup={this.deleteActionGroup}
               deleteAction={this.deleteAction}
               addTrigger={this.addTrigger}
+              addTriggersAfter={this.addTriggersAfter}
               deleteTrigger={this.deleteTrigger}
               saving={saving}
               error={error}

--- a/front/src/routes/scene/edit-scene/triggers/DeviceFeatureState.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/DeviceFeatureState.jsx
@@ -17,6 +17,28 @@ import LevelSensorDeviceState from './device-states/LevelSensorDeviceState';
 import LevelMatterSensorDeviceState from './device-states/LevelMatterSensorDeviceState';
 
 class TurnOnLight extends Component {
+  onAdditionalDeviceFeaturesSelected = additionalSelections => {
+    if (!this.props.addTriggersAfter || additionalSelections.length === 0) {
+      return;
+    }
+
+    const template = {
+      type: this.props.trigger.type,
+      value: this.props.trigger.value,
+      operator: this.props.trigger.operator,
+      for_duration: this.props.trigger.for_duration,
+      threshold: this.props.trigger.threshold
+    };
+
+    this.props.addTriggersAfter(
+      this.props.index,
+      additionalSelections.map(({ deviceFeature }) => ({
+        ...template,
+        device_feature: deviceFeature.selector
+      }))
+    );
+  };
+
   onDeviceFeatureChange = deviceFeature => {
     this.setState({ selectedDeviceFeature: deviceFeature });
     if (deviceFeature) {
@@ -108,6 +130,9 @@ class TurnOnLight extends Component {
               <SelectDeviceFeature
                 value={props.trigger.device_feature}
                 onDeviceFeatureChange={this.onDeviceFeatureChange}
+                withFilters
+                isMulti
+                onAdditionalDeviceFeaturesSelected={this.onAdditionalDeviceFeaturesSelected}
               />
             </div>
           </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description of change

Implémente la demande de la communauté [Scenes: Improve the "device state change" selection with filters and multi-select!](https://community.gladysassistant.com/t/scenes-ameliorer-la-selection-changement-detat-de-lappareil-avec-des-filtres-et-du-multi-select/8566).

Cette PR améliore la sélection des fonctionnalités d'appareils dans les scènes, en commençant par les deux cas d'usage les plus pénibles :

1. **Déclencheur « Changement d'état d'un appareil »**
2. **Action « Récupérer la dernière valeur »**

#### Filtres

Deux filtres optionnels sont ajoutés au-dessus du sélecteur react-select existant :

- **Filtrer par pièce** — limite la liste aux appareils d'une pièce
- **Filtrer par type de fonctionnalité** — limite la liste à un type précis (ex. « Mouvement », « Ouverture »)

Les filtres se combinent en logique **ET**. La recherche textuelle native de react-select reste disponible.

#### Multi-sélection

Le sélecteur passe en mode multi-sélection (react-select `isMulti`, sans checkboxes) :

- Le **premier** appareil sélectionné met à jour le déclencheur / l'action en cours
- Les **appareils supplémentaires** créent automatiquement de nouveaux déclencheurs (insérés juste après le déclencheur courant) ou de nouvelles actions « Récupérer la dernière valeur » (ajoutées au groupe d'actions parallèles)

Exemple : sélectionner 4 détecteurs de mouvement en une fois crée 4 déclencheurs au lieu de répéter 28 clics.

#### Périmètre volontairement limité

Comme suggéré par @pierre-gilles dans le fil de discussion, cette itération ne couvre pas encore « Contrôler un appareil » ni les autres écrans Gladys. Le composant `SelectDeviceFeature` expose les props `withFilters` et `isMulti` pour une extension future.

### Pull Request check-list

- [ ] If your changes affect the code, did you write the tests?
- [x] Are tests passing? (front: pas de tests unitaires ; changement UI uniquement)
- [x] Is the linter passing? (`npm run eslint` on front)
- [x] Did you run prettier?
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations`)
- [ ] Did you test this pull request in real life?
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation?
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation?
- [ ] Did you add fake requests data for the demo mode?

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f28c8-a140-7d55-90fb-9255ab2629fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f28c8-a140-7d55-90fb-9255ab2629fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

