### PR TITLE
docs: enrich AGENTS.md with PR/CI checklist for cloud agents

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,8 @@
 To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:
 
 - [ ] If your changes affect the code, did you write the tests?
-- [ ] Are tests passing? (`npm test` on both front/server)
+- [ ] Are server tests passing with coverage? (`cd server && npm run coverage`)
+- [ ] Did Cypress E2E tests pass? (`npm run cypress:run` from repo root, if UI changed)
 - [ ] Is the linter passing? (`npm run eslint` on both front/server)
 - [ ] Did you run prettier? (`npm run prettier` on both front/server)
 - [ ] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:
 
 - [ ] If your changes affect the code, did you write the tests?
-- [ ] Are server tests passing with coverage? (`cd server && npm run coverage`)
+- [ ] Are server tests passing with coverage? (`cd server && npm run coverage`) — Codecov requires **100% coverage on lines changed in this PR**
 - [ ] Did Cypress E2E tests pass? (`npm run cypress:run` from repo root, if UI changed)
 - [ ] Is the linter passing? (`npm run eslint` on both front/server)
 - [ ] Did you run prettier? (`npm run prettier` on both front/server)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,10 @@ npm run coverage   # runs ~4100 Mocha tests + generates coverage report
 
 - **Every new or changed server file must have tests.** Place tests in `server/test/` mirroring the source structure (e.g. `server/lib/foo/bar.js` → `server/test/lib/foo/bar.test.js`).
 - CI runs `npm run coverage`, not `npm test` alone. Always use `coverage` before pushing.
-- **Coverage target is 90%** (Codecov project target in `codecov.yml`), not 100%. New untested code can still fail CI if it lowers coverage or breaks existing tests.
+- **Codecov must pass** (`fail_ci_if_error: true` in CI). There are two separate checks:
+  - **Project coverage** (~90% on the whole server codebase — see `codecov.yml`). Legacy untested code is tolerated.
+  - **Patch coverage (100%)** — every line you add or modify in the PR must be executed by a test. This is the check that most often fails on agent PRs: one untested line in new code is enough to block the merge.
+- When writing server code, assume **100% patch coverage is required**. If you add a branch, error path, or helper, write a test that hits it.
 - Do not commit test databases (`gladys-test.db`, `gladys-cypress.db`).
 
 **If you modified `front/`:**
@@ -79,6 +82,7 @@ npm run cypress:run   # starts server + front, then runs E2E specs in front/cypr
 - **Prettier:** CI uses `prettier-check` (read-only). Run `npm run prettier` locally to auto-fix formatting before pushing.
 - **ESLint:** Server uses Airbnb config with JSDoc requirements on exported functions. Front lints `src/` and `cypress/`.
 - **Missing translations:** `compare-translations` checks that all `front/src/config/i18n/*.json` files share the same keys, and that `server/utils/constants.js` device features (`DEVICE_FEATURE_UNITS`, `DEVICE_FEATURE_CATEGORIES`, `DEVICE_FEATURE_TYPES`) have matching entries in `en.json`. Adding a key to one language file requires adding it to **all** language files.
+- **Codecov patch coverage:** CI uploads the coverage report to Codecov, which measures only the lines changed in your PR. Any new server line not hit by a test fails the `codecov/patch` status. Run `npm run coverage` locally and confirm your tests exercise every branch and path you added before pushing.
 - **Server tests:** Changes to `server/lib/`, `server/api/`, `server/controllers/`, or `server/services/` almost always need corresponding tests. Look at neighboring files in `server/test/` for patterns (Mocha + Chai + Sinon).
 - **Cypress:** UI changes to signup, dashboard, scenes, or integration pages can break E2E specs under `front/cypress/e2e/`.
 - **Front build:** Only runs on non-draft PRs. A webpack/build error will block merge when the PR is marked ready.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,13 +20,82 @@ From the repo root: `npm start` (runs `run-p start-server:dev start-front:dev`).
 - **Service dependencies:** the server has ~38 integration services under `server/services/*`, each with its own `package.json`. `cd server && npm install` runs a `postinstall` (`cli/install_service_dependencies.js`) that installs deps for every service. Set `INSTALL_SERVICES_SILENT_FAIL=true` so a single flaky service install does not abort the whole install.
 - **Native modules** (`sqlite3`, `bcrypt`, `sharp`, `duckdb`, USB/bluetooth services) compile from source; they need build tools (`gcc/g++/make/python3`) and `libudev-dev` on the system.
 
