### PR TITLE
Display signal quality in Activity screen

### DIFF
--- a/front/src/components/boxs/device-in-room/device-features/sensor-value/SignalQualityDeviceValue.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/sensor-value/SignalQualityDeviceValue.jsx
@@ -1,5 +1,6 @@
 import { Text } from 'preact-i18n';
 import SvgIcon from '../../../../icons/SvgIcon';
+import { getSignalQualityIcon, getSignalQualityLevel } from '../../../../../utils/signalQuality';
 
 const SignalQualityDeviceValue = ({ deviceFeature }) => {
   const { last_value: lastValue, min, max } = deviceFeature;
@@ -8,10 +9,10 @@ const SignalQualityDeviceValue = ({ deviceFeature }) => {
     return <Text id="dashboard.boxes.devicesInRoom.noValue" />;
   }
 
-  const ratio = Math.round(((lastValue - min) * 5) / (max - min));
+  const level = getSignalQualityLevel(lastValue, min, max);
   return (
     <div class="d-flex flex-row-reverse">
-      <SvgIcon icon={`tabler-antenna-bars-${ratio || 'off'}`} />
+      <SvgIcon icon={getSignalQualityIcon(level)} />
     </div>
   );
 };

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -4780,6 +4780,14 @@
       "lock": {
         "0": "Entriegelt",
         "1": "Verriegelt"
+      },
+      "signal": {
+        "0": "Kein Signal",
+        "1": "Sehr schwaches Signal",
+        "2": "Schwaches Signal",
+        "3": "Mittleres Signal",
+        "4": "Gutes Signal",
+        "5": "Ausgezeichnetes Signal"
       }
     }
   },

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -4780,6 +4780,14 @@
       "lock": {
         "0": "Unlocked",
         "1": "Locked"
+      },
+      "signal": {
+        "0": "No signal",
+        "1": "Very weak signal",
+        "2": "Weak signal",
+        "3": "Fair signal",
+        "4": "Good signal",
+        "5": "Excellent signal"
       }
     }
   },

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -4780,6 +4780,14 @@
       "lock": {
         "0": "Déverrouillée",
         "1": "Verrouillée"
+      },
+      "signal": {
+        "0": "Pas de signal",
+        "1": "Signal très faible",
+        "2": "Signal faible",
+        "3": "Signal moyen",
+        "4": "Bon signal",
+        "5": "Excellent signal"
       }
     }
   },

--- a/front/src/routes/history/EventLine.jsx
+++ b/front/src/routes/history/EventLine.jsx
@@ -3,8 +3,15 @@ import cx from 'classnames';
 import get from 'get-value';
 import dayjs from 'dayjs';
 
-import { DEVICE_FEATURE_TYPES } from '../../../../server/utils/constants';
+import { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } from '../../../../server/utils/constants';
+import SvgIcon from '../../components/icons/SvgIcon';
 import { DeviceFeatureCategoriesIcon } from '../../utils/consts';
+import {
+  DEFAULT_SIGNAL_MAX,
+  DEFAULT_SIGNAL_MIN,
+  getSignalQualityIcon,
+  getSignalQualityLevel
+} from '../../utils/signalQuality';
 import { getGroupOfCategory } from './categoryGroups';
 import style from './style.css';
 
@@ -17,10 +24,31 @@ const roundValue = value => {
   return Math.round(value * 100) / 100;
 };
 
-const EventValue = ({ event, intl }) => {
+const getSignalFeatureBounds = (event, featuresBySelector) => {
+  const featureMeta = featuresBySelector && featuresBySelector.get(event.device_feature.selector);
+  const min = event.device_feature.min ?? get(featureMeta, 'device_feature.min', { default: DEFAULT_SIGNAL_MIN });
+  const max = event.device_feature.max ?? get(featureMeta, 'device_feature.max', { default: DEFAULT_SIGNAL_MAX });
+  return { min, max };
+};
+
+const EventValue = ({ event, intl, featuresBySelector }) => {
   const { category, type, unit } = event.device_feature;
   const value = event.value;
   const dictionary = get(intl, 'dictionary', { default: {} });
+
+  if (category === DEVICE_FEATURE_CATEGORIES.SIGNAL) {
+    const { min, max } = getSignalFeatureBounds(event, featuresBySelector);
+    const level = getSignalQualityLevel(value, min, max);
+    if (level == null) {
+      return <Text id="dashboard.boxes.devicesInRoom.noValue" />;
+    }
+    return (
+      <span class={style.signalQualityValue}>
+        <SvgIcon icon={getSignalQualityIcon(level)} />
+        <Text id={`history.values.signal.${level}`} />
+      </span>
+    );
+  }
 
   // Binary/push sensors: "Opened"/"Closed", "Motion detected"...
   if (BINARY_TYPES.includes(type)) {
@@ -65,7 +93,7 @@ const EventValue = ({ event, intl }) => {
   );
 };
 
-const EventLine = ({ eventGroup, intl, toggleExpand, expanded }) => {
+const EventLine = ({ eventGroup, intl, toggleExpand, expanded, featuresBySelector }) => {
   const event = eventGroup.events[0];
   const { category, type } = event.device_feature;
   const group = getGroupOfCategory(category);
@@ -81,7 +109,7 @@ const EventLine = ({ eventGroup, intl, toggleExpand, expanded }) => {
         <div class={style.eventText}>
           <span class={style.eventDeviceName}>{event.device.name}</span>
           <span class={cx(style.eventValue, style[`eventValue-${group.colorClass}`])}>
-            <EventValue event={event} intl={intl} />
+            <EventValue event={event} intl={intl} featuresBySelector={featuresBySelector} />
           </span>
           {count > 1 && (
             <button type="button" class={cx('btn', style.eventCountBadge)} onClick={toggleExpand}>
@@ -104,7 +132,7 @@ const EventLine = ({ eventGroup, intl, toggleExpand, expanded }) => {
               <div class={style.eventOccurrence}>
                 <span class={style.eventOccurrenceTime}>{dayjs(oneEvent.created_at).format('HH:mm:ss')}</span>
                 <span>
-                  <EventValue event={oneEvent} intl={intl} />
+                  <EventValue event={oneEvent} intl={intl} featuresBySelector={featuresBySelector} />
                 </span>
               </div>
             ))}

--- a/front/src/routes/history/HistoryPage.jsx
+++ b/front/src/routes/history/HistoryPage.jsx
@@ -233,6 +233,7 @@ const HistoryPage = ({ intl, user, ...props }) => {
                             intl={intl}
                             expanded={props.expandedGroups[eventGroup.key]}
                             toggleExpand={() => props.toggleExpand(eventGroup.key)}
+                            featuresBySelector={props.featuresBySelector}
                           />
                         ))}
                       </div>

--- a/front/src/routes/history/index.js
+++ b/front/src/routes/history/index.js
@@ -40,7 +40,9 @@ class History extends Component {
               selector: feature.selector,
               category: feature.category,
               type: feature.type,
-              unit: feature.unit
+              unit: feature.unit,
+              min: feature.min,
+              max: feature.max
             },
             device: {
               name: device.name,
@@ -57,6 +59,7 @@ class History extends Component {
         });
       });
       this.featuresBySelector = featuresBySelector;
+      this.setState({ featuresLoaded: true });
     } catch (e) {
       console.error(e);
     }
