### PR TITLE
Publish Gladys Plus front automatically after production release

### DIFF
--- a/.github/workflows/docker-release-build.yml
+++ b/.github/workflows/docker-release-build.yml
@@ -184,3 +184,10 @@ jobs:
           docker pull ${{ env.DOCKERHUB_REPO }}@$DIGESTAMD64
           docker tag ${{ env.DOCKERHUB_REPO }}@$DIGESTAMD64 ${{ env.DOCKERHUB_REPO }}:v4-amd64
           docker push ${{ env.DOCKERHUB_REPO }}:v4-amd64
+  publish-gladys-plus:
+    name: Publish Gladys Plus front
+    needs: docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Cloudflare Pages deploy hook
+        run: curl -X POST "https://api.cloudflare.com/client/v4/pages/webhooks/deploy_hooks/${{ secrets.CLOUDFLARE_PAGES_GLADYS_PLUS_DEPLOY_HOOK }}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After a Gladys production release (tag `v*.*.*`), the workflow now automatically publishes the Gladys Plus front to production.

## Changes

- Added a `publish-gladys-plus` job at the end of `.github/workflows/docker-release-build.yml`
- The job runs after the Docker image build/push completes successfully
- It triggers the same Cloudflare Pages deploy hook used by `.github/workflows/publish-gladys-plus-production.yml`

## Notes

- The manual `workflow_dispatch` workflow for Gladys Plus publishing is unchanged and can still be used independently
- Requires the existing `CLOUDFLARE_PAGES_GLADYS_PLUS_DEPLOY_HOOK` secret
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef70676e-8624-41de-8dd6-2a3b08dce547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef70676e-8624-41de-8dd6-2a3b08dce547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated the Gladys Plus deployment process after successful Docker release builds.
  * Improved release delivery by triggering the associated hosted site deployment automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->