### PR TITLE
chore(matter): update matter.js to 0.17.6

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -52,7 +52,7 @@
         "ws": "^6.2.2"
       },
       "devDependencies": {
-        "@matter/main": "^0.17.4",
+        "@matter/main": "^0.17.6",
         "apidoc": "^1.0.3",
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
@@ -1513,9 +1513,9 @@
       }
     },
     "node_modules/@matter/general": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.4.tgz",
-      "integrity": "sha512-b1Q/Xdf1JHlcUFdaXU8uAaLeMSINMS0kKl/ElaDcE127Ax+3/UbZRtsLDclQopbpXtArXs73XBfdGFCA42gU8Q==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.6.tgz",
+      "integrity": "sha512-PiSly47lwR+31sMWZTxT9eVgibfC2PB3FflTwxhVDzektrNNYT4wh9+5abTNhQmszs/VnXixbyo64HSz+LQS8g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1523,83 +1523,83 @@
       }
     },
     "node_modules/@matter/main": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.4.tgz",
-      "integrity": "sha512-wQu1CRxtyOaX+dEbCfRgbnNx6RfuPRQOPXKrKpuxebMh/W4xxCGCyUj0Fkb6QkO3wvjgaSnXeKx1PT2/n7wXFA==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.6.tgz",
+      "integrity": "sha512-RBXVLxJGEd3IUZ63QrHPUpb7o1amErvs2MoK3bJpnUXYNqXAuN2IHLTYZ04j4yrdMHJlyGSDxdIYr5rN6zXqSA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.4",
-        "@matter/model": "0.17.4",
-        "@matter/node": "0.17.4",
-        "@matter/protocol": "0.17.4",
-        "@matter/types": "0.17.4"
+        "@matter/general": "0.17.6",
+        "@matter/model": "0.17.6",
+        "@matter/node": "0.17.6",
+        "@matter/protocol": "0.17.6",
+        "@matter/types": "0.17.6"
       },
       "optionalDependencies": {
-        "@matter/nodejs": "0.17.4"
+        "@matter/nodejs": "0.17.6"
       }
     },
     "node_modules/@matter/model": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.4.tgz",
-      "integrity": "sha512-q5Elw1ad5QykwkIVs9WhUkZQ1yMrHyRjnlKk+g2gO9aAtV9IoS1v+a6JA/dQbsDUiXnbdczU//jhGrOy/vkL6g==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.6.tgz",
+      "integrity": "sha512-ECf6r0zTq6FS6IA4ov8qtSu36iyO1oxEJT06RFYX/SVDOyfhgzRjQDSIsVtW4UwTMht8kSVnDJE9EAO0qY37YA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.4"
+        "@matter/general": "0.17.6"
       }
     },
     "node_modules/@matter/node": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.4.tgz",
-      "integrity": "sha512-sQZfPrVC9mxrWHuUjJDhDR2MGMQJFyiRMfZiCZx2kHrbRi404D2Cod5U+ay3hH1zzPxai/PkooA4/wvKR+S4yQ==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.6.tgz",
+      "integrity": "sha512-qtkh3/hz+73Wh7kY+Jz9HogrnpqjIMreYaY//VEMb9Jl/tY1A+3RFa7PDIY51LK2m+gWy3boXu/3kdYEvn00ig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.4",
-        "@matter/model": "0.17.4",
-        "@matter/protocol": "0.17.4",
-        "@matter/types": "0.17.4"
+        "@matter/general": "0.17.6",
+        "@matter/model": "0.17.6",
+        "@matter/protocol": "0.17.6",
+        "@matter/types": "0.17.6"
       }
     },
     "node_modules/@matter/nodejs": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.4.tgz",
-      "integrity": "sha512-c6uiT6yT5qPLhbDpVVo1Z5Q6jZCODB9sUviphwoI+dKcNMIwwjBVA/jRfggnTlR9A0cxiQuhVBQydzlAtCbI7w==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.6.tgz",
+      "integrity": "sha512-tvn2wLMgjd1YVKr/kAkKq50WU+8mUeoDVCPIyO6aXJMsy0GTOc8/vC3Lu3ZIUD1IwMiOgn67xnqBVozpp+ZjTw==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@matter/general": "0.17.4",
-        "@matter/node": "0.17.4",
-        "@matter/protocol": "0.17.4",
-        "@matter/types": "0.17.4"
+        "@matter/general": "0.17.6",
+        "@matter/node": "0.17.6",
+        "@matter/protocol": "0.17.6",
+        "@matter/types": "0.17.6"
       },
       "engines": {
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
       }
     },
     "node_modules/@matter/protocol": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.4.tgz",
