### PR TITLE
Add seconds unit for device state trigger duration condition

### DIFF
--- a/front/src/routes/scene/edit-scene/triggers/DeviceFeatureState.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/DeviceFeatureState.jsx
@@ -29,21 +29,57 @@ class TurnOnLight extends Component {
     }
   };
 
+  getForDurationUnit = trigger => trigger.unit || 'minute';
+
+  getForDurationMultiplier = unit => (unit === 'second' ? 1000 : 60 * 1000);
+
+  getForDurationDisplayValue = trigger => {
+    if (!Number.isInteger(trigger.for_duration)) {
+      return trigger.for_duration;
+    }
+
+    return trigger.for_duration / this.getForDurationMultiplier(this.getForDurationUnit(trigger));
+  };
+
   onForDurationChange = e => {
     e.preventDefault();
     if (e.target.value) {
-      this.props.updateTriggerProperty(this.props.index, 'for_duration', Number(e.target.value) * 60 * 1000);
+      const unit = this.getForDurationUnit(this.props.trigger);
+      this.props.updateTriggerProperty(
+        this.props.index,
+        'for_duration',
+        Number(e.target.value) * this.getForDurationMultiplier(unit)
+      );
     } else {
       this.props.updateTriggerProperty(this.props.index, 'for_duration', '');
     }
+  };
+
+  onForDurationUnitChange = e => {
+    e.preventDefault();
+    const newUnit = e.target.value;
+    const currentUnit = this.getForDurationUnit(this.props.trigger);
+
+    if (newUnit !== currentUnit && Number.isInteger(this.props.trigger.for_duration)) {
+      const displayValue = this.getForDurationDisplayValue(this.props.trigger);
+      this.props.updateTriggerProperty(
+        this.props.index,
+        'for_duration',
+        displayValue * this.getForDurationMultiplier(newUnit)
+      );
+    }
+
+    this.props.updateTriggerProperty(this.props.index, 'unit', newUnit);
   };
 
   enableOrDisableForDuration = e => {
     e.preventDefault();
     if (e.target.checked) {
       this.props.updateTriggerProperty(this.props.index, 'for_duration', 60 * 1000);
+      this.props.updateTriggerProperty(this.props.index, 'unit', 'minute');
     } else {
       this.props.updateTriggerProperty(this.props.index, 'for_duration', undefined);
+      this.props.updateTriggerProperty(this.props.index, 'unit', undefined);
     }
   };
 
@@ -147,19 +183,22 @@ class TurnOnLight extends Component {
                       type="number"
                       class="form-control"
                       placeholder={<Text id="editScene.triggersCard.newState.valuePlaceholder" />}
-                      value={
-                        Number.isInteger(props.trigger.for_duration)
-                          ? props.trigger.for_duration / 60 / 1000
-                          : props.trigger.for_duration
-                      }
+                      value={this.getForDurationDisplayValue(props.trigger)}
                       onChange={this.onForDurationChange}
                     />
                   </Localizer>
-                  <span class="input-group-append" id="basic-addon2">
-                    <span class="input-group-text">
-                      <Text id="deviceFeatureUnitShort.minutes" />
-                    </span>
-                  </span>
+                  <select
+                    class="custom-select"
+                    value={this.getForDurationUnit(props.trigger)}
+                    onChange={this.onForDurationUnitChange}
+                  >
+                    <option value="second">
+                      <Text id="editScene.triggersCard.scheduledTrigger.units.second" />
+                    </option>
+                    <option value="minute">
+                      <Text id="editScene.triggersCard.scheduledTrigger.units.minute" />
+                    </option>
+                  </select>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the **Device state change** scene trigger, the "run after condition has been valid for" option previously only allowed entering a duration in **minutes**.

This PR adds a unit selector so users can choose **seconds** or **minutes**.

## Changes

- Updated `DeviceFeatureState.jsx` to show a unit dropdown (seconds / minutes) next to the duration input
- Reuses the existing trigger `unit` field for persistence (already supported by the server schema)
- Keeps backward compatibility: existing scenes without a `unit` value default to minutes
- No server changes required — `for_duration` was already stored in milliseconds

## Testing

- [x] `npm run prettier` / `npm run prettier-check` in `front/`
- [x] `npm run eslint` in `front/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97ea3581-6fe1-4cf6-94f2-7ca78827c801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97ea3581-6fe1-4cf6-94f2-7ca78827c801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring trigger durations in either seconds or minutes.
  * Duration values now automatically convert when switching between units.

* **Bug Fixes**
  * Improved duration handling when enabling, disabling, and editing timed device actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->