-### Lint / test / build commands
+## Pull Request requirements (CI)
+
+Every PR to `master` triggers the workflow `.github/workflows/docker-pr-build.yml`. **Run the relevant checks locally before every push** — most first-time CI failures come from skipping them.
+
+### CI jobs overview
+
+| Job | When it runs | What it checks |
+|-----|--------------|----------------|
+| **Front test** | Always | `prettier-check`, `eslint`, `compare-translations` |
+| **Server test** | Always | `prettier-check`, `eslint`, `npm run coverage` + Codecov upload |
+| **Cypress run** | Always | E2E tests (signup, dashboard, integrations…) |
+| **Front build** | Non-draft PRs only | `npm run build-with-stats` |
+| **Docker build** | Non-draft PRs only | AMD64 Docker image build |
+
+Draft PRs skip the front build and Docker jobs. Mark a PR as "Ready for review" only after the build checks pass locally.
+
+### Mandatory checklist before push
+
+**Always (any code change):**
+
+1. Run `npm run prettier` (not just `prettier-check`) in every directory you touched, then verify with `npm run prettier-check`.
+2. Run `npm run eslint` in every directory you touched. Use `npm run eslint-fix` (server) if needed.
+
+**If you modified `server/`:**
+
+```bash
+cd server
+npm run prettier && npm run prettier-check
+npm run eslint
+npm run coverage   # runs ~4100 Mocha tests + generates coverage report
+```
+
+- **Every new or changed server file must have tests.** Place tests in `server/test/` mirroring the source structure (e.g. `server/lib/foo/bar.js` → `server/test/lib/foo/bar.test.js`).
+- CI runs `npm run coverage`, not `npm test` alone. Always use `coverage` before pushing.
+- **Coverage target is 90%** (Codecov project target in `codecov.yml`), not 100%. New untested code can still fail CI if it lowers coverage or breaks existing tests.
+- Do not commit test databases (`gladys-test.db`, `gladys-cypress.db`).
+
+**If you modified `front/`:**
+
+```bash
+cd front
+npm run prettier && npm run prettier-check
+npm run eslint
+npm run compare-translations   # required if i18n or device constants changed
+npm run build                  # required before marking PR as ready for review
+```
+
+- The front has **no unit-test script**. CI validates the front via eslint, `compare-translations`, build, and Cypress.
+- If you changed UI routes or components, run Cypress from the repo root:
+
+```bash
+npm run cypress:run   # starts server + front, then runs E2E specs in front/cypress/
+```
+
+### Common CI failure causes
+
+- **Prettier:** CI uses `prettier-check` (read-only). Run `npm run prettier` locally to auto-fix formatting before pushing.
+- **ESLint:** Server uses Airbnb config with JSDoc requirements on exported functions. Front lints `src/` and `cypress/`.
+- **Missing translations:** `compare-translations` checks that all `front/src/config/i18n/*.json` files share the same keys, and that `server/utils/constants.js` device features (`DEVICE_FEATURE_UNITS`, `DEVICE_FEATURE_CATEGORIES`, `DEVICE_FEATURE_TYPES`) have matching entries in `en.json`. Adding a key to one language file requires adding it to **all** language files.
+- **Server tests:** Changes to `server/lib/`, `server/api/`, `server/controllers/`, or `server/services/` almost always need corresponding tests. Look at neighboring files in `server/test/` for patterns (Mocha + Chai + Sinon).
+- **Cypress:** UI changes to signup, dashboard, scenes, or integration pages can break E2E specs under `front/cypress/e2e/`.
+- **Front build:** Only runs on non-draft PRs. A webpack/build error will block merge when the PR is marked ready.
+
+### Lint / test / build commands (reference)
 
 Server (run in `/server`):
-- Lint: `npm run eslint` and `npm run prettier-check`
-- Test: `npm test` (Mocha; ~4100 tests). Coverage: `npm run coverage`.
+
+- Format: `npm run prettier` / `npm run prettier-check`
+- Lint: `npm run eslint` / `npm run eslint-fix`
+- Test: `npm test` (Mocha; ~4100 tests)
+- Coverage (CI command): `npm run coverage`
 
 Front (run in `/front`):
-- Lint: `npm run eslint` and `npm run prettier-check`
+
+- Format: `npm run prettier` / `npm run prettier-check`
+- Lint: `npm run eslint`
+- Translations: `npm run compare-translations`
 - Build: `npm run build` (production bundle to `front/build`)
-- Note: the front has **no unit-test script**; CI validates the front via eslint, `compare-translations`, and build only.
+- E2E: `npm run cypress:run` (from `/front`, or `npm run cypress:run` from repo root)

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,9 @@ coverage:
         target: 90%
         flags:
           - server
+    patch:
+      default:
+        target: 100%
 
 flags:
   server:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Les PRs générées par Cursor échouent souvent au premier passage en CI faute de connaître les contraintes exactes. Cette PR documente ces contraintes directement dans `AGENTS.md`, là où les Cloud Agents les lisent.

## Changes

### `AGENTS.md`

- Nouvelle section **Pull Request requirements (CI)** avec :
  - Tableau des jobs CI (`docker-pr-build.yml`) et quand ils s'exécutent
  - **Checklist obligatoire avant push**, séparée server / front
  - **Codecov** : deux checks distincts
    - **Project** : ~90 % sur l'ensemble du codebase server (legacy toléré)
    - **Patch** : **100 % sur les lignes ajoutées/modifiées dans la PR** — c'est le check qui bloque le plus souvent les PRs agents
  - Pièges courants : prettier vs prettier-check, traductions i18n, tests server obligatoires, Cypress, build front (non-draft)
  - Commandes de référence réorganisées

### `codecov.yml`

- Ajout explicite de `patch: target: 100%` pour refléter la contrainte réelle

### `.github/PULL_REQUEST_TEMPLATE.md`

- Correction : remplace `npm test on both front/server` par `npm run coverage` côté server (avec mention du patch 100 %) et `npm run cypress:run` si l'UI a changé

## Motivation

`AGENTS.md` listait les commandes lint/test/build sans expliquer que la CI les bloque ni imposer de les exécuter avant push. La distinction project vs patch coverage n'était pas documentée — pourtant c'est le patch à 100 % qui fait échouer la plupart des PRs avec du code server non testé.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f28f5-f734-79c7-b6c6-8b4cc1f8fb7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f28f5-f734-79c7-b6c6-8b4cc1f8fb7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded PR and contribution guidance with a clearer pre-push checklist, CI overview, and local validation commands.
  * Added more specific server and front-end testing, linting, build, and Cypress guidance.

* **Chores**
  * Updated coverage rules to require full patch coverage for changed server lines.
  * Clarified when CI jobs run and common reasons builds fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->