### PR TITLE
Security: Potential Open Redirect via Unvalidated Link Box URL

### DIFF
--- a/front/src/components/boxs/link/LinkBox.jsx
+++ b/front/src/components/boxs/link/LinkBox.jsx
@@ -9,7 +9,9 @@ const LinkBox = ({ box }) => {
   const url = get(box, 'url', '');
   const icon = get(box, 'icon', DEFAULT_ICON);
 
-  if (!url) {
+  const isSafeUrl = /^(https?:|\/)/i.test(url);
+
+  if (!url || !isSafeUrl) {
     return (
       <div class="card">
         <div class="card-body text-muted text-center">


### PR DESCRIPTION
## Summary

Security: Potential Open Redirect via Unvalidated Link Box URL

## Problem

**Severity**: `Medium` | **File**: `front/src/components/boxs/link/LinkBox.jsx:L24`

The `LinkBox` component takes a `url` from the `box` configuration and renders it directly into an anchor tag's `href` attribute. If this `url` can be controlled by an attacker (e.g., through a compromised dashboard configuration or API), it can be used for open redirect attacks or to execute `javascript:` URIs, leading to Cross-Site Scripting (XSS).

## Solution

Validate that the `url` starts with a safe protocol (e.g., `http:`, `https:`) before rendering it in the `href` attribute. Reject or sanitize URLs with protocols like `javascript:` or `data:`.

## Changes

- `front/src/components/boxs/link/LinkBox.jsx` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link validation to allow only secure HTTP(S) or root-relative URLs.
  * Displays the fallback state for missing or unsafe links, helping prevent invalid navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->