### PR TITLE
Front: Expose Vite dev server on the network like preact-cli did

### DIFF
--- a/front/vite.config.mjs
+++ b/front/vite.config.mjs
@@ -83,6 +83,10 @@ export default defineConfig(({ mode }) => {
     server: {
       port: 1444,
       strictPort: true,
+      // preact-cli exposed the dev server on the network (0.0.0.0): keep that
+      // behavior so the dev front stays reachable from another device (tablet,
+      // phone) or through WSL2 port forwarding. Vite only binds localhost by default.
+      host: true,
       fs: {
         allow: ['..']
       },


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- ~~If your changes affect the code, did you write the tests?~~ *(dev-server config only, no runtime code)*
- ~~Are server tests passing with coverage?~~ *(no server code touched)*
- ~~Did Cypress E2E tests pass?~~ *(dev-server binding only, Cypress uses its own start scripts)*
- [x] Is the linter passing? *(prettier-check on the file)*
- [x] Did you run prettier?
- ~~If you are adding a new feature/service, did you run the integration comparator?~~ *(no i18n change)*
- [x] Did you test this pull request in real life? *(dev server reachable again via localhost, LAN IP and WSL2 port forwarding)*
- ~~If your changes modify the API (REST or Node.js), did you modify the API documentation?~~ *(no API change)*
- ~~If you are adding a new features/services which needs explanation, did you modify the user documentation?~~ *(dev tooling only)*
- ~~Did you add fake requests data for the demo mode?~~ *(no new request)*

### Description of change

As discussed on Slack: `preact-cli` bound the dev server to `0.0.0.0`, so the dev front was reachable from another device (tablet, phone) or through WSL2 port forwarding. Vite only binds `localhost` by default, which silently broke those workflows after the migration (`ERR_CONNECTION_RESET` through Windows `netsh portproxy`, unreachable from LAN devices).

Setting `server.host: true` restores the previous behavior. Production build and preview are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated the development server to be reachable from other devices and environments (no longer limited to localhost), including support for WSL port forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->