### PR TITLE
Use live device feature units in chart boxes

### DIFF
--- a/front/src/components/boxs/chart/Chart.jsx
+++ b/front/src/components/boxs/chart/Chart.jsx
@@ -204,6 +204,16 @@ class Chartbox extends Component {
 
       let emptySeries = true;
 
+      // The unit of a device feature can change after the box was configured (device re-created,
+      // integration updated...), and the "units" saved in the box config is only a snapshot taken
+      // when the feature was added. So we use the unit returned by the API as the source of truth,
+      // and only fallback on the box config when the feature has no unit.
+      // Note: "unit" (singular) is the legacy attribute, kept for boxes saved before "units" existed.
+      const unitsByFeature = data.map((oneFeature, index) => {
+        const unitFromBoxConfig = this.props.box.units ? this.props.box.units[index] : this.props.box.unit;
+        return get(oneFeature, 'deviceFeature.unit') || unitFromBoxConfig;
+      });
+
       let series = [];
 
       if (this.props.box.chart_type === 'timeline') {
@@ -248,7 +258,7 @@ class Chartbox extends Component {
         series.push(serie0);
       } else {
         series = data.map((oneFeature, index) => {
-          const oneUnit = this.props.box.units ? this.props.box.units[index] : this.props.box.unit;
+          const oneUnit = unitsByFeature[index];
           // Convert unit display format if necessary (using 0 as a dummy value since we only need the unit)
           const userUnitPreference = this.props.user.distance_unit_preference;
           const { unit: displayUnit } = checkAndConvertUnit(0, oneUnit, userUnitPreference);
@@ -282,16 +292,14 @@ class Chartbox extends Component {
       };
 
       if (data.length > 0 && this.props.box.chart_type !== 'timeline') {
-        // Before now, there was a "unit" attribute in this box instead of "units",
-        // so we need to support "unit" as some users may already have the box with that param
-        const unit = this.props.box.units ? this.props.box.units[0] : this.props.box.unit;
+        const unit = unitsByFeature[0];
 
         // Convert distance units if necessary
         const userUnitPreference = this.props.user.distance_unit_preference;
         let displayUnit = unit;
 
         // We check if all deviceFeatures selected are in the same unit
-        const allUnitsAreSame = this.props.box.units ? allEqual(this.props.box.units) : false;
+        const allUnitsAreSame = this.props.box.units ? allEqual(unitsByFeature) : false;
 
         // If all deviceFeatures selected are in the same unit
         // We do a average of all values

--- a/front/src/components/boxs/chart/EditChart.jsx
+++ b/front/src/components/boxs/chart/EditChart.jsx
@@ -174,9 +174,17 @@ class EditChart extends Component {
     const newDeviceFeature = this.state.selectedDeviceFeaturesOptions.map(o => {
       return o.value;
     });
+    // The units must always stay aligned with the device features: they are read by index
+    // in the chart. Re-computing them here keeps them in sync when features are re-ordered,
+    // and refreshes units that changed since the box was configured.
+    const newUnits = this.state.selectedDeviceFeaturesOptions.map(o => {
+      const deviceFeature = this.deviceFeatureBySelector.get(o.value);
+      return deviceFeature ? deviceFeature.unit : null;
+    });
     this.props.updateBoxConfig(this.props.x, this.props.y, {
       device_feature_names: newDeviceFeatureNames,
-      device_features: newDeviceFeature
+      device_features: newDeviceFeature,
+      units: newUnits
     });
   };
 

--- a/server/lib/device/device.getDeviceFeaturesAggregates.js
+++ b/server/lib/device/device.getDeviceFeaturesAggregates.js
@@ -138,6 +138,7 @@ async function getDeviceFeaturesAggregates(selector, intervalInMinutes, maxState
     },
     deviceFeature: {
       name: deviceFeature.name,
+      unit: deviceFeature.unit,
     },
     values,
   };

--- a/server/test/lib/device/device.getDeviceFeaturesAggregates.test.js
+++ b/server/test/lib/device/device.getDeviceFeaturesAggregates.test.js
@@ -366,4 +366,25 @@ describe('Device.getDeviceFeaturesAggregates binary feature', function Describe(
       expect(values[i].value).to.not.equal(values[i - 1].value);
     }
   });
+
+  it('should return the current unit of the device feature', async () => {
+    await insertStates(120);
+    const variable = {
+      getValue: fake.resolves(null),
+    };
+    const stateManager = {
+      get: fake.returns({
+        id: 'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4',
+        name: 'my-feature',
+        selector: 'test-device-feature',
+        unit: 'lux',
+      }),
+    };
+    const deviceInstance = new Device(event, {}, stateManager, {}, {}, variable, job);
+    const { deviceFeature } = await deviceInstance.getDeviceFeaturesAggregates('test-device-feature', 60, 100);
+    expect(deviceFeature).to.deep.equal({
+      name: 'my-feature',
+      unit: 'lux',
+    });
+  });
 });


### PR DESCRIPTION
### Description of change

This PR ensures that chart boxes always display the current unit of device features, rather than relying on potentially stale unit information saved in the box configuration.

**Problem:** When a device feature's unit changes (e.g., due to device recreation or integration updates), chart boxes continue to display the old unit that was saved when the feature was added to the box.

**Solution:** 
1. **Backend:** Modified `getDeviceFeaturesAggregates` to return the current `unit` from the device feature object
2. **Frontend:** Updated the chart component to prioritize the unit returned by the API, falling back to the box config only when the feature has no unit
3. **Frontend:** Modified the edit chart component to automatically refresh and sync units when features are reordered or the box is updated

**Key changes:**
- Server now includes `deviceFeature.unit` in the aggregates response
- Chart component uses `get(oneFeature, 'deviceFeature.unit')` as the source of truth for units
- EditChart component recomputes units from current device features when saving box configuration
- Added test coverage for the new unit return value

### Pull Request check-list

- [x] Added test case for returning device feature unit in `getDeviceFeaturesAggregates`
- [ ] Server tests passing with coverage (to be verified)
- [ ] Cypress E2E tests (to be verified if UI changes affect existing tests)
- [ ] Linter passing (to be verified)
- [ ] Prettier formatting (to be verified)
- [ ] Tested with real devices (recommended for verification)

https://claude.ai/code/session_01RbaKQ4uPbWMs5L7Gdm2ZYg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Chart metrics now use the latest unit information provided by each device feature, improving labels, conversions, and variation calculations.
  - Updated chart selections now correctly refresh their associated units, preventing mismatched or outdated unit displays.
  - Added fallback handling when device feature unit information is unavailable.

- **Tests**
  - Added coverage to verify that device feature names and units are returned correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->