### PR TITLE
fix(mqtt): clear manually-stopped status when saving MQTT configuration

### DIFF
--- a/server/services/mqtt/lib/saveConfiguration.js
+++ b/server/services/mqtt/lib/saveConfiguration.js
@@ -1,5 +1,6 @@
 const { promisify } = require('util');
 const { CONFIGURATION, DEFAULT } = require('./constants');
+const { SERVICE_STATUS } = require('../../../utils/constants');
 const { NotFoundError } = require('../../../utils/coreErrors');
 const containerParams = require('../docker/eclipse-mosquitto-container.json');
 
@@ -75,7 +76,18 @@ async function saveConfiguration({ mqttUrl, mqttUsername, mqttPassword, useEmbed
     );
   }
 
-  return this.connect({ mqttUrl, mqttUsername, mqttPassword, useEmbeddedBroker });
+  await this.connect({ mqttUrl, mqttUsername, mqttPassword, useEmbeddedBroker });
+
+  // Saving the configuration is an explicit request to have the service running:
+  // clear a previous "manually stopped" status, otherwise the service would
+  // still be skipped at next startup (see service.startAll).
+  const serviceInDb = await this.gladys.service.getLocalServiceByName('mqtt');
+  if (serviceInDb && serviceInDb.status === SERVICE_STATUS.STOPPED) {
+    serviceInDb.set({ status: SERVICE_STATUS.RUNNING });
+    await serviceInDb.save();
+  }
+
+  return null;
 }
 
 module.exports = {

--- a/server/test/services/mqtt/lib/installContainer.test.js
+++ b/server/test/services/mqtt/lib/installContainer.test.js
@@ -71,6 +71,9 @@ describe('mqttHandler.installContainer', () => {
       event: {
         emit: fake.resolves(true),
       },
+      service: {
+        getLocalServiceByName: fake.resolves(null),
+      },
       system: {
         pull: fake.resolves(false),
         createContainer: fake.resolves(false),

--- a/server/test/services/mqtt/lib/saveConfiguration.test.js
+++ b/server/test/services/mqtt/lib/saveConfiguration.test.js
@@ -6,7 +6,7 @@ const { assert, fake } = sinon;
 const { MockedMqttClient } = require('../mocks.test');
 const { CONFIGURATION, DEFAULT } = require('../../../../services/mqtt/lib/constants');
 const { SERVICE_STATUS } = require('../../../../utils/constants');
-const { NotFoundError } = require('../../../../utils/coreErrors');
+const { NotFoundError, ServiceNotConfiguredError } = require('../../../../utils/coreErrors');
 
 const saveConfiguration = proxyquire('../../../../services/mqtt/lib/saveConfiguration', {
   util: {
@@ -391,5 +391,37 @@ describe('mqttHandler.saveConfiguration', () => {
 
     assert.notCalled(serviceInDb.set);
     assert.notCalled(serviceInDb.save);
+  });
+
+  it('should saveConfiguration: not touch service status when connection fails', async () => {
+    const serviceInDb = {
+      status: SERVICE_STATUS.STOPPED,
+      set: fake.returns(null),
+      save: fake.resolves(null),
+    };
+    const gladys = {
+      service: {
+        getLocalServiceByName: fake.resolves(serviceInDb),
+      },
+      variable: {
+        destroy: fake.resolves('value'),
+        setValue: fake.resolves('value'),
+        getValue: fake.resolves(true),
+      },
+    };
+
+    // No mqttUrl: connect fails with ServiceNotConfiguredError
+    const config = {};
+
+    const mqttHandler = new MqttHandler(gladys, MockedMqttClient, serviceId);
+    try {
+      await mqttHandler.saveConfiguration(config);
+      assert.fail('Should have fail');
+    } catch (e) {
+      expect(e).to.be.instanceOf(ServiceNotConfiguredError);
+      assert.notCalled(gladys.service.getLocalServiceByName);
+      assert.notCalled(serviceInDb.set);
+      assert.notCalled(serviceInDb.save);
+    }
   });
 });

--- a/server/test/services/mqtt/lib/saveConfiguration.test.js
+++ b/server/test/services/mqtt/lib/saveConfiguration.test.js
@@ -5,6 +5,7 @@ const { expect } = require('chai');
 const { assert, fake } = sinon;
 const { MockedMqttClient } = require('../mocks.test');
 const { CONFIGURATION, DEFAULT } = require('../../../../services/mqtt/lib/constants');
+const { SERVICE_STATUS } = require('../../../../utils/constants');
 const { NotFoundError } = require('../../../../utils/coreErrors');
 
 const saveConfiguration = proxyquire('../../../../services/mqtt/lib/saveConfiguration', {
@@ -27,6 +28,9 @@ describe('mqttHandler.saveConfiguration', () => {
 
   it('should saveConfiguration: save all', async () => {
     const gladys = {
+      service: {
+        getLocalServiceByName: fake.resolves(null),
+      },
       variable: {
         setValue: fake.resolves('value'),
         getValue: fake.resolves(true),
@@ -57,6 +61,9 @@ describe('mqttHandler.saveConfiguration', () => {
 
   it('should saveConfiguration: destroy all', async () => {
     const gladys = {
+      service: {
+        getLocalServiceByName: fake.resolves(null),
+      },
       variable: {
         destroy: fake.resolves('value'),
         setValue: fake.resolves('value'),
@@ -80,6 +87,9 @@ describe('mqttHandler.saveConfiguration', () => {
 
   it('should saveConfiguration: init docker but no container', async () => {
     const gladys = {
+      service: {
+        getLocalServiceByName: fake.resolves(null),
+      },
       variable: {
         destroy: fake.resolves('value'),
         setValue: fake.resolves('value'),
@@ -120,6 +130,9 @@ describe('mqttHandler.saveConfiguration', () => {
 
   it('should saveConfiguration: init docker container no present (no user)', async () => {
     const gladys = {
+      service: {
+        getLocalServiceByName: fake.resolves(null),
+      },
       variable: {
         destroy: fake.resolves('value'),
         setValue: fake.resolves('value'),
@@ -167,6 +180,9 @@ describe('mqttHandler.saveConfiguration', () => {
 
   it('should saveConfiguration: init docker container not running (no user)', async () => {
     const gladys = {
+      service: {
+        getLocalServiceByName: fake.resolves(null),
+      },
       variable: {
         destroy: fake.resolves('value'),
         setValue: fake.resolves('value'),
@@ -214,6 +230,9 @@ describe('mqttHandler.saveConfiguration', () => {
 
   it('should saveConfiguration: init docker container is running (no user)', async () => {
     const gladys = {
+      service: {
+        getLocalServiceByName: fake.resolves(null),
+      },
       variable: {
         destroy: fake.resolves('value'),
         setValue: fake.resolves('value'),
@@ -262,6 +281,9 @@ describe('mqttHandler.saveConfiguration', () => {
 
   it('should saveConfiguration: init docker container is running (with user no old)', async () => {
     const gladys = {
+      service: {
+        getLocalServiceByName: fake.resolves(null),
+      },
       variable: {
         destroy: fake.resolves('value'),
         setValue: fake.resolves('value'),
@@ -308,5 +330,66 @@ describe('mqttHandler.saveConfiguration', () => {
     assert.calledOnce(gladys.system.getContainers);
     assert.calledOnce(gladys.system.exec);
     assert.calledOnce(gladys.system.restartContainer);
+  });
+
+  it('should saveConfiguration: reset service status when service was manually stopped', async () => {
+    const serviceInDb = {
+      status: SERVICE_STATUS.STOPPED,
+      set: fake.returns(null),
+      save: fake.resolves(null),
+    };
+    const gladys = {
+      service: {
+        getLocalServiceByName: fake.resolves(serviceInDb),
+      },
+      variable: {
+        setValue: fake.resolves('value'),
+        getValue: fake.resolves(true),
+      },
+    };
+
+    const config = {
+      mqttUrl: 'mqttUrl',
+      mqttUsername: 'mqttUsername',
+      mqttPassword: 'mqttPassword',
+      useEmbeddedBroker: false,
+    };
+
+    const mqttHandler = new MqttHandler(gladys, MockedMqttClient, serviceId);
+    await mqttHandler.saveConfiguration(config);
+
+    assert.calledWith(gladys.service.getLocalServiceByName, 'mqtt');
+    assert.calledWith(serviceInDb.set, { status: SERVICE_STATUS.RUNNING });
+    assert.calledOnce(serviceInDb.save);
+  });
+
+  it('should saveConfiguration: not touch service status when service is not stopped', async () => {
+    const serviceInDb = {
+      status: SERVICE_STATUS.RUNNING,
+      set: fake.returns(null),
+      save: fake.resolves(null),
+    };
+    const gladys = {
+      service: {
+        getLocalServiceByName: fake.resolves(serviceInDb),
+      },
+      variable: {
+        setValue: fake.resolves('value'),
+        getValue: fake.resolves(true),
+      },
+    };
+
+    const config = {
+      mqttUrl: 'mqttUrl',
+      mqttUsername: 'mqttUsername',
+      mqttPassword: 'mqttPassword',
+      useEmbeddedBroker: false,
+    };
+
+    const mqttHandler = new MqttHandler(gladys, MockedMqttClient, serviceId);
+    await mqttHandler.saveConfiguration(config);
+
+    assert.notCalled(serviceInDb.set);
+    assert.notCalled(serviceInDb.save);
   });
 });


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are server tests passing with coverage? (`cd server && npm run coverage`) — Codecov requires **100% coverage on lines changed in this PR** (both branches of the new condition are covered by dedicated tests)
- [ ] Did Cypress E2E tests pass? (`npm run cypress:run` from repo root, if UI changed) — N/A, no UI change
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front) — N/A
- [ ] Did you test this pull request in real life? With real devices? — not yet, the failing scenario is reproducible from the DB state described in #2699
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? — N/A, no API change
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? — N/A
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`)? — N/A

### Description of change

Fixes #2699.

When the MQTT service is stopped from **Settings → Services**, its status is persisted as `STOPPED`, and `service.startAll` then skips it at every startup ("Service mqtt was manually stopped, so it is ignored at startup").

The problem is that re-saving the MQTT configuration on the integration page (`POST /api/v1/service/mqtt/connect` → `saveConfiguration`) reconnects the MQTT client directly but never clears that `STOPPED` status. The service then works fine for the current session, but is silently skipped again at the next restart — which looks like the "manually stopped" flag comes back on every container restart, when in fact it was never cleared.

Saving the configuration is an explicit request to have the service running, so `saveConfiguration` now resets a `STOPPED` status back to `RUNNING` once the connection is established:

- `server/services/mqtt/lib/saveConfiguration.js`: after a successful `connect`, fetch the service row and reset `STOPPED` → `RUNNING`. Any other status is left untouched, and the reset is skipped when `connect` throws (e.g. missing URL).
- Tests: two new cases covering the reset and the no-op path, plus `service.getLocalServiceByName` added to the existing `gladys` mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMcYV5prjE8wkFuRcqXz25

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMcYV5prjE8wkFuRcqXz25)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - MQTT service status now correctly updates to **Running** after a successful configuration save when the service was previously **Stopped**.
  - Existing **Running** services remain unchanged.

- **Tests**
  - Expanded MQTT configuration tests to validate persisted service status behavior and ensure no unnecessary status changes occur when configuration is incomplete.
  - Updated MQTT container installation test fixtures to reflect additional service lookup mocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->