### PR TITLE
Fix black gap in multi-line scene variable chips

### DIFF
--- a/front/src/components/scene/TextWithVariablesInjected.css
+++ b/front/src/components/scene/TextWithVariablesInjected.css
@@ -1,0 +1,45 @@
+/*
+ * Tagify draws tag backgrounds with a fixed-size inset box-shadow (1.1em).
+ * When a variable label wraps onto multiple lines, the tag is taller than 2.2em
+ * and the shadow no longer fills the middle, leaving a visible gap (black in dark mode).
+ */
+.tagify__tag > div {
+  white-space: normal;
+}
+
+.tagify__tag > div::before {
+  box-shadow: none !important;
+  background: var(--tag-bg, #e5e5e5);
+}
+
+.tagify__tag:focus div::before,
+.tagify__tag:hover:not([readonly]) div::before {
+  box-shadow: none !important;
+  background: var(--tag-hover, #d3e2e2);
+}
+
+.tagify__tag__removeBtn:hover + div::before {
+  box-shadow: none !important;
+  background: var(--tag-remove-bg, rgba(211, 148, 148, 0.3));
+}
+
+.tagify__tag.tagify--notAllowed:not(.tagify__tag--editable) div::before {
+  box-shadow: none !important;
+  background: var(--tag-invalid-bg, rgba(211, 148, 148, 0.5));
+}
+
+.tagify__tag--editable > div::before {
+  box-shadow: none !important;
+  background: var(--tag-hover, #d3e2e2);
+}
+
+.tagify__tag--editable.tagify--invalid > div::before {
+  box-shadow: none !important;
+  background: var(--tag-invalid-color, #d39494);
+}
+
+/* Keep tag colors readable in dark mode (same double-invert trick as .tag badges). */
+:global(.dark-mode) .tagify__tag > div,
+:global(.dark-mode) .tagify__tag__removeBtn {
+  filter: invert(100%) hue-rotate(180deg);
+}

--- a/front/src/components/scene/TextWithVariablesInjected.jsx
+++ b/front/src/components/scene/TextWithVariablesInjected.jsx
@@ -1,6 +1,7 @@
 import { Component } from 'preact';
 import Tagify from '@yaireo/tagify';
 import '@yaireo/tagify/dist/tagify.css';
+import './TextWithVariablesInjected.css';
 import get from 'get-value';
 
 import withIntlAsProp from '../../utils/withIntlAsProp';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In scene actions that support variable injection (`{{`), when a variable chip wraps onto two lines (long device/feature names), a horizontal black band appears in the middle of the chip in dark mode.

![Bug screenshot from issue](https://github.com/user-attachments/assets/placeholder)

## Root cause

The `TextWithVariablesInjected` component uses [Tagify](https://github.com/yairEO/tagify) in mix mode. Tagify draws tag backgrounds with a fixed-size inset `box-shadow` (`1.1em`). When the tag content is taller than `2 × 1.1em` (i.e. two lines), the shadow no longer fills the full height and the input background shows through as a dark horizontal strip.

## Fix

Add a small CSS override (`TextWithVariablesInjected.css`) that:

- Replaces the inset `box-shadow` with a solid `background` on the `::before` pseudo-element (which already stretches to the full tag height)
- Allows tag content to wrap with `white-space: normal`
- Applies the same dark-mode double-invert trick used for `.tag` badges so chip colors stay readable

## Testing

- [x] `npm run prettier-check` and `npm run eslint` in `front/`
- [x] Verified the component loads the new CSS in the scene editor (Send Message action)
- [ ] Full visual reproduction requires a scene with a "Get device value" action before a "Control device" action with a long variable name — not available in the fresh dev VM, but the CSS root cause is confirmed in Tagify's source

## Affected screens

All usages of `TextWithVariablesInjected`: device set value (computed), delay, conditions, HTTP request, messages, MQTT, etc.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c060d00d-80b5-4f68-a339-3429013e2494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c060d00d-80b5-4f68-a339-3429013e2494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the appearance and readability of variable tags.
  * Added clearer visual states for hover, focus, removal, and invalid tags.
  * Improved tag text wrapping and dark-mode readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->