### PR TITLE
Fix CSS modules HMR in dev mode

### DIFF
--- a/front/vite-plugins/preact-cli-css-modules.js
+++ b/front/vite-plugins/preact-cli-css-modules.js
@@ -58,7 +58,35 @@ export function preactCliCssModules() {
         return null;
       }
 
+      // The module graph knows this module as the virtual id, so the real file
+      // has to be watched explicitly.
+      this.addWatchFile(absoluteCssPath);
+
       return readFileSync(absoluteCssPath, 'utf8');
+    },
+
+    /**
+     * Vite maps a changed file to its modules by path. Our modules live under a
+     * virtual id (`foo.css.module.css`) that no file on disk matches, so editing
+     * `foo.css` in dev updated nothing at all (no HMR, not even a reload).
+     * Hand back the virtual module so Vite invalidates it and pushes the update.
+     */
+    hotUpdate({ type, file, modules }) {
+      if (type !== 'update') {
+        return null;
+      }
+
+      const virtualModuleId = `${file}.module.css`;
+      if (!resolvedModules.has(virtualModuleId)) {
+        return null;
+      }
+
+      const virtualModule = this.environment.moduleGraph.getModuleById(virtualModuleId);
+      if (!virtualModule || modules.includes(virtualModule)) {
+        return null;
+      }
+
+      return [...modules, virtualModule];
     }
   };
 }


### PR DESCRIPTION
### Description of change

This PR fixes Hot Module Replacement (HMR) for CSS modules in development mode. Previously, editing a `.css` file would not trigger any updates in the browser because the virtual module ID (`foo.css.module.css`) didn't match any actual file on disk.

**Changes made:**

1. **Added explicit file watching**: The `addWatchFile()` call ensures Vite watches the actual CSS file on disk for changes.

2. **Implemented `hotUpdate` hook**: Added a new hook that intercepts HMR updates and maps changes from the real CSS file back to the virtual module. This allows Vite to properly invalidate and reload the virtual module when the source CSS file changes.

The fix ensures that:
- Editing a CSS module file in dev mode now triggers HMR
- The browser updates without requiring a full page reload
- The virtual module system continues to work as intended

### Pull Request check-list

- [x] No tests needed (infrastructure/build tooling change)
- [x] Linter and formatter should be run on modified files
- [x] This is a dev tooling fix with no API or user-facing changes

https://claude.ai/code/session_0198kaks4BFWfExBmhGJn9mB