### PR TITLE
ci(pr): add `/build-arm64` comment command for on-demand ARM64 images

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ To ensure your Pull Request can be accepted as fast as possible, make sure to re
 - [ ] Is the linter passing? (`npm run eslint` on both front/server)
 - [ ] Did you run prettier? (`npm run prettier` on both front/server)
 - [ ] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
-- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging.
+- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging. An AMD64 preview image is built automatically for non-draft PRs; for ARM64, comment `/build-arm64` on the PR.
 - [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
 - [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
 - [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

--- a/.github/workflows/docker-pr-arm64-build.yml
+++ b/.github/workflows/docker-pr-arm64-build.yml
@@ -1,0 +1,217 @@
+name: On-demand ARM64 Docker build
+run-name: ARM64 Docker build for PR #${{ github.event.issue.number }}
+
+# Triggered by commenting `/build-arm64` on a pull request.
+# issue_comment workflows always run from the default branch, so this file
+# must be merged to master before the command works.
+on:
+  issue_comment:
+    types: [created]
+  # Allow manual testing / re-runs without leaving a comment.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number to build'
+        required: true
+        type: string
+
+concurrency:
+  group: docker-pr-arm64-${{ github.event.issue.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  build-arm64:
+    name: Docker ARM64 build
+    runs-on: ubuntu-22.04
+    # Restrict who can trigger expensive ARM64 builds (QEMU emulation).
+    # workflow_dispatch is already limited to users with Actions write access.
+    if: >
+      (github.event_name == 'workflow_dispatch') ||
+      (
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '/build-arm64') &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      )
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
+    steps:
+      - name: 🔎 Resolve pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number || inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}")
+          HEAD_REF=$(echo "$PR_JSON" | jq -r .head.ref)
+          HEAD_SHA=$(echo "$PR_JSON" | jq -r .head.sha)
+          HEAD_REPO=$(echo "$PR_JSON" | jq -r .head.repo.full_name)
+          BASE_REPO=$(echo "$PR_JSON" | jq -r .base.repo.full_name)
+          DRAFT=$(echo "$PR_JSON" | jq -r .draft)
+
+          # Pass branch names through the environment (never interpolate into the
+          # shell from Actions expressions) to avoid script injection.
+          {
+            echo "number=${PR_NUMBER}"
+            echo "head_ref=${HEAD_REF}"
+            echo "head_sha=${HEAD_SHA}"
+            echo "head_repo=${HEAD_REPO}"
+            echo "base_repo=${BASE_REPO}"
+            echo "draft=${DRAFT}"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error::ARM64 builds are only supported for pull requests from this repository (not forks), for security reasons."
+            exit 1
+          fi
+
+      - name: 🚀 Acknowledge request
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            });
+
+      - name: 💬 Comment that the build started
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: docker-preview-image-arm64
+          number: ${{ steps.pr.outputs.number }}
+          message: |
+            🐳 **ARM64 Docker build requested** (`/build-arm64`)
+
+            Building `linux/arm64/v8` for commit `${{ steps.pr.outputs.head_sha }}`…
+
+            Track progress: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: ⬇️ Checkout pull request head
+        uses: actions/checkout@v3
+        with:
+          # Checkout the PR commit by SHA (immutable), not the branch name.
+          ref: ${{ steps.pr.outputs.head_sha }}
+
+      - name: 🏷️ Compute image tag from branch name
+        id: image_tag
+        env:
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+        run: |
+          # Docker tags only allow [a-zA-Z0-9_.-] and must be 128 chars max.
+          # Keep room for the "-arm64" suffix (6 chars).
+          BRANCH_TAG=$(echo "$HEAD_REF" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g' | cut -c1-122)
+          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          IMAGE="ghcr.io/${REPO}-preview:${BRANCH_TAG}-arm64"
+          echo "tag=${BRANCH_TAG}-arm64" >> "$GITHUB_OUTPUT"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - name: 💽 Setup nodejs
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'front/package.json'
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: 📦 Install NPM front packages
+        working-directory: ./front
+        run: |
+          npm ci
+
+      - name: 🏗️ Build front
+        working-directory: ./front
+        run: |
+          npm run build
+
+      - name: 📂 Prepare static front for Docker context
+        run: |
+          mkdir -p static
+          cp -r front/build/* static/
+
+      - name: 💽 Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: 🐳 Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: latest
+
+      - name: 🔑 Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🐳 Build ARM64 image and push it to ghcr.io
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./docker/Dockerfile.buildx
+          platforms: linux/arm64/v8
+          push: true
+          tags: ${{ steps.image_tag.outputs.image }}
+
+      - name: 💬 Comment the ARM64 image on the pull request
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: docker-preview-image-arm64
+          number: ${{ steps.pr.outputs.number }}
+          message: |
+            🐳 **An ARM64 Docker image has been built for this pull request and pushed to the GitHub Container Registry.**
+
+            Requested via `/build-arm64` for commit `${{ steps.pr.outputs.head_sha }}`.
+
+            You can test this pull request on ARM64 (e.g. Raspberry Pi, Apple Silicon) by pulling:
+
+            ```
+            ${{ steps.image_tag.outputs.image }}
+            ```
+
+            For example, run it with:
+
+            ```bash
+            sudo docker run -d \
+              --log-driver json-file \
+              --log-opt max-size=10m \
+              --cgroupns=host \
+              --restart=always \
+              --privileged \
+              --network=host \
+              --name gladys-${{ steps.image_tag.outputs.tag }} \
+              -e NODE_ENV=production \
+              -e SERVER_PORT=80 \
+              -e TZ=Europe/Paris \
+              -e SQLITE_FILE_PATH=/var/lib/gladysassistant/gladys-production.db \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              -v /var/lib/gladysassistant:/var/lib/gladysassistant \
+              -v /dev:/dev \
+              -v /run/udev:/run/udev:ro \
+              ${{ steps.image_tag.outputs.image }}
+            ```
+
+            Comment `/build-arm64` again to rebuild after new commits.
+
+      - name: 💬 Comment on failure
+        if: failure()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: docker-preview-image-arm64
+          number: ${{ steps.pr.outputs.number }}
+          message: |
+            ❌ **ARM64 Docker build failed** (`/build-arm64`)
+
+            The build for commit `${{ steps.pr.outputs.head_sha }}` did not succeed.
+
+            See logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            Comment `/build-arm64` again to retry.

--- a/.github/workflows/docker-pr-build.yml
+++ b/.github/workflows/docker-pr-build.yml
@@ -248,3 +248,5 @@ jobs:
             ```
 
             This comment and the image are automatically updated on every new commit pushed to this pull request.
+
+            Need an **ARM64** image (Raspberry Pi, Apple Silicon, …)? Comment `/build-arm64` on this pull request.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an on-demand way to build an **ARM64** Docker preview image for a pull request by commenting `/build-arm64` on the PR.

Today, PR CI only builds AMD64 (pushed to `ghcr.io/...-preview:<branch>`). Requesting an ARM64 image meant going through the manual `workflow_dispatch` on *Build Gladys dev images*, which is slow and awkward. This change makes it a one-line PR comment for maintainers.

## How it works

1. On a non-fork PR, a maintainer (OWNER / MEMBER / COLLABORATOR) comments `/build-arm64`.
2. The new workflow `.github/workflows/docker-pr-arm64-build.yml`:
   - reacts with 🚀 on the comment
   - builds the front, then a `linux/arm64/v8` image (via QEMU)
   - pushes it to `ghcr.io/<owner>/<repo>-preview:<branch>-arm64`
   - posts/updates a sticky PR comment with the image name and a ready-to-run `docker run`
3. Comment `/build-arm64` again after new commits to rebuild.

Also available via **Actions → On-demand ARM64 Docker build → Run workflow** (with a PR number), useful for testing before this lands on `master`.

**Note:** `issue_comment` workflows always run from the default branch, so `/build-arm64` only works once this PR is merged.

## Other changes

- AMD64 sticky comment now mentions `/build-arm64`.
- PR template checklist mentions the command for ARM64 testing.

## Security

- Only OWNER / MEMBER / COLLABORATOR can trigger the command.
- Fork PRs are rejected (avoids building untrusted Dockerfiles with package-write credentials).
- Branch names are passed via env vars (no expression interpolation into the shell).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea8ac273-214b-419d-a884-39d93a36df39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea8ac273-214b-419d-a884-39d93a36df39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added on-demand ARM64 Docker preview image builds for pull requests using the `/build-arm64` comment command.
  * Added automated status comments with build instructions on success or links to failure logs.

* **Documentation**
  * Updated pull request guidance to explain available AMD64 and ARM64 preview builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->