-      "integrity": "sha512-wyju0Km43PVWITr//aHyD4cKDVFVlIrx0x85fRyHn1F8Ab2RY5/IHXIxutcXYl6Jtm22AVeXdeYZUtE6HmWjzQ==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.6.tgz",
+      "integrity": "sha512-p3oc8v2RKKbV4RkkjKemDpzheNHFMQJnbxpij2yKpxsXYIXpYnwtexnvLxDpZCJPsd9Jv3igSxxURBEUexHmBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.4",
-        "@matter/model": "0.17.4",
-        "@matter/types": "0.17.4"
+        "@matter/general": "0.17.6",
+        "@matter/model": "0.17.6",
+        "@matter/types": "0.17.6"
       }
     },
     "node_modules/@matter/types": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.4.tgz",
-      "integrity": "sha512-nHiBrV6xoPMDPkuzL3+SQk90/2d4xbBgqwnxYQFqcvVrgITSwpGWzSGRC917BsuZE7koUNyD7T0Wlbt+GAlfkw==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.6.tgz",
+      "integrity": "sha512-zYCWx+om6hQR6s6CHniWJMaOsqzTNDKcxUoU0QI8ZgF39SCtIeIb+qOzNigoAtKKZzhVdo9B5IsbEbYY4PhO3g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.4",
-        "@matter/model": "0.17.4"
+        "@matter/general": "0.17.6",
+        "@matter/model": "0.17.6"
       }
     },
     "node_modules/@noble/curves": {
@@ -12469,81 +12469,81 @@
       }
     },
     "@matter/general": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.4.tgz",
-      "integrity": "sha512-b1Q/Xdf1JHlcUFdaXU8uAaLeMSINMS0kKl/ElaDcE127Ax+3/UbZRtsLDclQopbpXtArXs73XBfdGFCA42gU8Q==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.6.tgz",
+      "integrity": "sha512-PiSly47lwR+31sMWZTxT9eVgibfC2PB3FflTwxhVDzektrNNYT4wh9+5abTNhQmszs/VnXixbyo64HSz+LQS8g==",
       "dev": true,
       "requires": {
         "@noble/curves": "^2.2.0"
       }
     },
     "@matter/main": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.4.tgz",
-      "integrity": "sha512-wQu1CRxtyOaX+dEbCfRgbnNx6RfuPRQOPXKrKpuxebMh/W4xxCGCyUj0Fkb6QkO3wvjgaSnXeKx1PT2/n7wXFA==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.6.tgz",
+      "integrity": "sha512-RBXVLxJGEd3IUZ63QrHPUpb7o1amErvs2MoK3bJpnUXYNqXAuN2IHLTYZ04j4yrdMHJlyGSDxdIYr5rN6zXqSA==",
       "dev": true,
       "requires": {
-        "@matter/general": "0.17.4",
-        "@matter/model": "0.17.4",
-        "@matter/node": "0.17.4",
-        "@matter/nodejs": "0.17.4",
-        "@matter/protocol": "0.17.4",
-        "@matter/types": "0.17.4"
+        "@matter/general": "0.17.6",
+        "@matter/model": "0.17.6",
+        "@matter/node": "0.17.6",
+        "@matter/nodejs": "0.17.6",
+        "@matter/protocol": "0.17.6",
+        "@matter/types": "0.17.6"
       }
     },
     "@matter/model": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.4.tgz",
-      "integrity": "sha512-q5Elw1ad5QykwkIVs9WhUkZQ1yMrHyRjnlKk+g2gO9aAtV9IoS1v+a6JA/dQbsDUiXnbdczU//jhGrOy/vkL6g==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.6.tgz",
+      "integrity": "sha512-ECf6r0zTq6FS6IA4ov8qtSu36iyO1oxEJT06RFYX/SVDOyfhgzRjQDSIsVtW4UwTMht8kSVnDJE9EAO0qY37YA==",
       "dev": true,
       "requires": {
-        "@matter/general": "0.17.4"
+        "@matter/general": "0.17.6"
       }
     },
     "@matter/node": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.4.tgz",
