### PR TITLE
fix(rtsp-camera): log concise camera poll failures

### DIFF
--- a/server/services/rtsp-camera/lib/getImage.js
+++ b/server/services/rtsp-camera/lib/getImage.js
@@ -3,6 +3,7 @@ const path = require('path');
 const logger = require('../../../utils/logger');
 const { NotFoundError } = require('../../../utils/coreErrors');
 const { DEVICE_ROTATION } = require('../../../utils/constants');
+const { formatFfmpegError } = require('../utils/formatFfmpegError');
 
 const DEVICE_PARAM_CAMERA_URL = 'CAMERA_URL';
 const DEVICE_PARAM_CAMERA_ROTATION = 'CAMERA_ROTATION';
@@ -76,9 +77,13 @@ async function getImage(device) {
       },
       async (error, stdout, stderr) => {
         if (error) {
-          logger.warn(error);
+          const message = formatFfmpegError(error, stderr);
+          // Keep full stderr for deep debugging without dumping the Error object
+          if (stderr) {
+            logger.debug(`Camera ${device.selector || device.id} ffmpeg stderr: ${stderr}`);
+          }
           await fse.remove(filePath);
-          return reject(error);
+          return reject(new Error(message));
         }
         logger.debug('Camera image saved to disk. Reading disk.');
         let image;

--- a/server/services/rtsp-camera/lib/poll.js
+++ b/server/services/rtsp-camera/lib/poll.js
@@ -11,8 +11,8 @@ async function poll(device) {
     const cameraImage = await this.getImage(device);
     await this.gladys.device.camera.setImage(device.selector, cameraImage);
   } catch (e) {
-    logger.warn('Unable to poll camera');
-    logger.debug(e);
+    const reason = e && e.message ? e.message : e;
+    logger.warn(`Unable to poll camera "${device.selector}": ${reason}`);
   }
 }
 

--- a/server/services/rtsp-camera/utils/formatFfmpegError.js
+++ b/server/services/rtsp-camera/utils/formatFfmpegError.js
@@ -3,7 +3,7 @@ const MAX_REASON_LENGTH = 400;
 /**
  * @description Build a concise ffmpeg failure reason from stderr / error message.
  * @param {Error} error - Error thrown by child_process.
- * @param {string} [stderr] - stderr output from ffmpeg.
+ * @param {string} [stderr] - Stderr output from ffmpeg.
  * @returns {string} Concise human-readable failure reason.
  * @example
  * formatFfmpegError(error, stderr);

--- a/server/services/rtsp-camera/utils/formatFfmpegError.js
+++ b/server/services/rtsp-camera/utils/formatFfmpegError.js
@@ -1,0 +1,46 @@
+const MAX_REASON_LENGTH = 400;
+
+/**
+ * @description Build a concise ffmpeg failure reason from stderr / error message.
+ * @param {Error} error - Error thrown by child_process.
+ * @param {string} [stderr] - stderr output from ffmpeg.
+ * @returns {string} Concise human-readable failure reason.
+ * @example
+ * formatFfmpegError(error, stderr);
+ */
+function formatFfmpegError(error, stderr) {
+  const details = [];
+  if (error && error.signal) {
+    details.push(`signal=${error.signal}`);
+  } else if (error && error.code !== null && error.code !== undefined) {
+    details.push(`code=${error.code}`);
+  }
+
+  const raw = (stderr || (error && error.stderr) || (error && error.message) || String(error)).toString();
+  const lines = raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .filter((line) => !line.startsWith('ffmpeg version'))
+    .filter((line) => !line.startsWith('configuration:'))
+    .filter((line) => !line.startsWith('libav'))
+    .filter((line) => !/^built with /i.test(line))
+    .filter((line) => !/^Command failed:/i.test(line));
+
+  let reason = lines.slice(0, 2).join(' — ');
+  if (!reason) {
+    reason = (error && error.message) || String(error);
+  }
+
+  reason = reason.replace(/\s+/g, ' ').trim();
+  if (reason.length > MAX_REASON_LENGTH) {
+    reason = `${reason.slice(0, MAX_REASON_LENGTH)}…`;
+  }
+
+  const suffix = details.length ? ` (${details.join(', ')})` : '';
+  return `ffmpeg failed${suffix}: ${reason}`;
+}
+
+module.exports = {
+  formatFfmpegError,
+};

