### PR TITLE
Front: Fix infinite auto-load loop on Activity page

### DIFF
--- a/front/src/routes/history/HistoryPage.jsx
+++ b/front/src/routes/history/HistoryPage.jsx
@@ -241,7 +241,7 @@ const HistoryPage = ({ intl, user, ...props }) => {
                   </div>
                 ))}
 
-                {props.hasMore && !props.loading && <LoadMoreSentinel onVisible={props.loadMore} />}
+                {props.hasMore && !props.loading && <LoadMoreSentinel onVisible={props.autoLoadMore} />}
                 {props.hasMore && (
                   <div class={style.loadMoreContainer}>
                     <button

--- a/front/src/routes/history/index.js
+++ b/front/src/routes/history/index.js
@@ -14,6 +14,12 @@ const MAX_EVENTS_IN_MEMORY = 1000;
 // states per second; without batching, each one would run a full setState +
 // timeline rebuild and freeze the page.
 const LIVE_FLUSH_INTERVAL_MS = 1000;
+// When a filter matches a very chatty device feature, a whole page of states is
+// grouped into a single timeline row, so the page never fills the viewport, the
+// infinite-scroll sentinel never leaves it, and each response would immediately
+// trigger the next fetch, forever. Only allow this many sentinel-triggered loads
+// without a user scroll in between; past that, the "load more" button takes over.
+const MAX_AUTO_LOADS_WITHOUT_SCROLL = 3;
 
 class History extends Component {
   getRooms = async () => {
@@ -137,9 +143,25 @@ class History extends Component {
   refreshEvents = () => this.getEvents({ reset: true });
 
   loadMore = () => {
+    // Explicit user action: re-arm the auto-load budget.
+    this.autoLoadsWithoutScroll = 0;
     if (!this.state.loading && this.state.hasMore) {
       this.getEvents();
     }
+  };
+
+  autoLoadMore = () => {
+    if (this.autoLoadsWithoutScroll >= MAX_AUTO_LOADS_WITHOUT_SCROLL) {
+      return;
+    }
+    if (!this.state.loading && this.state.hasMore) {
+      this.autoLoadsWithoutScroll += 1;
+      this.getEvents();
+    }
+  };
+
+  onUserScroll = () => {
+    this.autoLoadsWithoutScroll = 0;
   };
 
   selectGroup = groupId => {
@@ -287,6 +309,7 @@ class History extends Component {
     this.featuresBySelector = null;
     this.liveEventBuffer = [];
     this.liveFlushTimeout = null;
+    this.autoLoadsWithoutScroll = 0;
     this.debouncedRefreshEvents = debounce(this.refreshEvents.bind(this), 300);
   }
 
@@ -295,10 +318,12 @@ class History extends Component {
     this.getRooms();
     this.getDevices();
     this.props.session.dispatcher.addListener(WEBSOCKET_MESSAGE_TYPES.DEVICE.NEW_STATE, this.onNewState);
+    window.addEventListener('scroll', this.onUserScroll, { passive: true });
   }
 
   componentWillUnmount() {
     this.props.session.dispatcher.removeListener(WEBSOCKET_MESSAGE_TYPES.DEVICE.NEW_STATE, this.onNewState);
+    window.removeEventListener('scroll', this.onUserScroll);
     if (this.liveFlushTimeout) {
       clearTimeout(this.liveFlushTimeout);
       this.liveFlushTimeout = null;
@@ -317,6 +342,7 @@ class History extends Component {
         backToLive={this.backToLive}
         search={this.search}
         loadMore={this.loadMore}
+        autoLoadMore={this.autoLoadMore}
         toggleExpand={this.toggleExpand}
         showPendingLiveEvents={this.showPendingLiveEvents}
         featuresBySelector={this.featuresBySelector}


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- ~~If your changes affect the code, did you write the tests?~~ *(front-only change, the front has no unit-test script; validated at runtime, see below)*
- ~~Are server tests passing with coverage?~~ *(no server code touched)*
- [ ] Did Cypress E2E tests pass? *(no dedicated spec for the Activity/history route)*
- [x] Is the linter passing? (`npm run eslint` on front)
- [x] Did you run prettier? (`npm run prettier-check` on front)
- ~~If you are adding a new feature/service, did you run the integration comparator?~~ *(no i18n change)*
- [ ] Did you test this pull request in real life? With real devices? *(in progress on a 457M-state installation — [WIP] will be removed once validated)*
- ~~If your changes modify the API (REST or Node.js), did you modify the API documentation?~~ *(no API change)*
- ~~If you are adding a new features/services which needs explanation, did you modify the user documentation?~~ *(bug fix only)*
- ~~Did you add fake requests data for the demo mode?~~ *(no new request)*

`npm run build` (Vite) passes locally.

### Description of change

#### Problem

On the Activity page, filtering on a category dominated by one very chatty device feature (e.g. a motion sensor with hundreds of consecutive states) triggers an **unbounded loop of `states_history` requests** (observed: 138+ requests at ~10 req/s since the server-side windowing fix made the endpoint fast).

#### Cause

`LoadMoreSentinel` (IntersectionObserver, `rootMargin: 300px`) calls `loadMore` whenever it is visible and `hasMore && !loading`. `buildTimeline` groups consecutive states of the same feature into a single timeline row, so each 80-state page collapses into **one visual row** (the "×N" badge). The page height never grows, the sentinel never leaves the viewport, and every response immediately re-triggers the next fetch. Since `events` is capped at `MAX_EVENTS_IN_MEMORY = 1000` (head slice), the loop never converges.

#### Fix

Give the sentinel a budget of `MAX_AUTO_LOADS_WITHOUT_SCROLL = 3` consecutive automatic loads without user interaction:

- the sentinel now calls `autoLoadMore`, which stops past the budget;
- a passive `scroll` listener on `window` and a click on the existing "load more" button both reset the counter (re-arm).

Normal infinite scrolling is unchanged (a user scrolling down re-arms the budget continuously); the pathological no-interaction loop stops after 3 pages and the existing "load more" button takes over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved history timeline infinite scrolling to prevent repeated automatic loading when viewing large timelines.
  * Automatic loading now pauses after several consecutive loads and resumes when you scroll or manually request more results.
  * Added safeguards to reduce unnecessary data fetching and improve browsing responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->