### PR TITLE
Activity: progressive time-window search for instant display on large databases

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -4731,6 +4731,7 @@
     "allRooms": "Alle Räume",
     "searchPlaceholder": "Gerät suchen",
     "loadMore": "Mehr laden",
+    "searchingOlder": "Suche nach Aktivitäten — {{date}}…",
     "newEvents": {
       "one": "1 neues Ereignis",
       "other": "{{count}} neue Ereignisse"

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -4731,6 +4731,7 @@
     "allRooms": "All rooms",
     "searchPlaceholder": "Search a device",
     "loadMore": "Load more",
+    "searchingOlder": "Searching activity — {{date}}…",
     "newEvents": {
       "one": "1 new event",
       "other": "{{count}} new events"

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -4731,6 +4731,7 @@
     "allRooms": "Toutes les pièces",
     "searchPlaceholder": "Rechercher un appareil",
     "loadMore": "Charger plus",
+    "searchingOlder": "Recherche d'activités — {{date}}…",
     "newEvents": {
       "one": "1 nouvel événement",
       "other": "{{count}} nouveaux événements"

--- a/front/src/routes/history/HistoryPage.jsx
+++ b/front/src/routes/history/HistoryPage.jsx
@@ -205,7 +205,7 @@ const HistoryPage = ({ intl, user, ...props }) => {
             >
               <div class="loader" />
               <div class="dimmer-content">
-                {props.initialized && timeline.length === 0 && !props.error && (
+                {props.initialized && timeline.length === 0 && !props.error && !props.loading && (
                   <div class="card">
                     <div class={cx('card-body', style.emptyState)}>
                       <div class={style.emptyStateIcon}>
@@ -244,6 +244,20 @@ const HistoryPage = ({ intl, user, ...props }) => {
                     </div>
                   </div>
                 ))}
+
+                {props.loading && props.searchedUntil && (
+                  <div class={style.searchingOlder}>
+                    <span class={cx('loader', style.searchingOlderLoader)} />
+                    <Text
+                      id="history.searchingOlder"
+                      fields={{
+                        date: dayjs(props.searchedUntil)
+                          .locale(language || 'en')
+                          .format('MMMM YYYY')
+                      }}
+                    />
+                  </div>
+                )}
 
                 {props.hasMore && !props.loading && <LoadMoreSentinel onVisible={props.autoLoadMore} />}
                 {props.hasMore && (

--- a/front/src/routes/history/index.js
+++ b/front/src/routes/history/index.js
@@ -9,6 +9,12 @@ import { ALL_GROUPS } from './categoryGroups';
 
 const PAGE_SIZE = 80;
 const MAX_EVENTS_IN_MEMORY = 1000;
+// Progressive background search: each request is bounded to a time window
+// ([since, before)) so the server always answers fast; results are displayed as
+// they arrive and the search keeps widening in the background (newest window
+// first, geometric growth) until the page is full or history is exhausted
+// (final unbounded request).
+const SEARCH_WINDOWS_MONTHS = [1, 2, 4, 8, 16, 32];
 // Live states are buffered and flushed at this interval instead of triggering a
 // render per websocket message. A chatty installation can emit hundreds of
 // states per second; without batching, each one would run a full setState +
@@ -92,51 +98,100 @@ class History extends Component {
   };
 
   getEvents = async ({ reset = false } = {}) => {
-    this.setState({ loading: true, error: false });
+    // Any new search (filter change, pagination) invalidates the windows still
+    // being probed in the background by the previous one.
+    this.searchGeneration += 1;
+    const generation = this.searchGeneration;
+    this.setState({ loading: true, error: false, searchedUntil: null });
     if (reset) {
       // Drop any live states buffered under the previous filter/date context.
       this.liveEventBuffer = [];
     }
     try {
-      const params = this.buildQueryParams();
+      const baseParams = this.buildQueryParams();
+      let before;
+      let beforeId = null;
       if (!reset && this.state.events.length > 0) {
         const lastEvent = this.state.events[this.state.events.length - 1];
-        params.before = lastEvent.created_at;
+        before = new Date(lastEvent.created_at);
         // Compound cursor: pass the last feature id so the server can break
         // created_at ties deterministically and never skip a state.
         if (lastEvent.device_feature && lastEvent.device_feature.id) {
-          params.before_id = lastEvent.device_feature.id;
+          beforeId = lastEvent.device_feature.id;
         }
       } else if (this.state.selectedDate) {
         // Jump to the end of the selected day, in the user's timezone
-        params.before = dayjs(this.state.selectedDate)
+        before = dayjs(this.state.selectedDate)
           .endOf('day')
-          .toISOString();
+          .toDate();
+      } else {
+        before = new Date();
       }
-      const newEvents = await this.props.httpClient.get('/api/v1/device_feature/states_history', params);
-      this.setState(prevState => {
-        let events;
-        if (reset) {
-          events = newEvents;
-        } else {
-          events = prevState.events.concat(newEvents);
+
+      // Probe [since, before) windows from the cursor backwards, widening
+      // geometrically, and render each batch as soon as it arrives. The final
+      // iteration has no lower bound: it is the only potentially slow request,
+      // and it only runs when every bounded window was too sparse.
+      let collected = 0;
+      let windowUpper = before;
+      let windowUpperId = beforeId;
+      let exhausted = false;
+      let firstBatch = reset;
+      for (let i = 0; i <= SEARCH_WINDOWS_MONTHS.length && collected < PAGE_SIZE && !exhausted; i += 1) {
+        const isFinalUnbounded = i === SEARCH_WINDOWS_MONTHS.length;
+        const since = isFinalUnbounded
+          ? null
+          : dayjs(before)
+              .subtract(SEARCH_WINDOWS_MONTHS[i], 'month')
+              .toDate();
+        const params = { ...baseParams, take: PAGE_SIZE - collected, before: windowUpper.toISOString() };
+        if (windowUpperId) {
+          params.before_id = windowUpperId;
+        }
+        if (since) {
+          params.since = since.toISOString();
+        }
+        // eslint-disable-next-line no-await-in-loop
+        const newEvents = await this.props.httpClient.get('/api/v1/device_feature/states_history', params);
+        if (generation !== this.searchGeneration) {
+          return;
+        }
+        collected += newEvents.length;
+        if (isFinalUnbounded) {
+          exhausted = newEvents.length < params.take;
+        }
+        const resetEvents = firstBatch;
+        firstBatch = false;
+        this.setState(prevState => {
+          let events = resetEvents ? newEvents : prevState.events.concat(newEvents);
           // Keep the array bounded during infinite scroll: drop the newest events
           // already scrolled past (array head) and keep the window being browsed.
           if (events.length > MAX_EVENTS_IN_MEMORY) {
             events = events.slice(events.length - MAX_EVENTS_IN_MEMORY);
           }
+          return {
+            events,
+            initialized: true,
+            searchedUntil: since,
+            pendingLiveEvents: resetEvents ? [] : prevState.pendingLiveEvents
+          };
+        });
+        // The next window continues strictly below this one: states exactly on
+        // the boundary were already returned by this window (since is inclusive).
+        if (since) {
+          windowUpper = since;
+          windowUpperId = null;
         }
-        return {
-          events,
-          hasMore: newEvents.length === PAGE_SIZE,
-          loading: false,
-          initialized: true,
-          pendingLiveEvents: reset ? [] : prevState.pendingLiveEvents
-        };
-      });
+      }
+      if (generation !== this.searchGeneration) {
+        return;
+      }
+      this.setState({ loading: false, initialized: true, hasMore: !exhausted, searchedUntil: null });
     } catch (e) {
       console.error(e);
-      this.setState({ loading: false, error: true, initialized: true });
+      if (generation === this.searchGeneration) {
+        this.setState({ loading: false, error: true, initialized: true, searchedUntil: null });
+      }
     }
   };
 
@@ -304,12 +359,14 @@ class History extends Component {
       initialized: false,
       hasMore: false,
       error: false,
-      featuresLoaded: false
+      featuresLoaded: false,
+      searchedUntil: null
     };
     this.featuresBySelector = null;
     this.liveEventBuffer = [];
     this.liveFlushTimeout = null;
     this.autoLoadsWithoutScroll = 0;
+    this.searchGeneration = 0;
     this.debouncedRefreshEvents = debounce(this.refreshEvents.bind(this), 300);
   }
 

--- a/front/src/routes/history/style.css
+++ b/front/src/routes/history/style.css
@@ -496,6 +496,21 @@
   height: 1px;
 }
 
+.searchingOlder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 1rem 0 1.5rem;
+  color: #9aa0ac;
+  font-size: 0.875rem;
+}
+
+.searchingOlderLoader {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
 @media (max-width: 575px) {
   .eventTime {
     font-size: 0.75rem;

--- a/server/lib/device/device.getDeviceStatesHistory.js
+++ b/server/lib/device/device.getDeviceStatesHistory.js
@@ -26,11 +26,51 @@ const PROGRESSIVE_WINDOWS_IN_MS = [
 ];
 
 /**
+ * @description Decorate raw DuckDB state rows with device/feature/room metadata.
+ * @param {Array} rows - Raw rows (device_feature_id, value, created_at).
+ * @param {Map} featuresById - Plain device features indexed by id.
+ * @returns {Array} States with device/feature/room metadata, deleted features filtered out.
+ * @example
+ * const states = mapRowsToStates(rows, featuresById);
+ */
+const mapRowsToStates = (rows, featuresById) =>
+  rows
+    .filter((row) => featuresById.has(row.device_feature_id))
+    .map((row) => {
+      const feature = featuresById.get(row.device_feature_id);
+      return {
+        value: row.value,
+        created_at: row.created_at,
+        device_feature: {
+          id: feature.id,
+          name: feature.name,
+          selector: feature.selector,
+          category: feature.category,
+          type: feature.type,
+          unit: feature.unit,
+        },
+        device: {
+          name: feature.device.name,
+          selector: feature.device.selector,
+        },
+        room: feature.device.room
+          ? {
+              name: feature.device.room.name,
+              selector: feature.device.room.selector,
+            }
+          : null,
+      };
+    });
+
+/**
  * @description Get the history of device states across all devices, most recent first.
  * @param {object} [options] - Options of the query.
  * @param {string} [options.before] - Only return states created strictly before this date (pagination cursor).
  * @param {string} [options.before_id] - Device feature id of the last returned state, used as a tiebreaker
  * to paginate deterministically when several states share the same created_at.
+ * @param {string} [options.since] - Only return states created at or after this date. When set, the query is
+ * a single bounded probe: it returns what the [since, before) window contains, even fewer than `take`,
+ * and never widens — the caller drives the progressive widening and can render partial results.
  * @param {number} [options.take] - Max number of states to return.
  * @param {string} [options.categories] - Comma-separated list of device feature categories to filter on.
  * @param {string} [options.room_id] - Only return states of devices in this room.
@@ -46,6 +86,10 @@ async function getDeviceStatesHistory(options = {}) {
     throw new BadParameters(`Invalid "before" date: ${options.before}`);
   }
   const beforeId = options.before_id || null;
+  const since = options.since ? new Date(options.since) : null;
+  if (since && Number.isNaN(since.getTime())) {
+    throw new BadParameters(`Invalid "since" date: ${options.since}`);
+  }
 
   const deviceFeatures = await db.DeviceFeature.findAll({
     attributes: ['id', 'name', 'selector', 'category', 'type', 'unit', 'last_value_changed'],
@@ -125,6 +169,24 @@ async function getDeviceStatesHistory(options = {}) {
 
   const featureIdPlaceholders = filteredFeatureIds.map(() => '?').join(',');
 
+  if (since) {
+    // Caller-driven bounded probe: a single [since, before) query returning what
+    // the window contains, even below `take`, without widening. The caller
+    // (Activity feed) probes windows newest-first and renders partial results
+    // as they arrive, so no request ever has to pay an unbounded scan upfront.
+    const queryParams = [since.toISOString(), ...cursorParams, ...filteredFeatureIds, take];
+    const query = `
+      SELECT device_feature_id, value, created_at
+      FROM t_device_feature_state
+      WHERE created_at >= CAST(? AS TIMESTAMPTZ) AND ${cursorClause}
+      AND device_feature_id IN (${featureIdPlaceholders})
+      ORDER BY created_at DESC, device_feature_id DESC
+      LIMIT ?
+    `;
+    const rows = await db.duckDbReadConnectionAllAsync(query, ...queryParams);
+    return mapRowsToStates(rows, featuresById);
+  }
+
   // Query progressively wider time windows and stop as soon as we have a full page.
   // A recent window is answered almost instantly thanks to zone map pruning; the
   // wider windows (up to the unbounded one) only run when recent states are scarce.
@@ -157,33 +219,7 @@ async function getDeviceStatesHistory(options = {}) {
     }
   }
 
-  return rows
-    .filter((row) => featuresById.has(row.device_feature_id))
-    .map((row) => {
-      const feature = featuresById.get(row.device_feature_id);
-      return {
-        value: row.value,
-        created_at: row.created_at,
-        device_feature: {
-          id: feature.id,
-          name: feature.name,
-          selector: feature.selector,
-          category: feature.category,
-          type: feature.type,
-          unit: feature.unit,
-        },
-        device: {
-          name: feature.device.name,
-          selector: feature.device.selector,
-        },
-        room: feature.device.room
-          ? {
-              name: feature.device.room.name,
-              selector: feature.device.room.selector,
-            }
-          : null,
-      };
-    });
+  return mapRowsToStates(rows, featuresById);
 }
 
 module.exports = {

--- a/server/test/lib/device/device.getDeviceStatesHistory.test.js
+++ b/server/test/lib/device/device.getDeviceStatesHistory.test.js
@@ -197,4 +197,51 @@ describe('Device.getDeviceStatesHistory', function Describe() {
     const promise = deviceInstance.getDeviceStatesHistory({ before: 'not-a-date' });
     await assert.isRejected(promise, 'Invalid "before" date');
   });
+
+  it('should return only the bounded window when since is provided, without widening', async () => {
+    const querySpy = spy(db, 'duckDbReadConnectionAllAsync');
+    try {
+      const states = await deviceInstance.getDeviceStatesHistory({
+        take: 10,
+        since: new Date('2025-08-28T15:01:00.000Z').toISOString(),
+        before: new Date('2026-01-01T00:00:00.000Z').toISOString(),
+      });
+      // Only the states inside [since, before) are returned, even though the page
+      // is not full: the lower bound is inclusive (the 15:01 temperature state is
+      // returned) and older states (15:00) are excluded.
+      expect(states).to.have.lengthOf(2);
+      expect(states[0].created_at).to.deep.equal(new Date('2025-08-28T15:02:00.000Z'));
+      expect(states[1].created_at).to.deep.equal(new Date('2025-08-28T15:01:00.000Z'));
+      // A single query: a bounded probe never widens, the caller does.
+      expect(querySpy.callCount).to.equal(1);
+    } finally {
+      querySpy.restore();
+    }
+  });
+
+  it('should return an empty array when the since window contains no state', async () => {
+    const states = await deviceInstance.getDeviceStatesHistory({
+      take: 10,
+      since: new Date('2025-09-01T00:00:00.000Z').toISOString(),
+      before: new Date('2025-10-01T00:00:00.000Z').toISOString(),
+    });
+    expect(states).to.have.lengthOf(0);
+  });
+
+  it('should reject on invalid since date', async () => {
+    const promise = deviceInstance.getDeviceStatesHistory({ since: 'not-a-date' });
+    await assert.isRejected(promise, 'Invalid "since" date');
+  });
+
+  it('should return a null room for a device outside any room', async () => {
+    try {
+      await db.Device.update({ room_id: null }, { where: { id: '7f85c2f8-86cc-4600-84db-6c074dadb4e8' } });
+      const states = await deviceInstance.getDeviceStatesHistory({ categories: 'light' });
+      expect(states).to.have.lengthOf(2);
+      expect(states[0].room).to.equal(null);
+    } finally {
+      // The test database is shared across the whole run: restore the seeded room.
+      await db.Device.update({ room_id: TEST_ROOM_ID }, { where: { id: '7f85c2f8-86cc-4600-84db-6c074dadb4e8' } });
+    }
+  });
 });


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests? *(4 new server tests: bounded probe semantics, inclusive lower bound, empty window, invalid `since`, null-room mapping — the touched file is at 100% statements/branches/functions/lines)*
- [x] Are server tests passing with coverage? (`npm run coverage` — full suite green locally)
- [x] Did Cypress E2E tests pass? *(no dedicated spec for the Activity/history route)*
- [x] Is the linter passing? (`npm run eslint` on front and server)
- [x] Did you run prettier? (front and server)
- [x] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` — new `history.searchingOlder` key added to en/fr/de)
- [x] Did you test this pull request in real life? With real devices? *(validated on a 448M-state installation, timings below — please also test on a regular-size install to confirm no regression on common usage)*
- [x] If your changes modify the API (REST or Node.js), did you modify the API documentation? *(JSDoc on `getDeviceStatesHistory` documents the new optional `since` query parameter; API is backward compatible)*
- ~~If you are adding a new features/services which needs explanation, did you modify the user documentation?~~ *(UX improvement of an existing screen)*
- ~~Did you add fake requests data for the demo mode?~~ *(same endpoint, `since` only narrows it)*

`npm run build` (Vite) passes locally.

### Description of change

#### Problem

On large databases, filtering the Activity feed on a sparse category is very slow: the server keeps widening its internal time windows until it has collected `take` states, however deep that requires scanning. On a 448M-state installation, "Openings" took 20-33s and "Buttons & remotes" 22-51s of frozen spinner — and every deeper "Load more" paid the same price. Anchoring (#2642) and window strategies cannot beat this: the cost floor is DuckDB's scan throughput times the volume to scan before the quota is filled.

#### Solution — let the client drive the widening

**Server** — `getDeviceStatesHistory` accepts an optional `since` lower bound. When provided, the query is a **single bounded `[since, before)` probe**: it returns what the window contains, even fewer than `take`, and never widens. Bounded probes are answered in milliseconds thanks to DuckDB zone-map pruning. Without `since`, behavior is strictly unchanged (backward compatible).

**Front** — the Activity feed probes windows of 1, 2, 4, 8, 16, 32 months back from the cursor, then one final unbounded request. Each batch is rendered **as soon as it arrives**, with a "Searching activity — {month}…" banner while older windows are probed in the background. A generation counter cancels in-flight probes when the filter, date or search changes.

#### Measured on a 448M-state installation

| Case | Before | After |
|---|---|---|
| Sparse category ("Openings") | 20-33s frozen spinner | **first states at ~100ms**, page completes in background |
| Very old sparse category ("Buttons", last states 17 months back) | 22-51s frozen spinner | instant banner showing scanned months, states stream in |
| Live feed / "All" / chatty categories | ~100ms | unchanged (~100ms) |

The total server work for the worst case is unchanged (the final unbounded request still scans deep history), but it happens in the background of an already-usable page instead of blocking the first paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * History now progressively searches older activity when needed, with a localized loading indicator showing the date being searched.
  * Infinite scrolling maintains bounded results and handles changing filters or pagination more reliably.

* **Bug Fixes**
  * Prevented the empty-history state from appearing while history is still loading.
  * Improved handling of device history within date ranges, including devices without assigned rooms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->