### PR TITLE
Update AI chat models: remove outdated models, add glm-5.2

### DIFF
--- a/server/test/controllers/gateway/gateway.controller.test.js
+++ b/server/test/controllers/gateway/gateway.controller.test.js
@@ -234,10 +234,10 @@ describe('GET /api/v1/gateway/aichat/models', () => {
 
     expect(response.body).to.have.property('models');
     expect(response.body.models).to.be.an('array');
-    expect(response.body.models.find((model) => model.id === 'llama-3.3-70b-instruct')).to.deep.equal({
-      id: 'llama-3.3-70b-instruct',
-      priceLabel: '€€',
-      priceTier: 2,
+    expect(response.body.models.find((model) => model.id === 'glm-5.2')).to.deep.equal({
+      id: 'glm-5.2',
+      priceLabel: '€€€',
+      priceTier: 3,
       vision: false,
     });
   });

--- a/server/test/controllers/message/message.test.js
+++ b/server/test/controllers/message/message.test.js
@@ -26,7 +26,7 @@ describe('POST /api/v1/message', () => {
       .post('/api/v1/message')
       .send({
         text: 'What time is it?',
-        model: 'llama-3.3-70b-instruct',
+        model: 'glm-5.2',
       })
       .expect('Content-Type', /json/)
       .expect(201)

--- a/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
+++ b/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
@@ -123,12 +123,12 @@ describe('gateway.forwardMessageToAiChat', () => {
     const replyByIntent = fake.resolves(null);
 
     await forwardMessageToAiChat.call(buildContext({ tools: [], aiChat, reply, replyByIntent }), {
-      message: { text: 'Turn on the light', model: 'llama-3.3-70b-instruct' },
+      message: { text: 'Turn on the light', model: 'glm-5.2' },
       previousQuestions: [],
       context: {},
     });
 
-    expect(aiChat.getCall(0).args[0].model).to.equal('llama-3.3-70b-instruct');
+    expect(aiChat.getCall(0).args[0].model).to.equal('glm-5.2');
   });
 
   it('should omit model from the AI gateway request when auto is selected', async () => {

--- a/server/test/utils/aiChatModels.test.js
+++ b/server/test/utils/aiChatModels.test.js
@@ -28,7 +28,7 @@ describe('aiChatModels utils', () => {
 
   it('should resolve allowed models', () => {
     expect(resolveAiChatModel(DEFAULT_TEXT_MODEL)).to.equal(DEFAULT_TEXT_MODEL);
-    expect(resolveAiChatModel('llama-3.3-70b-instruct')).to.equal('llama-3.3-70b-instruct');
+    expect(resolveAiChatModel('glm-5.2')).to.equal('glm-5.2');
   });
 
   it('should return null for invalid models', () => {
@@ -44,11 +44,17 @@ describe('aiChatModels utils', () => {
       priceTier: 1,
       priceLabel: '€',
     });
-    expect(models.find((model) => model.id === 'llama-3.3-70b-instruct')).to.deep.equal({
-      id: 'llama-3.3-70b-instruct',
-      vision: false,
+    expect(models.find((model) => model.id === 'qwen3.6-35b-a3b')).to.deep.equal({
+      id: 'qwen3.6-35b-a3b',
+      vision: true,
       priceTier: 2,
       priceLabel: '€€',
+    });
+    expect(models.find((model) => model.id === 'glm-5.2')).to.deep.equal({
+      id: 'glm-5.2',
+      vision: false,
+      priceTier: 3,
+      priceLabel: '€€€',
     });
     expect(models.find((model) => model.id === 'qwen3.5-397b-a17b')).to.deep.equal({
       id: 'qwen3.5-397b-a17b',

--- a/server/utils/aiChatModels.js
+++ b/server/utils/aiChatModels.js
@@ -22,14 +22,10 @@ const ALLOWED_SCALEWAY_MODELS = {
   [DEFAULT_VISION_MODEL]: { vision: true, priceTier: AI_CHAT_MODEL_PRICE_TIER.LOW },
   // Vision — image analysis (cameras, scene understanding)
   'qwen3.6-35b-a3b': { vision: true, priceTier: AI_CHAT_MODEL_PRICE_TIER.MEDIUM },
-  'pixtral-12b-2409': { vision: true, priceTier: AI_CHAT_MODEL_PRICE_TIER.LOW },
-  'gemma-3-27b-it': { vision: true, priceTier: AI_CHAT_MODEL_PRICE_TIER.LOW },
-  'holo2-30b-a3b': { vision: true, priceTier: AI_CHAT_MODEL_PRICE_TIER.LOW },
   // Premium vision — complex multimodal requests
   'qwen3.5-397b-a17b': { vision: true, priceTier: AI_CHAT_MODEL_PRICE_TIER.HIGH },
   // Text — richer reasoning for ambiguous or multi-step commands
-  'llama-3.3-70b-instruct': { vision: false, priceTier: AI_CHAT_MODEL_PRICE_TIER.MEDIUM },
-  'qwen3-235b-a22b-instruct-2507': { vision: false, priceTier: AI_CHAT_MODEL_PRICE_TIER.HIGH },
+  'glm-5.2': { vision: false, priceTier: AI_CHAT_MODEL_PRICE_TIER.HIGH },
 };
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the allowed Scaleway AI chat models list:

**Removed:**
- Holo2-30B (`holo2-30b-a3b`)
- Gemma 3-27B (`gemma-3-27b-it`)
- Pixtral 12B (`pixtral-12b-2409`)
- Llama 3.3-70B (`llama-3.3-70b-instruct`)
- Qwen3-235B (`qwen3-235b-a22b-instruct-2507`)

**Added:**
- `glm-5.2` — text-only (`vision: false`), high price tier (€€€) based on Scaleway serverless pricing (€1.80/M input, €5.50/M output)

## Test plan

- [x] Update unit/controller tests that referenced removed models
- [x] Run `npm run eslint` (0 errors) and targeted Mocha tests (10 passing)
- [x] Confirm `aiChatModels.js` has 100% line coverage on changed code
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6440800-b57d-4dca-8515-8c7157f8419f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6440800-b57d-4dca-8515-8c7157f8419f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the available text AI model to `glm-5.2`.
  * Refreshed model listings and metadata to reflect current availability.

* **Bug Fixes**
  * Updated message handling and gateway forwarding to consistently support the selected model.

* **Tests**
  * Revised coverage for allowed models, model listings, pricing metadata, and gateway requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->