### PR TITLE
Improve Activity page display (scrollbar + dark mode)

### DIFF
--- a/front/src/routes/history/style.css
+++ b/front/src/routes/history/style.css
@@ -505,3 +505,9 @@
     padding: 0.25rem 0.75rem;
   }
 }
+
+/* Dark mode: sticky bands must use the same pre-invert bg as .page (see dark-mode.css) */
+:global(.dark-mode) .groupChips,
+:global(.dark-mode) .dayHeader {
+  background: #e1e8f7 !important;
+}

--- a/front/src/routes/history/style.css
+++ b/front/src/routes/history/style.css
@@ -105,11 +105,15 @@
   padding: 0.5rem 0;
   margin-bottom: 0.75rem;
   -webkit-overflow-scrolling: touch;
-  scrollbar-width: thin;
+  scrollbar-width: none;
   position: sticky;
   top: 0;
   z-index: 20;
   background: #f5f7fb;
+}
+
+.groupChips::-webkit-scrollbar {
+  display: none;
 }
 
 .groupChip {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problems

1. **Windows**: The device category filter row showed a persistent, unsightly horizontal scrollbar (on macOS scrollbars are hidden by default until scrolling).
2. **Dark mode**: The sticky bands for the category selector and day separators ("Today", etc.) displayed a very dark rectangle, because their `#f5f7fb` background did not match the page background in dark mode (`#e1e8f7` before CSS inversion).

## Solution

- Hide the horizontal scrollbar on `.groupChips` (same pattern as the Integrations page).
- In dark mode, apply `#e1e8f7` to `.groupChips` and `.dayHeader` so they blend with the page background after CSS inversion.

## Modified file

- `front/src/routes/history/style.css`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d807bc3-c4b8-47cd-bfd3-c82bd3f66fd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d807bc3-c4b8-47cd-bfd3-c82bd3f66fd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Hid scrollbars in the history page’s horizontal chip navigation while preserving scrolling.
  * Improved dark mode consistency for sticky chip and day header sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->