### PR TITLE
fix(message): isolate messaging service failures in sendToUser

### DIFF
--- a/server/api/controllers/user.controller.js
+++ b/server/api/controllers/user.controller.js
@@ -162,9 +162,13 @@ module.exports = function UserController(gladys) {
     const link = `${req.body.origin}/reset-password?token=${session.access_token}`;
     // Try to send the link to the user if he has configured an external service like Telegram
     const text = gladys.brain.getReply(user.language, 'user.forgot-password.success', {});
-    await gladys.message.sendToUser(user.selector, text);
-    await gladys.message.sendToUser(user.selector, link);
-    // If not, we log the link to the logs.
+    try {
+      await gladys.message.sendToUser(user.selector, text);
+      await gladys.message.sendToUser(user.selector, link);
+    } catch (e) {
+      logger.error(`Error while sending forgot password message to user ${req.body.email}:`, e);
+    }
+    // Always log the link so an admin can still recover the reset URL if messaging fails.
     logger.info(`Forgot password initiated for user ${req.body.email}, link = ${link}`);
     res.json({
       success: true,

--- a/server/lib/message/message.reply.js
+++ b/server/lib/message/message.reply.js
@@ -1,6 +1,7 @@
 const logger = require('../../utils/logger');
 const { EVENTS, WEBSOCKET_MESSAGE_TYPES } = require('../../utils/constants');
 const db = require('../../models');
+const { forwardToService } = require('./message.sendToUser');
 
 const TOOL_CALL_EXTERNAL_SOURCES = new Set(['telegram', 'nextcloud-talk', 'callmebot']);
 
@@ -87,7 +88,7 @@ async function reply(originalMessage, text, context, file = null, options = {}) 
       // if the service exist and the user had telegram configured
       if (telegramService && user.telegram_user_id) {
         // we forward the message to Telegram
-        await telegramService.message.send(user.telegram_user_id, externalMessage);
+        await forwardToService('telegram', () => telegramService.message.send(user.telegram_user_id, externalMessage));
       }
       // We send the message to the nextcloud talk service
       const nextcloudTalkService = this.service.getService('nextcloud-talk');
@@ -101,7 +102,9 @@ async function reply(originalMessage, text, context, file = null, options = {}) 
         // if the user had nextcloud talk configured
         if (nextcloudTalkToken) {
           // we forward the message to Nextcloud Talk
-          await nextcloudTalkService.message.send(nextcloudTalkToken, externalMessage);
+          await forwardToService('nextcloud-talk', () =>
+            nextcloudTalkService.message.send(nextcloudTalkToken, externalMessage),
+          );
         }
       }
       // We send the message to the callmebot service
@@ -109,7 +112,7 @@ async function reply(originalMessage, text, context, file = null, options = {}) 
       // if the service exist
       if (callmebotService) {
         // we forward the message to CallMeBot
-        await callmebotService.message.send(user.id, externalMessage);
+        await forwardToService('callmebot', () => callmebotService.message.send(user.id, externalMessage));
       }
     } else {
       // then, we get the service sending the original message

--- a/server/lib/message/message.sendToUser.js
+++ b/server/lib/message/message.sendToUser.js
@@ -1,6 +1,23 @@
 const { EVENTS, WEBSOCKET_MESSAGE_TYPES } = require('../../utils/constants');
 const { NotFoundError } = require('../../utils/coreErrors');
+const logger = require('../../utils/logger');
 const db = require('../../models');
+
+/**
+ * @description Forward a message to an external service without blocking other channels on failure.
+ * @param {string} serviceName - Name of the messaging service for logging.
+ * @param {Function} sendFn - Async function that sends the message.
+ * @returns {Promise} Resolve when send succeeds or fails (errors are logged).
+ * @example
+ * await forwardToService('telegram', () => telegramService.message.send(userId, message));
+ */
+async function forwardToService(serviceName, sendFn) {
+  try {
+    await sendFn();
+  } catch (e) {
+    logger.error(`Error while forwarding message to ${serviceName}:`, e);
+  }
+}
 
 /**
  * @description Send a message to a user.
@@ -39,7 +56,7 @@ async function sendToUser(userSelector, text, file = null, options = {}) {
   // if the service exist and the user had telegram configured
   if (telegramService && user.telegram_user_id) {
     // we forward the message to Telegram
-    await telegramService.message.send(user.telegram_user_id, messageCreated);
+    await forwardToService('telegram', () => telegramService.message.send(user.telegram_user_id, messageCreated));
   }
   // We send the message to the nextcloud talk service
   const nextcloudTalkService = this.service.getService('nextcloud-talk');
@@ -53,7 +70,9 @@ async function sendToUser(userSelector, text, file = null, options = {}) {
     // if the user had nextcloud talk configured
     if (nextcloudTalkToken) {
       // we forward the message to Nextcloud Talk
-      await nextcloudTalkService.message.send(nextcloudTalkToken, messageCreated);
+      await forwardToService('nextcloud-talk', () =>
+        nextcloudTalkService.message.send(nextcloudTalkToken, messageCreated),
+      );
     }
   }
   // We send the message to the callmebot service
@@ -61,11 +80,12 @@ async function sendToUser(userSelector, text, file = null, options = {}) {
   // if the service exist
   if (callmebotService) {
     // we forward the message to CallMeBot
-    await callmebotService.message.send(user.id, messageCreated);
+    await forwardToService('callmebot', () => callmebotService.message.send(user.id, messageCreated));
   }
   return messageCreated;
 }
 
 module.exports = {
   sendToUser,
+  forwardToService,
 };

--- a/server/test/controllers/user/user.forgotPassword.controller.test.js
+++ b/server/test/controllers/user/user.forgotPassword.controller.test.js
@@ -1,0 +1,78 @@
+const { expect } = require('chai');
+const { fake, assert: sinonAssert } = require('sinon');
+
+const UserController = require('../../../api/controllers/user.controller');
+
+describe('user.controller forgotPassword', () => {
+  let res;
+  let gladys;
+
+  beforeEach(() => {
+    res = {
+      json: fake(),
+    };
+    gladys = {
+      user: {
+        forgotPassword: fake.resolves({
+          session: { access_token: 'reset-token' },
+          user: {
+            selector: 'tony',
+            language: 'en',
+          },
+        }),
+      },
+      brain: {
+        getReply: fake.returns('Password reset instructions'),
+      },
+      message: {
+        sendToUser: fake.resolves({}),
+      },
+    };
+  });
+
+  it('should send forgot password messages and return success', async () => {
+    const controller = UserController(gladys);
+    const req = {
+      body: {
+        email: 'demo@demo.com',
+        origin: 'http://localhost:1444',
+      },
+      headers: {
+        'user-agent': 'test-agent',
+      },
+    };
+
+    await controller.forgotPassword(req, res);
+
+    sinonAssert.calledOnce(gladys.user.forgotPassword);
+    sinonAssert.calledTwice(gladys.message.sendToUser);
+    sinonAssert.calledWith(gladys.message.sendToUser.firstCall, 'tony', 'Password reset instructions');
+    sinonAssert.calledWith(
+      gladys.message.sendToUser.secondCall,
+      'tony',
+      'http://localhost:1444/reset-password?token=reset-token',
+    );
+    sinonAssert.calledOnce(res.json);
+    expect(res.json.firstCall.args[0]).to.deep.equal({ success: true });
+  });
+
+  it('should still return success when sending forgot password message fails', async () => {
+    gladys.message.sendToUser = fake.rejects(new Error('callmebot failed'));
+    const controller = UserController(gladys);
+    const req = {
+      body: {
+        email: 'demo@demo.com',
+        origin: 'http://localhost:1444',
+      },
+      headers: {
+        'user-agent': 'test-agent',
+      },
+    };
+
+    await controller.forgotPassword(req, res);
+
+    sinonAssert.calledOnce(gladys.message.sendToUser);
+    sinonAssert.calledOnce(res.json);
+    expect(res.json.firstCall.args[0]).to.deep.equal({ success: true });
+  });
+});

--- a/server/test/lib/message/message.reply.test.js
+++ b/server/test/lib/message/message.reply.test.js
@@ -110,6 +110,25 @@ describe('message.reply', () => {
     assert.calledWith(nextCloudTalkService.message.send, 'next-cloud-talk-token');
     assert.calledWith(callmebotService.message.send, '0cd30aef-9c4e-4a23-88e3-3547971296e5');
   });
+  it('should continue sending AI reply to other services when one service fails', async () => {
+    telegramService.message.send = fake.rejects(new Error('telegram down'));
+    await messageHandler.reply(
+      {
+        language: 'en',
+        source: 'AI',
+        source_user_id: 'XXXX',
+        user: {
+          id: '0cd30aef-9c4e-4a23-88e3-3547971296e5',
+          language: 'en',
+        },
+      },
+      'hey!',
+      {},
+    );
+    assert.calledOnce(telegramService.message.send);
+    assert.calledWith(nextCloudTalkService.message.send, 'next-cloud-talk-token');
+    assert.calledWith(callmebotService.message.send, '0cd30aef-9c4e-4a23-88e3-3547971296e5');
+  });
   it('should fail to reply', async () => {
     variable.getValue = fake.rejects(new Error('cannot get'));
     await messageHandler.reply(

--- a/server/test/lib/message/message.sendToUser.test.js
+++ b/server/test/lib/message/message.sendToUser.test.js
@@ -135,4 +135,90 @@ describe('message.sendToUser', () => {
     const promise = messageHandler.sendToUser('user-not-found', 'coucou');
     return assertChai.isRejected(promise);
   });
+  it('should continue sending to other services when one service fails', async () => {
+    const event = new EventEmitter();
+    const stateManager = new StateManager();
+    const telegramSend = fake.rejects(new Error('telegram down'));
+    const nextcloudSend = fake.resolves(true);
+    const callmebotSend = fake.resolves(true);
+    const service = {
+      getService: stub()
+        .onFirstCall()
+        .returns({
+          message: {
+            send: telegramSend,
+          },
+        })
+        .onSecondCall()
+        .returns({
+          message: {
+            send: nextcloudSend,
+            serviceId: 'nextcloud-service-id',
+          },
+        })
+        .onThirdCall()
+        .returns({
+          message: {
+            send: callmebotSend,
+          },
+        }),
+    };
+    const variable = {
+      getValue: fake.resolves('a1z2e3'),
+    };
+    const messageHandler = new MessageHandler(event, {}, service, stateManager, variable);
+    stateManager.setState('user', 'test-user', {
+      id: '0cd30aef-9c4e-4a23-88e3-3547971296e5',
+      telegram_user_id: 'one-id',
+    });
+    const message = await messageHandler.sendToUser('test-user', 'coucou');
+    expect(message).to.have.property('id');
+    expect(message).to.have.property('text', 'coucou');
+    assert.calledOnce(telegramSend);
+    assert.calledOnce(nextcloudSend);
+    assert.calledOnce(callmebotSend);
+  });
+  it('should continue sending when callmebot fails after other services succeed', async () => {
+    const event = new EventEmitter();
+    const stateManager = new StateManager();
+    const telegramSend = fake.resolves(true);
+    const nextcloudSend = fake.resolves(true);
+    const callmebotSend = fake.rejects(new Error('Failed to send message: Apikey Correct'));
+    const service = {
+      getService: stub()
+        .onFirstCall()
+        .returns({
+          message: {
+            send: telegramSend,
+          },
+        })
+        .onSecondCall()
+        .returns({
+          message: {
+            send: nextcloudSend,
+            serviceId: 'nextcloud-service-id',
+          },
+        })
+        .onThirdCall()
+        .returns({
+          message: {
+            send: callmebotSend,
+          },
+        }),
+    };
+    const variable = {
+      getValue: fake.resolves('a1z2e3'),
+    };
+    const messageHandler = new MessageHandler(event, {}, service, stateManager, variable);
+    stateManager.setState('user', 'test-user', {
+      id: '0cd30aef-9c4e-4a23-88e3-3547971296e5',
+      telegram_user_id: 'one-id',
+    });
+    const message = await messageHandler.sendToUser('test-user', 'coucou');
+    expect(message).to.have.property('id');
+    expect(message).to.have.property('text', 'coucou');
+    assert.calledOnce(telegramSend);
+    assert.calledOnce(nextcloudSend);
+    assert.calledOnce(callmebotSend);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When requesting a password reset (`forgotPassword`), Gladys tries to send the reset message through every configured messaging channel (Telegram, Nextcloud Talk, CallMeBot).

If one channel failed (e.g. CallMeBot returning a false-negative / malformed response), `message.sendToUser` threw and:

1. Later channels in the same `sendToUser` call were never attempted
2. The second `sendToUser` call with the reset link was skipped
3. The reset link was never logged
4. The API returned an error even though the reset session had already been created

## Solution

- Add a `forwardToService` helper that catches and logs per-channel errors so one failing service never blocks the others
- Use it in both `sendToUser` and AI multi-channel `reply`
- Wrap `forgotPassword` messaging in try/catch so sending remains best-effort: the link is always logged and the endpoint still returns `{ success: true }`

## Tests

- `sendToUser` continues to other services when Telegram or CallMeBot fails
- AI `reply` continues to other services when Telegram fails
- `forgotPassword` controller still returns success when `sendToUser` rejects

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9e76525-9c3a-4e41-9a82-33d29bb40552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9e76525-9c3a-4e41-9a82-33d29bb40552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Password reset requests now complete successfully even if message delivery fails.
  - Notifications continue to be sent through remaining channels when one external service is unavailable.
  - Failures when forwarding messages are logged without interrupting the request or reply flow.

- **Tests**
  - Added coverage for password reset delivery failures and multi-channel notification resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->