@@ -278,7 +281,8 @@ class History extends Component {
       loading: true,
       initialized: false,
       hasMore: false,
-      error: false
+      error: false,
+      featuresLoaded: false
     };
     this.featuresBySelector = null;
     this.liveEventBuffer = [];
@@ -315,6 +319,7 @@ class History extends Component {
         loadMore={this.loadMore}
         toggleExpand={this.toggleExpand}
         showPendingLiveEvents={this.showPendingLiveEvents}
+        featuresBySelector={this.featuresBySelector}
       />
     );
   }

--- a/front/src/routes/history/style.css
+++ b/front/src/routes/history/style.css
@@ -393,6 +393,18 @@
   color: #6c757d;
 }
 
+.signalQualityValue {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.signalQualityValue svg {
+  width: 1.1rem;
+  height: 1.1rem;
+  flex-shrink: 0;
+}
+
 .eventCountBadge {
   display: inline-flex;
   align-items: center;

--- a/front/src/utils/signalQuality.js
+++ b/front/src/utils/signalQuality.js
@@ -1,0 +1,32 @@
+export const DEFAULT_SIGNAL_MIN = 0;
+export const DEFAULT_SIGNAL_MAX = 100;
+
+/**
+ * @description Map a signal strength value to a 0-5 bar level.
+ * @param {number} value - Signal strength value.
+ * @param {number} [min] - Minimum value of the feature.
+ * @param {number} [max] - Maximum value of the feature.
+ * @returns {number} Signal quality level from 0 (off) to 5.
+ */
+export const getSignalQualityLevel = (value, min = DEFAULT_SIGNAL_MIN, max = DEFAULT_SIGNAL_MAX) => {
+  if (value == null) {
+    return null;
+  }
+  if (max === min) {
+    return value > min ? 5 : 0;
+  }
+  const ratio = Math.round(((value - min) * 5) / (max - min));
+  return Math.max(0, Math.min(5, ratio));
+};
+
+/**
+ * @description Get the Tabler icon name for a signal quality level.
+ * @param {number|null} level - Signal quality level from 0 to 5.
+ * @returns {string|null} Tabler icon name.
+ */
+export const getSignalQualityIcon = level => {
+  if (level == null) {
+    return null;
+  }
+  return `tabler-antenna-bars-${level || 'off'}`;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problème

Dans la vue **Activité**, les événements de type « Intensité du signal » affichaient une valeur entière brute (ex. `82`), peu lisible pour l'utilisateur.

## Solution

- Réutilisation de l'échelle d'icônes en barres d'antenne (`tabler-antenna-bars-*`) déjà utilisée sur le tableau de bord
- Ajout d'un libellé textuel explicite pour chaque niveau (ex. « Bon signal », « Signal faible », « Pas de signal »)
- Extraction de la logique de calcul du niveau de signal dans un utilitaire partagé (`front/src/utils/signalQuality.js`)
- Prise en compte des bornes `min`/`max` de la fonctionnalité (via les métadonnées appareil) pour un affichage correct selon l'appareil

## Fichiers modifiés

- `front/src/routes/history/EventLine.jsx` — affichage icône + libellé pour la catégorie `signal`
- `front/src/utils/signalQuality.js` — utilitaire partagé
- `front/src/components/.../SignalQualityDeviceValue.jsx` — refactor pour utiliser l'utilitaire
- Traductions `en`, `fr`, `de` sous `history.values.signal`

## Aperçu

Au lieu de : `Capteur Zigbee 82`

On affiche maintenant : `[icône 4 barres] Bon signal`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2c266ac-22ff-482f-a848-acf0066fb2a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2c266ac-22ff-482f-a848-acf0066fb2a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer signal-quality indicators across device views and history.
  * Signal strength is now displayed with 0–5 levels and matching antenna icons.
  * Added localized signal-quality labels in English, German, and French.
  * History entries now account for device-specific signal ranges.

* **Bug Fixes**
  * Improved handling of missing or unavailable signal values.
  * Signal levels are consistently constrained to the supported range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->