--- a/server/test/services/rtsp-camera/formatFfmpegError.test.js
+++ b/server/test/services/rtsp-camera/formatFfmpegError.test.js
@@ -1,0 +1,82 @@
+const { expect } = require('chai');
+const { formatFfmpegError } = require('../../../services/rtsp-camera/utils/formatFfmpegError');
+
+describe('rtsp-camera formatFfmpegError', () => {
+  it('should extract a concise reason from dyld stderr', () => {
+    const error = Object.assign(new Error('Command failed: ffmpeg -i http://example.com'), {
+      signal: 'SIGABRT',
+      code: null,
+    });
+    const stderr = `dyld[23876]: Library not loaded: /opt/homebrew/opt/x265/lib/libx265.215.dylib
+  Referenced from: /opt/homebrew/Cellar/ffmpeg/8.1/bin/ffmpeg
+  Reason: tried: '/opt/homebrew/opt/x265/lib/libx265.215.dylib' (no such file), '/opt/homebrew/Cellar/x265/4.2/lib/libx265.215.dylib' (no such file)`;
+
+    const message = formatFfmpegError(error, stderr);
+
+    expect(message).to.equal(
+      'ffmpeg failed (signal=SIGABRT): dyld[23876]: Library not loaded: /opt/homebrew/opt/x265/lib/libx265.215.dylib — Referenced from: /opt/homebrew/Cellar/ffmpeg/8.1/bin/ffmpeg',
+    );
+    expect(message).to.not.include('tried:');
+    expect(message).to.not.include('Command failed');
+  });
+
+  it('should include exit code when no signal is present', () => {
+    const error = Object.assign(new Error('Command failed: ffmpeg'), {
+      code: 1,
+    });
+    const message = formatFfmpegError(error, 'Connection refused');
+
+    expect(message).to.equal('ffmpeg failed (code=1): Connection refused');
+  });
+
+  it('should skip ffmpeg banner lines in stderr', () => {
+    const error = new Error('Command failed: ffmpeg');
+    const stderr = `ffmpeg version 6.0 Copyright (c) 2000-2023
+configuration: --enable-gpl
+libavutil 58. 2.100
+built with gcc
+[rtsp @ 0x123] Unable to open stream`;
+
+    const message = formatFfmpegError(error, stderr);
+
+    expect(message).to.equal('ffmpeg failed: [rtsp @ 0x123] Unable to open stream');
+  });
+
+  it('should fall back to error message when stderr is empty', () => {
+    const error = new Error('broken url');
+    const message = formatFfmpegError(error, '');
+
+    expect(message).to.equal('ffmpeg failed: broken url');
+  });
+
+  it('should use error.stderr when stderr argument is missing', () => {
+    const error = Object.assign(new Error('Command failed'), {
+      stderr: 'Server returned 404 Not Found',
+    });
+    const message = formatFfmpegError(error);
+
+    expect(message).to.equal('ffmpeg failed: Server returned 404 Not Found');
+  });
+
+  it('should fall back to stringified error when message is empty', () => {
+    const message = formatFfmpegError('unexpected failure');
+
+    expect(message).to.equal('ffmpeg failed: unexpected failure');
+  });
+
+  it('should fall back when stderr only contains filtered banner lines', () => {
+    const error = new Error('Command failed: ffmpeg -i cam');
+    const message = formatFfmpegError(error, 'ffmpeg version 6.0\nconfiguration: --enable-gpl');
+
+    expect(message).to.equal('ffmpeg failed: Command failed: ffmpeg -i cam');
+  });
+
+  it('should truncate very long reasons', () => {
+    const error = new Error('Command failed');
+    const stderr = `Error: ${'x'.repeat(500)}`;
+    const message = formatFfmpegError(error, stderr);
+
+    expect(message.length).to.be.lessThan(450);
+    expect(message).to.match(/…$/);
+  });
+});

