### PR TITLE
Free Mobile: add multi-user support so each user can send/receive SMS

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -2580,7 +2580,7 @@
       },
       "smsSend": {
         "userLabel": "Empfänger der SMS",
-        "allUsersOption": "Alle Benutzer",
+        "allUsersOption": "Alle Free-Mobile-Benutzer",
         "textLabel": "Nachricht",
         "explanationText": "Um eine Variable in den Text einzufügen, gib \"{{\" ein. Um einen Variablenwert festzulegen, musst du zuerst das Feld \"Gerätewert abrufen\" verwenden.",
         "messagePlaceholder": "Meine Message"

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -616,6 +616,7 @@
       "description": "SMS von Gladys über Free Mobile senden.",
       "documentation": "Free Mobile Dokumentation",
       "introduction": "Dieses Plugin ermöglicht es Ihnen, SMS an Ihr Free-Handy über den Benachrichtigungsdienst von Free zu senden. Geben Sie Ihre Kundennummer und den Identifizierungsschlüssel unten ein, den Sie auf der <a href=\"https://mobile.free.fr\"> FreeMobile</a>-Website finden.",
+      "userConfigInfo": "Diese Konfiguration ist persönlich: Jeder Benutzer kann seine eigenen Free-Mobile-Zugangsdaten eingeben, um SMS zu empfangen. In Ihren Szenen können Sie dann auswählen, an welchen Benutzer eine SMS gesendet werden soll.",
       "username": "Free Mobile Kundennummer",
       "key": "Identifizierungsschlüssel für den Dienst",
       "configurationError": "Wir konnten diese Konfiguration nicht speichern.",
@@ -2578,6 +2579,8 @@
         "explanationText": "Um eine Variable einzufügen, geben Sie '{{' ein. Achten Sie darauf, dass Sie zuvor eine Variable in einer Aktion 'Letzten Zustand abrufen' definiert haben, die vor diesem Nachrichtenblock platziert wurde."
       },
       "smsSend": {
+        "userLabel": "Empfänger der SMS",
+        "allUsersOption": "Alle Benutzer",
         "textLabel": "Nachricht",
         "explanationText": "Um eine Variable in den Text einzufügen, gib \"{{\" ein. Um einen Variablenwert festzulegen, musst du zuerst das Feld \"Gerätewert abrufen\" verwenden.",
         "messagePlaceholder": "Meine Message"

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -616,6 +616,7 @@
       "description": "Send SMS from Gladys using Free Mobile.",
       "documentation": "Free Mobile Documentation",
       "introduction": "This plugin allows you to send SMS to your Free cell phone via the notification service provided by Free. Enter your customer ID and the identification key below, which you can find on the <a href=\"https://mobile.free.fr\"> FreeMobile</a> website.",
+      "userConfigInfo": "This configuration is personal: each user can enter their own Free Mobile credentials to receive SMS. In your scenes, you can then choose which user to send an SMS to.",
       "username": "Free Mobile Customer ID",
       "key": "Identification key for the service",
       "configurationError": "We could not save this configuration.",
@@ -2578,6 +2579,8 @@
         "explanationText": "To insert a variable, type '{{'. Be careful, you must have defined a variable beforehand in a 'Retrieve the last state' action placed before this message block."
       },
       "smsSend": {
+        "userLabel": "Recipient of the SMS",
+        "allUsersOption": "All users",
         "textLabel": "Message",
         "explanationText": "To inject a variable in the text, press '{{'. To set a variable value, you need to use the 'Get device value' box before this one.",
         "messagePlaceholder": "My message"

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -2580,7 +2580,7 @@
       },
       "smsSend": {
         "userLabel": "Recipient of the SMS",
-        "allUsersOption": "All users",
+        "allUsersOption": "All Free Mobile users",
         "textLabel": "Message",
         "explanationText": "To inject a variable in the text, press '{{'. To set a variable value, you need to use the 'Get device value' box before this one.",
         "messagePlaceholder": "My message"

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -854,6 +854,7 @@
       "description": "Envoyer des sms depuis Gladys grâce à Free Mobile.",
       "documentation": "Documentation Free Mobile",
       "introduction": "Ce plugin vous permet d'envoyer des sms à votre portable Free via le service de notification proposé par Free. Entrez votre identifiant client et la clé d'identification ci-dessous que vous retrouverez sur le site <a href=\"https://mobile.free.fr\"> FreeMobile</a>.",
+      "userConfigInfo": "Cette configuration est personnelle : chaque utilisateur peut renseigner ses propres identifiants Free Mobile pour recevoir des SMS. Dans vos scènes, vous pourrez alors choisir à quel utilisateur envoyer un SMS.",
       "username": "Identifiant client Free Mobile",
       "key": "Clé d'identification au service",
       "configurationError": "Nous n'avons pas pu sauvegarder cette configuration.",
@@ -2578,6 +2579,8 @@
         "explanationText": "Pour injecter une variable, tapez '{{'. Attention, vous devez avoir défini une variable auparavant dans une action 'Récupérer le dernier état' placé avant ce bloc message."
       },
       "smsSend": {
+        "userLabel": "Destinataire du SMS",
+        "allUsersOption": "Tous les utilisateurs",
         "textLabel": "Message",
         "explanationText": "Pour injecter une variable, tapez '{{'. Attention, vous devez avoir défini une variable auparavant dans une action 'Récupérer le dernier état' placé avant ce bloc message.",
         "messagePlaceholder": "Mon message"

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -2580,7 +2580,7 @@
       },
       "smsSend": {
         "userLabel": "Destinataire du SMS",
-        "allUsersOption": "Tous les utilisateurs",
+        "allUsersOption": "Tous les utilisateurs Free Mobile",
         "textLabel": "Message",
         "explanationText": "Pour injecter une variable, tapez '{{'. Attention, vous devez avoir défini une variable auparavant dans une action 'Récupérer le dernier état' placé avant ce bloc message.",
         "messagePlaceholder": "Mon message"

--- a/front/src/routes/integration/all/free-mobile/FreeMobile.jsx
+++ b/front/src/routes/integration/all/free-mobile/FreeMobile.jsx
@@ -48,6 +48,9 @@ const FreeMobilePage = ({ children, ...props }) => (
                       <p>
                         <MarkupText id="integration.free-mobile.introduction" />
                       </p>
+                      <p class="alert alert-info">
+                        <Text id="integration.free-mobile.userConfigInfo" />
+                      </p>
                       {props.freeMobileSaveSettingsStatus === RequestStatus.Error && (
                         <div class="alert alert-danger">
                           <Text id="integration.free-mobile.configurationError" />

--- a/front/src/routes/integration/all/free-mobile/actions.js
+++ b/front/src/routes/integration/all/free-mobile/actions.js
@@ -18,14 +18,33 @@ const actions = store => ({
       freeMobileGetSettingsStatus: RequestStatus.Getting
     });
     try {
-      const username = await state.httpClient.get('/api/v1/service/free-mobile/variable/FREE_MOBILE_USERNAME');
+      let username = '';
+      let accessToken = '';
+      try {
+        const usernameResponse = await state.httpClient.get(
+          '/api/v1/service/free-mobile/variable/FREE_MOBILE_USERNAME',
+          {
+            userRelated: true
+          }
+        );
+        username = usernameResponse.value || '';
+      } catch (e) {
+        // variable not set yet
+      }
+      try {
+        const accessTokenResponse = await state.httpClient.get(
+          '/api/v1/service/free-mobile/variable/FREE_MOBILE_ACCESS_TOKEN',
+          {
+            userRelated: true
+          }
+        );
+        accessToken = accessTokenResponse.value || '';
+      } catch (e) {
+        // variable not set yet
+      }
       store.setState({
-        freeMobileUsername: username.value
-      });
-
-      const accessToken = await state.httpClient.get('/api/v1/service/free-mobile/variable/FREE_MOBILE_ACCESS_TOKEN');
-      store.setState({
-        freeMobileAccessToken: accessToken.value,
+        freeMobileUsername: username,
+        freeMobileAccessToken: accessToken,
         freeMobileGetSettingsStatus: RequestStatus.Success
       });
     } catch (e) {
@@ -41,19 +60,21 @@ const actions = store => ({
       freeMobileSaveSettingsStatus: RequestStatus.Getting
     });
     try {
+      const username = (state.freeMobileUsername || '').trim();
+      const accessToken = (state.freeMobileAccessToken || '').trim();
       store.setState({
-        freeMobileUsername: state.freeMobileUsername.trim(),
-        freeMobileAccessToken: state.freeMobileAccessToken.trim()
+        freeMobileUsername: username,
+        freeMobileAccessToken: accessToken
       });
       await state.httpClient.post('/api/v1/service/free-mobile/variable/FREE_MOBILE_USERNAME', {
-        value: state.freeMobileUsername.trim()
+        value: username,
+        userRelated: true
       });
       await state.httpClient.post('/api/v1/service/free-mobile/variable/FREE_MOBILE_ACCESS_TOKEN', {
-        value: state.freeMobileAccessToken.trim()
+        value: accessToken,
+        userRelated: true
       });
 
-      // start service
-      await state.httpClient.post('/api/v1/service/free-mobile/start');
       store.setState({
         freeMobileSaveSettingsStatus: RequestStatus.Success
       });

--- a/front/src/routes/integration/all/free-mobile/actions.js
+++ b/front/src/routes/integration/all/free-mobile/actions.js
@@ -29,6 +29,9 @@ const actions = store => ({
         );
         username = usernameResponse.value || '';
       } catch (e) {
+        if (!e.response || e.response.status !== 404) {
+          throw e;
+        }
         // variable not set yet
       }
       try {
@@ -40,6 +43,9 @@ const actions = store => ({
         );
         accessToken = accessTokenResponse.value || '';
       } catch (e) {
+        if (!e.response || e.response.status !== 404) {
+          throw e;
+        }
         // variable not set yet
       }
       store.setState({

--- a/front/src/routes/scene/edit-scene/actions/SendSms.jsx
+++ b/front/src/routes/scene/edit-scene/actions/SendSms.jsx
@@ -26,11 +26,15 @@ class SendSms extends Component {
           value: user.selector
         });
       });
-      let selectedOption = userOptions[0];
+      let selectedOption;
       if (this.props.action.user) {
-        selectedOption = userOptions.find(option => option.value === this.props.action.user) || userOptions[0];
-      } else {
-        this.props.updateActionProperty(this.props.path, 'user', ALL_USERS_VALUE);
+        selectedOption = userOptions.find(option => option.value === this.props.action.user);
+      }
+      if (!selectedOption) {
+        // No user selected yet, or the selected user no longer exists: fall back to "all users"
+        // and persist the fallback so an invalid user id is never kept in the scene
+        selectedOption = userOptions[0];
+        this.props.updateActionProperty(this.props.path, 'user', selectedOption.value);
       }
       this.setState({ userOptions, selectedOption });
     } catch (e) {
@@ -48,11 +52,12 @@ class SendSms extends Component {
     }
   };
   refreshSelectedOptions = nextProps => {
-    let selectedOption = '';
-    if (nextProps.action.user && this.state.userOptions) {
-      const userOption = this.state.userOptions.find(option => option.value === nextProps.action.user);
-      if (userOption) {
-        selectedOption = userOption;
+    let selectedOption = null;
+    if (this.state.userOptions && this.state.userOptions.length > 0) {
+      selectedOption = this.state.userOptions.find(option => option.value === nextProps.action.user);
+      if (!selectedOption) {
+        // Unknown user: fall back to "all users" instead of a blank select
+        [selectedOption] = this.state.userOptions;
       }
     }
     this.setState({ selectedOption });

--- a/front/src/routes/scene/edit-scene/actions/SendSms.jsx
+++ b/front/src/routes/scene/edit-scene/actions/SendSms.jsx
@@ -1,17 +1,95 @@
+import Select from 'react-select';
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Localizer, Text } from 'preact-i18n';
 
+import get from 'get-value';
+
 import TextWithVariablesInjected from '../../../../components/scene/TextWithVariablesInjected';
+import withIntlAsProp from '../../../../utils/withIntlAsProp';
+
+const ALL_USERS_VALUE = 'all';
 
 class SendSms extends Component {
+  getOptions = async () => {
+    try {
+      const users = await this.props.httpClient.get('/api/v1/user');
+      const userOptions = [
+        {
+          label: get(this.props.intl.dictionary, 'editScene.actionsCard.smsSend.allUsersOption'),
+          value: ALL_USERS_VALUE
+        }
+      ];
+      users.forEach(user => {
+        userOptions.push({
+          label: user.firstname,
+          value: user.selector
+        });
+      });
+      let selectedOption = userOptions[0];
+      if (this.props.action.user) {
+        selectedOption = userOptions.find(option => option.value === this.props.action.user) || userOptions[0];
+      } else {
+        this.props.updateActionProperty(this.props.path, 'user', ALL_USERS_VALUE);
+      }
+      this.setState({ userOptions, selectedOption });
+    } catch (e) {
+      console.error(e);
+    }
+  };
   updateText = text => {
     this.props.updateActionProperty(this.props.path, 'text', text);
   };
-
-  render(props, {}) {
+  handleChange = selectedOption => {
+    if (selectedOption && selectedOption.value) {
+      this.props.updateActionProperty(this.props.path, 'user', selectedOption.value);
+    } else {
+      this.props.updateActionProperty(this.props.path, 'user', null);
+    }
+  };
+  refreshSelectedOptions = nextProps => {
+    let selectedOption = '';
+    if (nextProps.action.user && this.state.userOptions) {
+      const userOption = this.state.userOptions.find(option => option.value === nextProps.action.user);
+      if (userOption) {
+        selectedOption = userOption;
+      }
+    }
+    this.setState({ selectedOption });
+  };
+  constructor(props) {
+    super(props);
+    this.props = props;
+    this.state = {
+      selectedOption: '',
+      userOptions: []
+    };
+  }
+  componentDidMount() {
+    this.getOptions();
+  }
+  componentWillReceiveProps(nextProps) {
+    this.refreshSelectedOptions(nextProps);
+  }
+  render(props, { selectedOption, userOptions }) {
     return (
       <div>
+        <div class="form-group">
+          <label class="form-label">
+            <Text id="editScene.actionsCard.smsSend.userLabel" />
+          </label>
+          <Select
+            styles={{
+              // Fixes the overlapping problem of the component
+              menu: provided => ({ ...provided, zIndex: 2 })
+            }}
+            options={userOptions}
+            value={selectedOption}
+            onChange={this.handleChange}
+            className="react-select-container"
+            classNamePrefix="react-select"
+          />
+        </div>
         <div class="form-group">
           <label class="form-label">
             <Text id="editScene.actionsCard.smsSend.textLabel" />{' '}
@@ -39,4 +117,4 @@ class SendSms extends Component {
   }
 }
 
-export default connect('httpClient', {})(SendSms);
+export default withIntlAsProp(connect('httpClient', {})(SendSms));

--- a/server/lib/scene/scene.actions.js
+++ b/server/lib/scene/scene.actions.js
@@ -660,7 +660,12 @@ const actionsFunc = {
     );
     await Promise.each(configuredVariables, async (variable) => {
       if (variable.user_id) {
-        await freeMobileService.message.send(variable.user_id, message);
+        try {
+          await freeMobileService.message.send(variable.user_id, message);
+        } catch (e) {
+          // A failure for one recipient should not prevent sending to the others
+          logger.error(`Failed to send SMS to user ${variable.user_id}: ${e.message}`);
+        }
       }
     });
   },

--- a/server/lib/scene/scene.actions.js
+++ b/server/lib/scene/scene.actions.js
@@ -637,10 +637,32 @@ const actionsFunc = {
   [ACTIONS.SMS.SEND]: async (self, action, scope) => {
     const freeMobileService = self.service.getService('free-mobile');
 
-    if (freeMobileService) {
-      const textWithVariables = Handlebars.compile(action.text, { noEscape: true })(scope);
-      freeMobileService.sms.send(textWithVariables);
+    if (!freeMobileService) {
+      return;
     }
+
+    const textWithVariables = Handlebars.compile(action.text, { noEscape: true })(scope);
+    const message = { text: textWithVariables };
+
+    // If a specific user is targeted, only send the SMS to this user
+    if (action.user && action.user !== 'all') {
+      const user = self.stateManager.get('user', action.user);
+      if (user) {
+        await freeMobileService.message.send(user.id, message);
+      }
+      return;
+    }
+
+    // Otherwise, send the SMS to every user who configured Free Mobile
+    const configuredVariables = await self.variable.getVariables(
+      'FREE_MOBILE_USERNAME',
+      freeMobileService.message.serviceId,
+    );
+    await Promise.each(configuredVariables, async (variable) => {
+      if (variable.user_id) {
+        await freeMobileService.message.send(variable.user_id, message);
+      }
+    });
   },
   [ACTIONS.CONDITION.IF_THEN_ELSE]: async (self, action, scope, path) => {
     const { if: ifActions, then: thenActions, else: elseActions } = action;

--- a/server/services/free-mobile/index.js
+++ b/server/services/free-mobile/index.js
@@ -27,19 +27,27 @@ module.exports = function FreeMobileService(gladys, serviceId) {
     }
     const [admin] = admins;
 
-    logger.info(`Free Mobile: migrating global configuration to admin user ${admin.selector}`);
-
-    // Only migrate the values if the admin doesn't already have a per-user configuration
     const adminUsername = await gladys.variable.getValue('FREE_MOBILE_USERNAME', serviceId, admin.id);
-    if (!adminUsername && globalUsername) {
-      await gladys.variable.setValue('FREE_MOBILE_USERNAME', globalUsername, serviceId, admin.id);
-    }
     const adminAccessToken = await gladys.variable.getValue('FREE_MOBILE_ACCESS_TOKEN', serviceId, admin.id);
-    if (!adminAccessToken && globalAccessToken) {
+
+    if (!adminUsername && !adminAccessToken) {
+      // The admin has no per-user configuration yet: copy the legacy pair only if it is complete,
+      // to avoid creating a mismatched username/token pair
+      if (!globalUsername || !globalAccessToken) {
+        logger.warn('Free Mobile: legacy global configuration is incomplete, keeping it as-is');
+        return;
+      }
+      logger.info(`Free Mobile: migrating global configuration to admin user ${admin.selector}`);
+      await gladys.variable.setValue('FREE_MOBILE_USERNAME', globalUsername, serviceId, admin.id);
       await gladys.variable.setValue('FREE_MOBILE_ACCESS_TOKEN', globalAccessToken, serviceId, admin.id);
+    } else if (!adminUsername || !adminAccessToken) {
+      // The admin has a partial per-user configuration: don't mix it with legacy values,
+      // and keep the legacy variables so they remain recoverable
+      logger.warn('Free Mobile: admin user has a partial configuration, keeping the legacy global configuration');
+      return;
     }
 
-    // Remove the legacy global variables
+    // The admin now has a complete pair: remove the legacy global variables
     await gladys.variable.destroy('FREE_MOBILE_USERNAME', serviceId);
     await gladys.variable.destroy('FREE_MOBILE_ACCESS_TOKEN', serviceId);
   }
@@ -73,8 +81,14 @@ module.exports = function FreeMobileService(gladys, serviceId) {
    * const used = await gladys.services.free-mobile.isUsed();
    */
   async function isUsed() {
-    const usernames = await gladys.variable.getVariables('FREE_MOBILE_USERNAME', serviceId);
-    return usernames.some((variable) => variable.user_id && variable.value);
+    const [usernames, accessTokens] = await Promise.all([
+      gladys.variable.getVariables('FREE_MOBILE_USERNAME', serviceId),
+      gladys.variable.getVariables('FREE_MOBILE_ACCESS_TOKEN', serviceId),
+    ]);
+    const usersWithToken = new Set(
+      accessTokens.filter((variable) => variable.user_id && variable.value).map((variable) => variable.user_id),
+    );
+    return usernames.some((variable) => variable.user_id && variable.value && usersWithToken.has(variable.user_id));
   }
 
   return Object.freeze({

--- a/server/services/free-mobile/index.js
+++ b/server/services/free-mobile/index.js
@@ -1,10 +1,48 @@
 const logger = require('../../utils/logger');
-const { ServiceNotConfiguredError } = require('../../utils/coreErrors');
+const MessageHandler = require('./lib');
 
 module.exports = function FreeMobileService(gladys, serviceId) {
   const axios = require('axios');
-  let username;
-  let accessToken;
+  const messageHandler = new MessageHandler(gladys, axios, serviceId);
+
+  /**
+   * @description Migrate the legacy global Free Mobile configuration (stored without
+   * a user) to a per-user configuration attached to the admin user.
+   * @example
+   * await migrateGlobalConfiguration();
+   */
+  async function migrateGlobalConfiguration() {
+    const globalUsername = await gladys.variable.getValue('FREE_MOBILE_USERNAME', serviceId);
+    const globalAccessToken = await gladys.variable.getValue('FREE_MOBILE_ACCESS_TOKEN', serviceId);
+
+    // Nothing to migrate
+    if (!globalUsername && !globalAccessToken) {
+      return;
+    }
+
+    const admins = await gladys.user.getByRole('admin');
+    if (admins.length === 0) {
+      logger.warn('Free Mobile: no admin user found, cannot migrate global configuration');
+      return;
+    }
+    const [admin] = admins;
+
+    logger.info(`Free Mobile: migrating global configuration to admin user ${admin.selector}`);
+
+    // Only migrate the values if the admin doesn't already have a per-user configuration
+    const adminUsername = await gladys.variable.getValue('FREE_MOBILE_USERNAME', serviceId, admin.id);
+    if (!adminUsername && globalUsername) {
+      await gladys.variable.setValue('FREE_MOBILE_USERNAME', globalUsername, serviceId, admin.id);
+    }
+    const adminAccessToken = await gladys.variable.getValue('FREE_MOBILE_ACCESS_TOKEN', serviceId, admin.id);
+    if (!adminAccessToken && globalAccessToken) {
+      await gladys.variable.setValue('FREE_MOBILE_ACCESS_TOKEN', globalAccessToken, serviceId, admin.id);
+    }
+
+    // Remove the legacy global variables
+    await gladys.variable.destroy('FREE_MOBILE_USERNAME', serviceId);
+    await gladys.variable.destroy('FREE_MOBILE_ACCESS_TOKEN', serviceId);
+  }
 
   /**
    * @public
@@ -14,39 +52,7 @@ module.exports = function FreeMobileService(gladys, serviceId) {
    */
   async function start() {
     logger.info('Starting Free Mobile service');
-    username = await gladys.variable.getValue('FREE_MOBILE_USERNAME', serviceId);
-    accessToken = await gladys.variable.getValue('FREE_MOBILE_ACCESS_TOKEN', serviceId);
-
-    if (!username || username.length === 0) {
-      throw new ServiceNotConfiguredError('No FreeMobile username found. Not starting Free Mobile service');
-    }
-
-    if (!accessToken || accessToken.length === 0) {
-      throw new ServiceNotConfiguredError('No FreeMobile access_token found. Not starting Free Mobile service');
-    }
-  }
-
-  /**
-   * @description Send a sms.
-   * @param {string} message - The message to send.
-   * @example
-   * gladys.services.free-mobile.sms.send('hello')
-   */
-  async function send(message) {
-    const url = 'https://smsapi.free-mobile.fr/sendmsg';
-
-    const params = {
-      user: username,
-      pass: accessToken,
-      msg: message,
-    };
-
-    try {
-      const response = await axios.get(url, { params });
-      logger.debug('SMS successfully sent:', response.data);
-    } catch (e) {
-      logger.error('Error sending SMS:', e);
-    }
+    await migrateGlobalConfiguration();
   }
 
   /**
@@ -59,11 +65,22 @@ module.exports = function FreeMobileService(gladys, serviceId) {
     logger.info('Stopping Free Mobile service');
   }
 
+  /**
+   * @public
+   * @description This function returns if the Free Mobile service is used.
+   * @returns {Promise<boolean>} Returns true if the Free Mobile service is used.
+   * @example
+   * const used = await gladys.services.free-mobile.isUsed();
+   */
+  async function isUsed() {
+    const usernames = await gladys.variable.getVariables('FREE_MOBILE_USERNAME', serviceId);
+    return usernames.some((variable) => variable.user_id && variable.value);
+  }
+
   return Object.freeze({
     start,
     stop,
-    sms: {
-      send,
-    },
+    message: messageHandler,
+    isUsed,
   });
 };

--- a/server/services/free-mobile/lib/index.js
+++ b/server/services/free-mobile/lib/index.js
@@ -1,0 +1,19 @@
+const { send } = require('./message.send');
+
+/**
+ * @description Add ability to send Free Mobile SMS.
+ * @param {object} gladys - Gladys instance.
+ * @param {object} axios - Axios instance.
+ * @param {string} serviceId - UUID of the service in DB.
+ * @example
+ * const messageHandler = new MessageHandler(gladys, axios, serviceId);
+ */
+const MessageHandler = function MessageHandler(gladys, axios, serviceId) {
+  this.gladys = gladys;
+  this.axios = axios;
+  this.serviceId = serviceId;
+};
+
+MessageHandler.prototype.send = send;
+
+module.exports = MessageHandler;

--- a/server/services/free-mobile/lib/message.send.js
+++ b/server/services/free-mobile/lib/message.send.js
@@ -1,6 +1,7 @@
 const logger = require('../../../utils/logger');
 
 const FREE_MOBILE_SEND_URL = 'https://smsapi.free-mobile.fr/sendmsg';
+const FREE_MOBILE_TIMEOUT = 10 * 1000;
 
 /**
  * @description Send an SMS through Free Mobile for a given user.
@@ -30,10 +31,12 @@ async function send(userId, message) {
   };
 
   try {
-    const response = await this.axios.get(FREE_MOBILE_SEND_URL, { params });
+    const response = await this.axios.get(FREE_MOBILE_SEND_URL, { params, timeout: FREE_MOBILE_TIMEOUT });
     logger.debug('SMS successfully sent:', response.data);
   } catch (e) {
-    logger.error('Error sending SMS:', e);
+    // Don't log the raw error: the Axios config contains the Free Mobile access token
+    const status = e.response ? e.response.status : null;
+    logger.error(`Error sending SMS: ${e.message}${status ? ` (HTTP ${status})` : ''}`);
     throw e;
   }
 }

--- a/server/services/free-mobile/lib/message.send.js
+++ b/server/services/free-mobile/lib/message.send.js
@@ -1,0 +1,43 @@
+const logger = require('../../../utils/logger');
+
+const FREE_MOBILE_SEND_URL = 'https://smsapi.free-mobile.fr/sendmsg';
+
+/**
+ * @description Send an SMS through Free Mobile for a given user.
+ * @param {string} userId - The ID of the user to send the SMS to.
+ * @param {object} message - Message object to send.
+ * @example
+ * send('36816181-8f2a-4e36-8418-cf67b6164fbc', {
+ *   text: 'Hello from Gladys!'
+ * });
+ */
+async function send(userId, message) {
+  logger.debug(`Sending Free Mobile SMS for user ${userId}`);
+
+  // Get user-specific configuration
+  const username = await this.gladys.variable.getValue('FREE_MOBILE_USERNAME', this.serviceId, userId);
+  const accessToken = await this.gladys.variable.getValue('FREE_MOBILE_ACCESS_TOKEN', this.serviceId, userId);
+
+  if (!username || !accessToken) {
+    logger.debug('Free Mobile configuration not found for this user');
+    return;
+  }
+
+  const params = {
+    user: username,
+    pass: accessToken,
+    msg: message.text,
+  };
+
+  try {
+    const response = await this.axios.get(FREE_MOBILE_SEND_URL, { params });
+    logger.debug('SMS successfully sent:', response.data);
+  } catch (e) {
+    logger.error('Error sending SMS:', e);
+    throw e;
+  }
+}
+
+module.exports = {
+  send,
+};

--- a/server/test/lib/scene/actions/scene.action.sendSms.test.js
+++ b/server/test/lib/scene/actions/scene.action.sendSms.test.js
@@ -8,18 +8,25 @@ const actionsFunc = require('../../../../lib/scene/scene.actions');
 const StateManager = require('../../../../lib/state');
 
 const event = new EventEmitter();
+const serviceId = 'f87b7af2-ca8e-44fc-b754-444354b42fee';
 
 describe('scene.send-sms', () => {
   const { executeActions } = executeActionsFactory(actionsFunc);
-  it('should send message with value injected from device get-value', async () => {
+
+  it('should send SMS to a specific user with value injected from device get-value', async () => {
     const stateManager = new StateManager(event);
     stateManager.setState('deviceFeature', 'my-device-feature', {
       category: 'light',
       type: 'binary',
       last_value: 15,
     });
+    stateManager.setState('user', 'john', {
+      id: 'user-john',
+      selector: 'john',
+    });
     const freeMobileService = {
-      sms: {
+      message: {
+        serviceId,
         send: fake.resolves(null),
       },
     };
@@ -39,50 +46,72 @@ describe('scene.send-sms', () => {
         [
           {
             type: ACTIONS.SMS.SEND,
+            user: 'john',
             text: 'Temperature in the living room is {{0.0.last_value}} °C.',
           },
         ],
       ],
       scope,
     );
-    assert.calledWith(freeMobileService.sms.send, 'Temperature in the living room is 15 °C.');
+    assert.calledWith(freeMobileService.message.send, 'user-john', {
+      text: 'Temperature in the living room is 15 °C.',
+    });
   });
 
-  it('should send message with value injected from http-request', async () => {
+  it('should send SMS to all configured users when user is "all"', async () => {
     const stateManager = new StateManager(event);
-    const http = {
-      request: fake.resolves({ result: [15], error: null }),
-    };
     const freeMobileService = {
-      sms: {
+      message: {
+        serviceId,
         send: fake.resolves(null),
       },
     };
     const service = {
       getService: fake.returns(freeMobileService),
     };
+    const variable = {
+      getVariables: fake.resolves([
+        { user_id: 'user-1', value: 'user1' },
+        { user_id: 'user-2', value: 'user2' },
+      ]),
+    };
     const scope = {};
     await executeActions(
-      { stateManager, event, service, http },
+      { stateManager, event, service, variable },
       [
         [
           {
-            type: ACTIONS.HTTP.REQUEST,
-            method: 'post',
-            url: 'http://test.test',
-            body: '{"toto":"toto"}',
-            headers: [],
-          },
-        ],
-        [
-          {
             type: ACTIONS.SMS.SEND,
-            text: 'Temperature in the living room is {{0.0.result.[0]}} °C.',
+            user: 'all',
+            text: 'Alarm triggered',
           },
         ],
       ],
       scope,
     );
-    assert.calledWith(freeMobileService.sms.send, 'Temperature in the living room is 15 °C.');
+    assert.calledWith(variable.getVariables, 'FREE_MOBILE_USERNAME', serviceId);
+    assert.calledWith(freeMobileService.message.send, 'user-1', { text: 'Alarm triggered' });
+    assert.calledWith(freeMobileService.message.send, 'user-2', { text: 'Alarm triggered' });
+  });
+
+  it('should do nothing if free-mobile service is not available', async () => {
+    const stateManager = new StateManager(event);
+    const service = {
+      getService: fake.returns(null),
+    };
+    const scope = {};
+    await executeActions(
+      { stateManager, event, service },
+      [
+        [
+          {
+            type: ACTIONS.SMS.SEND,
+            user: 'all',
+            text: 'Alarm triggered',
+          },
+        ],
+      ],
+      scope,
+    );
   });
 });

--- a/server/test/lib/scene/actions/scene.action.sendSms.test.js
+++ b/server/test/lib/scene/actions/scene.action.sendSms.test.js
@@ -1,3 +1,4 @@
+const sinon = require('sinon');
 const { fake, assert } = require('sinon');
 const EventEmitter = require('events');
 
@@ -92,6 +93,106 @@ describe('scene.send-sms', () => {
     assert.calledWith(variable.getVariables, 'FREE_MOBILE_USERNAME', serviceId);
     assert.calledWith(freeMobileService.message.send, 'user-1', { text: 'Alarm triggered' });
     assert.calledWith(freeMobileService.message.send, 'user-2', { text: 'Alarm triggered' });
+  });
+
+  it('should not send SMS if the specific user is unknown', async () => {
+    const stateManager = new StateManager(event);
+    const freeMobileService = {
+      message: {
+        serviceId,
+        send: fake.resolves(null),
+      },
+    };
+    const service = {
+      getService: fake.returns(freeMobileService),
+    };
+    const scope = {};
+    await executeActions(
+      { stateManager, event, service },
+      [
+        [
+          {
+            type: ACTIONS.SMS.SEND,
+            user: 'unknown-user',
+            text: 'Alarm triggered',
+          },
+        ],
+      ],
+      scope,
+    );
+    assert.notCalled(freeMobileService.message.send);
+  });
+
+  it('should ignore configured variables without user_id when sending to all users', async () => {
+    const stateManager = new StateManager(event);
+    const freeMobileService = {
+      message: {
+        serviceId,
+        send: fake.resolves(null),
+      },
+    };
+    const service = {
+      getService: fake.returns(freeMobileService),
+    };
+    const variable = {
+      getVariables: fake.resolves([
+        { user_id: null, value: 'legacyGlobalUser' },
+        { user_id: 'user-1', value: 'user1' },
+      ]),
+    };
+    const scope = {};
+    await executeActions(
+      { stateManager, event, service, variable },
+      [
+        [
+          {
+            type: ACTIONS.SMS.SEND,
+            user: 'all',
+            text: 'Alarm triggered',
+          },
+        ],
+      ],
+      scope,
+    );
+    assert.calledOnceWithExactly(freeMobileService.message.send, 'user-1', { text: 'Alarm triggered' });
+  });
+
+  it('should keep sending to remaining users when one send fails', async () => {
+    const stateManager = new StateManager(event);
+    const send = sinon.stub();
+    send.withArgs('user-1').rejects(new Error('Free Mobile API error'));
+    send.resolves(null);
+    const freeMobileService = {
+      message: {
+        serviceId,
+        send,
+      },
+    };
+    const service = {
+      getService: fake.returns(freeMobileService),
+    };
+    const variable = {
+      getVariables: fake.resolves([
+        { user_id: 'user-1', value: 'user1' },
+        { user_id: 'user-2', value: 'user2' },
+      ]),
+    };
+    const scope = {};
+    await executeActions(
+      { stateManager, event, service, variable },
+      [
+        [
+          {
+            type: ACTIONS.SMS.SEND,
+            user: 'all',
+            text: 'Alarm triggered',
+          },
+        ],
+      ],
+      scope,
+    );
+    assert.calledWith(send, 'user-1', { text: 'Alarm triggered' });
+    assert.calledWith(send, 'user-2', { text: 'Alarm triggered' });
   });
 
   it('should do nothing if free-mobile service is not available', async () => {

--- a/server/test/services/free-mobile/index.test.js
+++ b/server/test/services/free-mobile/index.test.js
@@ -1,7 +1,6 @@
 const sinon = require('sinon');
 const { expect } = require('chai');
 const proxyquire = require('proxyquire').noCallThru();
-const logger = require('../../../utils/logger');
 
 const { assert, fake, stub } = sinon;
 
@@ -13,10 +12,8 @@ describe('FreeMobileService', () => {
   let axiosStub;
   let gladys;
   let freeMobileService;
-  let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
     axiosStub = {
       get: fake.resolves({ data: 'OK' }),
     };
@@ -38,10 +35,6 @@ describe('FreeMobileService', () => {
     };
 
     freeMobileService = FreeMobileService(gladys, serviceId);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   describe('start', () => {
@@ -94,6 +87,56 @@ describe('FreeMobileService', () => {
       assert.calledWith(gladys.variable.destroy, 'FREE_MOBILE_USERNAME', serviceId);
       assert.calledWith(gladys.variable.destroy, 'FREE_MOBILE_ACCESS_TOKEN', serviceId);
     });
+
+    it('should not migrate an incomplete legacy configuration (username only)', async () => {
+      gladys.variable.getValue = stub().resolves(null);
+      gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId).resolves('legacyUser');
+      gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId, adminId).resolves(null);
+      gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId, adminId).resolves(null);
+
+      await freeMobileService.start();
+
+      assert.notCalled(gladys.variable.setValue);
+      assert.notCalled(gladys.variable.destroy);
+    });
+
+    it('should not migrate an incomplete legacy configuration (token only)', async () => {
+      gladys.variable.getValue = stub().resolves(null);
+      gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId).resolves('legacyToken');
+      gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId, adminId).resolves(null);
+      gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId, adminId).resolves(null);
+
+      await freeMobileService.start();
+
+      assert.notCalled(gladys.variable.setValue);
+      assert.notCalled(gladys.variable.destroy);
+    });
+
+    it('should keep the legacy configuration when the admin has a partial configuration (username only)', async () => {
+      gladys.variable.getValue = stub().resolves(null);
+      gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId).resolves('legacyUser');
+      gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId).resolves('legacyToken');
+      gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId, adminId).resolves('existingUser');
+      gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId, adminId).resolves(null);
+
+      await freeMobileService.start();
+
+      assert.notCalled(gladys.variable.setValue);
+      assert.notCalled(gladys.variable.destroy);
+    });
+
+    it('should keep the legacy configuration when the admin has a partial configuration (token only)', async () => {
+      gladys.variable.getValue = stub().resolves(null);
+      gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId).resolves('legacyUser');
+      gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId).resolves('legacyToken');
+      gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId, adminId).resolves(null);
+      gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId, adminId).resolves('existingToken');
+
+      await freeMobileService.start();
+
+      assert.notCalled(gladys.variable.setValue);
+      assert.notCalled(gladys.variable.destroy);
+    });
   });
 
   describe('isUsed', () => {
@@ -103,58 +146,74 @@ describe('FreeMobileService', () => {
       expect(used).to.equal(false);
     });
 
-    it('should return true if at least one user configured Free Mobile', async () => {
-      gladys.variable.getVariables = fake.resolves([{ user_id: adminId, value: 'validUser' }]);
+    it('should return true if at least one user configured both username and token', async () => {
+      gladys.variable.getVariables = stub();
+      gladys.variable.getVariables
+        .withArgs('FREE_MOBILE_USERNAME', serviceId)
+        .resolves([{ user_id: adminId, value: 'validUser' }]);
+      gladys.variable.getVariables
+        .withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId)
+        .resolves([{ user_id: adminId, value: 'validToken' }]);
       const used = await freeMobileService.isUsed();
       expect(used).to.equal(true);
     });
 
     it('should return false if the variable is not user-related', async () => {
-      gladys.variable.getVariables = fake.resolves([{ user_id: null, value: 'validUser' }]);
+      gladys.variable.getVariables = stub();
+      gladys.variable.getVariables
+        .withArgs('FREE_MOBILE_USERNAME', serviceId)
+        .resolves([{ user_id: null, value: 'validUser' }]);
+      gladys.variable.getVariables
+        .withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId)
+        .resolves([{ user_id: null, value: 'validToken' }]);
       const used = await freeMobileService.isUsed();
       expect(used).to.equal(false);
     });
-  });
 
-  describe('message.send', () => {
-    it('should send SMS successfully for a user', async () => {
-      gladys.variable.getValue = stub();
-      gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId, adminId).resolves('validUsername');
-      gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId, adminId).resolves('validAccessToken');
-
-      await freeMobileService.message.send(adminId, { text: 'Hello' });
-
-      assert.calledWith(axiosStub.get, 'https://smsapi.free-mobile.fr/sendmsg', {
-        params: {
-          user: 'validUsername',
-          pass: 'validAccessToken',
-          msg: 'Hello',
-        },
-      });
+    it('should return false if the username is empty', async () => {
+      gladys.variable.getVariables = stub();
+      gladys.variable.getVariables
+        .withArgs('FREE_MOBILE_USERNAME', serviceId)
+        .resolves([{ user_id: adminId, value: '' }]);
+      gladys.variable.getVariables
+        .withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId)
+        .resolves([{ user_id: adminId, value: 'validToken' }]);
+      const used = await freeMobileService.isUsed();
+      expect(used).to.equal(false);
     });
 
-    it('should not send SMS if the user has no configuration', async () => {
-      gladys.variable.getValue = fake.resolves(null);
-      await freeMobileService.message.send(adminId, { text: 'Hello' });
-      assert.notCalled(axiosStub.get);
+    it('should return false if the user has a username but no token', async () => {
+      gladys.variable.getVariables = stub();
+      gladys.variable.getVariables
+        .withArgs('FREE_MOBILE_USERNAME', serviceId)
+        .resolves([{ user_id: adminId, value: 'validUser' }]);
+      gladys.variable.getVariables.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId).resolves([]);
+      const used = await freeMobileService.isUsed();
+      expect(used).to.equal(false);
     });
 
-    it('should throw and log an error if SMS fails', async () => {
-      gladys.variable.getValue = stub();
-      gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId, adminId).resolves('validUsername');
-      gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId, adminId).resolves('validAccessToken');
-      axiosStub.get = fake.rejects(new Error('Network error'));
-      const loggerErrorStub = sandbox.stub(logger, 'error');
+    it('should return false if the user has a username but an empty token', async () => {
+      gladys.variable.getVariables = stub();
+      gladys.variable.getVariables
+        .withArgs('FREE_MOBILE_USERNAME', serviceId)
+        .resolves([{ user_id: adminId, value: 'validUser' }]);
+      gladys.variable.getVariables
+        .withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId)
+        .resolves([{ user_id: adminId, value: '' }]);
+      const used = await freeMobileService.isUsed();
+      expect(used).to.equal(false);
+    });
 
-      try {
-        await freeMobileService.message.send(adminId, { text: 'Hello World' });
-        throw new Error('Expected an error to be thrown');
-      } catch (e) {
-        expect(e).to.be.instanceOf(Error);
-        expect(e.message).to.equal('Network error');
-      }
-      const errorArgs = loggerErrorStub.getCall(0).args;
-      expect(errorArgs[0]).to.equal('Error sending SMS:');
+    it('should return false if the username and the token belong to different users', async () => {
+      gladys.variable.getVariables = stub();
+      gladys.variable.getVariables
+        .withArgs('FREE_MOBILE_USERNAME', serviceId)
+        .resolves([{ user_id: adminId, value: 'validUser' }]);
+      gladys.variable.getVariables
+        .withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId)
+        .resolves([{ user_id: 'another-user-id', value: 'validToken' }]);
+      const used = await freeMobileService.isUsed();
+      expect(used).to.equal(false);
     });
   });
 

--- a/server/test/services/free-mobile/index.test.js
+++ b/server/test/services/free-mobile/index.test.js
@@ -1,8 +1,9 @@
 const sinon = require('sinon');
 const { expect } = require('chai');
-const { assert, fake, stub } = sinon;
 const proxyquire = require('proxyquire').noCallThru();
 const logger = require('../../../utils/logger');
+
+const { assert, fake, stub } = sinon;
 
 const serviceId = 'f87b7af2-ca8e-44fc-b754-444354b42fee';
 const adminId = 'd1d73559-a987-44eb-9453-3cbf5bcb5a2f';

--- a/server/test/services/free-mobile/index.test.js
+++ b/server/test/services/free-mobile/index.test.js
@@ -1,11 +1,11 @@
 const sinon = require('sinon');
 const { expect } = require('chai');
-const assert = require('assert');
+const { assert, fake, stub } = sinon;
 const proxyquire = require('proxyquire').noCallThru();
-const { ServiceNotConfiguredError } = require('../../../utils/coreErrors');
 const logger = require('../../../utils/logger');
 
 const serviceId = 'f87b7af2-ca8e-44fc-b754-444354b42fee';
+const adminId = 'd1d73559-a987-44eb-9453-3cbf5bcb5a2f';
 
 describe('FreeMobileService', () => {
   let FreeMobileService;
@@ -17,9 +17,7 @@ describe('FreeMobileService', () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     axiosStub = {
-      get: async () => {
-        return { data: 'OK' };
-      },
+      get: fake.resolves({ data: 'OK' }),
     };
 
     FreeMobileService = proxyquire('../../../services/free-mobile', {
@@ -27,16 +25,14 @@ describe('FreeMobileService', () => {
     });
 
     gladys = {
+      user: {
+        getByRole: fake.resolves([{ id: adminId, selector: 'john' }]),
+      },
       variable: {
-        getValue: async (key) => {
-          if (key === 'FREE_MOBILE_USERNAME') {
-            return 'validUsername';
-          }
-          if (key === 'FREE_MOBILE_ACCESS_TOKEN') {
-            return 'validAccessToken';
-          }
-          return null;
-        },
+        getValue: fake.resolves(null),
+        getVariables: fake.resolves([]),
+        setValue: fake.resolves(null),
+        destroy: fake.resolves(null),
       },
     };
 
@@ -48,85 +44,121 @@ describe('FreeMobileService', () => {
   });
 
   describe('start', () => {
-    it('should start service with success', async () => {
+    it('should start service without any legacy configuration to migrate', async () => {
+      await freeMobileService.start();
+      assert.notCalled(gladys.variable.setValue);
+      assert.notCalled(gladys.variable.destroy);
+    });
+
+    it('should migrate the legacy global configuration to the admin user', async () => {
+      gladys.variable.getValue = stub();
+      // Global values (called without userId)
+      gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId).resolves('legacyUser');
+      gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId).resolves('legacyToken');
+      // Admin per-user values (not set yet)
+      gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId, adminId).resolves(null);
+      gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId, adminId).resolves(null);
+
       await freeMobileService.start();
 
-      assert.strictEqual(await gladys.variable.getValue('FREE_MOBILE_USERNAME', serviceId), 'validUsername');
-      assert.strictEqual(await gladys.variable.getValue('FREE_MOBILE_ACCESS_TOKEN', serviceId), 'validAccessToken');
+      assert.calledWith(gladys.variable.setValue, 'FREE_MOBILE_USERNAME', 'legacyUser', serviceId, adminId);
+      assert.calledWith(gladys.variable.setValue, 'FREE_MOBILE_ACCESS_TOKEN', 'legacyToken', serviceId, adminId);
+      assert.calledWith(gladys.variable.destroy, 'FREE_MOBILE_USERNAME', serviceId);
+      assert.calledWith(gladys.variable.destroy, 'FREE_MOBILE_ACCESS_TOKEN', serviceId);
     });
 
-    it('should throw ServiceNotConfiguredError if username is missing', async () => {
-      gladys.variable.getValue = async (key) => {
-        if (key === 'FREE_MOBILE_USERNAME') {
-          return null;
-        }
-        if (key === 'FREE_MOBILE_ACCESS_TOKEN') {
-          return 'validAccessToken';
-        }
-        return null;
-      };
+    it('should not migrate if no admin user is found', async () => {
+      gladys.variable.getValue = stub();
+      gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId).resolves('legacyUser');
+      gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId).resolves('legacyToken');
+      gladys.user.getByRole = fake.resolves([]);
 
-      try {
-        await freeMobileService.start();
-        throw new Error('Expected ServiceNotConfiguredError to be thrown');
-      } catch (e) {
-        expect(e).instanceOf(ServiceNotConfiguredError);
-      }
+      await freeMobileService.start();
+
+      assert.notCalled(gladys.variable.setValue);
+      assert.notCalled(gladys.variable.destroy);
     });
 
-    it('should throw ServiceNotConfiguredError if accessToken is missing', async () => {
-      gladys.variable.getValue = async (key) => {
-        if (key === 'FREE_MOBILE_USERNAME') {
-          return 'validUsername';
-        }
-        if (key === 'FREE_MOBILE_ACCESS_TOKEN') {
-          return null;
-        }
-        return null;
-      };
+    it('should not overwrite an existing admin per-user configuration during migration', async () => {
+      gladys.variable.getValue = stub();
+      gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId).resolves('legacyUser');
+      gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId).resolves('legacyToken');
+      gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId, adminId).resolves('existingUser');
+      gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId, adminId).resolves('existingToken');
 
-      try {
-        await freeMobileService.start();
-        throw new Error('Expected ServiceNotConfiguredError to be thrown');
-      } catch (e) {
-        expect(e).instanceOf(ServiceNotConfiguredError);
-      }
+      await freeMobileService.start();
+
+      assert.notCalled(gladys.variable.setValue);
+      // Legacy values are still removed
+      assert.calledWith(gladys.variable.destroy, 'FREE_MOBILE_USERNAME', serviceId);
+      assert.calledWith(gladys.variable.destroy, 'FREE_MOBILE_ACCESS_TOKEN', serviceId);
     });
   });
 
-  describe('send', () => {
-    beforeEach(async () => {
-      await freeMobileService.start();
+  describe('isUsed', () => {
+    it('should return false if no user configured Free Mobile', async () => {
+      gladys.variable.getVariables = fake.resolves([]);
+      const used = await freeMobileService.isUsed();
+      expect(used).to.equal(false);
     });
 
-    it('should send SMS successfully', async () => {
-      axiosStub.get = async (url, options) => {
-        assert.strictEqual(url, 'https://smsapi.free-mobile.fr/sendmsg');
-        assert.deepStrictEqual(options.params, {
+    it('should return true if at least one user configured Free Mobile', async () => {
+      gladys.variable.getVariables = fake.resolves([{ user_id: adminId, value: 'validUser' }]);
+      const used = await freeMobileService.isUsed();
+      expect(used).to.equal(true);
+    });
+
+    it('should return false if the variable is not user-related', async () => {
+      gladys.variable.getVariables = fake.resolves([{ user_id: null, value: 'validUser' }]);
+      const used = await freeMobileService.isUsed();
+      expect(used).to.equal(false);
+    });
+  });
+
+  describe('message.send', () => {
+    it('should send SMS successfully for a user', async () => {
+      gladys.variable.getValue = stub();
+      gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId, adminId).resolves('validUsername');
+      gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId, adminId).resolves('validAccessToken');
+
+      await freeMobileService.message.send(adminId, { text: 'Hello' });
+
+      assert.calledWith(axiosStub.get, 'https://smsapi.free-mobile.fr/sendmsg', {
+        params: {
           user: 'validUsername',
           pass: 'validAccessToken',
           msg: 'Hello',
-        });
-        return { data: 'OK' };
-      };
-
-      await freeMobileService.sms.send('Hello');
+        },
+      });
     });
 
-    it('should log an error if SMS fails', async () => {
-      axiosStub.get = async () => {
-        throw new Error('Network error');
-      };
+    it('should not send SMS if the user has no configuration', async () => {
+      gladys.variable.getValue = fake.resolves(null);
+      await freeMobileService.message.send(adminId, { text: 'Hello' });
+      assert.notCalled(axiosStub.get);
+    });
+
+    it('should throw and log an error if SMS fails', async () => {
+      gladys.variable.getValue = stub();
+      gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId, adminId).resolves('validUsername');
+      gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId, adminId).resolves('validAccessToken');
+      axiosStub.get = fake.rejects(new Error('Network error'));
       const loggerErrorStub = sandbox.stub(logger, 'error');
-      await freeMobileService.sms.send('Hello World');
+
+      try {
+        await freeMobileService.message.send(adminId, { text: 'Hello World' });
+        throw new Error('Expected an error to be thrown');
+      } catch (e) {
+        expect(e).to.be.instanceOf(Error);
+        expect(e.message).to.equal('Network error');
+      }
       const errorArgs = loggerErrorStub.getCall(0).args;
       expect(errorArgs[0]).to.equal('Error sending SMS:');
-      expect(errorArgs[1]).to.be.instanceOf(Error);
     });
   });
 
   describe('stop', () => {
-    it('should stopping service', async () => {
+    it('should stop service', async () => {
       await freeMobileService.stop();
     });
   });

--- a/server/test/services/free-mobile/lib/index.test.js
+++ b/server/test/services/free-mobile/lib/index.test.js
@@ -1,0 +1,18 @@
+const { expect } = require('chai');
+
+const MessageHandler = require('../../../../services/free-mobile/lib');
+
+describe('FreeMobile MessageHandler', () => {
+  it('should store gladys, axios and serviceId', () => {
+    const gladys = {};
+    const axios = {};
+    const serviceId = 'f87b7af2-ca8e-44fc-b754-444354b42fee';
+
+    const messageHandler = new MessageHandler(gladys, axios, serviceId);
+
+    expect(messageHandler.gladys).to.equal(gladys);
+    expect(messageHandler.axios).to.equal(axios);
+    expect(messageHandler.serviceId).to.equal(serviceId);
+    expect(messageHandler.send).to.be.a('function');
+  });
+});

--- a/server/test/services/free-mobile/lib/message.send.test.js
+++ b/server/test/services/free-mobile/lib/message.send.test.js
@@ -1,0 +1,98 @@
+const sinon = require('sinon');
+const { expect } = require('chai');
+
+const MessageHandler = require('../../../../services/free-mobile/lib');
+const logger = require('../../../../utils/logger');
+
+const { assert, fake, stub } = sinon;
+
+const serviceId = 'f87b7af2-ca8e-44fc-b754-444354b42fee';
+const userId = 'd1d73559-a987-44eb-9453-3cbf5bcb5a2f';
+
+describe('FreeMobile message.send', () => {
+  let axiosStub;
+  let gladys;
+  let messageHandler;
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    axiosStub = {
+      get: fake.resolves({ data: 'OK' }),
+    };
+    gladys = {
+      variable: {
+        getValue: fake.resolves(null),
+      },
+    };
+    messageHandler = new MessageHandler(gladys, axiosStub, serviceId);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should send SMS successfully for a user', async () => {
+    gladys.variable.getValue = stub();
+    gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId, userId).resolves('validUsername');
+    gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId, userId).resolves('validAccessToken');
+
+    await messageHandler.send(userId, { text: 'Hello' });
+
+    assert.calledWith(axiosStub.get, 'https://smsapi.free-mobile.fr/sendmsg', {
+      params: {
+        user: 'validUsername',
+        pass: 'validAccessToken',
+        msg: 'Hello',
+      },
+      timeout: 10000,
+    });
+  });
+
+  it('should not send SMS if the user has no configuration', async () => {
+    gladys.variable.getValue = fake.resolves(null);
+    await messageHandler.send(userId, { text: 'Hello' });
+    assert.notCalled(axiosStub.get);
+  });
+
+  it('should throw and log a sanitized error if SMS fails', async () => {
+    gladys.variable.getValue = stub();
+    gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId, userId).resolves('validUsername');
+    gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId, userId).resolves('validAccessToken');
+    axiosStub.get = fake.rejects(new Error('Network error'));
+    const loggerErrorStub = sandbox.stub(logger, 'error');
+
+    try {
+      await messageHandler.send(userId, { text: 'Hello World' });
+      throw new Error('Expected an error to be thrown');
+    } catch (e) {
+      expect(e).to.be.instanceOf(Error);
+      expect(e.message).to.equal('Network error');
+    }
+    const errorArgs = loggerErrorStub.getCall(0).args;
+    expect(errorArgs).to.have.lengthOf(1);
+    expect(errorArgs[0]).to.equal('Error sending SMS: Network error');
+  });
+
+  it('should log the HTTP status without leaking the access token if SMS fails with a response', async () => {
+    gladys.variable.getValue = stub();
+    gladys.variable.getValue.withArgs('FREE_MOBILE_USERNAME', serviceId, userId).resolves('validUsername');
+    gladys.variable.getValue.withArgs('FREE_MOBILE_ACCESS_TOKEN', serviceId, userId).resolves('validAccessToken');
+    const httpError = new Error('Request failed with status code 400');
+    // @ts-ignore
+    httpError.response = { status: 400 };
+    axiosStub.get = fake.rejects(httpError);
+    const loggerErrorStub = sandbox.stub(logger, 'error');
+
+    try {
+      await messageHandler.send(userId, { text: 'Hello World' });
+      throw new Error('Expected an error to be thrown');
+    } catch (e) {
+      expect(e.message).to.equal('Request failed with status code 400');
+    }
+    const errorArgs = loggerErrorStub.getCall(0).args;
+    expect(errorArgs).to.have.lengthOf(1);
+    expect(errorArgs[0]).to.equal('Error sending SMS: Request failed with status code 400 (HTTP 400)');
+    expect(errorArgs[0]).to.not.include('validAccessToken');
+  });
+});


### PR DESCRIPTION
### Pull Request check-list

- [x] If your changes affect the code, did you write the tests?
- [x] Are server tests passing with coverage? (`cd server && npm run coverage`) — Codecov requires **100% coverage on lines changed in this PR**
- [ ] Did Cypress E2E tests pass? (`npm run cypress:run` from repo root, if UI changed)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices?
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation?
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation?
- [x] Did you add fake requests data for the demo mode? (N/A — no new widget)

### Description of change

This PR adds **multi-user support to the Free Mobile integration**.

#### Problem

Until now, only the **admin** account could configure a Free Mobile API key. The customer ID and access token were stored as **global** service variables, so Gladys could only send SMS to that single account. There was no way to send an SMS to another user, nor to build scenes targeting a specific user.

#### Solution

Free Mobile is now aligned with the **Telegram / CallMeBot** pattern:

- **Per-user configuration**: the `FREE_MOBILE_USERNAME` and `FREE_MOBILE_ACCESS_TOKEN` variables are now stored per-user (`userRelated: true`). Each user can enter their own credentials from the integration page to receive SMS.
- **Automatic migration**: on service start, the legacy global configuration (if any) is migrated to the **admin** user's per-user configuration, then the old global variables are removed. Existing installations keep working with no manual action.
- **New message handler**: a `message.send(userId, message)` handler reads the user's own credentials on the fly and sends the SMS.
- **Scene action**: the "Send an SMS" action now has a **recipient selector** — you can send to a specific user, or to **all users** who configured Free Mobile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Free Mobile credentials are now configured per user.
  - Scene SMS actions let you select a recipient (including “all users”).
  - The Free Mobile settings page now shows guidance for per-user SMS setup.
  - SMS sending now uses the scene text with variables expanded.

- **Bug Fixes**
  - The integration loads even when legacy or incomplete Free Mobile credentials are missing.
  - Legacy Free Mobile configuration is migrated automatically to per-user settings.
  - SMS sending skips recipients missing required credentials and continues for others.

- **Tests**
  - Expanded coverage for Free Mobile SMS sending and migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->