### PR TITLE
Fix gateway backup OOM: bound DuckDB memory during the backup export

### DIFF
--- a/server/lib/gateway/gateway.backup.js
+++ b/server/lib/gateway/gateway.backup.js
@@ -99,10 +99,11 @@ async function backup(jobId) {
     // This connection will be closed after export to release memory
     const backupInstance = await db.duckDbCreateBackupInstance();
     try {
+      // ZSTD compresses better than GZIP and needs less memory during the export
       await backupInstance.allAsync(
         ` EXPORT DATABASE '${duckDbBackupFolderPath}' (
             FORMAT PARQUET,
-            COMPRESSION GZIP
+            COMPRESSION ZSTD
         )`,
       );
     } finally {

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -91,11 +91,77 @@ Object.values(models)
 // DuckDB
 const duckDbFilePath = `${config.storage.replace('.db', '')}.duckdb`;
 // Configure DuckDB with memory limit to prevent excessive memory usage
-// Default to 30% of system RAM, can be overridden via DUCKDB_MEMORY_LIMIT env var
+// Default to 30% of the RAM available to this process, can be overridden via
+// DUCKDB_MEMORY_LIMIT env var.
+// In a container (Docker or LXC), os.totalmem() reports the HOST total memory:
+// Node.js implements it with the sysinfo syscall, which is not namespaced (and
+// lxcfs only virtualizes /proc files, not syscalls). process.constrainedMemory()
+// reads the cgroup memory limit of the container, so take the smallest of the
+// two when a limit is set — otherwise the default limit can exceed the memory
+// actually allocated to the container and get Gladys OOM-killed.
 const totalMemoryBytes = os.totalmem();
-const defaultMemoryLimitBytes = Math.floor(totalMemoryBytes * 0.3);
-const defaultMemoryLimitMB = Math.floor(defaultMemoryLimitBytes / (1024 * 1024));
+const constrainedMemoryBytes = process.constrainedMemory() || 0;
+const availableMemoryBytes =
+  constrainedMemoryBytes > 0 ? Math.min(totalMemoryBytes, constrainedMemoryBytes) : totalMemoryBytes;
+const defaultMemoryLimitBytes = Math.floor(availableMemoryBytes * 0.3);
+// Cap the default at 4GB: a typical Gladys workload gets no benefit from a
+// bigger DuckDB cache, and 30% of a large host would hold that memory forever.
+const defaultMemoryLimitMB = Math.min(4096, Math.floor(defaultMemoryLimitBytes / (1024 * 1024)));
 const duckDbMemoryLimit = process.env.DUCKDB_MEMORY_LIMIT || `${defaultMemoryLimitMB}MB`;
+
+// Parse a DuckDB memory limit string such as '512MB', '1.5GB' or '1024MiB'
+// into MB (possibly fractional, e.g. '512KB' -> 0.5), so the backup default
+// below can be compared against a user-provided DUCKDB_MEMORY_LIMIT. Returns
+// null when the format is not recognized.
+const parseMemoryLimitMB = (limit) => {
+  const match = /^\s*(\d+(?:\.\d+)?)\s*(B|KB|KIB|MB|MIB|GB|GIB|TB|TIB)\s*$/i.exec(limit || '');
+  if (!match) {
+    return null;
+  }
+  const mbPerUnit = {
+    B: 1 / (1024 * 1024),
+    KB: 1 / 1024,
+    KIB: 1 / 1024,
+    MB: 1,
+    MIB: 1,
+    GB: 1024,
+    GIB: 1024,
+    TB: 1024 * 1024,
+    TIB: 1024 * 1024,
+  };
+  return parseFloat(match[1]) * mbPerUnit[match[2].toUpperCase()];
+};
+
+// The nightly backup export runs on a separate, short-lived DuckDB instance
+// (see duckDbCreateBackupInstance) whose buffer pool adds up to the main one
+// while the export runs. The export is a streaming scan that only needs memory
+// for read and compression buffers, not a full-size cache, so it gets a much
+// smaller limit: min(1GB, effective main limit), so it never exceeds the main
+// limit even when DUCKDB_MEMORY_LIMIT is set below 1GB. When the effective main
+// limit is parseable and already at or below 1GB it is reused verbatim, which
+// also preserves sub-MB values without any unit conversion. Can be overridden
+// via DUCKDB_BACKUP_MEMORY_LIMIT env var.
+const mainMemoryLimitMB = parseMemoryLimitMB(duckDbMemoryLimit);
+let defaultBackupMemoryLimit;
+if (mainMemoryLimitMB === null) {
+  // Unparseable main limit: fall back on the computed default, capped at 1GB.
+  defaultBackupMemoryLimit = `${Math.min(1024, defaultMemoryLimitMB)}MB`;
+} else if (mainMemoryLimitMB <= 1024) {
+  defaultBackupMemoryLimit = duckDbMemoryLimit;
+} else {
+  defaultBackupMemoryLimit = '1024MB';
+}
+const duckDbBackupMemoryLimit = process.env.DUCKDB_BACKUP_MEMORY_LIMIT || defaultBackupMemoryLimit;
+
+// An explicit DUCKDB_MEMORY_LIMIT is applied as-is: warn when it exceeds the
+// memory this process can actually use (as far as it is detectable), because
+// the OOM protection above cannot help in that case.
+const availableMemoryLimitMB = Math.floor(availableMemoryBytes / (1024 * 1024));
+if (mainMemoryLimitMB !== null && mainMemoryLimitMB > availableMemoryLimitMB) {
+  logger.warn(
+    `DUCKDB_MEMORY_LIMIT (${duckDbMemoryLimit}) exceeds the memory available to this process (${availableMemoryLimitMB}MB): Gladys can get OOM-killed, especially during backups`,
+  );
+}
 
 // The DuckDB Node "Neo" API (@duckdb/node-api) replaces the deprecated `duckdb`
 // package. It is fully asynchronous: the database instance and its connections
@@ -151,9 +217,9 @@ const initializeDuckDb = async () => {
   duckDbWriteQueue = createSerialQueue();
   duckDbReadQueue = createSerialQueue();
   logger.info(
-    `DuckDB initialized with memory_limit=${duckDbMemoryLimit} (system RAM: ${Math.floor(
-      totalMemoryBytes / (1024 * 1024),
-    )}MB)`,
+    `DuckDB initialized with memory_limit=${duckDbMemoryLimit} (available RAM: ${Math.floor(
+      availableMemoryBytes / (1024 * 1024),
+    )}MB, system RAM: ${Math.floor(totalMemoryBytes / (1024 * 1024))}MB)`,
   );
 };
 
@@ -330,9 +396,15 @@ const duckDbSetTimezone = async (timezone) => {
  */
 const duckDbCreateBackupInstance = async () => {
   // Create a new database instance pointing to the same file
-  // This instance has its own buffer pool that will be released when closed
+  // This instance has its own buffer pool that will be released when closed.
+  // It gets the small dedicated backup memory limit, and few threads: part of
+  // the Parquet writer and compression buffers of the export is allocated
+  // outside the buffer pool that memory_limit accounts for, and that untracked
+  // memory grows with the number of threads.
+  logger.info(`DuckDB backup instance: opening with memory_limit=${duckDbBackupMemoryLimit}, threads=2, READ_ONLY`);
   const backupDatabase = await DuckDBInstance.create(duckDbFilePath, {
-    memory_limit: duckDbMemoryLimit,
+    memory_limit: duckDbBackupMemoryLimit,
+    threads: '2',
     access_mode: 'READ_ONLY',
   });
   const connection = await backupDatabase.connect();

--- a/server/test/lib/gateway/gateway.backup.test.js
+++ b/server/test/lib/gateway/gateway.backup.test.js
@@ -1,5 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
+const path = require('path');
+const { promises: fsPromises } = require('fs');
 const proxyquire = require('proxyquire').noCallThru();
 
 const GladysGatewayClientMock = require('./GladysGatewayClientMock.test');
@@ -87,6 +89,24 @@ describe('gateway.backup', async function describe() {
     assert.calledOnce(gateway.gladysGatewayClient.initializeMultiPartBackup);
     assert.calledOnce(gateway.gladysGatewayClient.uploadOneBackupChunk);
     assert.calledOnce(gateway.gladysGatewayClient.finalizeMultiPartBackup);
+  });
+
+  it('should export the DuckDB backup as Parquet compressed with ZSTD', async () => {
+    // Make sure the exported table has at least one row group to inspect
+    await db.duckDbInsertState('ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4', 12, new Date());
+
+    await gateway.backup();
+
+    const backupFiles = await fsPromises.readdir(gateway.config.backupsFolder);
+    const parquetFolder = backupFiles.find((file) => file.includes('_parquet_folder'));
+    expect(parquetFolder).to.not.equal(undefined);
+    const parquetMetadata = await db.duckDbReadConnectionAllAsync(
+      'SELECT DISTINCT compression FROM parquet_metadata(?)',
+      path.join(gateway.config.backupsFolder, parquetFolder, '*.parquet'),
+    );
+    const compressions = parquetMetadata.map((row) => row.compression);
+    expect(compressions.length).to.be.greaterThan(0);
+    expect(compressions.every((compression) => compression === 'ZSTD')).to.equal(true);
   });
 
   it('should start and abort backup', async () => {

--- a/server/test/models/index.test.js
+++ b/server/test/models/index.test.js
@@ -32,6 +32,164 @@ const buildMockDuckDbApi = ({ disconnectError, closeError } = {}) => {
 };
 
 describe('models/index', () => {
+  describe('DuckDB memory limits', () => {
+    // Use a dedicated sandbox for the process.constrainedMemory stub: calling
+    // sinon.restore() on the DEFAULT sandbox would untrack the fakes that other
+    // test files create at load time, so their sinon.reset() cleanup would stop
+    // clearing call history and every suite running after this file would leak
+    // call counts between tests.
+    const sandbox = sinon.createSandbox();
+    const savedMemoryLimitEnv = process.env.DUCKDB_MEMORY_LIMIT;
+    const savedBackupMemoryLimitEnv = process.env.DUCKDB_BACKUP_MEMORY_LIMIT;
+
+    const restoreEnv = (key, value) => {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    };
+
+    beforeEach(() => {
+      delete process.env.DUCKDB_MEMORY_LIMIT;
+      delete process.env.DUCKDB_BACKUP_MEMORY_LIMIT;
+    });
+
+    afterEach(() => {
+      restoreEnv('DUCKDB_MEMORY_LIMIT', savedMemoryLimitEnv);
+      restoreEnv('DUCKDB_BACKUP_MEMORY_LIMIT', savedBackupMemoryLimitEnv);
+      sandbox.restore();
+    });
+
+    const loadDbWithMemory = ({ totalMemBytes, constrainedMemBytes }) => {
+      const { api } = buildMockDuckDbApi();
+      sandbox.stub(process, 'constrainedMemory').returns(constrainedMemBytes);
+      const mockLogger = {
+        info: sinon.stub(),
+        warn: sinon.stub(),
+        debug: sinon.stub(),
+        error: sinon.stub(),
+      };
+      const db = proxyquire('../../models', {
+        '@duckdb/node-api': api,
+        '../utils/logger': mockLogger,
+        os: { totalmem: () => totalMemBytes },
+      });
+      return { api, db, mockLogger };
+    };
+
+    const findBackupCreateCall = (api) =>
+      api.DuckDBInstance.create.getCalls().find((call) => call.args[1] && call.args[1].access_mode === 'READ_ONLY');
+
+    it('should use the cgroup memory limit when it is lower than the host total memory', async () => {
+      // Host with 16GB of RAM, container limited to 6GB by cgroup:
+      // the default must be 30% of 6GB, not 30% of 16GB.
+      const { api, db } = loadDbWithMemory({
+        totalMemBytes: 16 * 1024 * 1024 * 1024,
+        constrainedMemBytes: 6 * 1024 * 1024 * 1024,
+      });
+      await db.duckDbReadConnectionAllAsync('SELECT 1');
+      // Same formula as models/index.js: floor(30% of 6GB) in MB = 1843MB.
+      const expectedMB = Math.floor(Math.floor(6 * 1024 * 1024 * 1024 * 0.3) / (1024 * 1024));
+      expect(api.DuckDBInstance.create.firstCall.args[1]).to.deep.equal({ memory_limit: `${expectedMB}MB` });
+    });
+
+    it('should ignore the cgroup value when no limit is set and cap the default at 4GB', async () => {
+      // No cgroup limit (constrainedMemory returns 0), 64GB host: 30% would be
+      // ~19GB, the default must be capped at 4GB, and the backup default at 1GB.
+      const { api, db } = loadDbWithMemory({
+        totalMemBytes: 64 * 1024 * 1024 * 1024,
+        constrainedMemBytes: 0,
+      });
+      await db.duckDbReadConnectionAllAsync('SELECT 1');
+      expect(api.DuckDBInstance.create.firstCall.args[1]).to.deep.equal({ memory_limit: '4096MB' });
+      await db.duckDbCreateBackupInstance();
+      expect(findBackupCreateCall(api).args[1].memory_limit).to.equal('1024MB');
+    });
+
+    it('should ignore a cgroup "no limit" sentinel larger than the host total memory', async () => {
+      // cgroup v2 "max" surfaces as a huge sentinel (e.g. 2^44 bytes): the
+      // default must stay based on the host total, capped at 4GB.
+      const { api, db } = loadDbWithMemory({
+        totalMemBytes: 16 * 1024 * 1024 * 1024,
+        constrainedMemBytes: 2 ** 44,
+      });
+      await db.duckDbReadConnectionAllAsync('SELECT 1');
+      // 30% of 16GB is ~4915MB, capped at 4096MB.
+      expect(api.DuckDBInstance.create.firstCall.args[1]).to.deep.equal({ memory_limit: '4096MB' });
+    });
+
+    it('should cap the default backup limit at 1GB when DUCKDB_MEMORY_LIMIT is above 1GB', async () => {
+      // Documented formula: min(1GB, effective main limit) — even when the
+      // computed default on this machine would be smaller than 1GB.
+      process.env.DUCKDB_MEMORY_LIMIT = '2GB';
+      const { api, db } = loadDbWithMemory({
+        totalMemBytes: 2 * 1024 * 1024 * 1024,
+        constrainedMemBytes: 0,
+      });
+      await db.duckDbCreateBackupInstance();
+      expect(findBackupCreateCall(api).args[1].memory_limit).to.equal('1024MB');
+    });
+
+    it('should warn when DUCKDB_MEMORY_LIMIT exceeds the detected available memory', async () => {
+      process.env.DUCKDB_MEMORY_LIMIT = '8GB';
+      const { mockLogger } = loadDbWithMemory({
+        totalMemBytes: 4 * 1024 * 1024 * 1024,
+        constrainedMemBytes: 0,
+      });
+      expect(mockLogger.warn.calledWithMatch(/DUCKDB_MEMORY_LIMIT \(8GB\) exceeds the memory available/)).to.equal(
+        true,
+      );
+    });
+
+    it('should not let the default backup limit exceed a custom DUCKDB_MEMORY_LIMIT', async () => {
+      // Custom main limit below 1GB and no backup override: the backup default
+      // must be clamped to the effective main limit, not to min(1GB, computed default).
+      process.env.DUCKDB_MEMORY_LIMIT = '512MB';
+      const { api, db } = loadDbWithMemory({
+        totalMemBytes: 16 * 1024 * 1024 * 1024,
+        constrainedMemBytes: 0,
+      });
+      await db.duckDbCreateBackupInstance();
+      expect(api.DuckDBInstance.create.firstCall.args[1]).to.deep.equal({ memory_limit: '512MB' });
+      const backupCreateCall = api.DuckDBInstance.create
+        .getCalls()
+        .find((call) => call.args[1] && call.args[1].access_mode === 'READ_ONLY');
+      expect(backupCreateCall.args[1].memory_limit).to.equal('512MB');
+    });
+
+    it('should reuse a sub-MB DUCKDB_MEMORY_LIMIT verbatim for the backup limit', async () => {
+      // Degenerate but explicit sub-MB main limit: the backup default must not
+      // exceed it, so the main limit string is reused as-is.
+      process.env.DUCKDB_MEMORY_LIMIT = '512KB';
+      const { api, db } = loadDbWithMemory({
+        totalMemBytes: 16 * 1024 * 1024 * 1024,
+        constrainedMemBytes: 0,
+      });
+      await db.duckDbCreateBackupInstance();
+      const backupCreateCall = api.DuckDBInstance.create
+        .getCalls()
+        .find((call) => call.args[1] && call.args[1].access_mode === 'READ_ONLY');
+      expect(backupCreateCall.args[1].memory_limit).to.equal('512KB');
+    });
+
+    it('should fall back on the computed default for the backup limit when DUCKDB_MEMORY_LIMIT is not parseable', async () => {
+      // Unparseable custom limit: it is still passed through to DuckDB verbatim,
+      // and the backup default falls back on min(1GB, computed default).
+      process.env.DUCKDB_MEMORY_LIMIT = '25% of RAM';
+      const { api, db } = loadDbWithMemory({
+        totalMemBytes: 16 * 1024 * 1024 * 1024,
+        constrainedMemBytes: 0,
+      });
+      await db.duckDbCreateBackupInstance();
+      expect(api.DuckDBInstance.create.firstCall.args[1]).to.deep.equal({ memory_limit: '25% of RAM' });
+      const backupCreateCall = api.DuckDBInstance.create
+        .getCalls()
+        .find((call) => call.args[1] && call.args[1].access_mode === 'READ_ONLY');
+      expect(backupCreateCall.args[1].memory_limit).to.equal('1024MB');
+    });
+  });
+
   describe('duckDbCreateBackupInstance', () => {
     it('should log warning when connection close fails but still close database', async () => {
       const connCloseError = new Error('Connection close failed');
@@ -111,6 +269,44 @@ describe('models/index', () => {
       expect(connection.disconnectSync.calledOnce).to.equal(true);
       expect(instance.closeSync.calledOnce).to.equal(true);
       expect(mockLogger.warn.called).to.equal(false);
+    });
+
+    it('should open the backup instance read-only with the dedicated backup memory limit and few threads', async () => {
+      const savedBackupMemoryLimitEnv = process.env.DUCKDB_BACKUP_MEMORY_LIMIT;
+      process.env.DUCKDB_BACKUP_MEMORY_LIMIT = '512MB';
+      try {
+        const { api } = buildMockDuckDbApi();
+
+        const mockLogger = {
+          info: sinon.stub(),
+          warn: sinon.stub(),
+          debug: sinon.stub(),
+          error: sinon.stub(),
+        };
+
+        const db = proxyquire('../../models', {
+          '@duckdb/node-api': api,
+          '../utils/logger': mockLogger,
+        });
+
+        await db.duckDbCreateBackupInstance();
+
+        const backupCreateCall = api.DuckDBInstance.create
+          .getCalls()
+          .find((call) => call.args[1] && call.args[1].access_mode === 'READ_ONLY');
+        expect(backupCreateCall).to.not.equal(undefined);
+        expect(backupCreateCall.args[1]).to.deep.equal({
+          memory_limit: '512MB',
+          threads: '2',
+          access_mode: 'READ_ONLY',
+        });
+      } finally {
+        if (savedBackupMemoryLimitEnv === undefined) {
+          delete process.env.DUCKDB_BACKUP_MEMORY_LIMIT;
+        } else {
+          process.env.DUCKDB_BACKUP_MEMORY_LIMIT = savedBackupMemoryLimitEnv;
+        }
+      }
     });
   });
 


### PR DESCRIPTION
### Pull Request check-list

- [x] If your changes affect the code, did you write the tests?
- [ ] Are server tests passing with coverage? (`cd server && npm run coverage`) — Codecov requires **100% coverage on lines changed in this PR** (targeted suites pass locally: `test/models/index.test.js`, `test/lib/gateway/gateway.backup.test.js`, `test/lib/gateway/gateway.restoreBackup.test.js`; full coverage run pending CI)
- [ ] Did Cypress E2E tests pass? (no UI change)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new feature/service, did you run the integration comparator? (not applicable)
- [ ] Did you test this pull request in real life? With real devices? — the AMD64 preview image of this PR should be shared on the [community topic](https://community.gladysassistant.com/t/surconsommation-de-memoire-par-le-backup-de-gateway/10387) so affected users can validate
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (no API change)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? — `DUCKDB_MEMORY_LIMIT` / `DUCKDB_BACKUP_MEMORY_LIMIT` should be documented for Proxmox/LXC users (v4-website)
- [ ] Did you add fake requests data for the demo mode? (not applicable)

### Description of change

The nightly Gladys Plus backup can get Gladys OOM-killed (exit code 137) while exporting DuckDB to Parquet. Reported and diagnosed on the community forum: [Surconsommation de mémoire par le backup de Gateway](https://community.gladysassistant.com/t/surconsommation-de-memoire-par-le-backup-de-gateway/10387).

Two root causes, three changes:

**1. The backup export could use up to 2× the DuckDB memory limit.**
The backup opens a second, short-lived DuckDB instance on the same file (intentional since #2420, so that its memory is fully released when it closes). But each instance gets its own buffer pool capped at `DUCKDB_MEMORY_LIMIT`, so the peak during the backup was `2 × limit`. The export is a streaming scan that doesn't benefit from a full-size cache, so the backup instance now gets:
- its own much smaller memory limit: `min(1GB, main limit)`, overridable via a new `DUCKDB_BACKUP_MEMORY_LIMIT` env var,
- `threads: 2`, because part of the Parquet writer/compression buffers is allocated outside what `memory_limit` tracks, and that untracked memory grows with the thread count.

The peak goes from `2 × limit` to `limit + ~1GB`, and the release-on-close behavior is preserved.

**2. The "30% of RAM" default was computed on the host's RAM, not the container's.**
`os.totalmem()` is implemented with the `sysinfo` syscall, which is not namespaced (and lxcfs only virtualizes `/proc` files, not syscalls), so inside Docker/LXC it returns the **host** total memory. Diagnostics from an affected user (16GB host, 6GB LXC) confirmed the default limit was computed as 30% of 16GB ≈ 4.7GB — already close to the whole container allocation, and ×2 during backup. The default now:
- also honors the cgroup limit when it is visible (`process.constrainedMemory()`, ignoring the "no limit" sentinel), which fixes plain Docker with `--memory`,
- is capped at 4GB in absolute terms to protect large hosts.

Note: in Docker-inside-LXC setups, no interface exposes the real container limit from inside the Docker container (the LXC limit lives in an ancestor cgroup, and `/proc/meminfo` bypasses lxcfs), so those users still need to set `DUCKDB_MEMORY_LIMIT` explicitly — to be documented on the website.

**3. Parquet export compression switched from GZIP to ZSTD.**
Better compression ratio with fewer memory buffers during the export. Restore is unaffected: `IMPORT DATABASE` reads both codecs (the restore test suite imports the existing GZIP fixture and passes unchanged).

### Tests

- New unit tests on the default memory limit computation (cgroup limit honored when lower than host RAM, 4GB cap, "no limit" sentinel ignored) and on the backup instance options (dedicated limit, `READ_ONLY`, reduced threads).
- The existing backup/restore integration tests run the real ZSTD export and re-import the old GZIP fixture, covering both codecs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKfbKkG6KroB79NZqdHqt1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved backup efficiency by exporting Parquet using **ZSTD** compression.
  - Made DuckDB memory configuration **container-aware** with safer defaults, clearer reporting, and a **separate backup memory limit**.
  - Set fixed backup threading for more predictable backup performance.
- **Bug Fixes**
  - Reduced the risk of excessive memory usage in constrained container environments.
- **Tests**
  - Added coverage for DuckDB memory limit selection across scenarios and verified Parquet backup compression uses **ZSTD**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->