-      "integrity": "sha512-sQZfPrVC9mxrWHuUjJDhDR2MGMQJFyiRMfZiCZx2kHrbRi404D2Cod5U+ay3hH1zzPxai/PkooA4/wvKR+S4yQ==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.6.tgz",
+      "integrity": "sha512-qtkh3/hz+73Wh7kY+Jz9HogrnpqjIMreYaY//VEMb9Jl/tY1A+3RFa7PDIY51LK2m+gWy3boXu/3kdYEvn00ig==",
       "dev": true,
       "requires": {
-        "@matter/general": "0.17.4",
-        "@matter/model": "0.17.4",
-        "@matter/protocol": "0.17.4",
-        "@matter/types": "0.17.4"
+        "@matter/general": "0.17.6",
+        "@matter/model": "0.17.6",
+        "@matter/protocol": "0.17.6",
+        "@matter/types": "0.17.6"
       }
     },
     "@matter/nodejs": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.4.tgz",
-      "integrity": "sha512-c6uiT6yT5qPLhbDpVVo1Z5Q6jZCODB9sUviphwoI+dKcNMIwwjBVA/jRfggnTlR9A0cxiQuhVBQydzlAtCbI7w==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.6.tgz",
+      "integrity": "sha512-tvn2wLMgjd1YVKr/kAkKq50WU+8mUeoDVCPIyO6aXJMsy0GTOc8/vC3Lu3ZIUD1IwMiOgn67xnqBVozpp+ZjTw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@matter/general": "0.17.4",
-        "@matter/node": "0.17.4",
-        "@matter/protocol": "0.17.4",
-        "@matter/types": "0.17.4"
+        "@matter/general": "0.17.6",
+        "@matter/node": "0.17.6",
+        "@matter/protocol": "0.17.6",
+        "@matter/types": "0.17.6"
       }
     },
     "@matter/protocol": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.4.tgz",
-      "integrity": "sha512-wyju0Km43PVWITr//aHyD4cKDVFVlIrx0x85fRyHn1F8Ab2RY5/IHXIxutcXYl6Jtm22AVeXdeYZUtE6HmWjzQ==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.6.tgz",
+      "integrity": "sha512-p3oc8v2RKKbV4RkkjKemDpzheNHFMQJnbxpij2yKpxsXYIXpYnwtexnvLxDpZCJPsd9Jv3igSxxURBEUexHmBA==",
       "dev": true,
       "requires": {
-        "@matter/general": "0.17.4",
-        "@matter/model": "0.17.4",
-        "@matter/types": "0.17.4"
+        "@matter/general": "0.17.6",
+        "@matter/model": "0.17.6",
+        "@matter/types": "0.17.6"
       }
     },
     "@matter/types": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.4.tgz",
-      "integrity": "sha512-nHiBrV6xoPMDPkuzL3+SQk90/2d4xbBgqwnxYQFqcvVrgITSwpGWzSGRC917BsuZE7koUNyD7T0Wlbt+GAlfkw==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.6.tgz",
+      "integrity": "sha512-zYCWx+om6hQR6s6CHniWJMaOsqzTNDKcxUoU0QI8ZgF39SCtIeIb+qOzNigoAtKKZzhVdo9B5IsbEbYY4PhO3g==",
       "dev": true,
       "requires": {
-        "@matter/general": "0.17.4",
-        "@matter/model": "0.17.4"
+        "@matter/general": "0.17.6",
+        "@matter/model": "0.17.6"
       }
     },
     "@noble/curves": {

--- a/server/package.json
+++ b/server/package.json
@@ -46,7 +46,7 @@
     ]
   },
   "devDependencies": {
-    "@matter/main": "^0.17.4",
+    "@matter/main": "^0.17.6",
     "apidoc": "^1.0.3",
     "chai": "^4.3.7",
     "chai-as-promised": "^7.1.1",

--- a/server/services/matter/package-lock.json
+++ b/server/services/matter/package-lock.json
@@ -16,93 +16,93 @@
         "win32"
       ],
       "dependencies": {
-        "@matter/main": "^0.17.4",
-        "@project-chip/matter.js": "^0.17.4",
+        "@matter/main": "^0.17.6",
+        "@project-chip/matter.js": "^0.17.6",
         "bluebird": "^3.7.2",
         "fs-extra": "^11.3.0"
       }
     },
     "node_modules/@matter/general": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.4.tgz",
