### PR TITLE
Fix dark mode preference being overwritten on iOS

### DIFF
--- a/front/src/actions/darkMode.js
+++ b/front/src/actions/darkMode.js
@@ -1,5 +1,8 @@
 import {
   applyDarkModeToDom,
+  DARK_MODE_PREFERENCE_DARK,
+  DARK_MODE_PREFERENCE_LIGHT,
+  DARK_MODE_PREFERENCE_SYSTEM,
   getDarkModePreference,
   setDarkModePreference,
   systemPrefersDarkMode
@@ -17,7 +20,7 @@ function createActionsDarkMode(store) {
       const currentDarkMode = store.getState().darkMode;
       const newDarkMode = !currentDarkMode;
 
-      setDarkModePreference(newDarkMode ? 'dark' : 'light');
+      setDarkModePreference(newDarkMode ? DARK_MODE_PREFERENCE_DARK : DARK_MODE_PREFERENCE_LIGHT);
       applyDarkModeToDom(newDarkMode);
 
       return { darkMode: newDarkMode };
@@ -27,7 +30,7 @@ function createActionsDarkMode(store) {
      * Set dark mode to a specific value
      */
     setDarkMode(state, darkMode) {
-      setDarkModePreference(darkMode ? 'dark' : 'light');
+      setDarkModePreference(darkMode ? DARK_MODE_PREFERENCE_DARK : DARK_MODE_PREFERENCE_LIGHT);
       applyDarkModeToDom(darkMode);
 
       return { darkMode };
@@ -38,7 +41,7 @@ function createActionsDarkMode(store) {
      * Only applies when the user has not set an explicit preference.
      */
     updateDarkModeFromSystem() {
-      if (getDarkModePreference() !== 'system') {
+      if (getDarkModePreference() !== DARK_MODE_PREFERENCE_SYSTEM) {
         return null;
       }
 

--- a/front/src/actions/darkMode.js
+++ b/front/src/actions/darkMode.js
@@ -1,15 +1,14 @@
+import {
+  applyDarkModeToDom,
+  getDarkModePreference,
+  setDarkModePreference,
+  systemPrefersDarkMode
+} from '../utils/darkModePreference';
+
 function createActionsDarkMode(store) {
   const actions = {
     initDarkMode(state) {
-      const { darkMode } = state;
-      // Apply or remove dark mode class from DOM
-      if (darkMode) {
-        document.documentElement.classList.add('dark-mode');
-        document.body.classList.add('dark-mode');
-      } else {
-        document.documentElement.classList.remove('dark-mode');
-        document.body.classList.remove('dark-mode');
-      }
+      applyDarkModeToDom(state.darkMode);
     },
     /**
      * Toggle dark mode
@@ -18,17 +17,8 @@ function createActionsDarkMode(store) {
       const currentDarkMode = store.getState().darkMode;
       const newDarkMode = !currentDarkMode;
 
-      // Save to localStorage
-      localStorage.setItem('dark-mode', newDarkMode);
-
-      // Apply or remove dark mode class from DOM
-      if (newDarkMode) {
-        document.documentElement.classList.add('dark-mode');
-        document.body.classList.add('dark-mode');
-      } else {
-        document.documentElement.classList.remove('dark-mode');
-        document.body.classList.remove('dark-mode');
-      }
+      setDarkModePreference(newDarkMode ? 'dark' : 'light');
+      applyDarkModeToDom(newDarkMode);
 
       return { darkMode: newDarkMode };
     },
@@ -37,40 +27,25 @@ function createActionsDarkMode(store) {
      * Set dark mode to a specific value
      */
     setDarkMode(state, darkMode) {
-      // Save to localStorage
-      localStorage.setItem('dark-mode', darkMode);
-
-      // Apply or remove dark mode class from DOM
-      if (darkMode) {
-        document.documentElement.classList.add('dark-mode');
-        document.body.classList.add('dark-mode');
-      } else {
-        document.documentElement.classList.remove('dark-mode');
-        document.body.classList.remove('dark-mode');
-      }
+      setDarkModePreference(darkMode ? 'dark' : 'light');
+      applyDarkModeToDom(darkMode);
 
       return { darkMode };
     },
 
     /**
-     * Update dark mode based on system preference
+     * Update dark mode based on system preference.
+     * Only applies when the user has not set an explicit preference.
      */
     updateDarkModeFromSystem() {
-      const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-
-      // Save to localStorage
-      localStorage.setItem('dark-mode', systemPrefersDark);
-
-      // Apply or remove dark mode class from DOM
-      if (systemPrefersDark) {
-        document.documentElement.classList.add('dark-mode');
-        document.body.classList.add('dark-mode');
-      } else {
-        document.documentElement.classList.remove('dark-mode');
-        document.body.classList.remove('dark-mode');
+      if (getDarkModePreference() !== 'system') {
+        return null;
       }
 
-      return { darkMode: systemPrefersDark };
+      const darkMode = systemPrefersDarkMode();
+      applyDarkModeToDom(darkMode);
+
+      return { darkMode };
     }
   };
 

--- a/front/src/utils/darkModePreference.js
+++ b/front/src/utils/darkModePreference.js
@@ -1,0 +1,76 @@
+const DARK_MODE_PREFERENCE_KEY = 'dark-mode-preference';
+const LEGACY_DARK_MODE_KEY = 'dark-mode';
+
+const VALID_PREFERENCES = ['light', 'dark', 'system'];
+
+function systemPrefersDarkMode() {
+  try {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  } catch (e) {
+    return false;
+  }
+}
+
+function migrateLegacyDarkModePreference() {
+  const legacyValue = localStorage.getItem(LEGACY_DARK_MODE_KEY);
+  if (legacyValue === null) {
+    return null;
+  }
+
+  const migratedPreference = legacyValue === 'true' ? 'dark' : 'light';
+  localStorage.setItem(DARK_MODE_PREFERENCE_KEY, migratedPreference);
+  localStorage.removeItem(LEGACY_DARK_MODE_KEY);
+  return migratedPreference;
+}
+
+function getDarkModePreference() {
+  try {
+    const savedPreference = localStorage.getItem(DARK_MODE_PREFERENCE_KEY);
+    if (VALID_PREFERENCES.includes(savedPreference)) {
+      return savedPreference;
+    }
+
+    const migratedPreference = migrateLegacyDarkModePreference();
+    if (migratedPreference) {
+      return migratedPreference;
+    }
+  } catch (e) {}
+
+  return 'system';
+}
+
+function setDarkModePreference(preference) {
+  localStorage.setItem(DARK_MODE_PREFERENCE_KEY, preference);
+  localStorage.removeItem(LEGACY_DARK_MODE_KEY);
+}
+
+function isDarkModeEnabled(preference = getDarkModePreference()) {
+  if (preference === 'dark') {
+    return true;
+  }
+  if (preference === 'light') {
+    return false;
+  }
+  return systemPrefersDarkMode();
+}
+
+function applyDarkModeToDom(darkMode) {
+  if (darkMode) {
+    document.documentElement.classList.add('dark-mode');
+    document.body.classList.add('dark-mode');
+  } else {
+    document.documentElement.classList.remove('dark-mode');
+    document.body.classList.remove('dark-mode');
+  }
+}
+
+export {
+  DARK_MODE_PREFERENCE_KEY,
+  LEGACY_DARK_MODE_KEY,
+  VALID_PREFERENCES,
+  applyDarkModeToDom,
+  getDarkModePreference,
+  isDarkModeEnabled,
+  setDarkModePreference,
+  systemPrefersDarkMode
+};

--- a/front/src/utils/darkModePreference.js
+++ b/front/src/utils/darkModePreference.js
@@ -1,7 +1,11 @@
 const DARK_MODE_PREFERENCE_KEY = 'dark-mode-preference';
 const LEGACY_DARK_MODE_KEY = 'dark-mode';
 
-const VALID_PREFERENCES = ['light', 'dark', 'system'];
+const DARK_MODE_PREFERENCE_LIGHT = 'light';
+const DARK_MODE_PREFERENCE_DARK = 'dark';
+const DARK_MODE_PREFERENCE_SYSTEM = 'system';
+
+const VALID_PREFERENCES = [DARK_MODE_PREFERENCE_LIGHT, DARK_MODE_PREFERENCE_DARK, DARK_MODE_PREFERENCE_SYSTEM];
 
 function systemPrefersDarkMode() {
   try {
@@ -17,7 +21,7 @@ function migrateLegacyDarkModePreference() {
     return null;
   }
 
-  const migratedPreference = legacyValue === 'true' ? 'dark' : 'light';
+  const migratedPreference = legacyValue === 'true' ? DARK_MODE_PREFERENCE_DARK : DARK_MODE_PREFERENCE_LIGHT;
   localStorage.setItem(DARK_MODE_PREFERENCE_KEY, migratedPreference);
   localStorage.removeItem(LEGACY_DARK_MODE_KEY);
   return migratedPreference;
@@ -36,19 +40,21 @@ function getDarkModePreference() {
     }
   } catch (e) {}
 
-  return 'system';
+  return DARK_MODE_PREFERENCE_SYSTEM;
 }
 
 function setDarkModePreference(preference) {
-  localStorage.setItem(DARK_MODE_PREFERENCE_KEY, preference);
-  localStorage.removeItem(LEGACY_DARK_MODE_KEY);
+  try {
+    localStorage.setItem(DARK_MODE_PREFERENCE_KEY, preference);
+    localStorage.removeItem(LEGACY_DARK_MODE_KEY);
+  } catch (e) {}
 }
 
 function isDarkModeEnabled(preference = getDarkModePreference()) {
-  if (preference === 'dark') {
+  if (preference === DARK_MODE_PREFERENCE_DARK) {
     return true;
   }
-  if (preference === 'light') {
+  if (preference === DARK_MODE_PREFERENCE_LIGHT) {
     return false;
   }
   return systemPrefersDarkMode();
@@ -65,7 +71,10 @@ function applyDarkModeToDom(darkMode) {
 }
 
 export {
+  DARK_MODE_PREFERENCE_DARK,
   DARK_MODE_PREFERENCE_KEY,
+  DARK_MODE_PREFERENCE_LIGHT,
+  DARK_MODE_PREFERENCE_SYSTEM,
   LEGACY_DARK_MODE_KEY,
   VALID_PREFERENCES,
   applyDarkModeToDom,

--- a/front/src/utils/getDefaultState.js
+++ b/front/src/utils/getDefaultState.js
@@ -7,6 +7,7 @@ import { Session } from './Session';
 import { DemoSession } from './DemoSession';
 import { GatewaySession } from './GatewaySession';
 import { GatewayHttpClient } from './GatewayHttpClient';
+import { isDarkModeEnabled } from './darkModePreference';
 
 function getDefaultState() {
   const session = config.gatewayMode ? new GatewaySession() : config.demoMode ? new DemoSession() : new Session();
@@ -34,9 +35,7 @@ function getDefaultState() {
   // Check for dark mode preference
   let darkMode = false;
   try {
-    const savedMode = localStorage.getItem('dark-mode');
-    const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)');
-    darkMode = savedMode !== null ? savedMode === 'true' : systemPrefersDark.matches;
+    darkMode = isDarkModeEnabled();
   } catch (e) {}
 
   const state = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Pull Request check-list

- [x] Is the linter passing? (`npm run eslint` on changed front files)
- [x] Did you run prettier? (`npm run prettier` on changed front files)
- [ ] If your changes affect the code, did you write the tests?
- [ ] Are tests passing? (`npm test` on both front/server)
- [ ] Did you test this pull request in real life? With real devices?

### Description of change

Fixes intermittent dark mode on iOS / Gladys Plus reported in community feedback.

**Root cause:** Since dark mode was added (#2343), the app listens to `prefers-color-scheme` changes and calls `updateDarkModeFromSystem()`, which always overwrites `localStorage` with the OS value — even after the user manually toggled light/dark mode.

On iOS Safari and PWAs, WebKit can fire spurious `prefers-color-scheme` change events (e.g. when resuming the app from background). This explains why a user with iOS permanently in light mode still sees dark mode more than half the time, while Firefox on macOS behaves correctly.

**Fix:**
- Introduce an explicit preference model: `light`, `dark`, or `system` (`front/src/utils/darkModePreference.js`)
- Manual toggle saves an explicit `light` / `dark` preference that is no longer overwritten by OS events
- System preference is only followed when the user has not chosen a mode (`system`)
- Migrate the legacy `dark-mode` localStorage key for backward compatibility
- `setDarkModePreference` is guarded against storage failures (CodeRabbit review)
- Preference values exported as named constants (CodeRabbit review)

**Note for affected users:** After this fix ships, toggling once to light mode will persist correctly across sessions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f28d2-0c6b-77d8-a9cd-50f7564a98ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f28d2-0c6b-77d8-a9cd-50f7564a98ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved dark mode preference handling with explicit **Light / Dark / System** options.
  * The app applies the correct theme consistently and follows system color-scheme changes when set to **System**.

* **Bug Fixes**
  * More reliable persistence of theme choices, including automatic migration of older saved values to the new preference format.
  * Reduced theme-toggle inconsistencies by ensuring updates are applied consistently across the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->