### PR TITLE
Server: Fix feature states purge and destroy guard left on SQLite since the DuckDB migration

### DIFF
--- a/server/lib/device/device.destroy.js
+++ b/server/lib/device/device.destroy.js
@@ -32,7 +32,9 @@ async function destroy(selector) {
   // Deleting a device cascade delete its device features and device feature states
   // This is a blocking operation that takes a lot of time
   // So if the device has too much states, we don't allow the user to delete the device
-  // and ask him to come back later
+  // and ask him to come back later.
+  // States live in DuckDB since the migration; the SQLite tables below only hold
+  // leftovers of installations that have not run the migration yet.
   const deviceStatesCount = await db.sequelize.query(
     `
       SELECT COUNT(s.id) as count
@@ -59,7 +61,17 @@ async function destroy(selector) {
     },
   );
 
-  const totalNumberOfStates = deviceStatesCount[0].count + deviceStatesCount[1].count;
+  let duckDbStatesCount = 0;
+  if (device.features.length > 0) {
+    const placeholders = device.features.map(() => '?').join(',');
+    const [{ count }] = await db.duckDbReadConnectionAllAsync(
+      `SELECT COUNT(*) AS count FROM t_device_feature_state WHERE device_feature_id IN (${placeholders})`,
+      ...device.features.map((feature) => feature.id),
+    );
+    duckDbStatesCount = Number(count);
+  }
+
+  const totalNumberOfStates = deviceStatesCount[0].count + deviceStatesCount[1].count + duckDbStatesCount;
   logger.info(`Deleting device ${selector}, device has ${totalNumberOfStates} states in DB`);
   if (totalNumberOfStates > this.MAX_NUMBER_OF_STATES_ALLOWED_TO_DELETE_DEVICE) {
     logger.info(`Deleting device ${selector}, device has too much states. Cleaning states first.`);

--- a/server/lib/device/device.purgeStatesByFeatureId.js
+++ b/server/lib/device/device.purgeStatesByFeatureId.js
@@ -14,11 +14,23 @@ const logger = require('../../utils/logger');
 async function purgeStatesByFeatureId(deviceFeatureId, jobId) {
   logger.info(`Purging states of device feature ${deviceFeatureId}`);
 
-  const numberOfDeviceFeatureStateToDelete = await db.DeviceFeatureState.count({
+  // Since the DuckDB migration, device states live in DuckDB.
+  const [{ count: duckDbCount }] = await db.duckDbReadConnectionAllAsync(
+    `SELECT COUNT(*) AS count FROM t_device_feature_state WHERE device_feature_id = ?`,
+    deviceFeatureId,
+  );
+  const numberOfDuckDbStatesToDelete = Number(duckDbCount);
+
+  // States may also remain in SQLite on installations that have not run the
+  // DuckDB migration yet: purge them too, or the migration would re-import
+  // states of a feature that was already purged.
+  const numberOfSqliteStatesToDelete = await db.DeviceFeatureState.count({
     where: {
       device_feature_id: deviceFeatureId,
     },
   });
+
+  const numberOfDeviceFeatureStateToDelete = numberOfDuckDbStatesToDelete + numberOfSqliteStatesToDelete;
 
   const numberOfDeviceFeatureStateAggregateToDelete = await db.DeviceFeatureStateAggregate.count({
     where: {
@@ -27,11 +39,13 @@ async function purgeStatesByFeatureId(deviceFeatureId, jobId) {
   });
 
   logger.info(
-    `Purging "${deviceFeatureId}": ${numberOfDeviceFeatureStateToDelete} states & ${numberOfDeviceFeatureStateAggregateToDelete} aggregates to delete.`,
+    `Purging "${deviceFeatureId}": ${numberOfDeviceFeatureStateToDelete} states` +
+      ` (${numberOfDuckDbStatesToDelete} DuckDB + ${numberOfSqliteStatesToDelete} SQLite)` +
+      ` & ${numberOfDeviceFeatureStateAggregateToDelete} aggregates to delete.`,
   );
 
   const numberOfIterationsStates = Math.ceil(
-    numberOfDeviceFeatureStateToDelete / this.STATES_TO_PURGE_PER_DEVICE_FEATURE_CLEAN_BATCH,
+    numberOfSqliteStatesToDelete / this.STATES_TO_PURGE_PER_DEVICE_FEATURE_CLEAN_BATCH,
   );
   const iterator = [...Array(numberOfIterationsStates)];
 
@@ -40,7 +54,8 @@ async function purgeStatesByFeatureId(deviceFeatureId, jobId) {
   );
   const iteratorAggregates = [...Array(numberOfIterationsStatesAggregates)];
 
-  const total = numberOfIterationsStates + numberOfIterationsStatesAggregates;
+  // 1 step for the DuckDB delete + the SQLite batches
+  const total = 1 + numberOfIterationsStates + numberOfIterationsStatesAggregates;
   let currentBatch = 0;
   let currentProgressPercent = 0;
 
@@ -54,6 +69,17 @@ async function purgeStatesByFeatureId(deviceFeatureId, jobId) {
       await this.job.updateProgress(jobId, currentProgressPercent);
     }
   };
+
+  // The DuckDB table has no id column, so states cannot be deleted in
+  // LIMIT-ed chunks like in SQLite: delete them in a single statement,
+  // like device.destroy does.
+  if (numberOfDuckDbStatesToDelete > 0) {
+    await db.duckDbWriteConnectionAllAsync(
+      'DELETE FROM t_device_feature_state WHERE device_feature_id = ?',
+      deviceFeatureId,
+    );
+  }
+  await updateProgressIfNeeded();
 
   await Promise.each(iterator, async () => {
     await db.sequelize.query(

--- a/server/test/lib/device/device.destroy.test.js
+++ b/server/test/lib/device/device.destroy.test.js
@@ -12,6 +12,9 @@ const event = new EventEmitter();
 const job = new Job(event);
 
 describe('Device.destroy', () => {
+  beforeEach(async () => {
+    await db.duckDbWriteConnectionAllAsync('DELETE FROM t_device_feature_state');
+  });
   it('should destroy device and states', async () => {
     const stateManager = new StateManager(event);
     const serviceManager = new ServiceManager({}, stateManager);
@@ -43,6 +46,7 @@ describe('Device.destroy', () => {
         selector: 'test-device',
       },
     ];
+    // SQLite leftovers (installation which has not run the DuckDB migration yet)
     await db.DeviceFeatureState.create({
       value: 10,
       device_feature_id: 'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4',
@@ -56,8 +60,14 @@ describe('Device.destroy', () => {
       type: 'daily',
       device_feature_id: 'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4',
     });
+    // States living in DuckDB (the normal case since the migration) must be
+    // counted by the guard too
+    await db.duckDbBatchInsertState('ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4', [
+      { value: 1, created_at: new Date() },
+      { value: 0, created_at: new Date() },
+    ]);
     const promise = device.destroy('test-device');
-    await assert.isRejected(promise, '3 states in DB. Too much states!');
+    await assert.isRejected(promise, '5 states in DB. Too much states!');
     sinonAssert.calledWith(
       eventFake.emit,
       EVENTS.DEVICE.PURGE_STATES_SINGLE_FEATURE,
@@ -83,6 +93,25 @@ describe('Device.destroy', () => {
       EVENTS.DEVICE.PURGE_STATES_SINGLE_FEATURE,
       '3b5b4870-145d-4584-bf0e-d97fdcf908b5',
     );
+  });
+  it('should destroy a device without features', async () => {
+    const stateManager = new StateManager(event);
+    const serviceManager = new ServiceManager({}, stateManager);
+    const device = new Device(event, {}, stateManager, serviceManager, {}, {}, job);
+    await db.Device.create({
+      id: 'a2b9ba3a-72b1-4a3e-89e5-4a4e5f0b0d3e',
+      service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
+      name: 'Device without features',
+      selector: 'device-without-features',
+      external_id: 'device-without-features',
+    });
+    await device.destroy('device-without-features');
+    const deletedDevice = await db.Device.findOne({
+      where: {
+        selector: 'device-without-features',
+      },
+    });
+    expect(deletedDevice).to.equal(null);
   });
   it('should return device not found', async () => {
     const stateManager = new StateManager(event);

--- a/server/test/lib/device/device.purgeStatesByFeatureId.test.js
+++ b/server/test/lib/device/device.purgeStatesByFeatureId.test.js
@@ -9,61 +9,93 @@ const Job = require('../../../lib/job');
 
 const event = new EventEmitter();
 
+const DEVICE_FEATURE_ID = 'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4';
+
 describe('device.purgeStatesByFeatureId', async function Describe() {
   this.timeout(5000);
   beforeEach(async () => {
-    const queryInterface = db.sequelize.getQueryInterface();
-    const deviceFeatureStateToInsert = [];
+    await db.duckDbWriteConnectionAllAsync('DELETE FROM t_device_feature_state');
+    // States live in DuckDB since the migration
+    const duckDbStatesToInsert = [];
     for (let i = 1; i <= 110; i += 1) {
+      duckDbStatesToInsert.push({ value: i, created_at: new Date() });
+    }
+    await db.duckDbBatchInsertState(DEVICE_FEATURE_ID, duckDbStatesToInsert);
+    // SQLite states are leftovers of an installation which has not run the migration yet
+    const queryInterface = db.sequelize.getQueryInterface();
+    const sqliteStatesToInsert = [];
+    for (let i = 1; i <= 5; i += 1) {
       const date = new Date();
-      deviceFeatureStateToInsert.push({
+      sqliteStatesToInsert.push({
         id: uuid.v4(),
-        device_feature_id: 'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4',
+        device_feature_id: DEVICE_FEATURE_ID,
         value: i,
         created_at: date,
         updated_at: date,
       });
     }
-    await queryInterface.bulkInsert('t_device_feature_state', deviceFeatureStateToInsert);
+    await queryInterface.bulkInsert('t_device_feature_state', sqliteStatesToInsert);
     await db.DeviceFeatureStateAggregate.create({
       type: 'daily',
-      device_feature_id: 'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4',
+      device_feature_id: DEVICE_FEATURE_ID,
       value: 12,
     });
     await db.DeviceFeatureStateAggregate.create({
       type: 'hourly',
-      device_feature_id: 'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4',
+      device_feature_id: DEVICE_FEATURE_ID,
       value: 12,
     });
     await db.DeviceFeatureStateAggregate.create({
       type: 'monthly',
-      device_feature_id: 'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4',
+      device_feature_id: DEVICE_FEATURE_ID,
       value: 12,
     });
   });
-  it('should purge states of a specific feature id', async () => {
+  it('should purge DuckDB states, SQLite leftover states and aggregates of a feature', async () => {
     const stateManager = new StateManager(event);
     const service = {};
     const job = new Job(event);
     const device = new Device(event, {}, stateManager, service, {}, {}, job);
     device.STATES_TO_PURGE_PER_DEVICE_FEATURE_CLEAN_BATCH = 1;
     device.WAIT_TIME_BETWEEN_DEVICE_FEATURE_CLEAN_BATCH = 1;
-    const res = await device.purgeStatesByFeatureId('ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4');
+    const res = await device.purgeStatesByFeatureId(DEVICE_FEATURE_ID);
     expect(res).to.deep.equal({
-      numberOfDeviceFeatureStateToDelete: 110,
+      numberOfDeviceFeatureStateToDelete: 115,
       numberOfDeviceFeatureStateAggregateToDelete: 3,
     });
+    const duckDbStates = await db.duckDbReadConnectionAllAsync(
+      'SELECT * FROM t_device_feature_state WHERE device_feature_id = ?',
+      DEVICE_FEATURE_ID,
+    );
+    expect(duckDbStates).to.have.lengthOf(0);
     const states = await db.DeviceFeatureState.findAll({
       where: {
-        device_feature_id: 'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4',
+        device_feature_id: DEVICE_FEATURE_ID,
       },
     });
     expect(states).to.have.lengthOf(0);
     const statesAggregates = await db.DeviceFeatureStateAggregate.findAll({
       where: {
-        device_feature_id: 'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4',
+        device_feature_id: DEVICE_FEATURE_ID,
       },
     });
     expect(statesAggregates).to.have.lengthOf(0);
+  });
+  it('should do nothing on a feature without any state', async () => {
+    const stateManager = new StateManager(event);
+    const service = {};
+    const job = new Job(event);
+    const device = new Device(event, {}, stateManager, service, {}, {}, job);
+    const res = await device.purgeStatesByFeatureId(uuid.v4());
+    expect(res).to.deep.equal({
+      numberOfDeviceFeatureStateToDelete: 0,
+      numberOfDeviceFeatureStateAggregateToDelete: 0,
+    });
+    // States of other features are untouched
+    const duckDbStates = await db.duckDbReadConnectionAllAsync(
+      'SELECT * FROM t_device_feature_state WHERE device_feature_id = ?',
+      DEVICE_FEATURE_ID,
+    );
+    expect(duckDbStates).to.have.lengthOf(110);
   });
 });


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests? *(both paths rewritten with real DuckDB states — the previous tests seeded SQLite only, which is why they kept passing despite the bug; new assertions fail on the old code)*
- [x] Are server tests passing with coverage? (`npm run coverage` green locally; changed lines at 100%)
- ~~Did Cypress E2E tests pass?~~ *(server-only change)*
- [x] Is the linter passing? (`npm run eslint` on server)
- [x] Did you run prettier?
- ~~If you are adding a new feature/service, did you run the integration comparator?~~ *(no i18n change)*
- [x] Did you test this pull request in real life? *(in progress on a 448M-state installation — [WIP] until validated)*
- ~~If your changes modify the API (REST or Node.js), did you modify the API documentation?~~ *(no API change)*
- ~~If you are adding a new features/services which needs explanation, did you modify the user documentation?~~ *(bug fix)*
- ~~Did you add fake requests data for the demo mode?~~ *(no request change)*

### Description of change

#### Problem

PR #2104 (v4.45.0, Aug 2024) moved device states to DuckDB but left two SQLite queries behind:

1. **`purgeStatesByFeatureId`** — triggered when "keep history" is toggled off on a device feature — counted and deleted states in **SQLite**, which is empty on migrated installations. It logs `Purging "<id>": 0 states & 0 aggregates to delete.` and returns instantly: **the DuckDB states are never purged**. The bug stayed invisible for 2 years because right after the migration the SQLite leftovers made the purge "delete something", and nothing visibly read per-feature history until the new Activity view.
2. **The `device.destroy` guard** ("too much states, cleaning first") also counted **SQLite** states, so on migrated installations it never triggers, defeating its purpose of avoiding a long blocking delete (the actual DuckDB deletion in `destroy` was correct).

#### Fix

- `purgeStatesByFeatureId`: count and delete the states in **DuckDB** — the exact query `device.destroy` already uses. The DuckDB table has no `id` column, so the old `LIMIT`-chunked delete cannot be transposed: it is a single `DELETE`, like `destroy` does. SQLite states and aggregates are still purged afterwards as leftovers of installations that have not run the migration yet — otherwise the migration would re-import states of an already-purged feature.
- `device.destroy` guard: add the DuckDB state count of the device's features to the total (SQLite counts kept for non-migrated installations).

#### Tests

- `purgeStatesByFeatureId`: seeded with 110 DuckDB states + 5 SQLite leftovers + 3 aggregates → all purged, counts returned; plus the no-state path.
- `destroy`: the "too much states" guard now counts DuckDB states (the updated assertion fails on the old code); plus destroying a device without features.

Follow-up (separate discussion): a one-shot cleanup of the states accumulated because of this bug ("zombie" states of `keep_history = false` features, and orphaned states whose feature was deleted) — could be attached to the existing database-cleaning action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device deletion checks now include states stored across both database systems, preventing deletion when states remain.
  * Device state purging now removes matching records from all supported storage layers.
  * Purge progress and deletion counts now accurately reflect all removed states.
  * Devices without features can now be deleted successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->