### PR TITLE
Netatmo: Stop replaying the OAuth callback on page refresh

### DIFF
--- a/front/src/routes/integration/all/netatmo/setup-page/index.js
+++ b/front/src/routes/integration/all/netatmo/setup-page/index.js
@@ -57,6 +57,10 @@ class NetatmoSetupPage extends Component {
         });
         console.error('Logs error', this.props);
       }
+      // strip the OAuth params so a page refresh does not replay the failed callback
+      setTimeout(() => {
+        route('/dashboard/integration/device/netatmo/setup', true);
+      }, 100);
     }
     if (this.props.code && this.props.state) {
       let successfulNewToken = false;
@@ -98,6 +102,12 @@ class NetatmoSetupPage extends Component {
           configured: true,
           errored: true
         });
+        // an OAuth code is single-use: strip it from the URL so a page refresh
+        // does not replay the exchange (400 invalid_grant shown as a misleading
+        // "account banned/disabled" message, and the service status clobbered)
+        setTimeout(() => {
+          route('/dashboard/integration/device/netatmo/setup', true);
+        }, 100);
       }
     }
   };


### PR DESCRIPTION
### Pull Request check-list

- [ ] ~~If your changes affect the code, did you write the tests?~~ *(front-only fix; the front has no unit test infrastructure)*
- [ ] ~~Are server tests passing with coverage? (`cd server && npm run coverage`) — Codecov requires **100% coverage on lines changed in this PR**~~ *(no server change)*
- [ ] ~~Did Cypress E2E tests pass? (`npm run cypress:run` from repo root, if UI changed)~~ *(no E2E scenario covers the Netatmo setup page)*
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] ~~If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)~~ *(no i18n change)*
- [x] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging. *(runtime validation in progress)*
- [ ] ~~If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)~~ *(no API change)*
- [ ] ~~If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).~~ *(bug fix, no new feature)*
- [ ] ~~Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).~~ *(not needed)*

## Summary

Bug found during real-life testing of the Netatmo webhook development (#2627), triggered by a simple manipulation: **refreshing the Netatmo setup page after an OAuth connection**.

After the Netatmo OAuth redirect, the setup page URL keeps the `?code=...&state=...` query parameters, and `detectCode()` re-runs the token exchange on **every page load**. But an OAuth code is single-use, and the anti-CSRF `state` lives in the server memory. Two real-life scenarios replay the callback and fail:

- **F5 on the page after a successful connection** → Netatmo answers `400 invalid_grant` (code already consumed);
- **reload after a server restart** (typical in development) → state mismatch ("The return does not correspond to the initial request").

In both cases the front displays a **misleading "account banned/disabled" message**, and the failed exchange clobbers the service status (error websocket + `disconnected`) even though the service is actually still connected and polling — the user legitimately believes they have been disconnected or banned.

## The fix

The success path already strips the query params via `route('/dashboard/integration/device/netatmo/setup', true)`. This PR applies the same cleanup in the two failure paths (denied consent / failed token exchange), so a page refresh can never replay the OAuth callback. 10 inserted lines, front only, no behavior change on the nominal flow.

## Scope

| Area | Insertions | Deletions |
| --- | ---: | ---: |
| Front (`front/src/routes/integration/all/netatmo/setup-page/index.js`) | 10 | 0 |
| **Total** | **10** | **0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Netatmo setup flow to redirect users back to the setup page after certain OAuth failures.
  * Prevents failed OAuth callbacks from being replayed on refresh, reducing confusing errors during setup.
  * Adds a smoother recovery path when token exchange fails, helping users restart the connection process more easily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->