### PR TITLE
MQTT: fix excessive vertical spacing in device list cards

### DIFF
--- a/front/src/routes/integration/all/mqtt/device-page/style.css
+++ b/front/src/routes/integration/all/mqtt/device-page/style.css
@@ -69,12 +69,15 @@
 }
 
 .deviceListItem {
-  align-items: center;
+  align-items: start;
   border: 1px solid rgba(0, 0, 0, 0.08);
   border-radius: 4px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+  display: grid;
+  gap: 0.5rem 0.75rem;
+  grid-template-areas:
+    'main actions'
+    'features features';
+  grid-template-columns: 1fr auto;
   padding: 0.75rem 1rem;
   transition: background-color 0.15s ease;
 }
@@ -89,7 +92,7 @@
 }
 
 .deviceListItemMain {
-  flex: 1 1 200px;
+  grid-area: main;
   min-width: 0;
 }
 
@@ -118,13 +121,7 @@
 }
 
 .deviceListItemFeatures {
-  flex: 1 1 100%;
-}
-
-@media (min-width: 768px) {
-  .deviceListItemFeatures {
-    flex: 1 1 200px;
-  }
+  grid-area: features;
 }
 
 .deviceListItemFeatures .device-features {
@@ -152,11 +149,11 @@
   display: flex;
   flex-shrink: 0;
   gap: 0.5rem;
-  margin-left: auto;
+  grid-area: actions;
 }
 
 .deviceListItemAlert {
-  flex: 1 1 100%;
+  grid-column: 1 / -1;
 }
 
 /* Device edit page */
@@ -485,12 +482,14 @@
 
 @media (max-width: 576px) {
   .deviceListItem {
-    flex-direction: column;
-    align-items: stretch;
+    grid-template-areas:
+      'main'
+      'features'
+      'actions';
+    grid-template-columns: 1fr;
   }
 
   .deviceListItemActions {
-    margin-left: 0;
     width: 100%;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the excessive vertical gap inside MQTT device list cards on the integration's first page (device list).

## Problem

Each device card showed a large empty space between the device name / feature count and the feature tags / action buttons. This was especially visible on mobile.

## Root cause

The card layout used flexbox with `flex-grow: 1` on both `.deviceListItemMain` and `.deviceListItemFeatures`. In column layout (mobile), both sections expanded to fill available height, stretching the card and creating dead space between content blocks.

## Solution

Replaced the flex-wrap layout with an explicit CSS Grid:

- **Row 1:** device name + meta on the left, Edit/Delete actions on the right
- **Row 2:** feature tags spanning the full width

On mobile, the grid stacks into three rows: name → tags → actions.

## Testing

- [x] `npm run prettier` / `npm run prettier-check` in `front/`
- [x] `npm run eslint` in `front/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db363431-b69b-4230-9668-9f7170a809ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db363431-b69b-4230-9668-9f7170a809ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the MQTT device list layout for clearer alignment and spacing.
  * Enhanced the responsive mobile layout by stacking device details, features, and actions more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->