### PR TITLE
Netatmo: Harden connection lifecycle and surface setValue failures

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -845,7 +845,7 @@
         "scan": "Scannen",
         "refresh": "Aktualisieren",
         "deviceError": {
-          "6": "Gerät für die Netatmo-API nicht erreichbar (ausgeschaltet oder außer Reichweite). Sie können es trotzdem speichern, die Werte werden übermittelt, sobald es wieder erreichbar ist.",
+          "6": "Gerät für die Netatmo-API nicht erreichbar (ausgeschaltet oder außer Reichweite). Sie können es trotzdem speichern, die Werte werden übermittelt, sobald es wieder erreichbar ist. (Code: 6)",
           "default": "Die Netatmo-API meldet einen Fehler für dieses Gerät (Code {{code}})."
         }
       },

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -843,7 +843,11 @@
         "updateButton": "Aktualisieren",
         "unmanagedModelButton": "Nicht unterstütztes Modell",
         "scan": "Scannen",
-        "refresh": "Aktualisieren"
+        "refresh": "Aktualisieren",
+        "deviceError": {
+          "6": "Gerät für die Netatmo-API nicht erreichbar (ausgeschaltet oder außer Reichweite). Sie können es trotzdem speichern, die Werte werden übermittelt, sobald es wieder erreichbar ist.",
+          "default": "Die Netatmo-API meldet einen Fehler für dieses Gerät (Code {{code}})."
+        }
       },
       "setup": {
         "title": "Netatmo-Konfiguration",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -738,7 +738,11 @@
         "unmanagedModelButton": "Unsupported model",
         "updateButton": "Update",
         "scan": "Scan",
-        "refresh": "Refresh"
+        "refresh": "Refresh",
+        "deviceError": {
+          "6": "Device unreachable for the Netatmo API (powered off or out of range). You can still save it, its values will be reported as soon as it is reachable again.",
+          "default": "The Netatmo API reports an error for this device (code {{code}})."
+        }
       },
       "setup": {
         "title": "Netatmo Setup",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -740,7 +740,7 @@
         "scan": "Scan",
         "refresh": "Refresh",
         "deviceError": {
-          "6": "Device unreachable for the Netatmo API (powered off or out of range). You can still save it, its values will be reported as soon as it is reachable again.",
+          "6": "Device unreachable for the Netatmo API (powered off or out of range). You can still save it, its values will be reported as soon as it is reachable again. (code: 6)",
           "default": "The Netatmo API reports an error for this device (code {{code}})."
         }
       },

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -978,7 +978,7 @@
         "scan": "Scanner",
         "refresh": "Rafraîchir",
         "deviceError": {
-          "6": "Appareil injoignable pour l'API Netatmo (hors tension ou hors de portée). Vous pouvez tout de même l'enregistrer, ses valeurs remonteront dès qu'il sera de nouveau joignable.",
+          "6": "Appareil injoignable pour l'API Netatmo (hors tension ou hors de portée). Vous pouvez tout de même l'enregistrer, ses valeurs remonteront dès qu'il sera de nouveau joignable. (code : 6)",
           "default": "L'API Netatmo signale une erreur pour cet appareil (code {{code}})."
         }
       },

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -976,7 +976,11 @@
         "updateButton": "Mettre à jour",
         "unmanagedModelButton": "Modèle non pris en charge",
         "scan": "Scanner",
