### PR TITLE
Display dashboard charts in Gladys system timezone

### DIFF
--- a/front/src/actions/main.js
+++ b/front/src/actions/main.js
@@ -1,6 +1,7 @@
 import createActionsProfilePicture from './profilePicture';
 import createActionsDarkMode from './darkMode';
 import { getDefaultState } from '../utils/getDefaultState';
+import { fetchSystemTimezone } from '../utils/systemTimezone';
 import { route } from 'preact-router';
 import get from 'get-value';
 import { isUrlInArray } from '../utils/url';
@@ -71,11 +72,13 @@ function createActions(store) {
         const tasks = [
           state.httpClient.get('/api/v1/me'),
           actionsProfilePicture.loadProfilePicture(state),
-          actions.refreshTabletMode(state)
+          actions.refreshTabletMode(state),
+          fetchSystemTimezone(state.httpClient)
         ];
-        const [user] = await Promise.all(tasks);
+        const [user, , , systemTimezone] = await Promise.all(tasks);
         store.setState({
-          user
+          user,
+          systemTimezone
         });
         if (state.session.getGatewayUser) {
           const gatewayUser = await state.session.getGatewayUser();

--- a/front/src/components/boxs/chart/ApexChartComponent.jsx
+++ b/front/src/components/boxs/chart/ApexChartComponent.jsx
@@ -6,7 +6,16 @@ import en from 'apexcharts/dist/locales/en.json';
 import de from 'apexcharts/dist/locales/de.json';
 
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
+import { connect } from 'unistore/preact';
+import {
+  DEFAULT_TIMEZONE,
+  formatInSystemTimezone,
+  getTooltipDateFormatForInterval,
+  getXAxisDateFormatForInterval
+} from '../../../utils/systemTimezone';
 import { getApexChartBarOptions } from './ApexChartBarOptions';
 import { getApexChartAreaOptions } from './ApexChartAreaOptions';
 import { getApexChartLineOptions } from './ApexChartLineOptions';
@@ -14,6 +23,8 @@ import { getApexChartStepLineOptions } from './ApexChartStepLineOptions';
 import { getApexChartTimelineOptions } from './ApexChartTimelineOptions';
 import mergeArray from '../../../utils/mergeArray';
 
+dayjs.extend(utc);
+dayjs.extend(timezone);
 dayjs.extend(localizedFormat);
 
 const DEFAULT_COLORS = [
@@ -31,21 +42,37 @@ const DEFAULT_COLORS_NAME = ['blue', 'red', 'green', 'yellow', 'purple', 'aqua',
 
 class ApexChartComponent extends Component {
   chartRef = createRef();
-  addDateFormatter(options) {
-    let formatter;
-    if (this.props.interval <= 24 * 60) {
-      formatter = value => {
-        return dayjs(value)
-          .locale(this.props.user.language)
-          .format('LLL');
-      };
-    } else {
-      formatter = value => {
-        return dayjs(value)
-          .locale(this.props.user.language)
-          .format('LL');
-      };
+
+  getTimezone = () => {
+    return this.props.systemTimezone || DEFAULT_TIMEZONE;
+  };
+
+  formatDate = (timestamp, format) => {
+    return formatInSystemTimezone(timestamp, format, this.props.user.language, this.getTimezone());
+  };
+
+  addXAxisDateFormatter(options) {
+    const xAxisFormat = this.props.xAxisDateFormat || getXAxisDateFormatForInterval(this.props.interval);
+    if (!options.xaxis) {
+      options.xaxis = {};
     }
+    if (!options.xaxis.labels) {
+      options.xaxis.labels = {};
+    }
+    options.xaxis.labels.formatter = (value, timestamp) => {
+      const dateValue = timestamp || value;
+      if (!dateValue) {
+        return '';
+      }
+      return this.formatDate(dateValue, xAxisFormat);
+    };
+  }
+
+  addDateFormatter(options) {
+    const tooltipFormat = getTooltipDateFormatForInterval(this.props.interval);
+    const formatter = value => {
+      return this.formatDate(value, tooltipFormat);
+    };
     // Configure tooltip with fixed position and date formatter
     options.tooltip = {
       followCursor: false,
@@ -85,23 +112,15 @@ class ApexChartComponent extends Component {
     const dictionnary = this.props.dictionary.dashboard.boxes.chart;
     if (this.props.interval <= 24 * 60) {
       formatter_custom = opts => {
-        const startDate = dayjs(opts.y1)
-          .locale(this.props.user.language)
-          .format('LL - LTS');
-        const endDate = dayjs(opts.y2)
-          .locale(this.props.user.language)
-          .format('LL - LTS');
+        const startDate = this.formatDate(opts.y1, 'LL - LTS');
+        const endDate = this.formatDate(opts.y2, 'LL - LTS');
 
         return createTooltipContent(opts, startDate, endDate);
       };
     } else {
       formatter_custom = opts => {
-        const startDate = dayjs(opts.y1)
-          .locale(this.props.user.language)
-          .format('LL');
-        const endDate = dayjs(opts.y2)
-          .locale(this.props.user.language)
-          .format('LL');
+        const startDate = this.formatDate(opts.y1, 'LL');
+        const endDate = this.formatDate(opts.y2, 'LL');
 
         return createTooltipContent(opts, startDate, endDate);
       };
@@ -234,6 +253,7 @@ class ApexChartComponent extends Component {
     } else {
       options = this.getAreaChartOptions();
     }
+    this.addXAxisDateFormatter(options);
     if (this.chart) {
       this.chart.updateOptions(options);
     } else {
@@ -256,6 +276,8 @@ class ApexChartComponent extends Component {
     const yAxisFormatterDifferent = nextProps.y_axis_formatter !== this.props.y_axis_formatter;
     const yAxisUnitDifferent = nextProps.y_axis_unit !== this.props.y_axis_unit;
     const colorsDifferent = nextProps.colors !== this.props.colors;
+    const systemTimezoneDifferent = nextProps.systemTimezone !== this.props.systemTimezone;
+    const xAxisDateFormatDifferent = nextProps.xAxisDateFormat !== this.props.xAxisDateFormat;
     if (
       seriesDifferent ||
       chartTypeDifferent ||
@@ -266,7 +288,9 @@ class ApexChartComponent extends Component {
       additionalHeightDifferent ||
       yAxisFormatterDifferent ||
       yAxisUnitDifferent ||
-      colorsDifferent
+      colorsDifferent ||
+      systemTimezoneDifferent ||
+      xAxisDateFormatDifferent
     ) {
       this.displayChart();
     }
@@ -281,6 +305,6 @@ class ApexChartComponent extends Component {
   }
 }
 
-export default ApexChartComponent;
+export default connect('systemTimezone')(ApexChartComponent);
 
 export { DEFAULT_COLORS, DEFAULT_COLORS_NAME };

--- a/front/src/components/boxs/energy-consumption/EnergyConsumption.jsx
+++ b/front/src/components/boxs/energy-consumption/EnergyConsumption.jsx
@@ -6,7 +6,7 @@ import DatePicker from 'react-datepicker';
 import withIntlAsProp from '../../../utils/withIntlAsProp';
 import ApexChartComponent, { DEFAULT_COLORS } from '../chart/ApexChartComponent';
 import { formatHttpError } from '../../../utils/formatErrors';
-import dayjs from 'dayjs';
+import { formatInSystemTimezone } from '../../../utils/systemTimezone';
 
 import fr from 'date-fns/locale/fr';
 
@@ -388,23 +388,28 @@ class EnergyConsumption extends Component {
 
   tooltipXFormatter = value => {
     const { selectedPeriod } = this.state;
+    const { user, systemTimezone } = this.props;
     // Format date based on period - show date only, not datetime
     if (selectedPeriod === PERIODS.DAY) {
       // For day view, show hour only
-      return dayjs(value)
-        .locale(this.props.user.language)
-        .format('HH:mm');
+      return formatInSystemTimezone(value, 'HH:mm', user.language, systemTimezone);
     } else if (selectedPeriod === PERIODS.MONTH) {
       // For month view, show day
-      return dayjs(value)
-        .locale(this.props.user.language)
-        .format('DD MMM YYYY');
+      return formatInSystemTimezone(value, 'DD MMM YYYY', user.language, systemTimezone);
     } else {
       // For year view, show month
-      return dayjs(value)
-        .locale(this.props.user.language)
-        .format('MMM YYYY');
+      return formatInSystemTimezone(value, 'MMM YYYY', user.language, systemTimezone);
     }
+  };
+
+  getXAxisDateFormat = () => {
+    const { selectedPeriod } = this.state;
+    if (selectedPeriod === PERIODS.DAY) {
+      return 'HH:mm';
+    } else if (selectedPeriod === PERIODS.MONTH) {
+      return 'DD MMM YYYY';
+    }
+    return 'MMM YYYY';
   };
 
   getDatePickerView = () => {
@@ -592,6 +597,7 @@ class EnergyConsumption extends Component {
                         y_axis_formatter={this.yAxisFormatter}
                         tooltip_y_formatter={this.tooltipYFormatter}
                         tooltip_x_formatter={this.tooltipXFormatter}
+                        xAxisDateFormat={this.getXAxisDateFormat()}
                         dictionary={props.intl.dictionary}
                         disable_zoom={true}
                       />
@@ -607,4 +613,7 @@ class EnergyConsumption extends Component {
   }
 }
 
-export default connect('user,session,httpClient,houses,devices,deviceFeatures', {})(withIntlAsProp(EnergyConsumption));
+export default connect(
+  'user,session,httpClient,houses,devices,deviceFeatures,systemTimezone',
+  {}
+)(withIntlAsProp(EnergyConsumption));

--- a/front/src/routes/settings/settings-system/SettingsSystemTimezone.jsx
+++ b/front/src/routes/settings/settings-system/SettingsSystemTimezone.jsx
@@ -29,6 +29,7 @@ class SettingsSystemTimezone extends Component {
       await this.props.httpClient.post(`/api/v1/variable/${SYSTEM_VARIABLE_NAMES.TIMEZONE}`, {
         value: option.value
       });
+      this.props.setSystemTimezone(option.value);
     } catch (e) {
       console.error(e);
     }
@@ -64,4 +65,6 @@ class SettingsSystemTimezone extends Component {
   }
 }
 
-export default connect('httpClient', null)(SettingsSystemTimezone);
+export default connect('httpClient', {
+  setSystemTimezone: (state, timezone) => ({ systemTimezone: timezone })
+})(SettingsSystemTimezone);

--- a/front/src/utils/getDefaultState.js
+++ b/front/src/utils/getDefaultState.js
@@ -45,6 +45,7 @@ function getDefaultState() {
     user: {
       language
     },
+    systemTimezone: null,
     showDropDown: false,
     darkMode
   };

--- a/front/src/utils/systemTimezone.js
+++ b/front/src/utils/systemTimezone.js
@@ -1,0 +1,80 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+import { SYSTEM_VARIABLE_NAMES } from '../../../server/utils/constants';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const DEFAULT_TIMEZONE = 'Europe/Paris';
+
+const ONE_DAY_IN_MINUTES = 24 * 60;
+const SEVEN_DAYS_IN_MINUTES = 7 * 24 * 60;
+const THIRTY_DAYS_IN_MINUTES = 30 * 24 * 60;
+
+/**
+ * @description Format a timestamp in the Gladys system timezone.
+ * @param {number|string|Date} timestamp - Timestamp to format.
+ * @param {string} format - dayjs format string.
+ * @param {string} language - User language for localization.
+ * @param {string} [timezoneName] - IANA timezone name.
+ * @returns {string} Formatted date string.
+ */
+function formatInSystemTimezone(timestamp, format, language, timezoneName = DEFAULT_TIMEZONE) {
+  return dayjs(timestamp)
+    .tz(timezoneName)
+    .locale(language)
+    .format(format);
+}
+
+/**
+ * @description Get the x-axis date format based on chart interval in minutes.
+ * @param {number} intervalMinutes - Chart interval in minutes.
+ * @returns {string} dayjs format string.
+ */
+function getXAxisDateFormatForInterval(intervalMinutes) {
+  if (!intervalMinutes || intervalMinutes <= ONE_DAY_IN_MINUTES) {
+    return 'HH:mm';
+  }
+  if (intervalMinutes <= SEVEN_DAYS_IN_MINUTES) {
+    return 'DD MMM';
+  }
+  if (intervalMinutes <= THIRTY_DAYS_IN_MINUTES) {
+    return 'DD MMM';
+  }
+  return 'MMM YY';
+}
+
+/**
+ * @description Get the tooltip date format based on chart interval in minutes.
+ * @param {number} intervalMinutes - Chart interval in minutes.
+ * @returns {string} dayjs format string.
+ */
+function getTooltipDateFormatForInterval(intervalMinutes) {
+  if (!intervalMinutes || intervalMinutes <= ONE_DAY_IN_MINUTES) {
+    return 'LLL';
+  }
+  return 'LL';
+}
+
+/**
+ * @description Load the Gladys system timezone from the API.
+ * @param {object} httpClient - HTTP client instance.
+ * @returns {Promise<string>} IANA timezone name.
+ */
+async function fetchSystemTimezone(httpClient) {
+  try {
+    const { value } = await httpClient.get(`/api/v1/variable/${SYSTEM_VARIABLE_NAMES.TIMEZONE}`);
+    return value || DEFAULT_TIMEZONE;
+  } catch (e) {
+    return DEFAULT_TIMEZONE;
+  }
+}
+
+export {
+  DEFAULT_TIMEZONE,
+  formatInSystemTimezone,
+  getXAxisDateFormatForInterval,
+  getTooltipDateFormatForInterval,
+  fetchSystemTimezone
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the feature request from [community topic #9286](https://community.gladysassistant.com/t/affichage-des-graphs-avec-heure-du-systeme-gladys/9286): dashboard charts now display dates and times in the Gladys system timezone (configured in Settings → System → Timezone) instead of the browser/device local timezone.

This matters when accessing Gladys remotely from a different timezone (e.g. via VPN while traveling): a water heater starting at 22:00 at home will now correctly show 22:00 on the chart, even if the phone is set to GMT-04.

## Changes

- Load the Gladys system timezone into the global store on session initialization
- Add a `systemTimezone` utility (`front/src/utils/systemTimezone.js`) using dayjs timezone plugin
- Update `ApexChartComponent` to format x-axis labels and tooltips in the system timezone (line, area, bar, stepline, timeline charts)
- Update the energy consumption box chart tooltips and x-axis labels similarly
- Refresh the store timezone immediately when changed in system settings

## Test plan

- [x] `npm run prettier` and `npm run prettier-check` in `front/`
- [x] `npm run eslint` in `front/`
- [ ] Verify chart x-axis and tooltip times match Gladys timezone when browser timezone differs (e.g. change laptop timezone or use devtools)
- [ ] Verify energy consumption box chart uses system timezone
- [ ] Verify changing timezone in Settings → System updates charts without page reload

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c0a-4e6c-7e95-8bfa-7b453c10b2d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c0a-4e6c-7e95-8bfa-7b453c10b2d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

