### PR TITLE
ci(pr): push branch Docker image to GitHub registry and comment on PR

### DIFF
--- a/.github/workflows/docker-pr-build.yml
+++ b/.github/workflows/docker-pr-build.yml
@@ -166,10 +166,15 @@ jobs:
         uses: actions/checkout@v3
       - name: 🏷️ Compute image tag from branch name
         id: image_tag
+        # github.head_ref is attacker-controlled (any branch name), so we pass it
+        # through the environment instead of interpolating it into the shell to
+        # avoid script injection.
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           # Docker tags only allow [a-zA-Z0-9_.-] and must be 128 chars max,
           # so we sanitize the branch name (e.g. "feature/foo" -> "feature-foo").
-          BRANCH_TAG=$(echo "${{ github.head_ref }}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g' | cut -c1-128)
+          BRANCH_TAG=$(echo "$HEAD_REF" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g' | cut -c1-128)
           # A Docker repository name must be lowercase, so we lowercase the
           # owner/repo part as well (e.g. "GladysAssistant/Gladys").
           REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')

--- a/.github/workflows/docker-pr-build.yml
+++ b/.github/workflows/docker-pr-build.yml
@@ -155,9 +155,24 @@ jobs:
     needs: build-front
     name: Docker magic !
     runs-on: ubuntu-22.04
+    # Needed to push the image to the GitHub Container Registry (ghcr.io)
+    # and to comment on the pull request.
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
     steps:
       - name: ⬇️ Checkout code
         uses: actions/checkout@v3
+      - name: 🏷️ Compute image tag from branch name
+        id: image_tag
+        run: |
+          # Docker tags only allow [a-zA-Z0-9_.-] and must be 128 chars max,
+          # so we sanitize the branch name (e.g. "feature/foo" -> "feature-foo").
+          BRANCH_TAG=$(echo "${{ github.head_ref }}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g' | cut -c1-128)
+          IMAGE="ghcr.io/${{ github.repository }}-preview:${BRANCH_TAG}"
+          echo "tag=${BRANCH_TAG}" >> "$GITHUB_OUTPUT"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
       - name: 💽 Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: 🐳 Set up Docker Buildx
@@ -170,10 +185,58 @@ jobs:
         with:
           name: static
           path: static
-      - name: 🐳 Build AMD64 images
+      # Pushing to ghcr.io only works for pull requests opened from a branch of
+      # this repository: pull requests coming from forks only get a read-only
+      # GITHUB_TOKEN and cannot push packages nor comment.
+      - name: 🔑 Login to GitHub Container Registry
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: 🐳 Build AMD64 image and push it to ghcr.io
         uses: docker/build-push-action@v3
         with:
           context: .
           file: ./docker/Dockerfile.buildx
           platforms: linux/amd64
-          push: false
+          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          tags: ${{ steps.image_tag.outputs.image }}
+      - name: 💬 Comment the image on the pull request
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: docker-preview-image
+          message: |
+            🐳 **A Docker image has been built for this branch and pushed to the GitHub Container Registry.**
+
+            You can test this pull request (AMD64 only) by pulling the image below:
+
+            ```
+            ${{ steps.image_tag.outputs.image }}
+            ```
+
+            For example, run it with:
+
+            ```bash
+            sudo docker run -d \
+              --log-driver json-file \
+              --log-opt max-size=10m \
+              --cgroupns=host \
+              --restart=always \
+              --privileged \
+              --network=host \
+              --name gladys-${{ steps.image_tag.outputs.tag }} \
+              -e NODE_ENV=production \
+              -e SERVER_PORT=80 \
+              -e TZ=Europe/Paris \
+              -e SQLITE_FILE_PATH=/var/lib/gladysassistant/gladys-production.db \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              -v /var/lib/gladysassistant:/var/lib/gladysassistant \
+              -v /dev:/dev \
+              -v /run/udev:/run/udev:ro \
+              ${{ steps.image_tag.outputs.image }}
+            ```
+
+            This comment and the image are automatically updated on every new commit pushed to this pull request.

--- a/.github/workflows/docker-pr-build.yml
+++ b/.github/workflows/docker-pr-build.yml
@@ -170,7 +170,10 @@ jobs:
           # Docker tags only allow [a-zA-Z0-9_.-] and must be 128 chars max,
           # so we sanitize the branch name (e.g. "feature/foo" -> "feature-foo").
           BRANCH_TAG=$(echo "${{ github.head_ref }}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g' | cut -c1-128)
-          IMAGE="ghcr.io/${{ github.repository }}-preview:${BRANCH_TAG}"
+          # A Docker repository name must be lowercase, so we lowercase the
+          # owner/repo part as well (e.g. "GladysAssistant/Gladys").
+          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          IMAGE="ghcr.io/${REPO}-preview:${BRANCH_TAG}"
           echo "tag=${BRANCH_TAG}" >> "$GITHUB_OUTPUT"
           echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
       - name: 💽 Set up QEMU


### PR DESCRIPTION
## Description

The pull request workflow (`docker-pr-build.yml`) already built an AMD64 Docker image, but only to validate that the build succeeds (`push: false`). This PR makes that image **usable**: it's pushed to the GitHub Container Registry (`ghcr.io`) tagged with the branch name, and a comment is posted on the pull request explaining how to test it.

## What changed

In the `docker` job of `.github/workflows/docker-pr-build.yml`:

- **Push the AMD64 image to `ghcr.io`** at `ghcr.io/<owner>/<repo>-preview:<branch>`. The branch name is sanitized into a valid Docker tag (lowercased, invalid characters replaced with `-`, e.g. `feature/foo` → `feature-foo`).
- **Post a sticky comment on the PR** (via `marocchino/sticky-pull-request-comment`) with a ready-to-run `docker run` command pointing at the built image. The comment is updated in place on every new commit.
- **Added permissions** to the job: `packages: write` (to push the image) and `pull-requests: write` (to comment).
- **Fork safety**: pull requests opened from forks only get a read-only `GITHUB_TOKEN`, so they can't push packages or comment. For those, the workflow keeps building the image without pushing (no failure), exactly as before.

## Example comment posted on the PR

> 🐳 A Docker image has been built for this branch and pushed to the GitHub Container Registry.
>
> You can test this pull request (AMD64 only) by pulling the image below:
>
> `ghcr.io/gladysassistant/gladys-preview:my-branch`
>
> ...followed by a full `docker run` command using that image.

## Notes for reviewers

- The image is pushed to a dedicated `-preview` package so it never collides with the production semver tags published by the release workflow.
- Only `linux/amd64` is built here (unchanged from the existing PR build), which matches the request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xhgmob6fLtk8SYc5NE2gLx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xhgmob6fLtk8SYc5NE2gLx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull requests can automatically build and publish container images to GHCR for testing, with the image reference shown in a sticky pull request comment.
  * Generated image tags are derived from the PR branch name (lowercased, sanitized, and length-limited).
  * Publish/login and comment updates now run only when the pull request originates from the main repository (not from forks).
* **Chores**
  * Removed the prior unconditional AMD64 image build step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->