### PR TITLE
AI chat: control light brightness, color and color temperature

### DIFF
--- a/server/config/prompts/aiChat.prompt.txt
+++ b/server/config/prompts/aiChat.prompt.txt
@@ -19,6 +19,7 @@ Rules:
 - For scene actions, strictly include all required fields for each action type. In particular, `ai.ask` requires both `user` and `text`.
 - In scene `ai.ask` text, when referencing previous `device.get-value` action outputs, use Handlebars coordinates such as `{{1.1.last_value}}` (or `{{0.0.last_value}}`) and `{{1.1.last_value_string}}`.
 - Scene actions in the same action group run in parallel. If an action depends on outputs from another action, place it in a later action group. Example: run `device.get-value` in one group, then `ai.ask` in the next group.
+- To change the brightness, the color, or the white color temperature (warm/cool white) of a light, use the `device_set_light` tool with a brightness percentage (0-100), a hexadecimal RGB color (for example #0000FF for blue), or a Kelvin temperature (for example 2700 for warm white, 4000 for neutral white, 6500 for cool white). Use `device_turn_on_off` only to turn lights on or off.
 - When the user asks to save, store, or record a value in a virtual sensor (for example a value read from a camera image), use the `sensor_set_state` tool.
 - Use the tool names and arguments exactly as provided by the tool schema.
 - After you receive tool results, provide a concise and accurate answer in plain language only.

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -1,5 +1,12 @@
 const z = require('zod/v4');
-const { SYSTEM_VARIABLE_NAMES, DEVICE_FEATURE_CATEGORIES, COVER_STATE } = require('../../../utils/constants');
+const {
+  SYSTEM_VARIABLE_NAMES,
+  DEVICE_FEATURE_CATEGORIES,
+  DEVICE_FEATURE_TYPES,
+  COVER_STATE,
+} = require('../../../utils/constants');
+const { normalize } = require('../../../utils/device');
+const { hexToInt, kelvinToMired } = require('../../../utils/colors');
 const {
   createSceneCreateInputSchema,
   formatSceneCreateZodIssue,
@@ -140,6 +147,37 @@ async function getAllResources() {
     homeSchema[device.room?.selector || noRoom.selector].devices[device.selector] = d;
   });
 
+  const lightControlDevices = allDevices
+    .filter((device) => {
+      return device.features.some((feature) => this.isLightControlFeature(feature));
+    })
+    .map((device) => ({
+      ...device,
+      features: device.features.filter((feature) => this.isLightControlFeature(feature)),
+    }));
+
+  lightControlDevices.forEach((device) => {
+    const d = {
+      name: device.name,
+      selector: device.selector,
+      features: device.features.map((feature) => ({
+        name: feature.name,
+        selector: feature.selector,
+        category: feature.category,
+        type: feature.type,
+        access: ['write', 'read'],
+      })),
+    };
+
+    if (homeSchema[device.room?.selector || noRoom.selector].devices[device.selector]?.name) {
+      homeSchema[device.room?.selector || noRoom.selector].devices[device.selector].features.push(...d.features);
+
+      return;
+    }
+
+    homeSchema[device.room?.selector || noRoom.selector].devices[device.selector] = d;
+  });
+
   const shutterDevices = allDevices
     .filter((device) => {
       return device.features.some((feature) => this.isShutterFeature(feature));
@@ -242,6 +280,24 @@ async function getAllTools(userId) {
   const availableSwitchableFeatureCategories = [
     ...new Set(
       switchableDevices
+        .map((device) => {
+          return device.features.map((feature) => feature.category);
+        })
+        .flat(),
+    ),
+  ];
+  const lightControlDevices = allDevices
+    .filter((device) => {
+      return device.features.some((feature) => this.isLightControlFeature(feature));
+    })
+    .map((device) => ({
+      ...device,
+      name: device.name,
+      features: device.features.filter((feature) => this.isLightControlFeature(feature)),
+    }));
+  const availableLightControlFeatureCategories = [
+    ...new Set(
+      lightControlDevices
         .map((device) => {
           return device.features.map((feature) => feature.category);
         })
@@ -424,6 +480,7 @@ async function getAllTools(userId) {
               ...new Set([
                 ...availableSensorFeatureCategories,
                 ...availableSwitchableFeatureCategories,
+                ...availableLightControlFeatureCategories,
                 ...availableShutterFeatureCategories,
               ]),
             ])
@@ -434,7 +491,7 @@ async function getAllTools(userId) {
       cb: async ({ room, device_type: deviceType }) => {
         const states = [];
 
-        let selectedDevices = [...sensorDevices, ...switchableDevices, ...shutterDevices];
+        let selectedDevices = [...sensorDevices, ...switchableDevices, ...lightControlDevices, ...shutterDevices];
 
         if (room && room !== '') {
           const { selector } = this.findBySimilarity(rooms, room);
@@ -841,6 +898,183 @@ async function getAllTools(userId) {
             {
               type: 'text',
               text: `device.set-shutter: ${successMessage}`,
+            },
+          ],
+        };
+      },
+    });
+  }
+
+  if (lightControlDevices.length > 0) {
+    tools.push({
+      intent: 'device.set-light',
+      config: {
+        title: 'Set light brightness, color and color temperature',
+        description:
+          'Set the brightness, the color and/or the white color temperature of lights. ' +
+          'Provide at least one of brightness (percent 0-100), color (hex RGB, for example #0000FF for blue) ' +
+          'or temperature (Kelvin, for example 2700 for warm white, 4000 for neutral white, 6500 for cool white). ' +
+          'Select the light by device name, or by room to target every light of the room. ' +
+          'This tool does not turn lights on or off, use device_turn_on_off for that.',
+        inputSchema: {
+          brightness: z
+            .number()
+            .min(0)
+            .max(100)
+            .optional()
+            .describe('Brightness as a percentage, from 0 to 100.'),
+          color: z
+            .string()
+            .regex(/^#?[0-9a-fA-F]{6}$/)
+            .optional()
+            .describe("Color as a 6 digit hexadecimal RGB value, for example '#FF0000' for red."),
+          temperature: z
+            .number()
+            .min(1000)
+            .max(10000)
+            .optional()
+            .describe(
+              'White color temperature in Kelvin, for example 2700 for warm white, 4000 for neutral white, 6500 for cool white.',
+            ),
+          device: z
+            .enum([...new Set(lightControlDevices.map(({ name }) => name))])
+            .describe('Light device name to control.')
+            .optional(),
+          room: z
+            .enum(rooms.map(({ name }) => name))
+            .describe('Room name, to control all lights of the room when device is not specified.')
+            .optional(),
+        },
+      },
+      cb: async ({ brightness, color, temperature, device, room }) => {
+        if (brightness === undefined && color === undefined && temperature === undefined) {
+          return {
+            content: [{ type: 'text', text: 'device.set-light: brightness, color or temperature is required' }],
+          };
+        }
+
+        if (!device && !room) {
+          return {
+            content: [{ type: 'text', text: 'device.set-light: device or room is required' }],
+          };
+        }
+
+        let selectedDevices = lightControlDevices;
+
+        if (room && room !== '') {
+          const { selector } = this.findBySimilarity(rooms, room);
+          selectedDevices = selectedDevices.filter((d) => (d.room?.selector || noRoom.selector) === selector);
+        }
+
+        if (device) {
+          const selectedDevice = this.findBySimilarity(selectedDevices, device);
+          if (selectedDevice?.name) {
+            selectedDevices = [selectedDevice];
+          } else {
+            return {
+              content: [{ type: 'text', text: 'device.set-light: no device found' }],
+            };
+          }
+        }
+
+        if (selectedDevices.length === 0) {
+          return {
+            content: [{ type: 'text', text: 'device.set-light: no device found' }],
+          };
+        }
+
+        const dispatchResults = [];
+
+        await Promise.all(
+          selectedDevices.map(async (d) => {
+            const sent = [];
+            const missing = [];
+
+            if (brightness !== undefined) {
+              const brightnessFeature = d.features.find((f) => f.type === DEVICE_FEATURE_TYPES.LIGHT.BRIGHTNESS);
+              if (brightnessFeature) {
+                const value = Math.round(normalize(brightness, 0, 100, brightnessFeature.min, brightnessFeature.max));
+                await this.gladys.device.setValue(d, brightnessFeature, value);
+                sent.push(`brightness ${brightness}%`);
+              } else {
+                missing.push('brightness');
+              }
+            }
+
+            if (color !== undefined) {
+              const colorFeature = d.features.find((f) => f.type === DEVICE_FEATURE_TYPES.LIGHT.COLOR);
+              if (colorFeature) {
+                await this.gladys.device.setValue(d, colorFeature, hexToInt(color));
+                sent.push(`color ${color}`);
+              } else {
+                missing.push('color');
+              }
+            }
+
+            if (temperature !== undefined) {
+              const temperatureFeature = d.features.find((f) => f.type === DEVICE_FEATURE_TYPES.LIGHT.TEMPERATURE);
+              if (temperatureFeature) {
+                // Color temperature features are stored in mired (min = coolest, max = warmest).
+                let value = Math.round(kelvinToMired(temperature));
+                if (value > temperatureFeature.max) {
+                  value = temperatureFeature.max;
+                }
+                if (value < temperatureFeature.min) {
+                  value = temperatureFeature.min;
+                }
+                await this.gladys.device.setValue(d, temperatureFeature, value);
+                sent.push(`temperature ${temperature}K`);
+              } else {
+                missing.push('temperature');
+              }
+            }
+
+            dispatchResults.push({ device: d.name, sent, missing });
+          }),
+        );
+
+        const successfulDevices = dispatchResults.filter((result) => result.sent.length > 0);
+        const devicesWithMissingFeatures = dispatchResults.filter((result) => result.missing.length > 0);
+
+        if (successfulDevices.length === 0) {
+          const missingByDevice = devicesWithMissingFeatures
+            .map((result) => `${result.device} (missing ${result.missing.join(' and ')} feature)`)
+            .join('; ');
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `device.set-light: no command sent, no matching feature on ${missingByDevice}`,
+              },
+            ],
+          };
+        }
+
+        const successMessage = successfulDevices
+          .map((result) => `${result.sent.join(' and ')} command sent for ${result.device}`)
+          .join('; ');
+
+        if (devicesWithMissingFeatures.length > 0) {
+          const partialFailures = devicesWithMissingFeatures
+            .map((result) => `${result.device} (missing ${result.missing.join(' and ')} feature)`)
+            .join('; ');
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `device.set-light: ${successMessage}; could not dispatch for ${partialFailures}`,
+              },
+            ],
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `device.set-light: ${successMessage}`,
             },
           ],
         };

--- a/server/services/mcp/lib/formatValue.js
+++ b/server/services/mcp/lib/formatValue.js
@@ -1,4 +1,5 @@
 const { COVER_STATE } = require('../../../utils/constants');
+const { intToHex } = require('../../../utils/colors');
 
 const coverStateLabels = {
   [COVER_STATE.OPEN]: 'open',
@@ -25,6 +26,11 @@ function formatValue(feature) {
     case 'air-conditioning':
       return {
         value: feature.last_value === 0 ? 'off' : 'on',
+        unit: null,
+      };
+    case 'light:color':
+      return {
+        value: feature.last_value === null ? null : `#${intToHex(feature.last_value)}`,
         unit: null,
       };
     case 'shutter:state':

--- a/server/services/mcp/lib/index.js
+++ b/server/services/mcp/lib/index.js
@@ -6,6 +6,7 @@ const { proxy } = require('./mcp.proxy');
 const {
   isSensorFeature,
   isSwitchableFeature,
+  isLightControlFeature,
   isShutterFeature,
   isHistoryFeature,
   isWritableSensorFeature,
@@ -41,6 +42,7 @@ MCPHandler.prototype.getAllResources = getAllResources;
 MCPHandler.prototype.getAllTools = getAllTools;
 MCPHandler.prototype.isSensorFeature = isSensorFeature;
 MCPHandler.prototype.isSwitchableFeature = isSwitchableFeature;
+MCPHandler.prototype.isLightControlFeature = isLightControlFeature;
 MCPHandler.prototype.isShutterFeature = isShutterFeature;
 MCPHandler.prototype.isHistoryFeature = isHistoryFeature;
 MCPHandler.prototype.isWritableSensorFeature = isWritableSensorFeature;

--- a/server/services/mcp/lib/selectFeature.js
+++ b/server/services/mcp/lib/selectFeature.js
@@ -44,6 +44,16 @@ const isSwitchableFeature = (deviceFeature) => {
   );
 };
 
+const lightControlFeatures = [
+  `${DEVICE_FEATURE_CATEGORIES.LIGHT}:${DEVICE_FEATURE_TYPES.LIGHT.BRIGHTNESS}`,
+  `${DEVICE_FEATURE_CATEGORIES.LIGHT}:${DEVICE_FEATURE_TYPES.LIGHT.COLOR}`,
+  `${DEVICE_FEATURE_CATEGORIES.LIGHT}:${DEVICE_FEATURE_TYPES.LIGHT.TEMPERATURE}`,
+];
+
+const isLightControlFeature = (deviceFeature) => {
+  return lightControlFeatures.includes(`${deviceFeature.category}:${deviceFeature.type}`);
+};
+
 const shutterFeatures = [
   `${DEVICE_FEATURE_CATEGORIES.SHUTTER}:${DEVICE_FEATURE_TYPES.SHUTTER.STATE}`,
   `${DEVICE_FEATURE_CATEGORIES.SHUTTER}:${DEVICE_FEATURE_TYPES.SHUTTER.POSITION}`,
@@ -106,6 +116,7 @@ const isWritableSensorFeature = (deviceFeature, device) => {
 module.exports = {
   isSensorFeature,
   isSwitchableFeature,
+  isLightControlFeature,
   isShutterFeature,
   isHistoryFeature,
   isWritableSensorFeature,

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -2480,6 +2480,23 @@ describe('build schemas', () => {
         },
       ],
     };
+    const noRoomLightDevice = {
+      selector: 'device-light-no-room',
+      name: 'No Room Light',
+      room: null,
+      features: [
+        {
+          id: 6,
+          selector: 'device-light-no-room-brightness',
+          name: 'Brightness',
+          category: 'light',
+          type: 'brightness',
+          min: 0,
+          max: 100,
+          last_value: 100,
+        },
+      ],
+    };
 
     const mcpHandler = {
       serviceId: 'test',
@@ -2504,9 +2521,9 @@ describe('build schemas', () => {
         area: { get: stub().resolves([]) },
         scene: { get: stub().resolves([]), create: stub().resolves({}) },
         device: {
-          get: stub().resolves([rgbLightDevice, colorStripDevice]),
+          get: stub().resolves([rgbLightDevice, colorStripDevice, noRoomLightDevice]),
           getBySelector: stub().callsFake(async (selector) => {
-            return [rgbLightDevice, colorStripDevice].find((d) => d.selector === selector);
+            return [rgbLightDevice, colorStripDevice, noRoomLightDevice].find((d) => d.selector === selector);
           }),
           setValue: stub().resolves(),
           getDeviceFeaturesAggregates: stub().resolves({ values: [] }),
@@ -2552,6 +2569,9 @@ describe('build schemas', () => {
         access: ['write', 'read'],
       },
     ]);
+
+    // Device without room is listed under the "no-room" entry.
+    expect(homeSchema['no-room'].devices).to.have.property('device-light-no-room');
 
     // Device without binary feature is added as a standalone entry.
     expect(homeSchema.salon.devices['device-color-strip']).to.deep.equal({
@@ -2627,6 +2647,14 @@ describe('build schemas', () => {
     expect(combinedResult.content[0].text).to.eq(
       'device.set-light: brightness 100% and color 00FF00 and temperature 2700K command sent for Living Room Light',
     );
+
+    mcpHandler.gladys.device.setValue.resetHistory();
+
+    const noRoomResult = await setLightTool.cb({ brightness: 10, room: 'No room' });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[0].name).to.eq('No Room Light');
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[2]).to.eq(10);
+    expect(noRoomResult.content[0].text).to.eq('device.set-light: brightness 10% command sent for No Room Light');
 
     const stateResult = await getStateTool.cb({ room: 'Salon', device_type: 'light' });
     expect(stateResult.content[0].text).to.eq('toonmockdata');

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -12,6 +12,7 @@ const {
 const {
   isSensorFeature,
   isSwitchableFeature,
+  isLightControlFeature,
   isShutterFeature,
   isHistoryFeature,
   isWritableSensorFeature,
@@ -118,6 +119,7 @@ describe('build schemas', () => {
       getAllResources,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -259,6 +261,7 @@ describe('build schemas', () => {
       getAllResources,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -367,6 +370,7 @@ describe('build schemas', () => {
       getAllResources,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -481,6 +485,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -952,6 +957,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -1027,6 +1033,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -1140,6 +1147,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -1238,6 +1246,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -1297,6 +1306,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -1340,6 +1350,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -1450,6 +1461,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -1522,6 +1534,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -1586,6 +1599,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -1685,6 +1699,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -1757,6 +1772,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -1836,6 +1852,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -1887,6 +1904,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -1954,6 +1972,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -2005,6 +2024,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -2072,6 +2092,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -2179,6 +2200,7 @@ describe('build schemas', () => {
       getAllResources,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -2240,6 +2262,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -2334,6 +2357,7 @@ describe('build schemas', () => {
       getAllTools,
       isSensorFeature,
       isSwitchableFeature,
+      isLightControlFeature,
       isShutterFeature,
       isHistoryFeature,
       isWritableSensorFeature,
@@ -2389,6 +2413,440 @@ describe('build schemas', () => {
     expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);
     expect(partialResult.content[0].text).to.eq(
       'device.set-shutter: open command sent for State Only Shutter; could not dispatch for State Only Shutter (missing position feature)',
+    );
+  });
+
+  it('should expose light control features in home schema and device.set-light tool', async () => {
+    const rooms = [{ id: 'room-1', name: 'Salon', selector: 'salon' }];
+    const rgbLightDevice = {
+      selector: 'device-light-rgb',
+      name: 'Living Room Light',
+      room: { selector: 'salon', name: 'Salon' },
+      features: [
+        {
+          id: 1,
+          selector: 'device-light-rgb-binary',
+          name: 'On/Off',
+          category: 'light',
+          type: 'binary',
+          last_value: 1,
+        },
+        {
+          id: 2,
+          selector: 'device-light-rgb-brightness',
+          name: 'Brightness',
+          category: 'light',
+          type: 'brightness',
+          min: 0,
+          max: 254,
+          last_value: 254,
+        },
+        {
+          id: 3,
+          selector: 'device-light-rgb-color',
+          name: 'Color',
+          category: 'light',
+          type: 'color',
+          min: 0,
+          max: 16777215,
+          last_value: 255,
+        },
+        {
+          id: 4,
+          selector: 'device-light-rgb-temperature',
+          name: 'Color temperature',
+          category: 'light',
+          type: 'temperature',
+          min: 153,
+          max: 500,
+          last_value: 250,
+        },
+      ],
+    };
+    const colorStripDevice = {
+      selector: 'device-color-strip',
+      name: 'Color Strip',
+      room: { selector: 'salon', name: 'Salon' },
+      features: [
+        {
+          id: 5,
+          selector: 'device-color-strip-color',
+          name: 'Color',
+          category: 'light',
+          type: 'color',
+          min: 0,
+          max: 16777215,
+          last_value: 65280,
+        },
+      ],
+    };
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllResources,
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isLightControlFeature,
+      isShutterFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      formatValue: stub().callsFake((feature) => ({
+        value: feature.last_value,
+        unit: feature.unit,
+      })),
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves(rooms) },
+        user: { get: stub().resolves([]) },
+        house: { get: stub().resolves([]) },
+        calendar: { get: stub().resolves([]) },
+        area: { get: stub().resolves([]) },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves([rgbLightDevice, colorStripDevice]),
+          getBySelector: stub().callsFake(async (selector) => {
+            return [rgbLightDevice, colorStripDevice].find((d) => d.selector === selector);
+          }),
+          setValue: stub().resolves(),
+          getDeviceFeaturesAggregates: stub().resolves({ values: [] }),
+          camera: { getImagesInRoom: stub().resolves([]) },
+        },
+        event: { emit: fake() },
+      },
+      levenshtein: { distance: stub().returns(0) },
+      toon: stub().returns('toonmockdata'),
+    };
+
+    const resources = await mcpHandler.getAllResources();
+    const homeSchema = JSON.parse((await resources[0].cb({ href: 'schema://home' })).contents[0].text);
+
+    // Light control features are merged with the existing binary feature of the device.
+    expect(homeSchema.salon.devices['device-light-rgb'].features).to.deep.equal([
+      {
+        name: 'On/Off',
+        selector: 'device-light-rgb-binary',
+        category: 'light',
+        type: 'binary',
+        access: ['write', 'read'],
+      },
+      {
+        name: 'Brightness',
+        selector: 'device-light-rgb-brightness',
+        category: 'light',
+        type: 'brightness',
+        access: ['write', 'read'],
+      },
+      {
+        name: 'Color',
+        selector: 'device-light-rgb-color',
+        category: 'light',
+        type: 'color',
+        access: ['write', 'read'],
+      },
+      {
+        name: 'Color temperature',
+        selector: 'device-light-rgb-temperature',
+        category: 'light',
+        type: 'temperature',
+        access: ['write', 'read'],
+      },
+    ]);
+
+    // Device without binary feature is added as a standalone entry.
+    expect(homeSchema.salon.devices['device-color-strip']).to.deep.equal({
+      name: 'Color Strip',
+      selector: 'device-color-strip',
+      features: [
+        {
+          name: 'Color',
+          selector: 'device-color-strip-color',
+          category: 'light',
+          type: 'color',
+          access: ['write', 'read'],
+        },
+      ],
+    });
+
+    const tools = await mcpHandler.getAllTools();
+    const setLightTool = tools.find((tool) => tool.intent === 'device.set-light');
+    const getStateTool = tools.find((tool) => tool.intent === 'device.get-state');
+
+    expect(setLightTool).to.not.equal(undefined);
+
+    const setLightApiTool = mcpToolsToChatApiFormat(tools).find((tool) => tool.function.name === 'device_set_light');
+    expect(setLightApiTool.function.parameters.properties).to.have.all.keys(
+      'brightness',
+      'color',
+      'temperature',
+      'device',
+      'room',
+    );
+
+    const brightnessResult = await setLightTool.cb({ brightness: 30, device: 'Living Room Light' });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[1].type).to.eq('brightness');
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[2]).to.eq(76); // 30% of 0-254
+    expect(brightnessResult.content[0].text).to.eq(
+      'device.set-light: brightness 30% command sent for Living Room Light',
+    );
+
+    mcpHandler.gladys.device.setValue.resetHistory();
+
+    const colorResult = await setLightTool.cb({ color: '#0000FF', device: 'Living Room Light' });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[1].type).to.eq('color');
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[2]).to.eq(255);
+    expect(colorResult.content[0].text).to.eq('device.set-light: color #0000FF command sent for Living Room Light');
+
+    mcpHandler.gladys.device.setValue.resetHistory();
+
+    const temperatureResult = await setLightTool.cb({ temperature: 4000, device: 'Living Room Light' });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[1].type).to.eq('temperature');
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[2]).to.eq(250); // 4000K = 250 mired
+    expect(temperatureResult.content[0].text).to.eq(
+      'device.set-light: temperature 4000K command sent for Living Room Light',
+    );
+
+    mcpHandler.gladys.device.setValue.resetHistory();
+
+    const combinedResult = await setLightTool.cb({
+      brightness: 100,
+      color: '00FF00',
+      temperature: 2700,
+      device: 'Living Room Light',
+    });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(3);
+    const setValues = mcpHandler.gladys.device.setValue.getCalls().map((call) => [call.args[1].type, call.args[2]]);
+    expect(setValues).to.deep.equal([
+      ['brightness', 254],
+      ['color', 65280],
+      ['temperature', 370], // 2700K = 370 mired
+    ]);
+    expect(combinedResult.content[0].text).to.eq(
+      'device.set-light: brightness 100% and color 00FF00 and temperature 2700K command sent for Living Room Light',
+    );
+
+    const stateResult = await getStateTool.cb({ room: 'Salon', device_type: 'light' });
+    expect(stateResult.content[0].text).to.eq('toonmockdata');
+    const states = mcpHandler.toon.lastCall.args[0];
+    const stateFeatureNames = states.map((state) => state.feature);
+    expect(stateFeatureNames).to.include.members(['On/Off', 'Brightness', 'Color', 'Color temperature']);
+  });
+
+  it('should cover device.set-light error and filtering branches', async () => {
+    const rooms = [
+      { id: 'room-1', name: 'Salon', selector: 'salon' },
+      { id: 'room-2', name: 'Chambre', selector: 'chambre' },
+      { id: 'room-3', name: 'Cuisine', selector: 'cuisine' },
+    ];
+    const lightDevices = [
+      {
+        selector: 'device-light-salon',
+        name: 'Salon Light',
+        room: { selector: 'salon', name: 'Salon' },
+        features: [
+          {
+            id: 1,
+            selector: 's-brightness',
+            name: 'Brightness',
+            category: 'light',
+            type: 'brightness',
+            min: 0,
+            max: 100,
+          },
+          { id: 2, selector: 's-color', name: 'Color', category: 'light', type: 'color', min: 0, max: 16777215 },
+          {
+            id: 3,
+            selector: 's-temperature',
+            name: 'Temperature',
+            category: 'light',
+            type: 'temperature',
+            min: 153,
+            max: 500,
+          },
+        ],
+      },
+      {
+        selector: 'device-light-chambre',
+        name: 'Bedroom Light',
+        room: { selector: 'chambre', name: 'Chambre' },
+        features: [
+          {
+            id: 4,
+            selector: 'c-brightness',
+            name: 'Brightness',
+            category: 'light',
+            type: 'brightness',
+            min: 0,
+            max: 100,
+          },
+        ],
+      },
+    ];
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isLightControlFeature,
+      isShutterFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      formatValue: stub().returns({ value: 0 }),
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves(rooms) },
+        user: { get: stub().resolves([]) },
+        house: { get: stub().resolves([]) },
+        calendar: { get: stub().resolves([]) },
+        area: { get: stub().resolves([]) },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves(lightDevices),
+          getBySelector: stub().resolves(lightDevices[0]),
+          setValue: stub().resolves(),
+          getDeviceFeaturesAggregates: stub().resolves({ values: [] }),
+          camera: { getImagesInRoom: stub().resolves([]) },
+        },
+        event: { emit: fake() },
+      },
+      levenshtein: { distance: stub().returns(10) },
+      toon: stub().returns('ok'),
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    const setLightTool = tools.find((tool) => tool.intent === 'device.set-light');
+
+    const missingValuesResult = await setLightTool.cb({ device: 'Salon Light' });
+    expect(missingValuesResult.content[0].text).to.eq('device.set-light: brightness, color or temperature is required');
+
+    const missingTargetResult = await setLightTool.cb({ brightness: 50 });
+    expect(missingTargetResult.content[0].text).to.eq('device.set-light: device or room is required');
+
+    const unknownDeviceResult = await setLightTool.cb({ brightness: 50, device: 'Unknown Light' });
+    expect(unknownDeviceResult.content[0].text).to.eq('device.set-light: no device found');
+
+    const noDeviceInRoomResult = await setLightTool.cb({ brightness: 50, room: 'Cuisine' });
+    expect(noDeviceInRoomResult.content[0].text).to.eq('device.set-light: no device found');
+
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(0);
+
+    const roomResult = await setLightTool.cb({ brightness: 50, room: 'Chambre' });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[0].name).to.eq('Bedroom Light');
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[2]).to.eq(50);
+    expect(roomResult.content[0].text).to.eq('device.set-light: brightness 50% command sent for Bedroom Light');
+
+    mcpHandler.gladys.device.setValue.resetHistory();
+
+    const roomAndDeviceResult = await setLightTool.cb({ color: '#FF0000', room: 'Salon', device: 'Salon Light' });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[0].name).to.eq('Salon Light');
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[2]).to.eq(16711680);
+    expect(roomAndDeviceResult.content[0].text).to.eq('device.set-light: color #FF0000 command sent for Salon Light');
+
+    mcpHandler.gladys.device.setValue.resetHistory();
+
+    // 10000K = 100 mired, clamped to feature min (153 mired).
+    const coolClampResult = await setLightTool.cb({ temperature: 10000, device: 'Salon Light' });
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[2]).to.eq(153);
+    expect(coolClampResult.content[0].text).to.eq('device.set-light: temperature 10000K command sent for Salon Light');
+
+    mcpHandler.gladys.device.setValue.resetHistory();
+
+    // 1000K = 1000 mired, clamped to feature max (500 mired).
+    const warmClampResult = await setLightTool.cb({ temperature: 1000, device: 'Salon Light' });
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[2]).to.eq(500);
+    expect(warmClampResult.content[0].text).to.eq('device.set-light: temperature 1000K command sent for Salon Light');
+  });
+
+  it('should report when device.set-light cannot dispatch a matching feature', async () => {
+    const rooms = [{ id: 'room-1', name: 'Salon', selector: 'salon' }];
+    const brightnessOnlyLight = {
+      selector: 'device-light-brightness-only',
+      name: 'Brightness Only Light',
+      room: { selector: 'salon', name: 'Salon' },
+      features: [
+        {
+          id: 1,
+          selector: 'b-brightness',
+          name: 'Brightness',
+          category: 'light',
+          type: 'brightness',
+          min: 0,
+          max: 100,
+        },
+      ],
+    };
+    const colorOnlyLight = {
+      selector: 'device-light-color-only',
+      name: 'Color Only Light',
+      room: { selector: 'salon', name: 'Salon' },
+      features: [
+        { id: 2, selector: 'c-color', name: 'Color', category: 'light', type: 'color', min: 0, max: 16777215 },
+      ],
+    };
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isLightControlFeature,
+      isShutterFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      formatValue: stub().returns({ value: 0 }),
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves(rooms) },
+        user: { get: stub().resolves([]) },
+        house: { get: stub().resolves([]) },
+        calendar: { get: stub().resolves([]) },
+        area: { get: stub().resolves([]) },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves([brightnessOnlyLight, colorOnlyLight]),
+          setValue: stub().resolves(),
+          getDeviceFeaturesAggregates: stub().resolves({ values: [] }),
+          camera: { getImagesInRoom: stub().resolves([]) },
+        },
+        event: { emit: fake() },
+      },
+      levenshtein: { distance: stub().returns(10) },
+      toon: stub().returns('ok'),
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    const setLightTool = tools.find((tool) => tool.intent === 'device.set-light');
+
+    const missingColorResult = await setLightTool.cb({ color: '#123456', device: 'Brightness Only Light' });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(0);
+    expect(missingColorResult.content[0].text).to.eq(
+      'device.set-light: no command sent, no matching feature on Brightness Only Light (missing color feature)',
+    );
+
+    const missingBrightnessAndTemperatureResult = await setLightTool.cb({
+      brightness: 20,
+      temperature: 3000,
+      device: 'Color Only Light',
+    });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(0);
+    expect(missingBrightnessAndTemperatureResult.content[0].text).to.eq(
+      'device.set-light: no command sent, no matching feature on Color Only Light (missing brightness and temperature feature)',
+    );
+
+    const partialResult = await setLightTool.cb({
+      brightness: 20,
+      color: '#FF0000',
+      device: 'Brightness Only Light',
+    });
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);
+    expect(partialResult.content[0].text).to.eq(
+      'device.set-light: brightness 20% command sent for Brightness Only Light; could not dispatch for Brightness Only Light (missing color feature)',
     );
   });
 });

