### PR TITLE
docs: require agent PRs to be created as ready for review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ All changes made by agents must follow this workflow:
 
 1. **Never commit directly to `master`.** Create a feature branch for every change (no matter how small) and open a pull request targeting `master`.
 2. **Write PR titles and descriptions in English**, even when the conversation with the user is in another language. This keeps the project history accessible to all contributors and matches the existing CI, templates, and documentation.
+3. **Create pull requests as ready for review (not draft).** When opening a PR, set `draft: false`. Do not create draft PRs.
 
 ## Pull Request requirements (CI)
 
@@ -37,10 +38,10 @@ Every PR to `master` triggers the workflow `.github/workflows/docker-pr-build.ym
 | **Front test** | Always | `prettier-check`, `eslint`, `compare-translations` |
 | **Server test** | Always | `prettier-check`, `eslint`, `npm run coverage` + Codecov upload |
 | **Cypress run** | Always | E2E tests (signup, dashboard, integrations…) |
-| **Front build** | Non-draft PRs only | `npm run build` (Vite) |
-| **Docker build** | Non-draft PRs only | AMD64 Docker image build |
+| **Front build** | Always (agent PRs are not draft) | `npm run build` (Vite) |
+| **Docker build** | Always (agent PRs are not draft) | AMD64 Docker image build |
 
-Draft PRs skip the front build and Docker jobs. Mark a PR as "Ready for review" only after the build checks pass locally.
+Agent PRs are opened as ready for review, so the front build and Docker jobs run in CI. Run the build checks locally before opening the PR.
 
 ### Mandatory checklist before push
 
@@ -73,7 +74,7 @@ cd front
 npm run prettier && npm run prettier-check
 npm run eslint
 npm run compare-translations   # required if i18n or device constants changed
-npm run build                  # required before marking PR as ready for review
+npm run build                  # required before opening the PR
 ```
 
 - The front has **no unit-test script**. CI validates the front via eslint, `compare-translations`, build, and Cypress.
@@ -91,7 +92,7 @@ npm run cypress:run   # starts server + front, then runs E2E specs in front/cypr
 - **Codecov patch coverage:** CI uploads the coverage report to Codecov, which measures only the lines changed in your PR. Any new server line not hit by a test fails the `codecov/patch` status. Run `npm run coverage` locally and confirm your tests exercise every branch and path you added before pushing.
 - **Server tests:** Changes to `server/lib/`, `server/api/`, `server/controllers/`, or `server/services/` almost always need corresponding tests. Look at neighboring files in `server/test/` for patterns (Mocha + Chai + Sinon).
 - **Cypress:** UI changes to signup, dashboard, scenes, or integration pages can break E2E specs under `front/cypress/e2e/`.
-- **Front build:** Only runs on non-draft PRs. A webpack/build error will block merge when the PR is marked ready.
+- **Front build:** Agent PRs are created as ready for review, so this job runs in CI. Run `npm run build` locally before opening the PR to catch errors early.
 
 ### Lint / test / build commands (reference)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,10 +38,10 @@ Every PR to `master` triggers the workflow `.github/workflows/docker-pr-build.ym
 | **Front test** | Always | `prettier-check`, `eslint`, `compare-translations` |
 | **Server test** | Always | `prettier-check`, `eslint`, `npm run coverage` + Codecov upload |
 | **Cypress run** | Always | E2E tests (signup, dashboard, integrations…) |
-| **Front build** | Always (agent PRs are not draft) | `npm run build` (Vite) |
-| **Docker build** | Always (agent PRs are not draft) | AMD64 Docker image build |
+| **Front build** | When the PR is ready for review (`draft: false`) | `npm run build` (Vite) |
+| **Docker build** | When the PR is ready for review (`draft: false`) | AMD64 Docker image build |
 
-Agent PRs are opened as ready for review, so the front build and Docker jobs run in CI. Run the build checks locally before opening the PR.
+When the PR is ready for review (`draft: false`), the front build and Docker jobs run in CI. Agent PRs should be opened that way, so run the build checks locally before opening the PR.
 
 ### Mandatory checklist before push
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `AGENTS.md` so Cursor Cloud Agents open pull requests as **ready for review** instead of drafts.

## Changes

- Add an explicit git workflow rule: create PRs with `draft: false`.
- Align CI documentation with this workflow (front build and Docker jobs run on agent PRs).
- Update front checklist wording to require `npm run build` before opening the PR.

## Motivation

Draft PRs skip the front build and Docker CI jobs. Opening agent PRs as ready for review ensures the full CI pipeline runs immediately.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f3dc886-828b-45ff-9ff7-bc24de2f1ae9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f3dc886-828b-45ff-9ff7-bc24de2f1ae9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated pull request guidance to clarify that agent-created pull requests should be opened as ready for review (non-draft).
  * Clarified which CI checks (Front build and Docker build) run for agent pull requests.
  * Updated the front-end workflow requirement to run `npm run build` before opening the pull request (rather than just before marking it ready).
  * Refreshed troubleshooting guidance for front-end build failures to match the CI behavior for agent pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->