### PR TITLE
fix(homekit): clamp ColorTemperature values exceeding HomeKit max (500)

### DIFF
--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -216,6 +216,43 @@ describe('Send state to HomeKit', () => {
     expect(updateCharacteristic.args[0][1]).eql(320);
   });
 
+  it('should clamp light temperature above HomeKit ColorTemperature max', async () => {
+    const updateCharacteristic = stub().returns();
+    const getCharacteristic = stub().returns({
+      props: {
+        minValue: 140,
+        maxValue: 500,
+      },
+    });
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns({
+        updateCharacteristic,
+        getCharacteristic,
+      }),
+    };
+
+    const event = {
+      type: EVENTS.DEVICE.NEW_STATE,
+      last_value: 525,
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Bande LED chambre Color Temperature',
+      category: DEVICE_FEATURE_CATEGORIES.LIGHT,
+      type: DEVICE_FEATURE_TYPES.LIGHT.TEMPERATURE,
+      min: 150,
+      max: 500,
+    };
+
+    await homekitHandler.sendState(accessory, feature, event);
+
+    expect(updateCharacteristic.args[0][0]).eql('COLORTEMPERATURE');
+    expect(updateCharacteristic.args[0][1]).eql(500);
+  });
+
   it('should notify sensor temperature Kelvin', async () => {
     const updateCharacteristic = stub().returns();
     const accessory = {

--- a/server/test/utils/device.test.js
+++ b/server/test/utils/device.test.js
@@ -372,4 +372,17 @@ describe('normalize', () => {
 
     expect(newValue).to.equal(180);
   });
+
+  it('should clamp values above the source max to the target max', async () => {
+    // HomeKit ColorTemperature max is 500 mireds; devices can report higher
+    expect(normalize(525, 150, 500, 140, 500)).to.equal(500);
+  });
+
+  it('should clamp values below the source min to the target min', async () => {
+    expect(normalize(100, 150, 500, 140, 500)).to.equal(140);
+  });
+
+  it('should return target min when source min equals source max', async () => {
+    expect(normalize(42, 10, 10, 140, 500)).to.equal(140);
+  });
 });

--- a/server/utils/device.js
+++ b/server/utils/device.js
@@ -223,7 +223,9 @@ function mergeDevices(newDevice, existingDevice, updateAttribute = 'updatable') 
 }
 
 /**
- * @description Normalize value to new range.
+ * @description Normalize value to new range and clamp it within target bounds.
+ * Values outside the source range are mapped then clamped so callers (e.g. HomeKit)
+ * never receive a value outside [newRangeMin, newRangeMax].
  * @param {number} value - Actual value.
  * @param {number} currentMin - Actual possible min value.
  * @param {number} currentMax - Actual possible max value.
@@ -234,7 +236,13 @@ function mergeDevices(newDevice, existingDevice, updateAttribute = 'updatable') 
  * normalize(5, 0, 255, 0, 360)
  */
 function normalize(value, currentMin, currentMax, newRangeMin, newRangeMax) {
-  return ((newRangeMax - newRangeMin) * (value - currentMin)) / (currentMax - currentMin) + newRangeMin;
+  if (currentMax === currentMin) {
+    return newRangeMin;
+  }
+  const normalized = ((newRangeMax - newRangeMin) * (value - currentMin)) / (currentMax - currentMin) + newRangeMin;
+  const lowerBound = Math.min(newRangeMin, newRangeMax);
+  const upperBound = Math.max(newRangeMin, newRangeMax);
+  return Math.min(upperBound, Math.max(lowerBound, normalized));
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

HomeKit HAP was logging warnings like:

```
[Gladys ...@Color Temperature] characteristic was supplied illegal value: number 525 exceeded maximum of 500
```

Devices (e.g. LED strips) can report color temperature in mireds outside their declared Gladys `min`/`max`. The `normalize()` helper mapped those values into the HomeKit range without clamping, so out-of-range values (e.g. `525`) were forwarded to the `ColorTemperature` characteristic (max `500`).

## Changes

- Clamp `normalize()` results to `[newRangeMin, newRangeMax]` (also handles equal source min/max).
- Add unit tests for clamping and a HomeKit `sendState` regression for color temperature above 500 mireds.

## Test plan

- [x] `npm run prettier` / `prettier-check` on touched files
- [x] eslint on touched files
- [ ] Targeted mocha tests for `normalize` and HomeKit `sendState`
- [ ] Server coverage for changed lines

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ad7d44e-1fc3-42f1-af59-87f982c1f619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ad7d44e-1fc3-42f1-af59-87f982c1f619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temperature handling by clamping values to supported HomeKit limits.
  * Prevented invalid normalized values when inputs exceed their source range or fall below it.
  * Added safe handling for inputs with no usable range, returning the target minimum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->