--- a/server/test/services/mcp/lib/formatValue.test.js
+++ b/server/test/services/mcp/lib/formatValue.test.js
@@ -79,6 +79,21 @@ describe('formatValue', () => {
     });
   });
 
+  it('should format light:color as hexadecimal color', () => {
+    expect(formatValue({ category: 'light', type: 'color', last_value: 255 })).to.deep.equal({
+      value: '#0000ff',
+      unit: null,
+    });
+    expect(formatValue({ category: 'light', type: 'color', last_value: 16711680 })).to.deep.equal({
+      value: '#ff0000',
+      unit: null,
+    });
+    expect(formatValue({ category: 'light', type: 'color', last_value: null })).to.deep.equal({
+      value: null,
+      unit: null,
+    });
+  });
+
   it('should format default case with value and unit', () => {
     const feature = {
       category: 'temperature-sensor',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Implements the feature request from the community forum: [Concernant l'IA : luminosité/température/couleur d'une ampoule](https://community.gladysassistant.com/t/concernant-lia-luminosite-temperature-couleur-dune-ampoule/10352).

Until now the AI assistant could only turn lights on or off (`device_turn_on_off` on `light:binary` features). This PR adds a new `device.set-light` MCP tool (exposed to the AI chat as `device_set_light`) so the assistant can handle requests like:

- "Set the brightness of the living room bulb to 30%"
- "Set the office light to cool white (6500K) / neutral white (4000K) / warm white (2700K)"
- "Bedroom lamp in blue"

## Changes

- **`server/services/mcp/lib/selectFeature.js`**: new `isLightControlFeature` helper matching `light:brightness`, `light:color` and `light:temperature` features.
- **`server/services/mcp/lib/buildSchemas.js`**: new `device.set-light` tool (registered only when at least one light control feature exists):
  - `brightness` as a percentage (0-100), normalized to the feature `min`/`max` range;
  - `color` as a hex RGB string (with or without `#`), converted to the integer color value;
  - `temperature` in Kelvin, converted to mired and clamped to the feature `min`/`max` range (same convention as the Google Actions ColorSetting trait);
  - target selection by device name or by room (all lights of the room), mirroring `device.set-shutter`.
  - Light control features are now also exposed in the `schema://home` resource and in `device.get-state`, so the AI can read the current brightness/color/temperature.
- **`server/services/mcp/lib/formatValue.js`**: `light:color` states are reported as hex colors (e.g. `#0000ff`) instead of a raw integer, which the model can interpret.
- **`server/config/prompts/aiChat.prompt.txt`**: prompt rule directing the model to `device_set_light` for brightness/color/temperature requests.

## Tests

- New tests in `server/test/services/mcp/lib/buildSchemas.test.js` covering the home schema exposure, the happy paths (brightness normalization, hex color conversion, Kelvin→mired conversion with clamping on both ends), room/device targeting, and every error branch (missing values, missing target, unknown device, empty room, missing features, partial dispatch).
- New tests in `server/test/services/mcp/lib/formatValue.test.js` for the hex color formatting (including `null` last value).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b30f67e3-6144-40c3-95c2-70888b4cd88c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b30f67e3-6144-40c3-95c2-70888b4cd88c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added light-control support for brightness, color, and color temperature.
  * Added controls for setting light properties by device or room.
  * Light colors are displayed in hexadecimal format.
  * Light-control devices and capabilities now appear in available device information.
* **Bug Fixes**
  * Improved handling and validation of brightness, color, and temperature values, including supported device limits.
  * Clarified that on/off controls toggle lights, while property changes use dedicated light settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->