### PR TITLE
feat(dashboard): choisir l'ordre d'affichage dans le widget Scènes

### DIFF
--- a/front/src/components/boxs/scene/EditSceneBox.jsx
+++ b/front/src/components/boxs/scene/EditSceneBox.jsx
@@ -4,22 +4,58 @@ import BaseEditBox from '../baseEditBox';
 import withIntlAsProp from '../../../utils/withIntlAsProp';
 import { connect } from 'unistore/preact';
 import Select from 'react-select';
+import update from 'immutability-helper';
 import { RequestStatus } from '../../../utils/consts';
+import { SceneListWithDragAndDrop } from '../../drag-and-drop/SceneListWithDragAndDrop';
 
 class EditSceneBox extends Component {
-  updateScenes = selectedSceneOptions => {
-    selectedSceneOptions = selectedSceneOptions || [];
-    const selectedScenes = selectedSceneOptions.map(option => option.value);
-    this.props.updateBoxConfig(this.props.x, this.props.y, {
-      scenes: selectedScenes
-    });
-    this.setState({ selectedSceneOptions });
-  };
-
   updateName = e => {
     this.props.updateBoxConfig(this.props.x, this.props.y, {
       name: e.target.value
     });
+  };
+
+  refreshScenesConfig = selectedSceneOptions => {
+    const selectedScenes = selectedSceneOptions.map(option => option.value);
+    this.props.updateBoxConfig(this.props.x, this.props.y, {
+      scenes: selectedScenes
+    });
+  };
+
+  addScene = async selectedSceneOption => {
+    if (!selectedSceneOption) {
+      return;
+    }
+    const newSelectedSceneOptions = [...this.state.selectedSceneOptions, selectedSceneOption];
+    await this.setState({ selectedSceneOptions: newSelectedSceneOptions });
+    this.refreshScenesConfig(newSelectedSceneOptions);
+  };
+
+  moveScene = async (currentIndex, newIndex) => {
+    const element = this.state.selectedSceneOptions[currentIndex];
+
+    const newStateWithoutElement = update(this.state, {
+      selectedSceneOptions: {
+        $splice: [[currentIndex, 1]]
+      }
+    });
+    const newState = update(newStateWithoutElement, {
+      selectedSceneOptions: {
+        $splice: [[newIndex, 0, element]]
+      }
+    });
+    await this.setState(newState);
+    this.refreshScenesConfig(newState.selectedSceneOptions);
+  };
+
+  removeScene = async index => {
+    const newStateWithoutElement = update(this.state, {
+      selectedSceneOptions: {
+        $splice: [[index, 1]]
+      }
+    });
+    await this.setState(newStateWithoutElement);
+    this.refreshScenesConfig(newStateWithoutElement.selectedSceneOptions);
   };
 
   getScenes = async () => {
@@ -53,14 +89,20 @@ class EditSceneBox extends Component {
 
   refreshSelectedOptions = async props => {
     const selectedSceneOptions = [];
-    if (this.state.sceneOptions) {
-      this.state.sceneOptions.forEach(sceneOption => {
-        if (props.box.scenes && props.box.scenes.indexOf(sceneOption.value) !== -1) {
+    if (this.state.sceneOptions && props.box.scenes) {
+      props.box.scenes.forEach(sceneSelector => {
+        const sceneOption = this.state.sceneOptions.find(option => option.value === sceneSelector);
+        if (sceneOption) {
           selectedSceneOptions.push(sceneOption);
         }
       });
     }
     await this.setState({ selectedSceneOptions });
+  };
+
+  getAvailableSceneOptions = () => {
+    const selectedSceneValues = (this.state.selectedSceneOptions || []).map(option => option.value);
+    return (this.state.sceneOptions || []).filter(option => !selectedSceneValues.includes(option.value));
   };
 
   componentDidMount = () => {
@@ -74,8 +116,11 @@ class EditSceneBox extends Component {
       }
     }
   }
-  render(props, { status, selectedSceneOptions, sceneOptions }) {
+
+  render(props, { status, selectedSceneOptions }) {
     const loading = status === RequestStatus.Getting && !status;
+    const availableSceneOptions = this.getAvailableSceneOptions();
+
     return (
       <BaseEditBox {...props} titleKey="dashboard.boxTitle.scene">
         <div class={loading ? 'dimmer active' : 'dimmer'}>
@@ -95,17 +140,28 @@ class EditSceneBox extends Component {
                 />
               </Localizer>
             </div>
-            {sceneOptions && (
+            <div class="form-group">
+              <label>
+                <Text id="dashboard.boxes.scene.editSceneLabel" />
+              </label>
+              {selectedSceneOptions && (
+                <SceneListWithDragAndDrop
+                  selectedSceneOptions={selectedSceneOptions}
+                  moveScene={this.moveScene}
+                  removeScene={this.removeScene}
+                  isTouchDevice={false}
+                />
+              )}
+            </div>
+            {availableSceneOptions.length > 0 && (
               <div class="form-group">
                 <label>
-                  <Text id="dashboard.boxes.scene.editSceneLabel" />
+                  <Text id="dashboard.boxes.scene.addSceneLabel" />
                 </label>
                 <Select
-                  defaultValue={[]}
-                  value={selectedSceneOptions}
-                  options={sceneOptions}
-                  isMulti
-                  onChange={this.updateScenes}
+                  onChange={this.addScene}
+                  value={[]}
+                  options={availableSceneOptions}
                   maxMenuHeight={220}
                   className="react-select-container"
                   classNamePrefix="react-select"

--- a/front/src/components/boxs/scene/SceneBox.jsx
+++ b/front/src/components/boxs/scene/SceneBox.jsx
@@ -4,6 +4,23 @@ import { RequestStatus } from '../../../utils/consts';
 import SceneRow from './SceneRow';
 import cx from 'classnames';
 
+const sortScenesByBoxOrder = (scenes, boxScenes) => {
+  if (!boxScenes || boxScenes.length === 0) {
+    return scenes;
+  }
+
+  const orderMap = boxScenes.reduce((acc, selector, index) => {
+    acc[selector] = index;
+    return acc;
+  }, {});
+
+  return [...scenes].sort((sceneA, sceneB) => {
+    const orderA = orderMap[sceneA.selector] !== undefined ? orderMap[sceneA.selector] : Number.MAX_SAFE_INTEGER;
+    const orderB = orderMap[sceneB.selector] !== undefined ? orderMap[sceneB.selector] : Number.MAX_SAFE_INTEGER;
+    return orderA - orderB;
+  });
+};
+
 class SceneBoxComponent extends Component {
   refreshData = () => {
     this.getScene();
@@ -16,7 +33,7 @@ class SceneBoxComponent extends Component {
         selectors: this.props.box.scenes.join(',')
       });
       this.setState({
-        scenes,
+        scenes: sortScenesByBoxOrder(scenes, this.props.box.scenes),
         status: RequestStatus.Success
       });
     } catch (e) {

--- a/front/src/components/drag-and-drop/SceneListWithDragAndDrop.jsx
+++ b/front/src/components/drag-and-drop/SceneListWithDragAndDrop.jsx
@@ -1,0 +1,70 @@
+import { DndProvider, useDrag, useDrop } from 'react-dnd';
+import { TouchBackend } from 'react-dnd-touch-backend';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import { useRef } from 'preact/hooks';
+import cx from 'classnames';
+import style from './style.css';
+
+const SCENE_TYPE = 'SCENE_TYPE';
+
+const SceneRow = ({ selectedScene, moveScene, index, removeScene }) => {
+  const ref = useRef(null);
+  const [{ isDragging }, drag, preview] = useDrag(() => ({
+    type: SCENE_TYPE,
+    item: () => {
+      return { index };
+    },
+    collect: monitor => ({
+      isDragging: !!monitor.isDragging()
+    })
+  }));
+  const [{ isActive }, drop] = useDrop({
+    accept: SCENE_TYPE,
+    collect: monitor => ({
+      isActive: monitor.canDrop() && monitor.isOver()
+    }),
+    drop(item) {
+      if (!ref.current) {
+        return;
+      }
+      moveScene(item.index, index);
+    }
+  });
+  preview(drop(ref));
+
+  const removeThisScene = () => {
+    removeScene(index);
+  };
+
+  return (
+    <div class="mb-1">
+      <div
+        class={cx('input-group', style.deviceListDragAndDrop, {
+          [style.deviceListDragAndDropActive]: isActive,
+          [style.deviceListDragAndDropDragging]: isDragging
+        })}
+        ref={ref}
+      >
+        <div class="input-group-prepend" ref={drag}>
+          <span class="input-group-text fe fe-list" />
+        </div>
+        <input type="text" class="form-control" value={selectedScene.label} readonly />
+        <div class={cx('input-group-append', style.deviceListRemoveButton)}>
+          <button class="btn btn-outline-danger" type="button" onClick={removeThisScene}>
+            <span class=" fe fe-x" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const SceneListWithDragAndDrop = ({ selectedSceneOptions, isTouchDevice, moveScene, removeScene }) => (
+  <DndProvider backend={isTouchDevice ? TouchBackend : HTML5Backend}>
+    {selectedSceneOptions.map((selectedScene, index) => (
+      <SceneRow selectedScene={selectedScene} index={index} moveScene={moveScene} removeScene={removeScene} />
+    ))}
+  </DndProvider>
+);
+
+export { SceneListWithDragAndDrop };

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -468,7 +468,8 @@
       "scene": {
         "editNameLabel": "Widget-Name (optional)",
         "editNamePlaceholder": "Name auf dem Dashboard angezeigt",
-        "editSceneLabel": "Wähle die Szene aus, die hier angezeigt werden soll."
+        "editSceneLabel": "Wähle die anzuzeigenden Szenen aus (ziehen zum Sortieren):",
+        "addSceneLabel": "Szene hinzufügen:"
       },
       "link": {
         "editTitleLabel": "Titel",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -485,7 +485,8 @@
       "scene": {
         "editNameLabel": "Widget Name (optional)",
         "editNamePlaceholder": "Name displayed on the dashboard",
-        "editSceneLabel": "Select the scene you want to display here."
+        "editSceneLabel": "Select the scenes you want to display (drag to reorder):",
+        "addSceneLabel": "Add a scene:"
       },
       "link": {
         "editTitleLabel": "Title",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -455,7 +455,8 @@
       "scene": {
         "editNameLabel": "Nom du widget (optionnel)",
         "editNamePlaceholder": "Nom affiché sur le tableau de bord",
-        "editSceneLabel": "Sélectionnez la scène que vous souhaitez afficher ici."
+        "editSceneLabel": "Sélectionnez les scènes à afficher (glissez pour réordonner) :",
+        "addSceneLabel": "Ajouter une scène :"
       },
       "link": {
         "editTitleLabel": "Titre",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implémente la demande de la communauté : [Dashboard] Choisir l'ordre d'affichage dans un widget Scènes](https://community.gladysassistant.com/t/dashboard-choisir-lordre-daffichage-dans-un-widget-scenes/9335).

## Problème

Dans un widget Scènes, l'ordre d'affichage était toujours alphabétique (tri côté API), même si l'utilisateur avait sélectionné les scènes dans un ordre précis. Il n'était pas possible de réordonner les scènes affichées.

## Solution

- **Affichage** : `SceneBox` trie désormais les scènes selon l'ordre stocké dans `box.scenes` (tableau déjà existant dans le schéma).
- **Édition** : `EditSceneBox` reprend le même pattern que le widget « Appareils » :
  - liste des scènes sélectionnées avec drag-and-drop pour réordonner ;
  - menu déroulant séparé pour ajouter une scène ;
  - bouton pour retirer une scène.
- **Traductions** : clés mises à jour en EN / FR / DE.

## Compatibilité widgets existants

- Aucun changement de schéma : le champ `box.scenes` (tableau de selectors) est inchangé.
- Les widgets déjà configurés continuent de fonctionner ; leur ordre d'affichage correspondra à l'ordre enregistré dans le tableau (au lieu de l'ordre alphabétique).
- Les scènes supprimées du système mais encore référencées dans un widget sont ignorées silencieusement (comportement existant).

## Fichiers modifiés

- `front/src/components/boxs/scene/SceneBox.jsx`
- `front/src/components/boxs/scene/EditSceneBox.jsx`
- `front/src/components/drag-and-drop/SceneListWithDragAndDrop.jsx` (nouveau)
- `front/src/config/i18n/{en,fr,de}.json`

## Tests

- [x] `npm run compare-translations` (front)
- [x] ESLint sur les fichiers modifiés (front)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f296b-a030-7345-97b3-d3465fde76f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f296b-a030-7345-97b3-d3465fde76f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

