### PR TITLE
fix(mqtt): ignore empty custom topic to avoid matching all MQTT messages

### DIFF
--- a/front/src/routes/integration/all/mqtt/device-page/setup/index.js
+++ b/front/src/routes/integration/all/mqtt/device-page/setup/index.js
@@ -460,7 +460,8 @@ class MqttDeviceSetupPage extends Component {
           // If we are here, it's ok, it means the device does not exist yet
         }
       }
-      // Remove params if there are params that exist with a feature that doesn't exist
+      // Remove params if there are params that exist with a feature that doesn't exist,
+      // or params with an empty value (an empty custom topic would match all MQTT messages)
       const paramsToDelete = [];
 
       this.state.device.params.forEach((param, paramIndex) => {
@@ -471,8 +472,8 @@ class MqttDeviceSetupPage extends Component {
           // We verify that the feature exist
           const featureId = param.name.split(':')[1];
           const feature = this.state.device.features.find(f => f.id === featureId);
-          if (!feature) {
-            // If the feature doesn't exist, we delete the param
+          if (!feature || !param.value) {
+            // If the feature doesn't exist or the param was emptied, we delete the param
             paramsToDelete.push(paramIndex);
           }
         }

--- a/server/services/mqtt/lib/listenToCustomMqttTopicIfNeeded.js
+++ b/server/services/mqtt/lib/listenToCustomMqttTopicIfNeeded.js
@@ -22,7 +22,7 @@ async function listenToCustomMqttTopicIfNeeded(device) {
     const mqttTopic = deviceCustomTopicParam.value;
     // If the topic is empty, we don't listen to it: an empty topic
     // would match all MQTT messages received
-    if (!mqttTopic || !mqttTopic.length) {
+    if (!mqttTopic) {
       logger.debug(
         `listenToCustomMqttTopicIfNeeded: Custom topic is empty for feature ${deviceFeatureId} of device ${device.selector}. Not listening.`,
       );

--- a/server/services/mqtt/lib/listenToCustomMqttTopicIfNeeded.js
+++ b/server/services/mqtt/lib/listenToCustomMqttTopicIfNeeded.js
@@ -19,6 +19,15 @@ async function listenToCustomMqttTopicIfNeeded(device) {
       );
       return;
     }
+    const mqttTopic = deviceCustomTopicParam.value;
+    // If the topic is empty, we don't listen to it: an empty topic
+    // would match all MQTT messages received
+    if (!mqttTopic || !mqttTopic.length) {
+      logger.debug(
+        `listenToCustomMqttTopicIfNeeded: Custom topic is empty for feature ${deviceFeatureId} of device ${device.selector}. Not listening.`,
+      );
+      return;
+    }
     // If the feature exists, we add custom listener
     logger.debug(`Adding custom listener for device ${device.selector}, feature = ${deviceFeatureId}`);
     const deviceCustomObjectPathParam = device.params.find((p) =>
@@ -28,7 +37,6 @@ async function listenToCustomMqttTopicIfNeeded(device) {
     if (deviceCustomObjectPathParam) {
       objectPath = deviceCustomObjectPathParam.value;
     }
-    const mqttTopic = deviceCustomTopicParam.value;
     // Add listener to list of custom listeners
     this.deviceFeatureCustomMqttTopics.push({
       topic: mqttTopic,
@@ -37,7 +45,7 @@ async function listenToCustomMqttTopicIfNeeded(device) {
       object_path: objectPath,
     });
     // Listen to MQTT topic
-    if (this.mqttClient && mqttTopic && mqttTopic.length) {
+    if (this.mqttClient) {
       logger.info(`Subscribing to MQTT topic ${mqttTopic}`);
       this.mqttClient.subscribe(mqttTopic);
     }

--- a/server/test/services/mqtt/lib/listenToCustomMqttTopicIfNeeded.test.js
+++ b/server/test/services/mqtt/lib/listenToCustomMqttTopicIfNeeded.test.js
@@ -116,6 +116,33 @@ describe('Mqtt.listenToCustomMqttTopicIfNeeded', () => {
     assert.notCalled(mqttApi.subscribe);
     expect(mqttHandler.deviceFeatureCustomMqttTopics).to.deep.equal([]);
   });
+  it('should add listener but not subscribe as mqtt client is not connected', async () => {
+    const notConnectedMqttHandler = new MqttHandler(gladys, MockedMqttClient, 'faea9c35-759a-44d5-bcc9-2af1de37b8b4');
+    const device = {
+      selector: 'my-device',
+      features: [
+        {
+          id: 'b42d3688-4403-479a-9376-9f5227ab543a',
+        },
+      ],
+      params: [
+        {
+          name: 'mqtt_custom_topic_feature:b42d3688-4403-479a-9376-9f5227ab543a',
+          value: 'custom_mqtt_topic/test/test',
+        },
+      ],
+    };
+    await notConnectedMqttHandler.listenToCustomMqttTopicIfNeeded(device);
+    assert.notCalled(mqttApi.subscribe);
+    expect(notConnectedMqttHandler.deviceFeatureCustomMqttTopics).to.deep.equal([
+      {
+        device_feature_id: 'b42d3688-4403-479a-9376-9f5227ab543a',
+        regex_key: 'custom_mqtt_topic/test/test',
+        topic: 'custom_mqtt_topic/test/test',
+        object_path: null,
+      },
+    ]);
+  });
   it('should not connect to custom mqtt topic as feature does not exist anymore', async () => {
     const device = {
       selector: 'my-device',

--- a/server/test/services/mqtt/lib/listenToCustomMqttTopicIfNeeded.test.js
+++ b/server/test/services/mqtt/lib/listenToCustomMqttTopicIfNeeded.test.js
@@ -93,6 +93,29 @@ describe('Mqtt.listenToCustomMqttTopicIfNeeded', () => {
       },
     ]);
   });
+  it('should not connect to custom mqtt topic as topic is empty', async () => {
+    const device = {
+      selector: 'my-device',
+      features: [
+        {
+          id: 'b42d3688-4403-479a-9376-9f5227ab543a',
+        },
+      ],
+      params: [
+        {
+          name: 'mqtt_custom_topic_feature:b42d3688-4403-479a-9376-9f5227ab543a',
+          value: '',
+        },
+        {
+          name: 'mqtt_custom_object_path_feature:b42d3688-4403-479a-9376-9f5227ab543a',
+          value: 'data.temperature',
+        },
+      ],
+    };
+    await mqttHandler.listenToCustomMqttTopicIfNeeded(device);
+    assert.notCalled(mqttApi.subscribe);
+    expect(mqttHandler.deviceFeatureCustomMqttTopics).to.deep.equal([]);
+  });
   it('should not connect to custom mqtt topic as feature does not exist anymore', async () => {
     const device = {
       selector: 'my-device',


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are server tests passing with coverage? (`cd server && npm run coverage`) — Codecov requires **100% coverage on lines changed in this PR** (100% statements/branches/functions/lines on `listenToCustomMqttTopicIfNeeded.js`)
- [ ] Did Cypress E2E tests pass? (`npm run cypress:run` from repo root, if UI changed)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front) — N/A, no translation change
- [ ] Did you test this pull request in real life? With real devices?
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? — N/A, no API change
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? — N/A, bug fix
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`)? — N/A

### Description of change

Fixes #2683

**Bug**: when the "custom topic" field of an MQTT device feature was emptied and saved, the feature started receiving the values of **all** topics from the MQTT broker.

**Root cause**: emptying the field kept the `mqtt_custom_topic_feature:<featureId>` param with an empty string value. On save, `listenToCustomMqttTopicIfNeeded` registered a custom listener with `regex_key: ''`, and in `handleNewMessage`, `topic.match('')` matches every incoming MQTT message — so every message on every subscribed topic was forwarded to the feature as a new state.

**Fix**:
- **Server** (`server/services/mqtt/lib/listenToCustomMqttTopicIfNeeded.js`): skip custom topic params with an empty value, so no listener (and no subscription) is registered for them. This also protects installations that already have empty params stored in database.
- **Front** (`front/src/routes/integration/all/mqtt/device-page/setup/index.js`): when saving the device, custom topic / object path params with an empty value are removed from the payload, so the server deletes them from the database (params absent from the payload are destroyed on update in `device.create.js`).

**Tests**: added two cases to `listenToCustomMqttTopicIfNeeded.test.js` (empty custom topic → no listener registered and no subscribe; MQTT client not connected → listener registered but no subscribe). The changed file is at 100% coverage on statements, branches, functions and lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BaQ6rVmvAm2q62nuy1cGqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaQ6rVmvAm2q62nuy1cGqy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty custom MQTT topics and object paths from being saved or used.
  * Avoided unnecessary MQTT subscriptions when a custom topic is missing.
  * Improved handling of custom MQTT listeners when the MQTT connection is unavailable.

* **Tests**
  * Added coverage for empty topics and disconnected MQTT clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->