-      "integrity": "sha512-b1Q/Xdf1JHlcUFdaXU8uAaLeMSINMS0kKl/ElaDcE127Ax+3/UbZRtsLDclQopbpXtArXs73XBfdGFCA42gU8Q==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.6.tgz",
+      "integrity": "sha512-PiSly47lwR+31sMWZTxT9eVgibfC2PB3FflTwxhVDzektrNNYT4wh9+5abTNhQmszs/VnXixbyo64HSz+LQS8g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^2.2.0"
       }
     },
     "node_modules/@matter/main": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.4.tgz",
-      "integrity": "sha512-wQu1CRxtyOaX+dEbCfRgbnNx6RfuPRQOPXKrKpuxebMh/W4xxCGCyUj0Fkb6QkO3wvjgaSnXeKx1PT2/n7wXFA==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.6.tgz",
+      "integrity": "sha512-RBXVLxJGEd3IUZ63QrHPUpb7o1amErvs2MoK3bJpnUXYNqXAuN2IHLTYZ04j4yrdMHJlyGSDxdIYr5rN6zXqSA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.4",
-        "@matter/model": "0.17.4",
-        "@matter/node": "0.17.4",
-        "@matter/protocol": "0.17.4",
-        "@matter/types": "0.17.4"
+        "@matter/general": "0.17.6",
+        "@matter/model": "0.17.6",
+        "@matter/node": "0.17.6",
+        "@matter/protocol": "0.17.6",
+        "@matter/types": "0.17.6"
       },
       "optionalDependencies": {
-        "@matter/nodejs": "0.17.4"
+        "@matter/nodejs": "0.17.6"
       }
     },
     "node_modules/@matter/model": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.4.tgz",
-      "integrity": "sha512-q5Elw1ad5QykwkIVs9WhUkZQ1yMrHyRjnlKk+g2gO9aAtV9IoS1v+a6JA/dQbsDUiXnbdczU//jhGrOy/vkL6g==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.6.tgz",
+      "integrity": "sha512-ECf6r0zTq6FS6IA4ov8qtSu36iyO1oxEJT06RFYX/SVDOyfhgzRjQDSIsVtW4UwTMht8kSVnDJE9EAO0qY37YA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.4"
+        "@matter/general": "0.17.6"
       }
     },
     "node_modules/@matter/node": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.4.tgz",
-      "integrity": "sha512-sQZfPrVC9mxrWHuUjJDhDR2MGMQJFyiRMfZiCZx2kHrbRi404D2Cod5U+ay3hH1zzPxai/PkooA4/wvKR+S4yQ==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.6.tgz",
+      "integrity": "sha512-qtkh3/hz+73Wh7kY+Jz9HogrnpqjIMreYaY//VEMb9Jl/tY1A+3RFa7PDIY51LK2m+gWy3boXu/3kdYEvn00ig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.4",
-        "@matter/model": "0.17.4",
-        "@matter/protocol": "0.17.4",
-        "@matter/types": "0.17.4"
+        "@matter/general": "0.17.6",
+        "@matter/model": "0.17.6",
+        "@matter/protocol": "0.17.6",
+        "@matter/types": "0.17.6"
       }
     },
     "node_modules/@matter/nodejs": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.4.tgz",
-      "integrity": "sha512-c6uiT6yT5qPLhbDpVVo1Z5Q6jZCODB9sUviphwoI+dKcNMIwwjBVA/jRfggnTlR9A0cxiQuhVBQydzlAtCbI7w==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.6.tgz",
+      "integrity": "sha512-tvn2wLMgjd1YVKr/kAkKq50WU+8mUeoDVCPIyO6aXJMsy0GTOc8/vC3Lu3ZIUD1IwMiOgn67xnqBVozpp+ZjTw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@matter/general": "0.17.4",
-        "@matter/node": "0.17.4",
-        "@matter/protocol": "0.17.4",
-        "@matter/types": "0.17.4"
+        "@matter/general": "0.17.6",
+        "@matter/node": "0.17.6",
+        "@matter/protocol": "0.17.6",
+        "@matter/types": "0.17.6"
       },
       "engines": {
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
       }
     },
     "node_modules/@matter/protocol": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.4.tgz",
-      "integrity": "sha512-wyju0Km43PVWITr//aHyD4cKDVFVlIrx0x85fRyHn1F8Ab2RY5/IHXIxutcXYl6Jtm22AVeXdeYZUtE6HmWjzQ==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.6.tgz",
+      "integrity": "sha512-p3oc8v2RKKbV4RkkjKemDpzheNHFMQJnbxpij2yKpxsXYIXpYnwtexnvLxDpZCJPsd9Jv3igSxxURBEUexHmBA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.4",
-        "@matter/model": "0.17.4",
-        "@matter/types": "0.17.4"
+        "@matter/general": "0.17.6",
+        "@matter/model": "0.17.6",
+        "@matter/types": "0.17.6"
       }
     },
     "node_modules/@matter/types": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.4.tgz",
