### PR TITLE
fix(zigbee2mqtt): keep IEEE address and Z2M link after saving a device

### DIFF
--- a/front/src/routes/integration/all/zigbee2mqtt/device-page/actions.js
+++ b/front/src/routes/integration/all/zigbee2mqtt/device-page/actions.js
@@ -111,6 +111,7 @@ function createActions(store) {
       const device = state.zigbee2mqttDevices[index];
       const savedDevice = await state.httpClient.post(`/api/v1/device`, device);
       savedDevice.model = device.model;
+      savedDevice.ieee_address = device.ieee_address;
       const zigbee2mqttDevices = update(state.zigbee2mqttDevices, {
         $splice: [[index, 1, savedDevice]]
       });


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [ ] If your changes affect the code, did you write the tests?
- [ ] Are server tests passing with coverage? (`cd server && npm run coverage`) — Codecov requires **100% coverage on lines changed in this PR**
- [ ] Did Cypress E2E tests pass? (`npm run cypress:run` from repo root, if UI changed)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
- [x] Did you test this pull request in real life? With real devices?
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation?
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation?
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`)?

### Description of change

On the Zigbee2mqtt device page, the IEEE address field and the "Open in Zigbee2mqtt" link (added in #2488) disappeared as soon as the device was saved (e.g. after changing its room), and only came back after a full page reload.

**Why:** `ieee_address` is not stored in the Gladys database. It is enriched client-side when the device list is loaded, by matching saved devices against the devices discovered by Zigbee2mqtt. When saving a device, `saveDevice` replaces the device in the state with the raw server response, which doesn't contain `ieee_address`, so the whole block was hidden. The `model` field had the exact same issue and was already copied back after save — `ieee_address` was simply missing.

**Fix:** one line in `front/src/routes/integration/all/zigbee2mqtt/device-page/actions.js`: copy `ieee_address` from the local device to the saved device, exactly like `model`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved Zigbee device IEEE addresses after saving, ensuring device details remain accurate in the device list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->