### PR TITLE
Front: Fix signal quality SVG icons invisible in development

### DIFF
--- a/front/src/components/icons/SvgIcon.jsx
+++ b/front/src/components/icons/SvgIcon.jsx
@@ -1,4 +1,7 @@
-import IconSprite from '/assets/icons/icon-sprite.svg';
+// Reference the sprite by its public URL instead of importing it: in development,
+// preact-cli inlines imported SVGs as data URIs and browsers refuse external
+// <use> references on data URIs, which made these icons invisible in dev.
+const ICON_SPRITE_URL = '/assets/icons/icon-sprite.svg';
 
 const TablerIcon = ({ icon }) => (
   <svg
@@ -10,7 +13,7 @@ const TablerIcon = ({ icon }) => (
     stroke-linecap="round"
     stroke-linejoin="round"
   >
-    <use href={`${IconSprite}#${icon}`} />
+    <use href={`${ICON_SPRITE_URL}#${icon}`} />
   </svg>
 );
 


### PR DESCRIPTION
### Pull Request check-list

- [ ] ~~If your changes affect the code, did you write the tests?~~ *(no front unit test infrastructure for this component; one-line rendering fix)*
- [ ] ~~Are server tests passing with coverage?~~ *(front only)*
- [x] Did Cypress E2E tests pass? (`npm run cypress:run` from repo root, if UI changed)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] ~~If you are adding a new feature/service, did you run the integration comparator?~~ *(no i18n change)*
- [x] Did you test this pull request in real life? With real devices? *(validated on a real dev installation — the signal icons render correctly in development)*
- [ ] ~~If your changes modify the API (REST or Node.js), did you modify the API documentation?~~ *(no API change)*
- [ ] ~~If you are adding a new features/services which needs explanation, did you modify the user documentation?~~ *(no user-facing behavior change in production)*
- [ ] ~~Did you add fake requests data for the demo mode?~~ *(not needed)*

## Summary

The signal quality icons (`tabler-antenna-bars-*`, used for RF/WiFi strength values in the dashboard device boxes) render **blank in development mode**, while working fine in production. One-line root cause in `SvgIcon.jsx`.

## Details

The tabler icon sprite was imported as a module (`import IconSprite from '/assets/icons/icon-sprite.svg'`) and referenced with `<use href={`${IconSprite}#icon`}>`. preact-cli 3 bundles binary assets with **`file-loader` in production** (real URL → works) but **`url-loader` in development**, which inlines the 3.2 KB sprite as a `data:` URI — and browsers refuse external `<use>` references on data URIs, so the icon silently renders nothing in dev.

The fix references the sprite by its public URL (`/assets/icons/icon-sprite.svg#icon`): `src/assets` is served at `/assets` by both the dev server and the production build (same pattern as the integration device images), so the icon now renders identically in both environments.

## Scope

Diff computed against `master`:

| Area | Insertions | Deletions |
| --- | ---: | ---: |
| Front (`front/src/components/icons`) | 5 | 2 |
| **Total** | **5** | **2** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated icon rendering to use a stable public SVG sprite URL, preventing missing or broken icons during development.
  * Improved external SVG references so sprite-based icons load reliably across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

