### PR TITLE
Front: Sort scene triggers and actions alphabetically

### DIFF
--- a/front/src/routes/scene/edit-scene/actions/ChooseActionTypeCard.jsx
+++ b/front/src/routes/scene/edit-scene/actions/ChooseActionTypeCard.jsx
@@ -60,10 +60,12 @@ class ChooseActionType extends Component {
   };
   render(props, { currentAction }) {
     const actionListFiltered = props.action && props.action.filter ? props.action.filter : ACTION_LIST;
-    const options = actionListFiltered.map(action => ({
-      value: action,
-      label: props[`editScene.actions.${action}`]
-    }));
+    const options = actionListFiltered
+      .map(action => ({
+        value: action,
+        label: props[`editScene.actions.${action}`] || action
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label));
 
     return (
       <div>

--- a/front/src/routes/scene/edit-scene/triggers/ChooseTriggerTypeCard.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/ChooseTriggerTypeCard.jsx
@@ -47,7 +47,7 @@ class ChooseTriggerType extends Component {
         value: trigger,
         label: get(props.intl.dictionary, `editScene.triggers.${trigger}`, { default: trigger })
       };
-    });
+    }).sort((a, b) => a.label.localeCompare(b.label));
 
     this.state = {
       options,


### PR DESCRIPTION
Description :
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [ ] If your changes affect the code, did you write the tests? — N/A, display order only, no logic change
- [ ] Are server tests passing with coverage? (`cd server && npm run coverage`) — N/A, front-end only
- [x] Did Cypress E2E tests pass? (`npm run cypress:run` from repo root, if UI changed)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front) — N/A
- [x] Did you test this pull request in real life? With real devices?
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? — N/A
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? — N/A
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`)? — N/A

### Description of change

In the scene editor, the trigger and action dropdowns listed their entries in
the raw order of the server constants (historical order of addition), which
makes items hard to find as the lists grow. This PR sorts both lists
alphabetically **by translated label, at render time**, so the order follows
the user's language (fr/en/de) and any trigger/action added in the future is
sorted without extra work:

- **Scene trigger selector** (`ChooseTriggerTypeCard`): options were already
  built from the i18n dictionary (`editScene.triggers.*`), they are now
  sorted with `localeCompare` (accent-aware).
- **Scene action selector** (`ChooseActionTypeCard`): options are sorted the
  same way on their translated label (`editScene.actions.*`), with the raw
  action type as fallback when a translation is missing. The sort also
  applies to filtered action lists used in condition blocks (if/then/else).


<img width="564" height="454" alt="image" src="https://github.com/user-attachments/assets/094e3e96-3427-4f29-9cc7-4376cf3d3081" />
<img width="399" height="488" alt="image" src="https://github.com/user-attachments/assets/c54fb199-6cae-45ad-881b-eb44337dfea0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Alphabetized available action and trigger types for easier browsing.
  * Added a fallback label when an action translation is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->