### PR TITLE
feat(front): compléter le color picker avec une palette de couleurs

### DIFF
--- a/front/src/components/boxs/device-in-room/device-features/ColorDeviceFeature.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/ColorDeviceFeature.jsx
@@ -3,14 +3,16 @@ import cx from 'classnames';
 import iro from '@jaames/iro';
 
 import { intToHex, hexToInt } from '../../../../../../server/utils/colors';
+import ColorPalette from '../../../device/ColorPalette';
 
 import style from './style.css';
 
 class ColorDeviceType extends Component {
   colorPickerRef = createRef();
+  popoverContentRef = createRef();
 
   blur = event => {
-    if (!event.composedPath().includes(this.colorPickerRef.current.parentElement)) {
+    if (!event.composedPath().includes(this.popoverContentRef.current)) {
       this.closeColorPicker(false);
     }
   };
@@ -37,6 +39,13 @@ class ColorDeviceType extends Component {
 
   updateValue = color => {
     const colorInt = hexToInt(color.hexString);
+    this.props.updateValue(this.props.deviceFeature, colorInt);
+  };
+
+  selectPaletteColor = colorInt => {
+    if (this.colorPicker) {
+      this.colorPicker.color.hexString = `#${intToHex(colorInt)}`;
+    }
     this.props.updateValue(this.props.deviceFeature, colorInt);
   };
 
@@ -99,7 +108,8 @@ class ColorDeviceType extends Component {
               })}
             >
               <div class="row justify-content-end">
-                <div class="col-8 py-3 d-flex justify-content-center">
+                <div class="col-10 py-3 d-flex flex-column align-items-center" ref={this.popoverContentRef}>
+                  <ColorPalette value={deviceLastValue} onSelectColor={this.selectPaletteColor} />
                   <div ref={this.colorPickerRef} />
                 </div>
                 <div class="col-2">

--- a/front/src/components/device/ColorPalette.css
+++ b/front/src/components/device/ColorPalette.css
@@ -1,0 +1,38 @@
+.colorPalette {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.colorPaletteRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  justify-content: center;
+}
+
+.colorSwatch {
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border: 2px solid rgba(0, 0, 0, 0.15);
+  border-radius: 0.25rem;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.colorSwatch:hover {
+  transform: scale(1.08);
+}
+
+.colorSwatchSelected {
+  border-color: #467fcf;
+  box-shadow: 0 0 0 2px rgba(70, 127, 207, 0.35);
+}
+
+.colorSwatch:focus {
+  outline: none;
+  border-color: #467fcf;
+  box-shadow: 0 0 0 2px rgba(70, 127, 207, 0.35);
+}

--- a/front/src/components/device/ColorPalette.jsx
+++ b/front/src/components/device/ColorPalette.jsx
@@ -1,0 +1,53 @@
+import { Component } from 'preact';
+import cx from 'classnames';
+
+import { hexToInt, intToHex } from '../../../../server/utils/colors';
+import { BASIC_COLOR_PALETTE, WHITE_COLOR_PALETTE } from '../../utils/colorPalette';
+import withIntlAsProp from '../../utils/withIntlAsProp';
+
+import style from './ColorPalette.css';
+
+class ColorPalette extends Component {
+  getLabel = labelKey => {
+    const [section, key] = labelKey.split('.');
+    return this.props.intl.dictionary[section][key];
+  };
+
+  selectColor = hex => {
+    this.props.onSelectColor(hexToInt(hex));
+  };
+
+  isSelected = hex => {
+    const { value } = this.props;
+    if (value === undefined || value === null) {
+      return false;
+    }
+
+    return intToHex(value).toLowerCase() === hex.replace('#', '').toLowerCase();
+  };
+
+  renderSwatch = color => (
+    <button
+      key={color.hex}
+      type="button"
+      class={cx(style.colorSwatch, {
+        [style.colorSwatchSelected]: this.isSelected(color.hex)
+      })}
+      style={{ backgroundColor: color.hex }}
+      onClick={() => this.selectColor(color.hex)}
+      title={this.getLabel(color.labelKey)}
+      aria-label={this.getLabel(color.labelKey)}
+    />
+  );
+
+  render() {
+    return (
+      <div class={style.colorPalette}>
+        <div class={style.colorPaletteRow}>{BASIC_COLOR_PALETTE.map(this.renderSwatch)}</div>
+        <div class={style.colorPaletteRow}>{WHITE_COLOR_PALETTE.map(this.renderSwatch)}</div>
+      </div>
+    );
+  }
+}
+
+export default withIntlAsProp(ColorPalette);

--- a/front/src/components/device/ColorPicker.jsx
+++ b/front/src/components/device/ColorPicker.jsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 import iro from '@jaames/iro';
 
 import { intToHex, hexToInt } from '../../../../server/utils/colors';
+import ColorPalette from './ColorPalette';
 
 class ColorDeviceType extends Component {
   colorPickerRef = createRef();
@@ -12,6 +13,13 @@ class ColorDeviceType extends Component {
       const colorInt = hexToInt(color.hexString);
       this.props.updateValue(colorInt);
     }
+  };
+
+  selectPaletteColor = colorInt => {
+    if (this.colorPicker) {
+      this.colorPicker.color.hexString = `#${intToHex(colorInt)}`;
+    }
+    this.props.updateValue(colorInt);
   };
 
   componentDidMount() {
@@ -41,7 +49,7 @@ class ColorDeviceType extends Component {
     }
   }
 
-  render({}, {}) {
+  render({ value }) {
     return (
       <div
         class={cx('fade', 'w-100', 'mw-100', {
@@ -49,7 +57,8 @@ class ColorDeviceType extends Component {
         })}
       >
         <div class="row justify-content-end">
-          <div class="col-12 py-3 d-flex justify-content-center">
+          <div class="col-12 py-3 d-flex flex-column align-items-center">
+            <ColorPalette value={value} onSelectColor={this.selectPaletteColor} />
             <div ref={this.colorPickerRef} />
           </div>
         </div>

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -47,6 +47,11 @@
     "red": "Rot",
     "yellow": "Gelb"
   },
+  "colorPicker": {
+    "coolWhite": "Kaltweiß",
+    "neutralWhite": "Neutralweiß",
+    "warmWhite": "Warmweiß"
+  },
   "calendar": {
     "allDay": "Ganztägig",
     "previous": "Zurück",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -47,6 +47,11 @@
     "red": "Red",
     "yellow": "Yellow"
   },
+  "colorPicker": {
+    "coolWhite": "Cool white",
+    "neutralWhite": "Neutral white",
+    "warmWhite": "Warm white"
+  },
   "calendar": {
     "allDay": "All Day",
     "previous": "Previous",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -47,6 +47,11 @@
     "red": "Rouge",
     "yellow": "Jaune"
   },
+  "colorPicker": {
+    "coolWhite": "Blanc froid",
+    "neutralWhite": "Blanc neutre",
+    "warmWhite": "Blanc chaud"
+  },
   "calendar": {
     "allDay": "Toute la journée",
     "previous": "Précédent",

--- a/front/src/utils/colorPalette.js
+++ b/front/src/utils/colorPalette.js
@@ -1,0 +1,28 @@
+const { kelvinToRGB, rgbToInt, intToHex } = require('../../../server/utils/colors');
+
+const kelvinToHex = kelvin => `#${intToHex(rgbToInt(kelvinToRGB(kelvin)))}`;
+
+const BASIC_COLOR_PALETTE = [
+  { hex: '#FF0000', labelKey: 'color.red' },
+  { hex: '#FF8000', labelKey: 'color.orange' },
+  { hex: '#FFFF00', labelKey: 'color.yellow' },
+  { hex: '#00FF00', labelKey: 'color.green' },
+  { hex: '#00FFFF', labelKey: 'color.aqua' },
+  { hex: '#0000FF', labelKey: 'color.blue' },
+  { hex: '#8000FF', labelKey: 'color.purple' },
+  { hex: '#FF00FF', labelKey: 'color.pink' }
+];
+
+const WHITE_COLOR_PALETTE = [
+  { hex: kelvinToHex(6500), labelKey: 'colorPicker.coolWhite' },
+  { hex: kelvinToHex(4000), labelKey: 'colorPicker.neutralWhite' },
+  { hex: kelvinToHex(2700), labelKey: 'colorPicker.warmWhite' }
+];
+
+const COLOR_PALETTE = [...BASIC_COLOR_PALETTE, ...WHITE_COLOR_PALETTE];
+
+module.exports = {
+  BASIC_COLOR_PALETTE,
+  WHITE_COLOR_PALETTE,
+  COLOR_PALETTE
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Implémente la fonctionnalité demandée sur le forum : [Compléter le color picker avec palette](https://community.gladysassistant.com/t/completer-le-color-picker-avec-palette/7678).

Le sélecteur de couleur des ampoules (roue iro) est désormais complété par une palette de couleurs prédéfinies, inspirée de l'interface zigbee2mqtt :

- **8 couleurs de base** : rouge, orange, jaune, vert, aqua, bleu, violet, rose
- **3 blancs** : blanc froid (6500K), blanc neutre (4000K), blanc chaud (2700K)
- La roue de couleur reste disponible pour un réglage fin

### Changements

- Nouveau composant partagé `ColorPalette` utilisé dans :
  - le contrôle couleur des boxs appareils du dashboard (`ColorDeviceFeature`)
  - l'éditeur de scènes (`ColorPicker`)
- Constantes de palette centralisées dans `front/src/utils/colorPalette.js`
- Traductions ajoutées (en, fr, de) pour les libellés des blancs
- Correction du clic hors popover dans `ColorDeviceFeature` pour ne pas fermer le picker lors d'un clic sur la palette

### Check-list

- [x] Linter front OK (`npm run eslint`)
- [x] Prettier OK (`npm run prettier-check`)
- [x] Traductions synchronisées (`npm run compare-translations`)
- [x] Build front OK (`npm run build`)
- [ ] Testé avec un appareil réel

Closes https://community.gladysassistant.com/t/completer-le-color-picker-avec-palette/7678
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2969-ad6e-7ec1-9c90-10735becaf20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2969-ad6e-7ec1-9c90-10735becaf20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

