### PR TITLE
Front: Sort widget types alphabetically by translated label in dashbo…

### DIFF
--- a/front/src/components/boxs/SelectBoxType.jsx
+++ b/front/src/components/boxs/SelectBoxType.jsx
@@ -1,6 +1,8 @@
 import { Component } from 'preact';
 import { Text } from 'preact-i18n';
+import get from 'get-value';
 import { DASHBOARD_BOX_TYPE_LIST } from '../../../../server/utils/constants';
+import withIntlAsProp from '../../utils/withIntlAsProp';
 
 // Widget "devices in room" is deprecated and will be removed soon
 const DASHBOARD_BOX_TYPE_LIST_FILTERED = DASHBOARD_BOX_TYPE_LIST.filter(
@@ -14,6 +16,10 @@ class SelectBoxType extends Component {
     this.props.updateNewSelectedBox(this.props.x, this.props.y, e.target.value);
   };
   render(props) {
+    const sortedBoxTypes = DASHBOARD_BOX_TYPE_LIST_FILTERED.map(dashboardBoxType => ({
+      type: dashboardBoxType,
+      label: get(props.intl.dictionary, `dashboard.boxTitle.${dashboardBoxType}`, { default: dashboardBoxType })
+    })).sort((a, b) => a.label.localeCompare(b.label));
     return (
       <BaseEditBox {...props} titleKey="dashboard.selectBoxType">
         <div class="form-group">
@@ -24,10 +30,8 @@ class SelectBoxType extends Component {
             <option>
               <Text id="global.emptySelectOption" />
             </option>
-            {DASHBOARD_BOX_TYPE_LIST_FILTERED.map(dashboardBoxType => (
-              <option value={dashboardBoxType}>
-                <Text id={`dashboard.boxTitle.${dashboardBoxType}`} />
-              </option>
+            {sortedBoxTypes.map(({ type, label }) => (
+              <option value={type}>{label}</option>
             ))}
           </select>
         </div>
@@ -36,4 +40,4 @@ class SelectBoxType extends Component {
   }
 }
 
-export default SelectBoxType;
+export default withIntlAsProp(SelectBoxType);


### PR DESCRIPTION
Titre :
Front: Sort widget types alphabetically in dashboard box selector

Description :
### Pull Request check-list

- [x] If your changes affect the code, did you write the tests?
- [ ] Are server tests passing with coverage? (`cd server && npm run coverage`) — N/A, front-end only
- [ ] Did Cypress E2E tests pass? (`npm run cypress:run` from repo root, if UI changed)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new feature/service, did you run the integration comparator? — N/A
- [x] Did you test this pull request in real life? With real devices?
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? — N/A
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? — N/A
- [ ] Did you add fake requests data for the demo mode? — N/A

### Description of change

In the dashboard editor, the "Select a type" dropdown listed widgets in the raw
order of the `DASHBOARD_BOX_TYPE_LIST` constant (historical order of addition),
which makes it hard to find a widget as the list grows.

This PR sorts the widget list alphabetically **by translated label, at render
time**:

- `SelectBoxType` now gets the i18n dictionary through the existing
  `withIntlAsProp` helper, resolves each `dashboard.boxTitle.*` label and sorts
  the options with `localeCompare` (accent-aware, e.g. "Écowatt",
  "Consommation Énergétique").
- The sort automatically follows the user's language (fr/en/de) and any widget
  added to `DASHBOARD_BOX_TYPE_LIST` in the future will be sorted without any
  extra work. If a translation is missing, the widget type is used as fallback.
- The empty "---------" option stays on top, and the `value` sent on selection
  is still the raw box type — no behavior change besides the display order.

<img width="391" height="617" alt="image" src="https://github.com/user-attachments/assets/f866bbd3-7a79-4576-9681-dcd39057bf91" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Box type options are now displayed alphabetically using their translated labels.
  * Improved handling of localized box type names in the selection menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->