### PR TITLE
Matter: Fix "Cannot mix BigInt and other types" crash on electrical attributes

### DIFF
--- a/server/services/matter/lib/matter.listenToStateChange.js
+++ b/server/services/matter/lib/matter.listenToStateChange.js
@@ -404,8 +404,8 @@ async function listenToStateChange(nodeId, devicePath, device) {
     // Subscribe to ActivePower attribute changes
     electricalPowerMeasurement.addActivePowerAttributeListener((value) => {
       logger.debug(`Matter: ElectricalPowerMeasurement ActivePower attribute changed to ${value}`);
-      // Value is in milliwatts, convert to watts
-      const powerInWatts = value !== null ? value / 1000 : null;
+      // Value is in milliwatts (int64, may be a BigInt), convert to watts
+      const powerInWatts = value !== null ? Number(value) / 1000 : null;
       this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
         device_feature_external_id: `matter:${nodeId}:${devicePath}:${ElectricalPowerMeasurement.Complete.id}:power`,
         state: powerInWatts,
@@ -415,8 +415,8 @@ async function listenToStateChange(nodeId, devicePath, device) {
     if (electricalPowerMeasurement.addVoltageAttributeListener) {
       electricalPowerMeasurement.addVoltageAttributeListener((value) => {
         logger.debug(`Matter: ElectricalPowerMeasurement Voltage attribute changed to ${value}`);
-        // Value is in millivolts, convert to volts
-        const voltageInVolts = value !== null ? value / 1000 : null;
+        // Value is in millivolts (int64, may be a BigInt), convert to volts
+        const voltageInVolts = value !== null ? Number(value) / 1000 : null;
         this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
           device_feature_external_id: `matter:${nodeId}:${devicePath}:${ElectricalPowerMeasurement.Complete.id}:voltage`,
           state: voltageInVolts,
@@ -427,8 +427,8 @@ async function listenToStateChange(nodeId, devicePath, device) {
     if (electricalPowerMeasurement.addActiveCurrentAttributeListener) {
       electricalPowerMeasurement.addActiveCurrentAttributeListener((value) => {
         logger.debug(`Matter: ElectricalPowerMeasurement ActiveCurrent attribute changed to ${value}`);
-        // Value is in milliamps, convert to amps
-        const currentInAmps = value !== null ? value / 1000 : null;
+        // Value is in milliamps (int64, may be a BigInt), convert to amps
+        const currentInAmps = value !== null ? Number(value) / 1000 : null;
         this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
           device_feature_external_id: `matter:${nodeId}:${devicePath}:${ElectricalPowerMeasurement.Complete.id}:current`,
           state: currentInAmps,
@@ -447,8 +447,9 @@ async function listenToStateChange(nodeId, devicePath, device) {
     if (electricalEnergyMeasurement.addCumulativeEnergyImportedAttributeListener) {
       electricalEnergyMeasurement.addCumulativeEnergyImportedAttributeListener((value) => {
         logger.debug(`Matter: ElectricalEnergyMeasurement CumulativeEnergyImported attribute changed to`, value);
-        // Value is an object with energy field in milliwatt-hours, convert to kilowatt-hours
-        const energyInKwh = value && value.energy !== null ? value.energy / 1000000 : null;
+        // Value is an object with energy field in milliwatt-hours (int64, may be a BigInt),
+        // convert to kilowatt-hours
+        const energyInKwh = value && value.energy !== null ? Number(value.energy) / 1000000 : null;
         const externalId = `matter:${nodeId}:${devicePath}:${ElectricalEnergyMeasurement.Complete.id}:energy`;
         this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
           device_feature_external_id: externalId,

--- a/server/services/matter/lib/matter.readInitialDeviceStates.js
+++ b/server/services/matter/lib/matter.readInitialDeviceStates.js
@@ -225,21 +225,21 @@ async function readInitialDeviceStates(nodeId, devicePath, device) {
     if (activePower !== undefined) {
       emitState(
         `matter:${nodeId}:${devicePath}:${ElectricalPowerMeasurement.Complete.id}:power`,
-        activePower !== null ? activePower / 1000 : null,
+        activePower !== null ? Number(activePower) / 1000 : null,
       );
     }
     const voltage = await safeReadAttribute(() => electricalPowerMeasurement.getVoltageAttribute());
     if (voltage !== undefined) {
       emitState(
         `matter:${nodeId}:${devicePath}:${ElectricalPowerMeasurement.Complete.id}:voltage`,
-        voltage !== null ? voltage / 1000 : null,
+        voltage !== null ? Number(voltage) / 1000 : null,
       );
     }
     const activeCurrent = await safeReadAttribute(() => electricalPowerMeasurement.getActiveCurrentAttribute());
     if (activeCurrent !== undefined) {
       emitState(
         `matter:${nodeId}:${devicePath}:${ElectricalPowerMeasurement.Complete.id}:current`,
-        activeCurrent !== null ? activeCurrent / 1000 : null,
+        activeCurrent !== null ? Number(activeCurrent) / 1000 : null,
       );
     }
   }
@@ -250,7 +250,7 @@ async function readInitialDeviceStates(nodeId, devicePath, device) {
     if (value !== undefined) {
       emitState(
         `matter:${nodeId}:${devicePath}:${ElectricalEnergyMeasurement.Complete.id}:energy`,
-        value && value.energy !== null ? value.energy / 1000000 : null,
+        value && value.energy !== null ? Number(value.energy) / 1000000 : null,
       );
     }
   }

--- a/server/test/services/matter/lib/listenToStateChange.test.js
+++ b/server/test/services/matter/lib/listenToStateChange.test.js
@@ -624,6 +624,90 @@ describe('Matter.listenToStateChange', () => {
       state: 1500,
     });
   });
+  it('should listen to state change (ElectricalPowerMeasurement - ActivePower as BigInt)', async () => {
+    const clusterClient = {
+      id: ElectricalPowerMeasurement.Complete.id,
+      addActivePowerAttributeListener: (callback) => {
+        callback(1500000n); // 1500000 mW = 1500 W
+      },
+      addVoltageAttributeListener: () => {},
+      addActiveCurrentAttributeListener: () => {},
+    };
+    const device = {
+      number: 1,
+      getClusterClientById: (id) => (id === clusterClient.id ? clusterClient : null),
+    };
+    await matterHandler.listenToStateChange(1234n, '1', device);
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'matter:1234:1:144:power',
+      state: 1500,
+    });
+  });
+  it('should listen to state change (ElectricalPowerMeasurement - Voltage as BigInt)', async () => {
+    const clusterClient = {
+      id: ElectricalPowerMeasurement.Complete.id,
+      supportedFeatures: {
+        voltage: true,
+      },
+      addActivePowerAttributeListener: () => {},
+      addVoltageAttributeListener: (callback) => {
+        callback(230000n); // 230000 mV = 230 V
+      },
+      addActiveCurrentAttributeListener: () => {},
+    };
+    const device = {
+      number: 1,
+      getClusterClientById: (id) => (id === clusterClient.id ? clusterClient : null),
+    };
+    await matterHandler.listenToStateChange(1234n, '1', device);
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'matter:1234:1:144:voltage',
+      state: 230,
+    });
+  });
+  it('should listen to state change (ElectricalPowerMeasurement - ActiveCurrent as BigInt)', async () => {
+    const clusterClient = {
+      id: ElectricalPowerMeasurement.Complete.id,
+      supportedFeatures: {
+        current: true,
+      },
+      addActivePowerAttributeListener: () => {},
+      addVoltageAttributeListener: () => {},
+      addActiveCurrentAttributeListener: (callback) => {
+        callback(6500n); // 6500 mA = 6.5 A
+      },
+    };
+    const device = {
+      number: 1,
+      getClusterClientById: (id) => (id === clusterClient.id ? clusterClient : null),
+    };
+    await matterHandler.listenToStateChange(1234n, '1', device);
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'matter:1234:1:144:current',
+      state: 6.5,
+    });
+  });
+  it('should listen to state change (ElectricalEnergyMeasurement - CumulativeEnergy as BigInt)', async () => {
+    const clusterClient = {
+      id: ElectricalEnergyMeasurement.Complete.id,
+      supportedFeatures: {
+        cumulativeEnergy: true,
+      },
+      addCumulativeEnergyImportedAttributeListener: (callback) => {
+        // 4500000000 mWh = 4500 kWh, above INT32_MAX so matter.js delivers a BigInt
+        callback({ energy: 4500000000n });
+      },
+    };
+    const device = {
+      number: 1,
+      getClusterClientById: (id) => (id === clusterClient.id ? clusterClient : null),
+    };
+    await matterHandler.listenToStateChange(1234n, '1', device);
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'matter:1234:1:145:energy',
+      state: 4500,
+    });
+  });
   it('should listen to state change (HepaFilterMonitoring)', async () => {
     const clusterClient = {
       id: HepaFilterMonitoring.Complete.id,

--- a/server/test/services/matter/lib/matter.readInitialDeviceStates.test.js
+++ b/server/test/services/matter/lib/matter.readInitialDeviceStates.test.js
@@ -242,6 +242,45 @@ describe('Matter.readInitialDeviceStates', () => {
     expect(gladys.event.emit.callCount).to.be.greaterThan(20);
   });
 
+  it('should read initial electrical measurements delivered as BigInt', async () => {
+    const nodeId = 1234n;
+    const devicePath = '1';
+    const clusterClients = {
+      [ElectricalPowerMeasurement.Complete.id]: {
+        getActivePowerAttribute: fake.resolves(5000n),
+        getVoltageAttribute: fake.resolves(230000n),
+        getActiveCurrentAttribute: fake.resolves(1000n),
+      },
+      [ElectricalEnergyMeasurement.Complete.id]: {
+        // 4500000000 mWh = 4500 kWh, above INT32_MAX so matter.js delivers a BigInt
+        getCumulativeEnergyImportedAttribute: fake.resolves({ energy: 4500000000n }),
+      },
+    };
+
+    const device = {
+      getClusterClientById: (id) => clusterClients[id] || null,
+    };
+
+    await matterHandler.readInitialDeviceStates(nodeId, devicePath, device);
+
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: `matter:${nodeId}:${devicePath}:${ElectricalPowerMeasurement.Complete.id}:power`,
+      state: 5,
+    });
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: `matter:${nodeId}:${devicePath}:${ElectricalPowerMeasurement.Complete.id}:voltage`,
+      state: 230,
+    });
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: `matter:${nodeId}:${devicePath}:${ElectricalPowerMeasurement.Complete.id}:current`,
+      state: 1,
+    });
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: `matter:${nodeId}:${devicePath}:${ElectricalEnergyMeasurement.Complete.id}:energy`,
+      state: 4500,
+    });
+  });
+
   it('should skip null electrical measurements and undefined vacuum modes', async () => {
     const clusterClients = {
       [ElectricalPowerMeasurement.Complete.id]: {


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are server tests passing with coverage? (`cd server && npm run coverage`) — Codecov requires **100% coverage on lines changed in this PR** (all 8 modified lines are exercised by the new BigInt tests; full matter service suite passes: 245 tests)
- [ ] Did Cypress E2E tests pass? (`npm run cypress:run` from repo root, if UI changed) — N/A, no UI change
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new feature/service, did you run the integration comparator? — N/A, bug fix only
- [ ] Did you test this pull request in real life? With real devices? — Not tested with a real device; reproduced and verified through unit tests feeding BigInt values exactly as matter.js delivers them
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? — N/A
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? — N/A
- [ ] Did you add fake requests data for the demo mode? — N/A

### Description of change

Fixes #2656.

**Root cause** (in Gladys, not Matterbridge nor matter.js): the Matter electrical attributes `activePower` (mW), `voltage` (mV), `activeCurrent` (mA) and `cumulativeEnergyImported.energy` (mWh) are **int64** in the Matter spec. In matter.js, int64 TLV values are decoded through `TlvLongNumberSchema`, which — unlike the ≤32-bit schemas — does **not** convert BigInt to number: the decoded value is `number | bigint` depending on the TLV encoding width. Since Matter TLV uses minimal-size integer encoding, the value arrives as a plain `number` while it fits in 4 bytes, but as a **`BigInt`** as soon as it's encoded on 8 bytes — i.e. as soon as it exceeds `INT32_MAX`. For a cumulative energy index that's only ~2 147 kWh, which any energy meter reaches quickly.

Gladys then did `value.energy / 1000000` (and `value / 1000` for power/voltage/current), and mixing a BigInt with a number in arithmetic throws `TypeError: Cannot mix BigInt and other types, use explicit conversions`. The exception propagated up through `AttributeClient.update`, breaking the handling of the whole incoming subscription message (the `ExchangeManager` WARN in the issue). The stack trace's `matter.listenToStateChange.js:432:75` maps exactly to the `value.energy / 1000000` expression in v4.81.0.

**Fix**: explicitly convert with `Number()` before arithmetic at the 8 affected call sites:

- `matter.listenToStateChange.js`: activePower, voltage, activeCurrent, cumulativeEnergyImported listeners
- `matter.readInitialDeviceStates.js`: the same 4 attributes on initial read

`Number()` is lossless in practice here: precision loss would only start above 2^53 mWh ≈ 9 TWh.

**Tests**: 5 new unit tests feeding BigInt values (including an energy value above `INT32_MAX`, the real-world trigger) for both the state-change listeners and the initial state read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EmEhQerqW99f5ZsxgX43k

---
_Generated by [Claude Code](https://claude.ai/code/session_011EmEhQerqW99f5ZsxgX43k)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Matter electrical measurement handling for power, voltage, current, and energy readings.
  * Corrected unit conversions so readings remain accurate when devices provide large or specialized numeric values.
  * Ensured both newly initialized devices and live updates report consistent numeric measurements.

* **Tests**
  * Added coverage for electrical measurements using large numeric readings, including values exceeding standard integer limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->