--- a/server/test/services/rtsp-camera/rtspCamera.test.js
+++ b/server/test/services/rtsp-camera/rtspCamera.test.js
@@ -205,8 +205,89 @@ describe('RtspCameraManager commands', () => {
       childProcessMock,
       'de051f90-f34a-4fd5-be2e-e502339ec9bc',
     );
-    rtspCameraManagerBroken.getImage = fake.rejects('NOT_WORKING');
+    rtspCameraManagerBroken.getImage = fake.rejects(new Error('ffmpeg failed (code=1): Connection refused'));
     await rtspCameraManagerBroken.poll(device);
+  });
+  it('should return a concise ffmpeg error on getImage failure', async () => {
+    const childProcessWithStderr = {
+      execFile: (prog, args, options, cb) => {
+        const error = Object.assign(new Error('Command failed: ffmpeg -i broken'), {
+          signal: 'SIGABRT',
+          code: null,
+        });
+        cb(
+          error,
+          '',
+          `dyld[1]: Library not loaded: /opt/homebrew/opt/x265/lib/libx265.215.dylib
+  Referenced from: /opt/homebrew/Cellar/ffmpeg/8.1/bin/ffmpeg
+  Reason: tried: '/opt/homebrew/opt/x265/lib/libx265.215.dylib' (no such file)`,
+        );
+      },
+    };
+    const manager = new RtspCameraManager(gladys, childProcessWithStderr, 'de051f90-f34a-4fd5-be2e-e502339ec9bc');
+    try {
+      await manager.getImage(brokenDevice);
+      assertChai.fail('should have thrown');
+    } catch (e) {
+      expect(e.message).to.equal(
+        'ffmpeg failed (signal=SIGABRT): dyld[1]: Library not loaded: /opt/homebrew/opt/x265/lib/libx265.215.dylib — Referenced from: /opt/homebrew/Cellar/ffmpeg/8.1/bin/ffmpeg',
+      );
+      expect(e.message).to.not.include('tried:');
+      expect(e.message).to.not.include('Command failed');
+    }
+  });
+  it('should log ffmpeg stderr using device id when selector is missing', async () => {
+    const deviceWithoutSelector = {
+      id: 'a6fb4cb8-ccc2-4234-a752-b25d1eb5ab6b',
+      params: [
+        {
+          name: 'CAMERA_URL',
+          value: 'broken',
+        },
+      ],
+    };
+    const childProcessWithStderr = {
+      execFile: (prog, args, options, cb) => {
+        cb(new Error('Command failed'), '', 'Connection timed out');
+      },
+    };
+    const manager = new RtspCameraManager(gladys, childProcessWithStderr, 'de051f90-f34a-4fd5-be2e-e502339ec9bc');
+    const promise = manager.getImage(deviceWithoutSelector);
+    return assertChai.isRejected(promise, 'ffmpeg failed: Connection timed out');
+  });
+  it('should log a concise warn when poll fails', async () => {
+    const proxyquire = require('proxyquire').noCallThru();
+    const warn = fake();
+    const { poll } = proxyquire('../../../services/rtsp-camera/lib/poll', {
+      '../../../utils/logger': {
+        warn,
+        debug: fake(),
+      },
+    });
+    const handler = {
+      getImage: fake.rejects(new Error('ffmpeg failed (signal=SIGABRT): Library not loaded')),
+      gladys,
+    };
+    await poll.call(handler, device);
+    assert.calledOnce(warn);
+    assert.calledWith(warn, 'Unable to poll camera "my-camera": ffmpeg failed (signal=SIGABRT): Library not loaded');
+  });
+  it('should log non-Error rejection reasons when poll fails', async () => {
+    const proxyquire = require('proxyquire').noCallThru();
+    const warn = fake();
+    const { poll } = proxyquire('../../../services/rtsp-camera/lib/poll', {
+      '../../../utils/logger': {
+        warn,
+        debug: fake(),
+      },
+    });
+    const handler = {
+      getImage: fake.rejects('NOT_WORKING'),
+      gladys,
+    };
+    await poll.call(handler, device);
+    assert.calledOnce(warn);
+    assert.calledWith(warn, 'Unable to poll camera "my-camera": NOT_WORKING');
   });
   it('should stop service', async () => {
     const rtspCameraService = RtspCameraService(gladys, 'de051f90-f34a-4fd5-be2e-e502339ec9bc');

--- a/server/test/services/rtsp-camera/rtspCamera.test.js
+++ b/server/test/services/rtsp-camera/rtspCamera.test.js
@@ -2,6 +2,7 @@ const { expect } = require('chai');
 const fse = require('fs-extra');
 const assertChai = require('chai').assert;
 const { fake, assert } = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
 const RtspCameraManager = require('../../../services/rtsp-camera/lib');
 const RtspCameraService = require('../../../services/rtsp-camera');
 
@@ -256,7 +257,6 @@ describe('RtspCameraManager commands', () => {
     return assertChai.isRejected(promise, 'ffmpeg failed: Connection timed out');
   });
   it('should log a concise warn when poll fails', async () => {
-    const proxyquire = require('proxyquire').noCallThru();
     const warn = fake();
     const { poll } = proxyquire('../../../services/rtsp-camera/lib/poll', {
       '../../../utils/logger': {
@@ -273,7 +273,6 @@ describe('RtspCameraManager commands', () => {
     assert.calledWith(warn, 'Unable to poll camera "my-camera": ffmpeg failed (signal=SIGABRT): Library not loaded');
   });
   it('should log non-Error rejection reasons when poll fails', async () => {
-    const proxyquire = require('proxyquire').noCallThru();
     const warn = fake();
     const { poll } = proxyquire('../../../services/rtsp-camera/lib/poll', {
       '../../../utils/logger': {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When an RTSP camera poll fails (e.g. broken ffmpeg / missing dylib), Gladys was dumping the full `child_process` Error object at debug/warn — including the full command, multi-line dyld/ffmpeg stderr, Node stack, and extra properties (`code`, `signal`, `cmd`). That made logs very noisy on every poll interval.

This change keeps the failure reason but formats it as a single concise warn line:

```text
Unable to poll camera "my-camera": ffmpeg failed (signal=SIGABRT): dyld[23876]: Library not loaded: /opt/homebrew/opt/x265/lib/libx265.215.dylib — Referenced from: /opt/homebrew/Cellar/ffmpeg/8.1/bin/ffmpeg
```

- New `formatFfmpegError` helper extracts the useful stderr lines (skips ffmpeg banners), includes exit code/signal, and truncates very long output.
- `getImage` rejects with that clean message and logs full stderr only at debug.
- `poll` logs one warn with the camera selector and the reason (no Error object dump).

## Test plan

- [x] Unit tests for `formatFfmpegError` (dyld stderr, exit code, banners, truncation, fallbacks)
- [x] RTSP camera tests updated for concise getImage errors and poll warn logging
- [x] `npm test -- --grep "RtspCameraManager|formatFfmpegError"` (25 passing)
- [x] prettier + eslint on touched server files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-377e3df1-796c-4066-8d97-9b4b1a9e0730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-377e3df1-796c-4066-8d97-9b4b1a9e0730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RTSP camera error messages with concise, human-readable details.
  * Added clearer camera-specific warnings when polling fails.
  * Preserved relevant diagnostic information, including failure codes and signals.
  * Improved cleanup and logging when image capture fails, helping prevent polling disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->