### PR TITLE
feat(ai-chat): increase AI debug context history to 200 messages

### DIFF
--- a/server/lib/gateway/gateway.getAiChatDebugContext.js
+++ b/server/lib/gateway/gateway.getAiChatDebugContext.js
@@ -6,11 +6,14 @@ const { mcpToolsToChatApiFormat } = require('../../services/mcp/lib/mcpToolsToCh
 const {
   buildExchangesFromMessages,
   exchangesToApiMessages,
-  FETCH_MESSAGE_LIMIT,
 } = require('../message/message.getPreviousQuestionsForUser');
 const { buildSystemPromptWithCurrentTime } = require('./gateway.forwardMessageToAiChat');
 
 const DEFAULT_TIMEZONE = 'Europe/Paris';
+
+// Number of most recent messages to include in the AI chat debug context.
+// Larger than the live chat fetch limit so the debug payload shows more history.
+const DEBUG_MESSAGE_LIMIT = 200;
 
 /**
  * @description Return MCP handler from service manager.
@@ -158,7 +161,7 @@ async function getAiChatDebugContext(userId) {
     },
     attributes: ['sender_id', 'text', 'file', 'message_type', 'tool_name', 'tool_status', 'created_at'],
     order: [['created_at', 'desc']],
-    limit: FETCH_MESSAGE_LIMIT,
+    limit: DEBUG_MESSAGE_LIMIT,
   });
 
   const plainMessages = recentMessages.map((message) => message.get({ plain: true }));
@@ -187,6 +190,7 @@ async function getAiChatDebugContext(userId) {
 }
 
 module.exports = {
+  DEBUG_MESSAGE_LIMIT,
   getAiChatDebugContext,
   dbMessageToApiMessage,
   formatFileAsImageUrl,

--- a/server/test/lib/gateway/gateway.getAiChatDebugContext.test.js
+++ b/server/test/lib/gateway/gateway.getAiChatDebugContext.test.js
@@ -208,7 +208,7 @@ describe('gateway.getAiChatDebugContext', () => {
     expect(payload._debug.exchangeCount).to.equal(1);
 
     assert.calledOnce(messageFindAll);
-    expect(messageFindAll.firstCall.args[0].limit).to.equal(30);
+    expect(messageFindAll.firstCall.args[0].limit).to.equal(200);
   });
 
   it('should default timezone when not configured', async () => {


### PR DESCRIPTION
## Description

The AI chat debug context (`getAiChatDebugContext`) reused the live chat fetch limit (`FETCH_MESSAGE_LIMIT`), so the debug/replay payload only exposed a handful of the most recent messages.

This PR introduces a dedicated `DEBUG_MESSAGE_LIMIT` (200) used only for the debug payload, so it now includes far more conversation history. The live chat context is left untouched — it still uses its own (smaller) fetch limit and keeps only the last few exchanges, so this change has no impact on what is actually sent to the model during normal chat.

## Changes

- `server/lib/gateway/gateway.getAiChatDebugContext.js`: add and export a dedicated `DEBUG_MESSAGE_LIMIT = 200` constant and use it for the debug message fetch instead of the shared live-chat limit.
- `server/test/lib/gateway/gateway.getAiChatDebugContext.test.js`: update the fetch-limit assertion to `200`.

## Testing

- `npx mocha test/lib/gateway/gateway.getAiChatDebugContext.test.js` — 15 passing.
- ESLint clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3hU8UrkdgJ75PkRzVvfda)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI chat debugging and replay data by including a larger history of recent messages.
  * Debug context now retains up to 200 messages for more complete conversation analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->