-        "refresh": "Rafraîchir"
+        "refresh": "Rafraîchir",
+        "deviceError": {
+          "6": "Appareil injoignable pour l'API Netatmo (hors tension ou hors de portée). Vous pouvez tout de même l'enregistrer, ses valeurs remonteront dès qu'il sera de nouveau joignable.",
+          "default": "L'API Netatmo signale une erreur pour cet appareil (code {{code}})."
+        }
       },
       "setup": {
         "title": "Configuration Netatmo",

--- a/front/src/routes/integration/all/netatmo/NetatmoDeviceBox.jsx
+++ b/front/src/routes/integration/all/netatmo/NetatmoDeviceBox.jsx
@@ -137,9 +137,11 @@ class NetatmoDeviceBox extends Component {
 
     let categoryAPI = null;
     let apiNotConfigured = null;
+    let apiErrorCode = null;
     if (device.deviceNetatmo) {
       categoryAPI = device.deviceNetatmo.categoryAPI;
       apiNotConfigured = device.deviceNetatmo.apiNotConfigured;
+      apiErrorCode = device.deviceNetatmo.apiErrorCode !== undefined ? device.deviceNetatmo.apiErrorCode : null;
     }
     const isDeviceReachable = (device, now = new Date()) => {
       const isRecent = (date, time) => (now - new Date(date)) / (1000 * 60) <= time;
@@ -161,7 +163,8 @@ class NetatmoDeviceBox extends Component {
       plugName,
       online,
       categoryAPI,
-      apiNotConfigured
+      apiNotConfigured,
+      apiErrorCode
     };
   };
 
@@ -186,7 +189,8 @@ class NetatmoDeviceBox extends Component {
       plugName,
       online,
       categoryAPI,
-      apiNotConfigured
+      apiNotConfigured,
+      apiErrorCode
     } = this.getDeviceProperty();
     const sidDevice = device.external_id.replace('netatmo:', '') || (device.deviceNetatmo && device.deviceNetatmo.id);
     const saveButtonCondition =
@@ -224,6 +228,13 @@ class NetatmoDeviceBox extends Component {
                 {tooMuchStatesError && (
                   <div class="alert alert-warning">
                     <MarkupText id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
+                  </div>
+                )}
+                {apiErrorCode !== null && (
+                  <div class="alert alert-warning">
+                    <Text id={`integration.netatmo.discover.deviceError.${apiErrorCode}`}>
+                      <Text id="integration.netatmo.discover.deviceError.default" fields={{ code: apiErrorCode }} />
+                    </Text>
                   </div>
                 )}
                 <div class="form-group">

--- a/front/src/routes/integration/all/netatmo/NetatmoDeviceBox.jsx
+++ b/front/src/routes/integration/all/netatmo/NetatmoDeviceBox.jsx
@@ -144,6 +144,10 @@ class NetatmoDeviceBox extends Component {
       apiErrorCode = device.deviceNetatmo.apiErrorCode !== undefined ? device.deviceNetatmo.apiErrorCode : null;
     }
     const isDeviceReachable = (device, now = new Date()) => {
+      // the API explicitly flags the module unreachable: it wins over the room heuristics
+      if (device.deviceNetatmo && device.deviceNetatmo.reachable === false) {
+        return false;
+      }
       const isRecent = (date, time) => (now - new Date(date)) / (1000 * 60) <= time;
       const hasRecentFeature = device.features.some(feature => isRecent(feature.last_value_changed, 15));
       const isNetatmoDeviceReachable =

--- a/front/src/routes/integration/all/netatmo/NetatmoDeviceBox.jsx
+++ b/front/src/routes/integration/all/netatmo/NetatmoDeviceBox.jsx
@@ -65,7 +65,7 @@ class NetatmoDeviceBox extends Component {
       });
     } catch (e) {
       let errorMessage = 'integration.netatmo.error.defaultError';
-      if (e.response.status === 409) {
+      if (e.response && e.response.status === 409) {
         errorMessage = 'integration.netatmo.error.conflictError';
       }
       this.setState({
@@ -147,7 +147,7 @@ class NetatmoDeviceBox extends Component {
       const isNetatmoDeviceReachable =
         device.deviceNetatmo &&
         (device.deviceNetatmo.reachable ||
-          device.deviceNetatmo.room.reachable ||
+          (device.deviceNetatmo.room && device.deviceNetatmo.room.reachable) ||
           isRecent(device.deviceNetatmo.last_plug_seen * 1000, 180) ||
           isRecent(device.deviceNetatmo.last_therm_seen * 1000, 180));
       return hasRecentFeature || isNetatmoDeviceReachable;

--- a/server/services/netatmo/lib/device/netatmo.convertDeviceEnergy.js
+++ b/server/services/netatmo/lib/device/netatmo.convertDeviceEnergy.js
@@ -25,7 +25,7 @@ function convertDeviceEnergy(netatmoDevice) {
   const { home, name, type: model, room = {}, plug = {} } = netatmoDevice;
   const id = netatmoDevice.id || netatmoDevice._id;
   const homeId = home || netatmoDevice.home_id;
-  const nameDevice = name || netatmoDevice.module_name;
+  const nameDevice = name || netatmoDevice.module_name || netatmoDevice.station_name;
   const externalId = `netatmo:${id}`;
   logger.debug(`Netatmo convert Energy device "${nameDevice}, ${model}"`);
   const features = [];

--- a/server/services/netatmo/lib/device/netatmo.convertDeviceEnergy.js
+++ b/server/services/netatmo/lib/device/netatmo.convertDeviceEnergy.js
@@ -30,7 +30,6 @@ function convertDeviceEnergy(netatmoDevice) {
   logger.debug(`Netatmo convert Energy device "${nameDevice}, ${model}"`);
   const features = [];
   let params = [];
-  let roomName = 'undefined';
   const isNotBatteryDevice = model === SUPPORTED_MODULE_TYPE.PLUG;
   const isBatteryDevice = model === SUPPORTED_MODULE_TYPE.THERMOSTAT || model === SUPPORTED_MODULE_TYPE.NRV;
 
@@ -57,15 +56,14 @@ function convertDeviceEnergy(netatmoDevice) {
   /* params common to all devices features */
   params.push({ name: PARAMS.HOME_ID, value: homeId });
   if (room.id) {
-    roomName = room.name;
-    params.push({ name: PARAMS.ROOM_ID, value: room.id }, { name: PARAMS.ROOM_NAME, value: roomName });
+    params.push({ name: PARAMS.ROOM_ID, value: room.id }, { name: PARAMS.ROOM_NAME, value: room.name });
   }
   switch (model) {
     case SUPPORTED_MODULE_TYPE.THERMOSTAT: {
       /* features common Netatmo */
       features.push(buildFeatureTemperature(nameDevice, externalId, 'temperature'));
       if (room.id) {
-        features.push(buildFeatureTemperature(`room ${roomName}`, externalId, 'therm_measured_temperature'));
+        features.push(buildFeatureTemperature(`room ${room.name}`, externalId, 'therm_measured_temperature'));
       }
       /* features specific Energy */
       features.push(buildFeatureThermSetpointTemperature(nameDevice, externalId));
@@ -81,7 +79,7 @@ function convertDeviceEnergy(netatmoDevice) {
     case SUPPORTED_MODULE_TYPE.NRV: {
       /* features common Netatmo */
       if (room.id) {
-        features.push(buildFeatureTemperature(`room ${roomName}`, externalId, 'therm_measured_temperature'));
+        features.push(buildFeatureTemperature(`room ${room.name}`, externalId, 'therm_measured_temperature'));
       }
       /* features specific Energy */
       features.push(buildFeatureThermSetpointTemperature(nameDevice, externalId));

--- a/server/services/netatmo/lib/device/netatmo.convertDeviceWeather.js
+++ b/server/services/netatmo/lib/device/netatmo.convertDeviceWeather.js
@@ -33,7 +33,8 @@ function convertDeviceWeather(netatmoDevice) {
   logger.debug(`Netatmo convert Weather device "${nameDevice}, ${model}"`);
   const features = [];
   let params = [];
-  let roomName = 'undefined';
+  const minTempName = room.id ? `Minimum in ${room.name}` : `Minimum - ${nameDevice}`;
+  const maxTempName = room.id ? `Maximum in ${room.name}` : `Maximum - ${nameDevice}`;
   const isNotBatteryDevice = model === SUPPORTED_MODULE_TYPE.NAMAIN;
   const isBatteryDevice =
     model === SUPPORTED_MODULE_TYPE.NAMODULE1 ||
@@ -63,8 +64,7 @@ function convertDeviceWeather(netatmoDevice) {
   /* params common to all devices features */
   params.push({ name: PARAMS.HOME_ID, value: homeId });
   if (room.id) {
-    roomName = room.name;
-    params.push({ name: PARAMS.ROOM_ID, value: room.id }, { name: PARAMS.ROOM_NAME, value: roomName });
+    params.push({ name: PARAMS.ROOM_ID, value: room.id }, { name: PARAMS.ROOM_NAME, value: room.name });
   }
 
   switch (model) {
@@ -72,23 +72,13 @@ function convertDeviceWeather(netatmoDevice) {
       /* features common Netatmo */
       features.push(buildFeatureTemperature(nameDevice, externalId, 'temperature'));
       if (room.id) {
-        features.push(buildFeatureTemperature(`room ${roomName}`, externalId, 'therm_measured_temperature'));
+        features.push(buildFeatureTemperature(`room ${room.name}`, externalId, 'therm_measured_temperature'));
       }
       features.push(
-        buildFeatureTemperature(
-          `Minimum in ${roomName}`,
-          externalId,
-          'min_temp',
-          DEVICE_FEATURE_TYPES.TEMPERATURE_SENSOR.MIN,
-        ),
+        buildFeatureTemperature(minTempName, externalId, 'min_temp', DEVICE_FEATURE_TYPES.TEMPERATURE_SENSOR.MIN),
       );
       features.push(
-        buildFeatureTemperature(
-          `Maximum in ${roomName}`,
-          externalId,
-          'max_temp',
-          DEVICE_FEATURE_TYPES.TEMPERATURE_SENSOR.MAX,
-        ),
+        buildFeatureTemperature(maxTempName, externalId, 'max_temp', DEVICE_FEATURE_TYPES.TEMPERATURE_SENSOR.MAX),
       );
       /* features specific Netatmo Weather */
       features.push(buildFeatureCo2(nameDevice, externalId));
@@ -102,20 +92,10 @@ function convertDeviceWeather(netatmoDevice) {
       /* features common Netatmo */
       features.push(buildFeatureTemperature(nameDevice, externalId, 'temperature'));
       features.push(
-        buildFeatureTemperature(
-          `Minimum in ${roomName}`,
-          externalId,
-          'min_temp',
-          DEVICE_FEATURE_TYPES.TEMPERATURE_SENSOR.MIN,
-        ),
+        buildFeatureTemperature(minTempName, externalId, 'min_temp', DEVICE_FEATURE_TYPES.TEMPERATURE_SENSOR.MIN),
       );
       features.push(
-        buildFeatureTemperature(
-          `Maximum in ${roomName}`,
-          externalId,
-          'max_temp',
-          DEVICE_FEATURE_TYPES.TEMPERATURE_SENSOR.MAX,
-        ),
+        buildFeatureTemperature(maxTempName, externalId, 'max_temp', DEVICE_FEATURE_TYPES.TEMPERATURE_SENSOR.MAX),
       );
       /* features specific Netatmo Weather */
       features.push(buildFeatureHumidity(nameDevice, externalId));
@@ -156,23 +136,13 @@ function convertDeviceWeather(netatmoDevice) {
       /* features common Netatmo */
       features.push(buildFeatureTemperature(nameDevice, externalId, 'temperature'));
       if (room.id) {
-        features.push(buildFeatureTemperature(`room ${roomName}`, externalId, 'therm_measured_temperature'));
+        features.push(buildFeatureTemperature(`room ${room.name}`, externalId, 'therm_measured_temperature'));
       }
       features.push(
-        buildFeatureTemperature(
-          `Minimum in ${roomName}`,
-          externalId,
-          'min_temp',
-          DEVICE_FEATURE_TYPES.TEMPERATURE_SENSOR.MIN,
-        ),
+        buildFeatureTemperature(minTempName, externalId, 'min_temp', DEVICE_FEATURE_TYPES.TEMPERATURE_SENSOR.MIN),
       );
       features.push(
-        buildFeatureTemperature(
-          `Maximum in ${roomName}`,
-          externalId,
-          'max_temp',
-          DEVICE_FEATURE_TYPES.TEMPERATURE_SENSOR.MAX,
-        ),
+        buildFeatureTemperature(maxTempName, externalId, 'max_temp', DEVICE_FEATURE_TYPES.TEMPERATURE_SENSOR.MAX),
       );
       /* features specific Netatmo Weather */
       features.push(buildFeatureCo2(nameDevice, externalId));

--- a/server/services/netatmo/lib/index.js
+++ b/server/services/netatmo/lib/index.js
@@ -24,7 +24,11 @@ const {
   scheduleReconnectAttempt,
 } = require('./netatmo.pollRefreshingToken');
 const { handleApiAuthError } = require('./netatmo.handleApiAuthError');
-const { pollRefreshingValues, refreshNetatmoValues } = require('./netatmo.pollRefreshingValues');
+const {
+  pollRefreshingValues,
+  refreshNetatmoValues,
+  refreshNetatmoValuesNow,
+} = require('./netatmo.pollRefreshingValues');
 const { setValue } = require('./netatmo.setValue');
 const { updateValues } = require('./netatmo.updateValues');
 const { updateNAPlug } = require('./update/netatmo.updateNAPlug');
@@ -62,6 +66,7 @@ const NetatmoHandler = function NetatmoHandler(gladys, serviceId) {
   this.reconnectTimeout = undefined;
   this.reconnectAttempt = 0;
   this.firstFatalAt = null;
+  this.refreshingValues = false;
 };
 
 NetatmoHandler.prototype.init = init;
@@ -86,6 +91,7 @@ NetatmoHandler.prototype.loadThermostatDetails = loadThermostatDetails;
 NetatmoHandler.prototype.loadWeatherStationDetails = loadWeatherStationDetails;
 NetatmoHandler.prototype.pollRefreshingValues = pollRefreshingValues;
 NetatmoHandler.prototype.refreshNetatmoValues = refreshNetatmoValues;
+NetatmoHandler.prototype.refreshNetatmoValuesNow = refreshNetatmoValuesNow;
 NetatmoHandler.prototype.pollRefreshingToken = pollRefreshingToken;
 NetatmoHandler.prototype.refreshNetatmoTokens = refreshNetatmoTokens;
 NetatmoHandler.prototype.scheduleReconnectAttempt = scheduleReconnectAttempt;

--- a/server/services/netatmo/lib/netatmo.loadDeviceDetails.js
+++ b/server/services/netatmo/lib/netatmo.loadDeviceDetails.js
@@ -2,6 +2,45 @@ const { fetch } = require('undici');
 const logger = require('../../../utils/logger');
 const { API, SUPPORTED_MODULE_TYPE, SUPPORTED_CATEGORY_TYPE } = require('./utils/netatmo.constants');
 
+const ENERGY_MODULE_TYPES = [SUPPORTED_MODULE_TYPE.THERMOSTAT, SUPPORTED_MODULE_TYPE.PLUG, SUPPORTED_MODULE_TYPE.NRV];
+const WEATHER_MODULE_TYPES = [
+  SUPPORTED_MODULE_TYPE.NAMAIN,
+  SUPPORTED_MODULE_TYPE.NAMODULE1,
+  SUPPORTED_MODULE_TYPE.NAMODULE2,
+  SUPPORTED_MODULE_TYPE.NAMODULE3,
+  SUPPORTED_MODULE_TYPE.NAMODULE4,
+];
+
+/**
+ * @description Resolve support flags and API category of a Netatmo module type.
+ * @param {string} model - Netatmo module type.
+ * @param {object} configuration - Netatmo service configuration.
+ * @returns {object} Module support flag, API category and configuration flag.
+ * @example
+ * getModuleCategory('NRV', this.configuration);
+ */
+function getModuleCategory(model, configuration) {
+  if (ENERGY_MODULE_TYPES.includes(model)) {
+    return {
+      moduleSupported: true,
+      categoryAPI: SUPPORTED_CATEGORY_TYPE.ENERGY,
+      apiNotConfigured: !configuration.energyApi,
+    };
+  }
+  if (WEATHER_MODULE_TYPES.includes(model)) {
+    return {
+      moduleSupported: true,
+      categoryAPI: SUPPORTED_CATEGORY_TYPE.WEATHER,
+      apiNotConfigured: !configuration.weatherApi,
+    };
+  }
+  return {
+    moduleSupported: false,
+    categoryAPI: SUPPORTED_CATEGORY_TYPE.UNKNOWN,
+    apiNotConfigured: false,
+  };
+}
+
 /**
  * @description Discover Netatmo cloud devices.
  * @param {object} homeData - House.
@@ -34,43 +73,12 @@ async function loadDeviceDetails(homeData) {
 
     const data = JSON.parse(rawBody);
     const { body, status } = data;
-    const { rooms: roomsHomestatus, modules: modulesHomestatus } = body.home;
+    const { rooms: roomsHomestatus = [], modules: modulesHomestatus, errors: errorsHomestatus = [] } = body.home;
 
     if (status === 'ok') {
       if (modulesHomestatus) {
         listDevices = modulesHomestatus.map((module) => {
-          let moduleSupported = false;
-          let apiNotConfigured = false;
-          let categoryAPI = SUPPORTED_CATEGORY_TYPE.UNKNOWN;
-          const { type: model } = module;
-          if (
-            model === SUPPORTED_MODULE_TYPE.THERMOSTAT ||
-            model === SUPPORTED_MODULE_TYPE.PLUG ||
-            model === SUPPORTED_MODULE_TYPE.NRV
-          ) {
-            if (!this.configuration.energyApi) {
-              apiNotConfigured = true;
-            } else {
-              apiNotConfigured = false;
-            }
-            moduleSupported = true;
-            categoryAPI = SUPPORTED_CATEGORY_TYPE.ENERGY;
-          }
-          if (
-            model === SUPPORTED_MODULE_TYPE.NAMAIN ||
-            model === SUPPORTED_MODULE_TYPE.NAMODULE1 ||
-            model === SUPPORTED_MODULE_TYPE.NAMODULE2 ||
-            model === SUPPORTED_MODULE_TYPE.NAMODULE3 ||
-            model === SUPPORTED_MODULE_TYPE.NAMODULE4
-          ) {
-            if (!this.configuration.weatherApi) {
-              apiNotConfigured = true;
-            } else {
-              apiNotConfigured = false;
-            }
-            moduleSupported = true;
-            categoryAPI = SUPPORTED_CATEGORY_TYPE.WEATHER;
-          }
+          const { moduleSupported, categoryAPI, apiNotConfigured } = getModuleCategory(module.type, this.configuration);
 
           const moduleHomeData = modulesHomeData.find((mod) => mod.id === module.id);
           const roomDevice = {
@@ -99,6 +107,46 @@ async function loadDeviceDetails(homeData) {
             not_handled: true,
           };
         });
+
+        /* Modules referenced in homesdata but absent from the homestatus "modules" array
+        (e.g. powered-off devices reported in the homestatus "errors" array) are rebuilt
+        from homesdata so they can still be discovered and saved. */
+        const unreachableModules = modulesHomeData
+          .filter((moduleHomeData) => !modulesHomestatus.some((module) => module.id === moduleHomeData.id))
+          .map((moduleHomeData) => {
+            const { moduleSupported, categoryAPI, apiNotConfigured } = getModuleCategory(
+              moduleHomeData.type,
+              this.configuration,
+            );
+            const moduleError = errorsHomestatus.find((error) => error.id === moduleHomeData.id);
+            const roomDevice = {
+              ...roomsHomeData.find((roomHomeData) => roomHomeData.id === moduleHomeData.room_id),
+              ...roomsHomestatus.find((room) => room.id === moduleHomeData.room_id),
+            };
+            const plugDevice = {
+              ...modulesHomeData.find((mod) => mod.id === moduleHomeData.bridge),
+              ...modulesHomestatus.find((modulePlug) => modulePlug.id === moduleHomeData.bridge),
+            };
+            const plug = Object.keys(plugDevice).length === 0 ? undefined : plugDevice;
+            const deviceSupported = {
+              ...moduleHomeData,
+              home: homeId,
+              room: roomDevice,
+              plug,
+              reachable: false,
+              apiErrorCode: moduleError ? moduleError.code : undefined,
+              categoryAPI,
+              apiNotConfigured,
+            };
+            if (moduleSupported) {
+              return deviceSupported;
+            }
+            return {
+              ...deviceSupported,
+              not_handled: true,
+            };
+          });
+        listDevices = [...listDevices, ...unreachableModules];
       } else {
         listDevices = undefined;
       }

--- a/server/services/netatmo/lib/netatmo.loadDeviceDetails.js
+++ b/server/services/netatmo/lib/netatmo.loadDeviceDetails.js
@@ -73,7 +73,9 @@ async function loadDeviceDetails(homeData) {
 
     const data = JSON.parse(rawBody);
     const { body, status } = data;
-    const { rooms: roomsHomestatus = [], modules: modulesHomestatus, errors: errorsHomestatus = [] } = body.home;
+    const { rooms: roomsHomestatus = [], modules: modulesHomestatus } = body.home;
+    // Depending on the API response, unreachable module errors are reported at body or home level.
+    const errorsHomestatus = body.home.errors ?? body.errors ?? [];
 
     if (status === 'ok') {
       if (modulesHomestatus) {

--- a/server/services/netatmo/lib/netatmo.loadDevices.js
+++ b/server/services/netatmo/lib/netatmo.loadDevices.js
@@ -61,7 +61,8 @@ async function loadDevices() {
           const plugEnergy = plugs.find((plug) => plug._id === id);
           const thermostat = thermostats.find((t) => t._id === id);
           if (plugEnergy) {
-            deviceList = { ...deviceList, ...plugEnergy };
+            // keep the room object built from homesdata/homestatus over the legacy room id string
+            deviceList = { ...deviceList, ...plugEnergy, room: deviceList.room };
           }
           if (thermostat) {
             const plugThermostat = plugs

--- a/server/services/netatmo/lib/netatmo.pollRefreshingToken.js
+++ b/server/services/netatmo/lib/netatmo.pollRefreshingToken.js
@@ -1,5 +1,10 @@
 const logger = require('../../../utils/logger');
-const { STATUS, RECONNECT_BACKOFF_MS, RECONNECT_RECURRENT_MS } = require('./utils/netatmo.constants');
+const {
+  STATUS,
+  RECONNECT_BACKOFF_MS,
+  RECONNECT_RECURRENT_MS,
+  ACCESS_TOKEN_REFRESH_RATIO,
+} = require('./utils/netatmo.constants');
 
 /**
  * @description Schedule the next short-retry attempt after a transient refresh failure.
@@ -67,13 +72,16 @@ async function refreshNetatmoTokens() {
 }
 
 /**
- * @description Start polling the Netatmo refresh token endpoint at the access-token expiry cadence.
+ * @description Start polling the Netatmo refresh token endpoint before the access-token expires.
  * @example
  * this.pollRefreshingToken();
  */
 function pollRefreshingToken() {
   if (this.expireInToken > 0) {
-    this.pollRefreshToken = setInterval(this.refreshNetatmoTokens.bind(this), this.expireInToken * 1000);
+    this.pollRefreshToken = setInterval(
+      this.refreshNetatmoTokens.bind(this),
+      Math.round(this.expireInToken * 1000 * ACCESS_TOKEN_REFRESH_RATIO),
+    );
   }
 }
 

--- a/server/services/netatmo/lib/netatmo.pollRefreshingValues.js
+++ b/server/services/netatmo/lib/netatmo.pollRefreshingValues.js
@@ -7,6 +7,23 @@ const logger = require('../../../utils/logger');
  * @example refreshNetatmoValues();
  */
 async function refreshNetatmoValues() {
+  if (this.refreshingValues) {
+    logger.debug('Netatmo: a devices values refresh is already running, skipping this one');
+    return;
+  }
+  this.refreshingValues = true;
+  try {
+    await this.refreshNetatmoValuesNow();
+  } finally {
+    this.refreshingValues = false;
+  }
+}
+
+/**
+ * @description Poll values of Netatmo devices (single-flight body).
+ * @example refreshNetatmoValuesNow();
+ */
+async function refreshNetatmoValuesNow() {
   logger.debug('Looking for Netatmo devices values...');
   await this.saveStatus({ statusType: STATUS.GET_DEVICES_VALUES, message: null });
 
@@ -56,4 +73,5 @@ function pollRefreshingValues() {
 module.exports = {
   pollRefreshingValues,
   refreshNetatmoValues,
+  refreshNetatmoValuesNow,
 };

--- a/server/services/netatmo/lib/netatmo.retrieveTokens.js
+++ b/server/services/netatmo/lib/netatmo.retrieveTokens.js
@@ -63,6 +63,7 @@ async function retrieveTokens(body) {
     await this.saveStatus({ statusType: STATUS.CONNECTED });
     logger.debug('Netatmo new access tokens well loaded');
     if (this.configuration.energyApi || this.configuration.weatherApi) {
+      await this.refreshNetatmoValues();
       await this.pollRefreshingValues();
     }
     await this.pollRefreshingToken();

--- a/server/services/netatmo/lib/netatmo.retrieveTokens.js
+++ b/server/services/netatmo/lib/netatmo.retrieveTokens.js
@@ -63,12 +63,11 @@ async function retrieveTokens(body) {
     await this.saveStatus({ statusType: STATUS.CONNECTED });
     logger.debug('Netatmo new access tokens well loaded');
     if (this.configuration.energyApi || this.configuration.weatherApi) {
-      try {
-        await this.refreshNetatmoValues();
-      } catch (e) {
-        // the polling started below will retry; a failed initial refresh must not clobber the connected status
+      // fire-and-forget: the initial refresh must not delay the OAuth callback response,
+      // must not clobber the connected status, and the polling started below will retry
+      this.refreshNetatmoValues().catch((e) => {
         logger.error('Netatmo: initial devices values refresh failed after connection - Details: ', e);
-      }
+      });
       await this.pollRefreshingValues();
     }
     await this.pollRefreshingToken();

--- a/server/services/netatmo/lib/netatmo.retrieveTokens.js
+++ b/server/services/netatmo/lib/netatmo.retrieveTokens.js
@@ -63,7 +63,12 @@ async function retrieveTokens(body) {
     await this.saveStatus({ statusType: STATUS.CONNECTED });
     logger.debug('Netatmo new access tokens well loaded');
     if (this.configuration.energyApi || this.configuration.weatherApi) {
-      await this.refreshNetatmoValues();
+      try {
+        await this.refreshNetatmoValues();
+      } catch (e) {
+        // the polling started below will retry; a failed initial refresh must not clobber the connected status
+        logger.error('Netatmo: initial devices values refresh failed after connection - Details: ', e);
+      }
       await this.pollRefreshingValues();
     }
     await this.pollRefreshingToken();

--- a/server/services/netatmo/lib/netatmo.setValue.js
+++ b/server/services/netatmo/lib/netatmo.setValue.js
@@ -63,19 +63,12 @@ async function setValue(device, deviceFeature, value) {
           message: 'set_devices_value_error_unknown',
         });
       }
-    } else {
-      logger.debug(`Value has been changed on the device ${device.name} / ${featureName}: ${transformedValue}`);
+      throw new Error(`Netatmo setValue error: HTTP ${responseSetRoomThermpoint.status}`);
     }
+    logger.debug(`Value has been changed on the device ${device.name} / ${featureName}: ${transformedValue}`);
   } catch (e) {
-    logger.error(
-      'setValue error with status code: ',
-      e.code,
-      ' - ',
-      e.response.status,
-      'and with status message: ',
-      e.response.statusText,
-    );
-    logger.error('error details: ', e.response.data.error.code, ' - ', e.response.data.error.message);
+    logger.error(`setValue Netatmo error on device ${device.name} / ${featureName}: `, e);
+    throw e;
   }
 }
 

--- a/server/services/netatmo/lib/utils/netatmo.constants.js
+++ b/server/services/netatmo/lib/utils/netatmo.constants.js
@@ -52,6 +52,8 @@ const STATUS = {
 const RECONNECT_BACKOFF_MS = [30 * 1000, 60 * 1000, 120 * 1000, 300 * 1000];
 const RECONNECT_RECURRENT_MS = 300 * 1000;
 const FATAL_RETRY_WINDOW_MS = 24 * 60 * 60 * 1000;
+// Refresh the access token before it expires so API calls never run with a dead token.
+const ACCESS_TOKEN_REFRESH_RATIO = 0.8;
 
 const GITHUB_BASE_URL = 'https://github.com/GladysAssistant/Gladys/issues/new';
 const BASE_API = 'https://api.netatmo.com';
@@ -112,4 +114,5 @@ module.exports = {
   RECONNECT_BACKOFF_MS,
   RECONNECT_RECURRENT_MS,
   FATAL_RETRY_WINDOW_MS,
+  ACCESS_TOKEN_REFRESH_RATIO,
 };

--- a/server/test/services/netatmo/lib/device/netatmo.convertDeviceEnergy.test.js
+++ b/server/test/services/netatmo/lib/device/netatmo.convertDeviceEnergy.test.js
@@ -43,6 +43,19 @@ describe('Netatmo Convert Energy Device', () => {
     expect(gladysDevice.params).to.be.an('array');
   });
 
+  it('should fall back to station_name when the device has no name and no module_name', () => {
+    const deviceNetatmoMock = {
+      ...JSON.parse(JSON.stringify(devicesNetatmoMock.filter((device) => device.type === 'NAPlug')[0])),
+    };
+    delete deviceNetatmoMock.name;
+    delete deviceNetatmoMock.module_name;
+    deviceNetatmoMock.station_name = 'Relais PAC Maison';
+
+    const gladysDevice = netatmoHandler.convertDeviceEnergy(deviceNetatmoMock);
+
+    expect(gladysDevice).to.have.property('name', 'Relais PAC Maison');
+  });
+
   it('should correctly convert a Netatmo Thermostat device', () => {
     const deviceGladysMock = { ...devicesGladysMock.filter((device) => device.model === 'NATherm1')[0] };
     const deviceNetatmoMock = { ...devicesNetatmoMock.filter((device) => device.type === 'NATherm1')[0] };

--- a/server/test/services/netatmo/lib/device/netatmo.convertDeviceWeather.test.js
+++ b/server/test/services/netatmo/lib/device/netatmo.convertDeviceWeather.test.js
@@ -152,14 +152,14 @@ describe('Netatmo Convert Weather Device', () => {
   it('should correctly convert a Netatmo Weather Station device without modules_bridged and without room', () => {
     const deviceGladysMock = { ...devicesGladysMock.filter((device) => device.model === 'NAMain')[0] };
     const deviceNetatmoMock = { ...devicesNetatmoMock.filter((device) => device.type === 'NAMain')[0] };
-    const roomNameParam = deviceGladysMock.params.find((param) => param.name === 'room_name');
-    if (roomNameParam) {
-      deviceGladysMock.features.forEach((feature) => {
-        if (feature.category === 'temperature-sensor') {
-          feature.name = feature.name.replace(roomNameParam.value, 'undefined');
-        }
-      });
-    }
+    deviceGladysMock.features.forEach((feature) => {
+      if (feature.external_id.endsWith(':min_temp')) {
+        feature.name = `Temperature - Minimum - ${deviceGladysMock.name}`;
+      }
+      if (feature.external_id.endsWith(':max_temp')) {
+        feature.name = `Temperature - Maximum - ${deviceGladysMock.name}`;
+      }
+    });
     deviceGladysMock.features = deviceGladysMock.features.filter(
       (feature) => feature.external_id !== 'netatmo:70:ee:50:jj:jj:jj:therm_measured_temperature',
     );
@@ -194,14 +194,14 @@ describe('Netatmo Convert Weather Device', () => {
   it('should correctly convert a Netatmo Weather Station NAModule4 device without room and without plug', () => {
     const deviceGladysMock = { ...devicesGladysMock.filter((device) => device.model === 'NAModule4')[0] };
     const deviceNetatmoMock = { ...devicesNetatmoMock.filter((device) => device.type === 'NAModule4')[0] };
-    const roomNameParam = deviceGladysMock.params.find((param) => param.name === 'room_name');
-    if (roomNameParam) {
-      deviceGladysMock.features.forEach((feature) => {
-        if (feature.category === 'temperature-sensor') {
-          feature.name = feature.name.replace(roomNameParam.value, 'undefined');
-        }
-      });
-    }
+    deviceGladysMock.features.forEach((feature) => {
+      if (feature.external_id.endsWith(':min_temp')) {
+        feature.name = `Temperature - Minimum - ${deviceGladysMock.name}`;
+      }
+      if (feature.external_id.endsWith(':max_temp')) {
+        feature.name = `Temperature - Maximum - ${deviceGladysMock.name}`;
+      }
+    });
     deviceGladysMock.features = deviceGladysMock.features.filter(
       (feature) => feature.external_id !== 'netatmo:03:00:00:yy:yy:yy:therm_measured_temperature',
     );

--- a/server/test/services/netatmo/lib/netatmo.loadDeviceDetails.test.js
+++ b/server/test/services/netatmo/lib/netatmo.loadDeviceDetails.test.js
@@ -261,7 +261,8 @@ describe('Netatmo Load Device Details', () => {
     bodyHomeStatusMockFake.home.modules = bodyHomeStatusMockFake.home.modules.filter(
       (module) => module.id !== unreachableModuleId,
     );
-    bodyHomeStatusMockFake.home.errors = [{ code: 6, id: unreachableModuleId }];
+    // real API responses report unreachable module errors at body level, next to "home"
+    bodyHomeStatusMockFake.errors = [{ code: 6, id: unreachableModuleId }];
 
     // Intercept specific to this test
     netatmoMock
@@ -297,6 +298,7 @@ describe('Netatmo Load Device Details', () => {
       (module) => module.id !== unreachableCameraId && module.id !== unreachableThermostatId,
     );
     bodyHomeStatusMockFake.home.rooms = undefined;
+    bodyHomeStatusMockFake.home.errors = [{ code: 6, id: unreachableThermostatId }];
 
     // Intercept specific to this test
     netatmoMock
@@ -320,6 +322,7 @@ describe('Netatmo Load Device Details', () => {
     const unreachableThermostat = devices.find((device) => device.id === unreachableThermostatId);
     expect(unreachableThermostat).to.not.equal(undefined);
     expect(unreachableThermostat.reachable).to.equal(false);
+    expect(unreachableThermostat.apiErrorCode).to.equal(6);
     expect(unreachableThermostat.not_handled).to.equal(undefined);
     expect(unreachableThermostat.plug).to.not.equal(undefined);
     expect(unreachableThermostat.plug.id).to.equal('70:ee:50:xx:xx:xx');

--- a/server/test/services/netatmo/lib/netatmo.loadDeviceDetails.test.js
+++ b/server/test/services/netatmo/lib/netatmo.loadDeviceDetails.test.js
@@ -253,6 +253,78 @@ describe('Netatmo Load Device Details', () => {
     });
   });
 
+  it('should rebuild from homesdata the modules reported in homestatus errors', async () => {
+    netatmoHandler.configuration.energyApi = true;
+    netatmoHandler.configuration.weatherApi = true;
+    const unreachableModuleId = '70:ee:50:yy:yy:yy';
+    const bodyHomeStatusMockFake = JSON.parse(JSON.stringify(bodyHomeStatusMock));
+    bodyHomeStatusMockFake.home.modules = bodyHomeStatusMockFake.home.modules.filter(
+      (module) => module.id !== unreachableModuleId,
+    );
+    bodyHomeStatusMockFake.home.errors = [{ code: 6, id: unreachableModuleId }];
+
+    // Intercept specific to this test
+    netatmoMock
+      .intercept({
+        method: 'GET',
+        path: `/api/homestatus?home_id=${homesMock.id}`,
+      })
+      .reply(200, {
+        body: bodyHomeStatusMockFake,
+        status: 'ok',
+      });
+
+    const devices = await netatmoHandler.loadDeviceDetails(homesMock);
+
+    expect(devices).to.have.lengthOf(10);
+    const unreachableDevice = devices.find((device) => device.id === unreachableModuleId);
+    expect(unreachableDevice).to.not.equal(undefined);
+    expect(unreachableDevice.name).to.equal('Relais Salon Test');
+    expect(unreachableDevice.type).to.equal('NAPlug');
+    expect(unreachableDevice.reachable).to.equal(false);
+    expect(unreachableDevice.apiErrorCode).to.equal(6);
+    expect(unreachableDevice.categoryAPI).to.equal('Energy');
+    expect(unreachableDevice.not_handled).to.equal(undefined);
+  });
+
+  it('should rebuild not handled and bridged modules missing from homestatus without error code', async () => {
+    netatmoHandler.configuration.energyApi = true;
+    netatmoHandler.configuration.weatherApi = true;
+    const unreachableCameraId = '70:ee:00:xx:xx:xx';
+    const unreachableThermostatId = '04:00:00:xx:xx:xx';
+    const bodyHomeStatusMockFake = JSON.parse(JSON.stringify(bodyHomeStatusMock));
+    bodyHomeStatusMockFake.home.modules = bodyHomeStatusMockFake.home.modules.filter(
+      (module) => module.id !== unreachableCameraId && module.id !== unreachableThermostatId,
+    );
+    bodyHomeStatusMockFake.home.rooms = undefined;
+
+    // Intercept specific to this test
+    netatmoMock
+      .intercept({
+        method: 'GET',
+        path: `/api/homestatus?home_id=${homesMock.id}`,
+      })
+      .reply(200, {
+        body: bodyHomeStatusMockFake,
+        status: 'ok',
+      });
+
+    const devices = await netatmoHandler.loadDeviceDetails(homesMock);
+
+    expect(devices).to.have.lengthOf(10);
+    const unreachableCamera = devices.find((device) => device.id === unreachableCameraId);
+    expect(unreachableCamera).to.not.equal(undefined);
+    expect(unreachableCamera.reachable).to.equal(false);
+    expect(unreachableCamera.apiErrorCode).to.equal(undefined);
+    expect(unreachableCamera.not_handled).to.equal(true);
+    const unreachableThermostat = devices.find((device) => device.id === unreachableThermostatId);
+    expect(unreachableThermostat).to.not.equal(undefined);
+    expect(unreachableThermostat.reachable).to.equal(false);
+    expect(unreachableThermostat.not_handled).to.equal(undefined);
+    expect(unreachableThermostat.plug).to.not.equal(undefined);
+    expect(unreachableThermostat.plug.id).to.equal('70:ee:50:xx:xx:xx');
+  });
+
   it('should no load device details without modules', async () => {
     const homesMockFake = { ...JSON.parse(JSON.stringify(homesMock)) };
     homesMockFake.modules = homesMockFake.modules.filter((module) => module.type !== 'NATherm1');

--- a/server/test/services/netatmo/lib/netatmo.pollRefreshingValues.test.js
+++ b/server/test/services/netatmo/lib/netatmo.pollRefreshingValues.test.js
@@ -86,6 +86,17 @@ describe('Netatmo pollRefreshingValues', () => {
     sinon.assert.called(netatmoHandler.updateValues);
   });
 
+  it('should skip the refresh when one is already running', async () => {
+    netatmoHandler.status = 'connected';
+    netatmoHandler.loadDevices = sinon.stub().resolves(devicesMock);
+    netatmoHandler.refreshingValues = true;
+
+    await netatmoHandler.refreshNetatmoValues();
+
+    sinon.assert.notCalled(netatmoHandler.loadDevices);
+    netatmoHandler.refreshingValues = false;
+  });
+
   it('should refresh device values without device existing in Gladys', async () => {
     netatmoHandler.status = 'connected';
     netatmoHandler.loadDevices = sinon.stub().resolves(devicesMock);

--- a/server/test/services/netatmo/lib/netatmo.retrieveToken.test.js
+++ b/server/test/services/netatmo/lib/netatmo.retrieveToken.test.js
@@ -165,6 +165,33 @@ describe('Netatmo retrieveTokens', () => {
     sinon.assert.calledOnce(netatmoHandler.pollRefreshingToken);
   });
 
+  it('should stay connected when the initial values refresh fails', async () => {
+    const tokens = {
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      expire_in: 3600,
+    };
+    netatmoHandler.configuration.energyApi = true;
+    netatmoHandler.refreshNetatmoValues = fake.rejects(new Error('refresh failed'));
+
+    // Intercept the HTTP/2 call via undici
+    netatmoMock
+      .intercept({
+        method: 'POST',
+        path: '/oauth2/token',
+      })
+      .reply(200, tokens);
+
+    const result = await netatmoHandler.retrieveTokens(body);
+
+    expect(result).to.deep.equal({ success: true });
+    expect(netatmoHandler.status).to.equal('connected');
+    sinon.assert.calledOnce(netatmoHandler.pollRefreshingValues);
+    sinon.assert.calledOnce(netatmoHandler.pollRefreshingToken);
+
+    netatmoHandler.refreshNetatmoValues = fake.resolves(null);
+  });
+
   it('should throw an error when axios request fails', async () => {
     const bodyFake = { codeOAuth: 'test-code', state: 'valid-state', redirectUri: 'test-redirect-uri' };
     netatmoHandler.configuration.clientId = 'test-client-id';

--- a/server/test/services/netatmo/lib/netatmo.retrieveToken.test.js
+++ b/server/test/services/netatmo/lib/netatmo.retrieveToken.test.js
@@ -19,6 +19,7 @@ const serviceId = 'serviceId';
 const netatmoHandler = new NetatmoHandler(gladys, serviceId);
 netatmoHandler.pollRefreshingToken = fake.resolves(null);
 netatmoHandler.pollRefreshingValues = fake.resolves(null);
+netatmoHandler.refreshNetatmoValues = fake.resolves(null);
 
 describe('Netatmo retrieveTokens', () => {
   let body;
@@ -125,6 +126,7 @@ describe('Netatmo retrieveTokens', () => {
         payload: { status: 'processing token' },
       }),
     ).to.equal(true);
+    sinon.assert.notCalled(netatmoHandler.refreshNetatmoValues);
     sinon.assert.notCalled(netatmoHandler.pollRefreshingValues);
     sinon.assert.calledOnce(netatmoHandler.pollRefreshingToken);
   });
@@ -158,6 +160,7 @@ describe('Netatmo retrieveTokens', () => {
         payload: { status: 'processing token' },
       }),
     ).to.equal(true);
+    sinon.assert.calledOnce(netatmoHandler.refreshNetatmoValues);
     sinon.assert.calledOnce(netatmoHandler.pollRefreshingValues);
     sinon.assert.calledOnce(netatmoHandler.pollRefreshingToken);
   });

--- a/server/test/services/netatmo/lib/netatmo.setValue.test.js
+++ b/server/test/services/netatmo/lib/netatmo.setValue.test.js
@@ -152,7 +152,12 @@ describe('Netatmo Set Value', () => {
         },
       });
 
-    await netatmoHandler.setValue(deviceMock, deviceFeatureMock, newValue);
+    try {
+      await netatmoHandler.setValue(deviceMock, deviceFeatureMock, newValue);
+      expect.fail('setValue should have thrown an error');
+    } catch (e) {
+      expect(e.message).to.equal('Netatmo setValue error: HTTP 400');
+    }
 
     expect(netatmoHandler.gladys.event.emit.callCount).to.equal(2);
     expect(
@@ -188,7 +193,12 @@ describe('Netatmo Set Value', () => {
         },
       });
 
-    await netatmoHandler.setValue(deviceMock, deviceFeatureMock, newValue);
+    try {
+      await netatmoHandler.setValue(deviceMock, deviceFeatureMock, newValue);
+      expect.fail('setValue should have thrown an error');
+    } catch (e) {
+      expect(e.message).to.equal('Netatmo setValue error: HTTP 403');
+    }
 
     expect(netatmoHandler.gladys.event.emit.callCount).to.equal(2);
     expect(


### PR DESCRIPTION
### Pull Request check-list

- [x] If your changes affect the code, did you write the tests?
- [x] Are server tests passing with coverage? (`cd server && npm run coverage`) — Codecov requires **100% coverage on lines changed in this PR**
- [ ] ~~Did Cypress E2E tests pass? (`npm run cypress:run` from repo root, if UI changed)~~ *(no UI change in this PR)*
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] ~~If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)~~ *(no i18n change in this PR)*
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging. *(validated on a real installation with real Netatmo devices)*
- [ ] ~~If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~~ *(no API change)*
- [ ] ~~If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).~~ *(no new feature)*
- [ ] ~~Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).~~ *(not needed)*

> **Merge order:** please merge #2620 first — its discovery-page fix is required to test this PR on a real installation that has powered-off modules. This branch already includes #2620.

## Summary

Five small robustness fixes on the Netatmo service, following up on the resilience work from #2561/#2562. No new feature, no schema change.

## Details

1. **`setValue` no longer fails silently (or crashes).** The `catch` block accessed `e.response.status`, a leftover from the axios era: with undici, a network timeout has no `response`, so the handler crashed with a `TypeError`. And in every failure case the error was swallowed, so the user believed their setpoint was applied. The error is now logged with context and re-thrown so callers get proper feedback. An HTTP error response also throws (after the existing status/websocket reporting) instead of returning silently.
2. **Access token refreshed at 80% of its TTL.** The refresh interval was exactly `expire_in`, meaning the token was refreshed at the moment it died — leaving a window where business API calls could run with an expired token and trigger the reconnect cycle for nothing. New constant `ACCESS_TOKEN_REFRESH_RATIO = 0.8`.
3. **Device values fetched immediately after OAuth connect.** `retrieveTokens` armed the 120s polling interval without an initial fetch, so a fresh connection showed no values for up to 2 minutes. It now triggers an immediate refresh **in the background** (fire-and-forget, so the OAuth callback response is not delayed and a transient refresh failure cannot clobber the freshly connected status) before arming the polling.
4. **No more `Minimum in undefined` feature names.** `convertDeviceWeather`/`convertDeviceEnergy` initialized `roomName` with the literal string `'undefined'`; outdoor modules without a room produced features named `Temperature - Minimum in undefined`. Min/max features now fall back to the device name (`Temperature - Minimum - <device>`), and the dead sentinel variable is removed. Only affects newly imported devices.
5. **Single-flight guard on the values refresh** *(review follow-up)*: `refreshNetatmoValues` now skips when a refresh is already running, so the startup refresh, the 120s interval ticks and the reconnect-triggered refreshes can never overlap — the polling interval previously had no in-flight guard at all.

Tests updated accordingly (setValue error paths now assert the thrown error, no-room conversion tests assert the new names, dedicated cases for the background refresh and the single-flight guard), 100% coverage on all touched files.

## Scope

Diff computed against the parent branch (#2620), which this branch already includes:

| Area | Insertions | Deletions |
| --- | ---: | ---: |
| Production code (`server/services/netatmo`) | 62 | 61 |
| Tests (`server/test/services/netatmo`) | 69 | 18 |
| **Total** | **131** | **79** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable access-token refresh scheduling, plus an immediate, non-blocking refresh when energy/weather are enabled.
  * Introduced a “single-flight” refresh to prevent overlapping value updates, with a manual “refresh now” option.
* **Bug Fixes**
  * Improved device-name fallback to use station name when name/module name are missing.
  * Corrected room-aware temperature feature naming and room metadata wiring (min/max/thermostat).
  * Discovery now rebuilds unreachable modules with proper reachability, error codes, and UI warnings.
  * Energy API merge now preserves existing room details; setValue error handling is clearer and more consistent.
* **Tests**
  * Expanded/updated Netatmo conversion, discovery, value refresh, setValue, and token-refresh coverage.
* **Documentation**
  * Updated Netatmo discovery i18n with a dedicated device error message for code 6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


