### PR TITLE
feat(ai-chat): answer energy consumption (kWh) and cost questions over date ranges

### DIFF
--- a/server/config/prompts/aiChat.prompt.txt
+++ b/server/config/prompts/aiChat.prompt.txt
@@ -12,6 +12,7 @@ Rules:
 - Previous assistant messages may describe actions that were never executed. Ignore them and always call tools again for any new action request.
 - For any request about current state, measurements, status, or execution result, you MUST fetch fresh data with tools in this turn before answering.
 - If the user repeats the same question (for example asking twice for a temperature), call tools again and return live data again.
+- For questions about electricity consumption (kWh) or its cost over a period (a specific day, a month, a date range), use the `device_get_energy_consumption` tool with start_date and end_date in YYYY-MM-DD format (both inclusive), and unit "kwh" for consumption or "currency" for cost. Never use `device_get_history` to compute consumption totals or costs.
 - To change the brightness, the color, or the white color temperature (warm/cool white) of a light, use the `device_set_light` tool with a brightness percentage (0-100), a hexadecimal RGB color (for example #0000FF for blue), or a Kelvin temperature (for example 2700 for warm white, 4000 for neutral white, 6500 for cool white). Use `device_turn_on_off` only to turn lights on or off.
 - When the user asks to save, store, or record a value in a virtual sensor (for example a value read from a camera image), use the `sensor_set_state` tool.
 - Use the tool names and arguments exactly as provided by the tool schema.

--- a/server/lib/gateway/gateway.classifyAiChatToolCategories.js
+++ b/server/lib/gateway/gateway.classifyAiChatToolCategories.js
@@ -7,7 +7,7 @@ const MAX_ROUTER_HISTORY_CHARS = 200;
 const ROUTER_SYSTEM_PROMPT = `You are an intent router for a smart home assistant. Classify the user's last message into one or more of these categories:
 - "scenes": create, modify or configure a home automation scene/routine/automation, anything that should happen automatically later, on a schedule or on an event (for example "every day at 8am...", "when the door opens...", "create a scene...").
 - "device_control": act on the home right now: turn devices on or off, change light brightness/color/temperature, open or close shutters, start an existing scene, write a value to a sensor.
-- "device_query": read information from the home: current device states, temperatures, sensor values, device history, camera images.
+- "device_query": read information from the home: current device states, temperatures, sensor values, device history, energy consumption (kWh) or energy cost over a period, camera images.
 - "web_and_time": fetch a public web page, or compare times, schedules or opening hours.
 - "other": greetings, general questions or anything that does not fit the categories above.
 

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -1324,15 +1324,12 @@ async function getAllTools(userId) {
           };
         }
 
-        const results = await this.gladys.device.energySensorManager.getConsumptionByDates(
-          [selectedFeature.selector],
-          {
-            from,
-            to,
-            group_by: groupBy || 'day',
-            display_mode: displayMode,
-          },
-        );
+        const results = await this.gladys.device.energySensorManager.getConsumptionByDates([selectedFeature.selector], {
+          from,
+          to,
+          group_by: groupBy || 'day',
+          display_mode: displayMode,
+        });
 
         const deviceResult = results.find((result) => !result.deviceFeature?.is_subscription);
         const subscriptionResult = results.find((result) => result.deviceFeature?.is_subscription);

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -1259,6 +1259,12 @@ async function getAllTools(userId) {
             return null;
           }
           const [year, month, day] = value.split('-').map(Number);
+          // Reject calendar-invalid dates (2026-02-30, 2026-13-01) that the
+          // Date constructor would silently roll over to another day.
+          const date = new Date(year, month - 1, day);
+          if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+            return null;
+          }
           return { year, month, day };
         };
 
@@ -1269,7 +1275,7 @@ async function getAllTools(userId) {
             content: [
               {
                 type: 'text',
-                text: 'device.get-energy-consumption: start_date and end_date are required in YYYY-MM-DD format',
+                text: 'device.get-energy-consumption: start_date and end_date must be valid dates in YYYY-MM-DD format',
               },
             ],
           };

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -375,6 +375,20 @@ async function getAllTools(userId) {
       features: device.features.filter((feature) => this.isWritableSensorFeature(feature, device)),
     }));
 
+  const isEnergyMonitoringFeature = (feature) =>
+    feature.category === DEVICE_FEATURE_CATEGORIES.ENERGY_SENSOR &&
+    [
+      DEVICE_FEATURE_TYPES.ENERGY_SENSOR.THIRTY_MINUTES_CONSUMPTION,
+      DEVICE_FEATURE_TYPES.ENERGY_SENSOR.THIRTY_MINUTES_CONSUMPTION_COST,
+    ].includes(feature.type);
+  const energyMonitoringDevices = allDevices
+    .filter((device) => device.features.some(isEnergyMonitoringFeature))
+    .map((device) => ({
+      ...device,
+      name: device.name,
+      features: device.features.filter(isEnergyMonitoringFeature),
+    }));
+
   const tools = [
     {
       intent: 'camera.get-image',
@@ -1197,6 +1211,166 @@ async function getAllTools(userId) {
             {
               type: 'text',
               text: `sensor.set-state: set ${selectedDevice.name} / ${selectedFeature.name} to ${parsedValue}`,
+            },
+          ],
+        };
+      },
+    });
+  }
+
+  if (energyMonitoringDevices.length > 0) {
+    tools.push({
+      intent: 'device.get-energy-consumption',
+      config: {
+        title: 'Get energy consumption and cost over a period',
+        description:
+          'Get the electricity consumption (in kWh) or the consumption cost (in the home currency, for example euros) ' +
+          'of an energy monitoring device over a date range. ' +
+          'Dates are inclusive: for a single day use the same start_date and end_date, ' +
+          'for a full month use the first and last day of the month. ' +
+          'The result contains the total over the period and the detail per group_by period. ' +
+          'In currency mode, a separate home_subscription entry may be present: it is the fixed subscription cost ' +
+          'of the whole home electricity contract, and is not part of the device consumption cost.',
+        categories: [AI_CHAT_TOOL_CATEGORIES.DEVICE_QUERY, AI_CHAT_TOOL_CATEGORIES.OTHER],
+        inputSchema: {
+          device: z
+            .enum([...new Set(energyMonitoringDevices.map(({ name }) => name))])
+            .describe('Energy monitoring device name.'),
+          start_date: z
+            .string()
+            .regex(/^\d{4}-\d{2}-\d{2}$/)
+            .describe('Start date of the period in YYYY-MM-DD format, inclusive.'),
+          end_date: z
+            .string()
+            .regex(/^\d{4}-\d{2}-\d{2}$/)
+            .describe('End date of the period in YYYY-MM-DD format, inclusive.'),
+          unit: z
+            .enum(['kwh', 'currency'])
+            .describe('Use kwh to get the consumption in kWh, currency to get the cost in the home currency.'),
+          group_by: z
+            .enum(['hour', 'day', 'week', 'month', 'year'])
+            .optional()
+            .describe('Aggregation of the returned detail values. Defaults to day.'),
+        },
+      },
+      cb: async ({ device, start_date: startDate, end_date: endDate, unit, group_by: groupBy }) => {
+        const parseDateInput = (value) => {
+          if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+            return null;
+          }
+          const [year, month, day] = value.split('-').map(Number);
+          return { year, month, day };
+        };
+
+        const parsedStart = parseDateInput(startDate);
+        const parsedEnd = parseDateInput(endDate);
+        if (!parsedStart || !parsedEnd) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'device.get-energy-consumption: start_date and end_date are required in YYYY-MM-DD format',
+              },
+            ],
+          };
+        }
+
+        const selectedDevice = this.findBySimilarity(energyMonitoringDevices, device);
+        if (!selectedDevice?.name) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `device.get-energy-consumption: no energy monitoring device found matching "${device}"`,
+              },
+            ],
+          };
+        }
+
+        const consumptionFeature = selectedDevice.features.find(
+          (f) => f.type === DEVICE_FEATURE_TYPES.ENERGY_SENSOR.THIRTY_MINUTES_CONSUMPTION,
+        );
+        const costFeature = selectedDevice.features.find(
+          (f) => f.type === DEVICE_FEATURE_TYPES.ENERGY_SENSOR.THIRTY_MINUTES_CONSUMPTION_COST,
+        );
+        const displayMode = unit === 'currency' ? 'currency' : 'kwh';
+        // In kwh mode a cost feature also works: getConsumptionByDates hot-swaps it
+        // with its parent consumption feature through energy_parent_id.
+        const selectedFeature = displayMode === 'currency' ? costFeature : consumptionFeature || costFeature;
+        if (!selectedFeature) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text:
+                  `device.get-energy-consumption: no consumption cost tracking configured on ${selectedDevice.name}. ` +
+                  'An energy contract with prices must be configured in the energy monitoring settings.',
+              },
+            ],
+          };
+        }
+
+        // Same date boundaries as the energy dashboard: local midnight, end exclusive.
+        const from = new Date(parsedStart.year, parsedStart.month - 1, parsedStart.day);
+        const to = new Date(parsedEnd.year, parsedEnd.month - 1, parsedEnd.day + 1);
+        if (!(from < to)) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'device.get-energy-consumption: start_date must be before or equal to end_date',
+              },
+            ],
+          };
+        }
+
+        const results = await this.gladys.device.energySensorManager.getConsumptionByDates(
+          [selectedFeature.selector],
+          {
+            from,
+            to,
+            group_by: groupBy || 'day',
+            display_mode: displayMode,
+          },
+        );
+
+        const deviceResult = results.find((result) => !result.deviceFeature?.is_subscription);
+        const subscriptionResult = results.find((result) => result.deviceFeature?.is_subscription);
+
+        const decimalPlaces = displayMode === 'currency' ? 2 : 3;
+        const roundValue = (value) => Number(value.toFixed(decimalPlaces));
+        const deviceValues = deviceResult?.values ?? [];
+
+        const response = {
+          device: selectedDevice.name,
+          feature: selectedFeature.name,
+          unit: displayMode === 'currency' ? deviceResult?.deviceFeature?.currency_unit || 'currency' : 'kWh',
+          start_date: startDate,
+          end_date: endDate,
+          group_by: groupBy || 'day',
+          total: roundValue(deviceValues.reduce((acc, value) => acc + value.sum_value, 0)),
+          values: deviceValues.map((value) => ({
+            date: value.created_at,
+            value: roundValue(value.sum_value),
+          })),
+        };
+
+        if (subscriptionResult) {
+          response.home_subscription = {
+            name: subscriptionResult.deviceFeature.name,
+            total: roundValue(subscriptionResult.values.reduce((acc, value) => acc + value.sum_value, 0)),
+          };
+        }
+
+        if (deviceValues.length === 0) {
+          response.note = 'No consumption data recorded for this device over this period.';
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: this.toon(response),
             },
           ],
         };

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -1053,6 +1053,353 @@ describe('build schemas', () => {
     expect(turnOnResult.content[0].text).to.eq('device.turn-on command sent for Light Without Room');
   });
 
+  it('should expose device.get-energy-consumption for energy monitoring devices', async () => {
+    const rooms = [{ id: 'room-1', name: 'Salon', selector: 'salon' }];
+
+    const devices = [
+      {
+        selector: 'prise-onduleur',
+        name: 'Prise onduleur',
+        room: { selector: 'salon', name: 'Salon' },
+        features: [
+          {
+            id: 'feature-consumption',
+            selector: 'prise-onduleur-thirty-minutes-consumption',
+            name: 'Consommation',
+            category: 'energy-sensor',
+            type: 'thirty-minutes-consumption',
+            unit: 'watt-hour',
+            keep_history: true,
+          },
+          {
+            id: 'feature-cost',
+            selector: 'prise-onduleur-thirty-minutes-consumption-cost',
+            name: 'Coût',
+            category: 'energy-sensor',
+            type: 'thirty-minutes-consumption-cost',
+            unit: 'euro',
+            energy_parent_id: 'feature-consumption',
+            keep_history: true,
+          },
+        ],
+      },
+      {
+        selector: 'prise-tele',
+        name: 'Prise télé',
+        room: { selector: 'salon', name: 'Salon' },
+        features: [
+          {
+            id: 'feature-tele-consumption',
+            selector: 'prise-tele-thirty-minutes-consumption',
+            name: 'Consommation',
+            category: 'energy-sensor',
+            type: 'thirty-minutes-consumption',
+            unit: 'watt-hour',
+            keep_history: true,
+          },
+        ],
+      },
+    ];
+
+    const getConsumptionByDates = stub().resolves([
+      {
+        device: { name: 'Prise onduleur' },
+        deviceFeature: {
+          name: 'Consommation',
+          selector: 'prise-onduleur-thirty-minutes-consumption',
+          currency_unit: null,
+        },
+        values: [{ created_at: '2026-07-12T00:00:00.000Z', value: 0.05, sum_value: 2.345678, count_value: 48 }],
+      },
+    ]);
+
+    const mcpHandler = {
+      serviceId: '7056e3d4-31cc-4d2a-bbdd-128cd49755e6',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isLightControlFeature,
+      isShutterFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      formatValue: stub().callsFake((feature) => ({
+        value: feature.last_value,
+        unit: feature.unit,
+      })),
+      findBySimilarity,
+      gladys: {
+        room: {
+          getAll: stub().resolves(rooms),
+        },
+        user: {
+          get: stub().resolves([{ id: 'user-1', name: 'John', selector: 'john' }]),
+        },
+        house: {
+          get: stub().resolves([{ id: 'house-1', name: 'Main house', selector: 'main-house' }]),
+        },
+        calendar: {
+          get: stub().resolves([]),
+        },
+        area: {
+          get: stub().resolves([]),
+        },
+        scene: {
+          get: stub().resolves([]),
+          create: stub(),
+        },
+        device: {
+          get: stub().resolves(devices),
+          getBySelector: stub().callsFake((selector) => {
+            return Promise.resolve(devices.find((d) => d.selector === selector));
+          }),
+          setValue: stub().resolves(),
+          energySensorManager: {
+            getConsumptionByDates,
+          },
+          camera: {
+            getImagesInRoom: stub().resolves([]),
+          },
+        },
+        event: {
+          emit: fake(),
+        },
+      },
+      levenshtein: {
+        distance: stub().returns(4),
+      },
+      toon: stub().returns('toonmockdata'),
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    const energyTool = tools.find((tool) => tool.intent === 'device.get-energy-consumption');
+
+    expect(energyTool).to.not.eq(undefined);
+    expect(energyTool.config.categories).to.deep.equal([
+      AI_CHAT_TOOL_CATEGORIES.DEVICE_QUERY,
+      AI_CHAT_TOOL_CATEGORIES.OTHER,
+    ]);
+
+    // Consumption in kWh for a single day: uses the consumption feature.
+    const kwhResult = await energyTool.cb({
+      device: 'Prise onduleur',
+      start_date: '2026-07-12',
+      end_date: '2026-07-12',
+      unit: 'kwh',
+    });
+    expect(getConsumptionByDates.callCount).to.eq(1);
+    expect(getConsumptionByDates.firstCall.args[0]).to.deep.equal(['prise-onduleur-thirty-minutes-consumption']);
+    expect(getConsumptionByDates.firstCall.args[1]).to.deep.equal({
+      from: new Date(2026, 6, 12),
+      to: new Date(2026, 6, 13),
+      group_by: 'day',
+      display_mode: 'kwh',
+    });
+    expect(kwhResult.content[0].text).to.eq('toonmockdata');
+    expect(mcpHandler.toon.lastCall.args[0]).to.deep.equal({
+      device: 'Prise onduleur',
+      feature: 'Consommation',
+      unit: 'kWh',
+      start_date: '2026-07-12',
+      end_date: '2026-07-12',
+      group_by: 'day',
+      total: 2.346,
+      values: [{ date: '2026-07-12T00:00:00.000Z', value: 2.346 }],
+    });
+
+    // Cost in currency for a full month: uses the cost feature and includes the
+    // home subscription as a separate entry.
+    getConsumptionByDates.resetHistory();
+    getConsumptionByDates.resolves([
+      {
+        device: { name: 'Prise onduleur' },
+        deviceFeature: {
+          name: 'Abonnement',
+          currency_unit: 'euro',
+          is_subscription: true,
+        },
+        values: [
+          { created_at: '2026-06-01T00:00:00.000Z', value: 0.42, sum_value: 0.42 },
+          { created_at: '2026-06-02T00:00:00.000Z', value: 0.42, sum_value: 0.42 },
+        ],
+      },
+      {
+        device: { name: 'Prise onduleur' },
+        deviceFeature: {
+          name: 'Coût',
+          selector: 'prise-onduleur-thirty-minutes-consumption-cost',
+          currency_unit: 'euro',
+        },
+        values: [
+          { created_at: '2026-06-01T00:00:00.000Z', value: 0.1, sum_value: 1.234567 },
+          { created_at: '2026-06-02T00:00:00.000Z', value: 0.1, sum_value: 2.1 },
+        ],
+      },
+    ]);
+
+    const currencyResult = await energyTool.cb({
+      device: 'Prise onduleur',
+      start_date: '2026-06-01',
+      end_date: '2026-06-30',
+      unit: 'currency',
+    });
+    expect(getConsumptionByDates.callCount).to.eq(1);
+    expect(getConsumptionByDates.firstCall.args[0]).to.deep.equal(['prise-onduleur-thirty-minutes-consumption-cost']);
+    expect(getConsumptionByDates.firstCall.args[1]).to.deep.equal({
+      from: new Date(2026, 5, 1),
+      to: new Date(2026, 6, 1),
+      group_by: 'day',
+      display_mode: 'currency',
+    });
+    expect(currencyResult.content[0].text).to.eq('toonmockdata');
+    expect(mcpHandler.toon.lastCall.args[0]).to.deep.equal({
+      device: 'Prise onduleur',
+      feature: 'Coût',
+      unit: 'euro',
+      start_date: '2026-06-01',
+      end_date: '2026-06-30',
+      group_by: 'day',
+      total: 3.33,
+      values: [
+        { date: '2026-06-01T00:00:00.000Z', value: 1.23 },
+        { date: '2026-06-02T00:00:00.000Z', value: 2.1 },
+      ],
+      home_subscription: {
+        name: 'Abonnement',
+        total: 0.84,
+      },
+    });
+
+    // Cost on a device without cost tracking configured.
+    getConsumptionByDates.resetHistory();
+    const noCostResult = await energyTool.cb({
+      device: 'Prise télé',
+      start_date: '2026-06-01',
+      end_date: '2026-06-30',
+      unit: 'currency',
+    });
+    expect(getConsumptionByDates.callCount).to.eq(0);
+    expect(noCostResult.content[0].text).to.contain('no consumption cost tracking configured on Prise télé');
+
+    // Empty period: adds an explicit note.
+    getConsumptionByDates.resolves([
+      {
+        device: { name: 'Prise télé' },
+        deviceFeature: {
+          name: 'Consommation',
+          selector: 'prise-tele-thirty-minutes-consumption',
+          currency_unit: null,
+        },
+        values: [],
+      },
+    ]);
+    const emptyResult = await energyTool.cb({
+      device: 'Prise télé',
+      start_date: '2026-07-12',
+      end_date: '2026-07-12',
+      unit: 'kwh',
+    });
+    expect(emptyResult.content[0].text).to.eq('toonmockdata');
+    expect(mcpHandler.toon.lastCall.args[0].total).to.eq(0);
+    expect(mcpHandler.toon.lastCall.args[0].note).to.eq(
+      'No consumption data recorded for this device over this period.',
+    );
+
+    // Unknown device.
+    const unknownDeviceResult = await energyTool.cb({
+      device: 'Unknown device',
+      start_date: '2026-07-12',
+      end_date: '2026-07-12',
+      unit: 'kwh',
+    });
+    expect(unknownDeviceResult.content[0].text).to.eq(
+      'device.get-energy-consumption: no energy monitoring device found matching "Unknown device"',
+    );
+
+    // Invalid dates.
+    const invalidDateResult = await energyTool.cb({
+      device: 'Prise onduleur',
+      start_date: '12/07/2026',
+      end_date: '2026-07-12',
+      unit: 'kwh',
+    });
+    expect(invalidDateResult.content[0].text).to.eq(
+      'device.get-energy-consumption: start_date and end_date are required in YYYY-MM-DD format',
+    );
+
+    const reversedDatesResult = await energyTool.cb({
+      device: 'Prise onduleur',
+      start_date: '2026-07-12',
+      end_date: '2026-07-10',
+      unit: 'kwh',
+    });
+    expect(reversedDatesResult.content[0].text).to.eq(
+      'device.get-energy-consumption: start_date must be before or equal to end_date',
+    );
+  });
+
+  it('should not expose device.get-energy-consumption without energy monitoring devices', async () => {
+    const mcpHandler = {
+      serviceId: '7056e3d4-31cc-4d2a-bbdd-128cd49755e6',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isLightControlFeature,
+      isShutterFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      findBySimilarity,
+      gladys: {
+        room: {
+          getAll: stub().resolves([{ id: 'room-1', name: 'Salon', selector: 'salon' }]),
+        },
+        user: {
+          get: stub().resolves([]),
+        },
+        house: {
+          get: stub().resolves([]),
+        },
+        calendar: {
+          get: stub().resolves([]),
+        },
+        area: {
+          get: stub().resolves([]),
+        },
+        scene: {
+          get: stub().resolves([]),
+          create: stub(),
+        },
+        device: {
+          get: stub().resolves([
+            {
+              selector: 'device-temp-1',
+              name: 'Temperature Sensor',
+              room: { selector: 'salon', name: 'Salon' },
+              features: [
+                {
+                  id: 1,
+                  selector: 'device-temp-1-temp',
+                  name: 'Temperature',
+                  category: 'temperature-sensor',
+                  type: 'decimal',
+                },
+              ],
+            },
+          ]),
+        },
+        event: {
+          emit: fake(),
+        },
+      },
+      levenshtein: {
+        distance: stub().returns(4),
+      },
+      toon: stub().returns('toonmockdata'),
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    expect(tools.find((tool) => tool.intent === 'device.get-energy-consumption')).to.eq(undefined);
+  });
+
   it('should return detailed scene.create errors for SequelizeValidationError and unknown errors', async () => {
     const mcpHandler = {
       serviceId: '7056e3d4-31cc-4d2a-bbdd-128cd49755e6',

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -1323,7 +1323,18 @@ describe('build schemas', () => {
       unit: 'kwh',
     });
     expect(invalidDateResult.content[0].text).to.eq(
-      'device.get-energy-consumption: start_date and end_date are required in YYYY-MM-DD format',
+      'device.get-energy-consumption: start_date and end_date must be valid dates in YYYY-MM-DD format',
+    );
+
+    // Calendar-invalid date that would roll over in the Date constructor.
+    const rolledOverDateResult = await energyTool.cb({
+      device: 'Prise onduleur',
+      start_date: '2026-02-30',
+      end_date: '2026-03-02',
+      unit: 'kwh',
+    });
+    expect(rolledOverDateResult.content[0].text).to.eq(
+      'device.get-energy-consumption: start_date and end_date must be valid dates in YYYY-MM-DD format',
     );
 
     const reversedDatesResult = await energyTool.cb({


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are server tests passing with coverage? (`cd server && npm run coverage`) — Codecov requires **100% coverage on lines changed in this PR** (all new lines in `buildSchemas.js` are covered by the two new tests)
- [ ] Did Cypress E2E tests pass? (`npm run cypress:run` from repo root, if UI changed) — no UI change
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front) — no front change
- [ ] Did you test this pull request in real life? With real devices? — tested with unit tests only; real-life testing with an energy monitoring setup welcome
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? — no REST API change, the new tool is documented through its MCP/JSON schema description
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation?
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? — not needed, server-side only

### Description of change

This PR lets the AI Chat answer questions like:

- « quelle a été la consommation en kWh de la prise onduleur pour la journée du 12 juillet 2026 »
- « quel coût en euro pour la consommation de la prise télé pour le mois de juin 2026 »

Previously the chat only had `device_get_history`, which works with relative intervals (`last-day`, `last-month`…) and averaged aggregates, so it could neither target a specific date/month nor compute a consumption total or a cost.

**What's added:**

1. **New MCP tool `device.get-energy-consumption`** (`server/services/mcp/lib/buildSchemas.js`), exposed only when at least one device has `energy-sensor` features of type `thirty-minutes-consumption` or `thirty-minutes-consumption-cost`. It reuses the existing `device.energySensorManager.getConsumptionByDates()` (same code path as the energy dashboard):
   - `device`: energy monitoring device name (enum),
   - `start_date` / `end_date`: inclusive `YYYY-MM-DD` dates (same local-midnight boundaries as the dashboard),
   - `unit`: `kwh` (consumption, with automatic Wh → kWh conversion) or `currency` (cost, using the cost feature's currency unit),
   - `group_by`: optional `hour`/`day`/`week`/`month`/`year` detail (defaults to `day`).
   
   The response contains the period total first, then the per-period detail. In currency mode, the home electricity contract subscription is returned as a separate `home_subscription` entry so the model doesn't mix it up with the device's own consumption cost. Friendly error messages are returned for unknown devices, invalid dates, or devices without cost tracking configured.

2. **Intent router update** (`gateway.classifyAiChatToolCategories.js`): the `device_query` category description now mentions energy consumption (kWh) and energy cost over a period, so these questions are routed with the right tools.

3. **System prompt update** (`aiChat.prompt.txt`): a rule instructs the model to use `device_get_energy_consumption` with inclusive `YYYY-MM-DD` dates for consumption/cost questions, and never `device_get_history` for consumption totals or costs.

4. **Tests** (`buildSchemas.test.js`): two new tests covering the kWh single-day query, the monthly cost query with subscription entry, the no-cost-tracking case, empty periods, unknown device, invalid/reversed dates, and the tool not being exposed without energy monitoring devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwzEsLH8BRLUUQu9iUBvYA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UwzEsLH8BRLUUQu9iUBvYA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an energy consumption and cost reporting tool for supported smart-home devices.
  * Supports inclusive date-range queries (YYYY-MM-DD) with daily grouping and totals in kWh or currency.
  * Includes subscription cost details when available, and adds notes when no data exists for the selected period.
* **Bug Fixes**
  * Energy totals and costs now rely on dedicated energy measurements rather than historical activity.
* **Tests**
  * Added end-to-end coverage for tool exposure, output shaping, and validation/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->