### PR TITLE
Front: Keep expanded Activity group open when live events arrive

### DIFF
--- a/front/src/routes/history/HistoryPage.jsx
+++ b/front/src/routes/history/HistoryPage.jsx
@@ -25,6 +25,10 @@ const buildTimeline = events => {
     }
     if (currentEventGroup && currentEventGroup.selector === event.device_feature.selector) {
       currentEventGroup.events.push(event);
+      // Key the group on its oldest event: a live event prepended to the group
+      // must not change the key, or the expanded/collapsed state (stored by key)
+      // would be lost and the group would collapse on every incoming state.
+      currentEventGroup.key = `${event.device_feature.selector}-${event.created_at}`;
     } else {
       currentEventGroup = {
         key: `${event.device_feature.selector}-${event.created_at}`,


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- ~~If your changes affect the code, did you write the tests?~~ *(front-only change, the front has no unit-test script; validated at runtime, see below)*
- ~~Are server tests passing with coverage?~~ *(no server code touched)*
- [ ] Did Cypress E2E tests pass? *(no dedicated spec for the Activity/history route)*
- [x] Is the linter passing? (`npm run eslint` on front)
- [x] Did you run prettier? (`npm run prettier-check` on front)
- ~~If you are adding a new feature/service, did you run the integration comparator?~~ *(no i18n change)*
- [x] Did you test this pull request in real life? With real devices? *(validated on a live installation with a chatty motion sensor: the expanded group now stays open while live states keep arriving)*
- ~~If your changes modify the API (REST or Node.js), did you modify the API documentation?~~ *(no API change)*
- ~~If you are adding a new features/services which needs explanation, did you modify the user documentation?~~ *(bug fix only)*
- ~~Did you add fake requests data for the demo mode?~~ *(no new request)*

`npm run build` (Vite) passes locally.

### Description of change

#### Problem

On the Activity page, expanding a grouped burst (the "×N" badge) is unusable while live: the group collapses again as soon as the next live state arrives — on a chatty sensor, that is every second.

#### Cause

`buildTimeline` keys each group as `selector + created_at of its newest event`. When a live event is prepended to the group, the newest event changes, so the key changes; the expanded/collapsed state is stored by key (`expandedGroups`), so the entry is orphaned and the group renders collapsed again.

#### Fix

Key the group on its **oldest** event instead: prepending live events never moves it, so the expanded state survives. (The oldest-event key can still move when infinite scroll merges the bottom group with the next page, but that only happens on an explicit user action, not once per incoming state.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the history timeline when ongoing events receive updates.
  * Preserved expanded and collapsed sections as new events appear, providing a more consistent browsing experience.
  * Ensured related events remain grouped correctly throughout live updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->