### PR TITLE
Zigbee2MQTT: add support for Tuya/Moes TS0601 garage door opener

### DIFF
--- a/server/services/zigbee2mqtt/exposes/binaryType.js
+++ b/server/services/zigbee2mqtt/exposes/binaryType.js
@@ -14,6 +14,12 @@ const names = {
     },
     reversedValue: true,
   },
+  garage_door_contact: {
+    feature: {
+      category: DEVICE_FEATURE_CATEGORIES.OPENING_SENSOR,
+      type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
+    },
+  },
   eco_mode: {
     feature: {
       category: DEVICE_FEATURE_CATEGORIES.SWITCH,
@@ -76,6 +82,12 @@ const names = {
         category: DEVICE_FEATURE_CATEGORIES.SWITCH,
         type: DEVICE_FEATURE_TYPES.SWITCH.BINARY,
       },
+    },
+  },
+  trigger: {
+    feature: {
+      category: DEVICE_FEATURE_CATEGORIES.SWITCH,
+      type: DEVICE_FEATURE_TYPES.SWITCH.BINARY,
     },
   },
   vibration: {

--- a/server/test/services/zigbee2mqtt/utils/payloads/TS0601_garage_door_opener.json
+++ b/server/test/services/zigbee2mqtt/utils/payloads/TS0601_garage_door_opener.json
@@ -1,0 +1,146 @@
+{
+  "name": "TS0601_garage_door_opener",
+  "mqttDevice": {
+    "definition": {
+      "model": "TS0601_garage_door_opener",
+      "exposes": [
+        {
+          "access": 3,
+          "description": "Request door to close (= false) or open (= true), will not pulse output if contact shows door is already in requested state",
+          "name": "trigger",
+          "property": "trigger",
+          "type": "binary",
+          "value_off": false,
+          "value_on": true
+        },
+        {
+          "access": 3,
+          "description": "Countdown to trigger door movement after a certain time, will pulse output in all cases",
+          "name": "countdown",
+          "property": "countdown",
+          "type": "numeric",
+          "unit": "s",
+          "value_max": 43200,
+          "value_min": 0
+        },
+        {
+          "access": 1,
+          "description": "Indicates if the garage door contact is closed (= true) or open (= false)",
+          "name": "garage_door_contact",
+          "property": "garage_door_contact",
+          "type": "binary",
+          "value_off": false,
+          "value_on": true
+        },
+        {
+          "access": 3,
+          "description": "Configure the time to wait for the door contact status to change before triggering a run time alarm",
+          "name": "run_time",
+          "property": "run_time",
+          "type": "numeric",
+          "unit": "s",
+          "value_max": 120,
+          "value_min": 0
+        },
+        {
+          "access": 3,
+          "description": "Configure the amount of time the door may be open before an open time alarm is triggered",
+          "name": "open_alarm_time",
+          "property": "open_alarm_time",
+          "type": "numeric",
+          "unit": "s",
+          "value_max": 86400,
+          "value_min": 0
+        },
+        {
+          "access": 1,
+          "description": "Indicates run time alarm, door open alarm or normal status, will not return to normal until door is triggered again",
+          "name": "status",
+          "property": "status",
+          "type": "enum",
+          "values": ["Open Time Alarm", "Run Time Alarm", "Normal"]
+        },
+        {
+          "access": 1,
+          "description": "Link quality (signal strength)",
+          "name": "linkquality",
+          "property": "linkquality",
+          "type": "numeric",
+          "unit": "lqi",
+          "value_max": 255,
+          "value_min": 0
+        }
+      ]
+    },
+    "friendly_name": "Garage door",
+    "ieee_address": "0xa4c1382720b9e514"
+  },
+  "gladysDevice": {
+    "service_id": "a4c859f0-32d2-46b7-8f5a-3285960f498a",
+    "external_id": "zigbee2mqtt:Garage door",
+    "ieee_address": "0xa4c1382720b9e514",
+    "features": [
+      {
+        "external_id": "zigbee2mqtt:Garage door:switch:binary:trigger",
+        "selector": "zigbee2mqtt-garage-door-switch-binary-trigger",
+        "name": "Trigger",
+        "category": "switch",
+        "type": "binary",
+        "min": 0,
+        "max": 1,
+        "unit": null,
+        "read_only": false,
+        "has_feedback": true
+      },
+      {
+        "external_id": "zigbee2mqtt:Garage door:opening-sensor:binary:garage_door_contact",
+        "selector": "zigbee2mqtt-garage-door-opening-sensor-binary-garage-door-contact",
+        "name": "Garage door contact",
+        "category": "opening-sensor",
+        "type": "binary",
+        "min": 0,
+        "max": 1,
+        "unit": null,
+        "read_only": true,
+        "has_feedback": false
+      },
+      {
+        "external_id": "zigbee2mqtt:Garage door:signal:integer:linkquality",
+        "selector": "zigbee2mqtt-garage-door-signal-integer-linkquality",
+        "name": "Linkquality",
+        "category": "signal",
+        "type": "integer",
+        "min": 0,
+        "max": 5,
+        "unit": null,
+        "read_only": true,
+        "has_feedback": false
+      }
+    ],
+    "name": "Garage door",
+    "model": "TS0601_garage_door_opener",
+    "should_poll": false
+  },
+  "values": [
+    {
+      "internal": 1,
+      "external": true,
+      "property": "trigger"
+    },
+    {
+      "internal": 0,
+      "external": false,
+      "property": "trigger"
+    },
+    {
+      "internal": 1,
+      "external": true,
+      "property": "garage_door_contact"
+    },
+    {
+      "internal": 0,
+      "external": false,
+      "property": "garage_door_contact"
+    }
+  ]
+}

--- a/server/test/services/zigbee2mqtt/utils/payloads/index.js
+++ b/server/test/services/zigbee2mqtt/utils/payloads/index.js
@@ -1,5 +1,6 @@
 const CCT5015 = require('./CCT5015.json');
 const ZSSZKTHL = require('./ZSS-ZK-THL.json');
 const SNZB01M = require('./SNZB-01M.json');
+const TS0601GarageDoorOpener = require('./TS0601_garage_door_opener.json');
 
-module.exports = [CCT5015, ZSSZKTHL, SNZB01M];
+module.exports = [CCT5015, ZSSZKTHL, SNZB01M, TS0601GarageDoorOpener];


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are server tests passing with coverage? (`cd server && npm run coverage`) — Codecov requires **100% coverage on lines changed in this PR** (the new mapping entries are exercised by the new real-device payload test)
- [x] Did Cypress E2E tests pass? (`npm run cypress:run` from repo root, if UI changed) — no UI change
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? — no new service, no translation change
- [ ] Did you test this pull request in real life? With real devices? — needs testing by the community member who owns the device ([forum thread](https://community.gladysassistant.com/t/moes-porte-de-garage-ts0601-par-tze204-jktmrpoj/10362))
- [x] If your changes modify the API (REST or Node.js), did you modify the API documentation? — no API change
- [x] If you are adding a new features/services which needs explanation, did you modify the user documentation? — device is auto-discovered through the existing Zigbee2MQTT integration
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.js`)? — not needed

### Description of change

Adds native support for the Tuya `TS0601_garage_door_opener` (Moes ZM-102-M `_TZE204_jktmrpoj`, also MatSee Plus PJ-ZGD01 `_TZE204_nklqjk62`) in the Zigbee2MQTT integration, as requested on the forum: https://community.gladysassistant.com/t/moes-porte-de-garage-ts0601-par-tze204-jktmrpoj/10362

Until now, only the `linkquality` expose of this device was mapped, so the device showed a single feature in Gladys and the door could only be controlled through a raw MQTT scene action.

Two new entries are added to the binary exposes mapping (`server/services/zigbee2mqtt/exposes/binaryType.js`):

- **`trigger`** → `switch` / `binary` feature (writable, with feedback). Turning it on publishes `{"trigger": true}` to request the door to open, turning it off publishes `{"trigger": false}` to request it to close.
- **`garage_door_contact`** → `opening-sensor` / `binary` feature (read-only). In Zigbee2MQTT this expose reports `true` when the contact is closed and `false` when open (`value_on: true` / `value_off: false` per the zigbee-herdsman-converters definition), which maps directly to Gladys' `OPENING_SENSOR_STATE` (`CLOSE = 1`, `OPEN = 0`) — so unlike the standard `contact` expose, no reversed value is needed.

The other exposes of this device (`countdown`, `run_time`, `open_alarm_time`, `status`) are configuration/alarm properties and remain unmapped.

A real-device test payload (`TS0601_garage_door_opener.json`) is added to the `realZigbee2mqttDevices` test suite: it checks the generated Gladys device (trigger switch, door contact sensor, link quality) and the value conversion in both directions for the two new features.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMkbyfpQSryxVRnKPnjitK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Zigbee garage door openers, including trigger controls and garage door contact sensors.
  - Added recognition of related device status, runtime, countdown, alarm, and signal information.
- **Tests**
  - Added coverage for the TS0601 garage door opener and its supported device features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->