-      "integrity": "sha512-nHiBrV6xoPMDPkuzL3+SQk90/2d4xbBgqwnxYQFqcvVrgITSwpGWzSGRC917BsuZE7koUNyD7T0Wlbt+GAlfkw==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.6.tgz",
+      "integrity": "sha512-zYCWx+om6hQR6s6CHniWJMaOsqzTNDKcxUoU0QI8ZgF39SCtIeIb+qOzNigoAtKKZzhVdo9B5IsbEbYY4PhO3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.4",
-        "@matter/model": "0.17.4"
+        "@matter/general": "0.17.6",
+        "@matter/model": "0.17.6"
       }
     },
     "node_modules/@noble/curves": {
@@ -133,16 +133,16 @@
       }
     },
     "node_modules/@project-chip/matter.js": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.4.tgz",
-      "integrity": "sha512-q29M1tYKw0YRrKCDFWZjsUCZkhvDiH7rrcszYDb0mR7MLBEtMUDm7TxrAE6ISy+VDIL91FJBH3cPpiW1TusSqQ==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.6.tgz",
+      "integrity": "sha512-E/FvTvY3G8cPTbpMJDgYdUY8oUHkWN47dXJ6aRjmiDrLFToRb40rrW53p0g6wOOvMnWE9nhVLbJxbE9kOpJIyg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.4",
-        "@matter/model": "0.17.4",
-        "@matter/node": "0.17.4",
-        "@matter/protocol": "0.17.4",
-        "@matter/types": "0.17.4"
+        "@matter/general": "0.17.6",
+        "@matter/model": "0.17.6",
+        "@matter/node": "0.17.6",
+        "@matter/protocol": "0.17.6",
+        "@matter/types": "0.17.6"
       }
     },
     "node_modules/bluebird": {

--- a/server/services/matter/package.json
+++ b/server/services/matter/package.json
@@ -12,8 +12,8 @@
     "arm64"
   ],
   "dependencies": {
-    "@matter/main": "^0.17.4",
-    "@project-chip/matter.js": "^0.17.4",
+    "@matter/main": "^0.17.6",
+    "@project-chip/matter.js": "^0.17.6",
     "bluebird": "^3.7.2",
     "fs-extra": "^11.3.0"
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests? (dependency bump only, no code change — existing Matter tests cover it)
- [x] Are server tests passing with coverage? (`cd server && npm run coverage`) — 4321 passing, 1 pending
- [ ] Did Cypress E2E tests pass? (`npm run cypress:run` from repo root, if UI changed) — no UI change
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front) — N/A
- [ ] Did you test this pull request in real life? With real devices? — not tested with real Matter devices
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? — N/A
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? — N/A
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`)? — N/A

### Description of change

Updates matter.js from `0.17.4` to `0.17.6` (latest release):

- `server/services/matter/package.json`: `@matter/main` and `@project-chip/matter.js` bumped to `^0.17.6` (lockfile regenerated)
- `server/package.json`: `@matter/main` devDependency bumped to `^0.17.6` (lockfile updated)

Notable upstream changes since 0.17.4 (see the [matter.js changelog](https://github.com/project-chip/matter.js/blob/main/CHANGELOG.md)):

- **0.17.5**: upgrade to Matter specification 1.6.0 (backward compatible), server- and controller-side ICD (Intermittently Connected Device) support, subscription `minIntervalFloor` optimization for faster switch events, many protocol fixes
- **0.17.6**: fixes for peer session selection (dead sessions no longer outrank fresh ones), attributes added at runtime now readable, event listeners survive behavior drop/re-inject, `Observable` async iteration fixes

Verification:

- `npm run test-service --service=matter`: 237 passing
- `cd server && npm run coverage`: 4321 passing, 1 pending, 0 failing
- `prettier-check` and `eslint` pass on `server/`
- Sanity check: `@matter/main` and `@project-chip/matter.js` 0.17.6 load correctly and the Matter service module requires cleanly under Node 22
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-027bccec-9e18-4cec-a05b-0f620017b510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-027bccec-9e18-4cec-a05b-0f620017b510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Matter integration components to version 0.17.6 for improved compatibility and maintenance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->