### PR TITLE
Force tool calls for device query/control AI intents

### DIFF
--- a/server/lib/gateway/gateway.forwardMessageToAiChat.js
+++ b/server/lib/gateway/gateway.forwardMessageToAiChat.js
@@ -5,7 +5,13 @@ const utc = require('dayjs/plugin/utc');
 const timezone = require('dayjs/plugin/timezone');
 
 const logger = require('../../utils/logger');
-const { EVENTS, WEBSOCKET_MESSAGE_TYPES, SYSTEM_VARIABLE_NAMES, AI_CHAT_PURPOSES } = require('../../utils/constants');
+const {
+  EVENTS,
+  WEBSOCKET_MESSAGE_TYPES,
+  SYSTEM_VARIABLE_NAMES,
+  AI_CHAT_PURPOSES,
+  AI_CHAT_TOOL_CATEGORIES,
+} = require('../../utils/constants');
 const { Error429 } = require('../../utils/httpErrors');
 const { resizeImage } = require('../../utils/resizeImage');
 const { mcpToolsToChatApiFormat, toolNameFromIntent } = require('../../services/mcp/lib/mcpToolsToChatApiFormat');
@@ -17,6 +23,15 @@ const MAX_TOOL_CALL_ITERATIONS = 5;
 const MAX_TOOL_RESULT_CHARS = 4000;
 const MAX_FALLBACK_ANSWER_CHARS = 2000;
 const MAX_NESTED_VALUE_CHARS = 2000;
+
+// Categories where answering without a tool call risks hallucinating home state or actions.
+const FORCE_TOOL_CHOICE_CATEGORIES = new Set([
+  AI_CHAT_TOOL_CATEGORIES.DEVICE_QUERY,
+  AI_CHAT_TOOL_CATEGORIES.DEVICE_CONTROL,
+]);
+
+const FORCE_TOOL_RETRY_MESSAGE =
+  'You must call a tool before answering. Use the available tools to fetch live data or perform the requested action.';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -45,6 +60,39 @@ function buildSystemPromptWithCurrentTime(timezoneName, now = new Date(), { incl
     .format('dddd YYYY-MM-DD HH:mm');
   const basePrompt = includeSceneRules ? `${SYSTEM_PROMPT}\n${SCENES_SYSTEM_PROMPT}` : SYSTEM_PROMPT;
   return `${basePrompt}\n\nCurrent date and time (${timezoneName}): ${formattedNow}`;
+}
+
+/**
+ * @description Whether device query/control intents should force at least one tool call.
+ * @param {Array<string>|null|undefined} toolCategories - Categories selected by the intent router.
+ * @returns {boolean} True when tool use must be required on the first model turn.
+ * @example
+ * shouldForceToolChoice(['device_query']);
+ */
+function shouldForceToolChoice(toolCategories) {
+  if (!Array.isArray(toolCategories) || toolCategories.length === 0) {
+    return false;
+  }
+  return toolCategories.some((category) => FORCE_TOOL_CHOICE_CATEGORIES.has(category));
+}
+
+/**
+ * @description Resolve OpenAI-compatible tool_choice for the current AI chat iteration.
+ * Force tools only before any tool has run for device_query/device_control intents.
+ * After tools have executed, switch back to auto so the model can produce a final answer.
+ * @param {object} options - Resolution options.
+ * @param {boolean} options.forceToolUse - Whether the intent requires a tool call.
+ * @param {boolean} options.hasTools - Whether at least one tool is available to the model.
+ * @param {boolean} options.hasCompletedToolIteration - Whether a tool turn already ran.
+ * @returns {'required'|'auto'} tool_choice value for the API request.
+ * @example
+ * resolveToolChoice({ forceToolUse: true, hasTools: true, hasCompletedToolIteration: false });
+ */
+function resolveToolChoice({ forceToolUse, hasTools, hasCompletedToolIteration }) {
+  if (forceToolUse && hasTools && !hasCompletedToolIteration) {
+    return 'required';
+  }
+  return 'auto';
 }
 
 /**
@@ -433,17 +481,27 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
     let lastSceneCreateErrorText = null;
     let sceneCreateSuccessCount = 0;
     let toolIterations = 0;
+    const forceToolUse = shouldForceToolChoice(toolCategories) && toolsForApi.length > 0;
+    let forcedToolRetryUsed = false;
     const selectedModel = resolveAiChatModel(message?.model);
     if (message?.model && selectedModel === null) {
       logger.warn(`[AI_CHAT] Ignoring invalid model=${message.model}`);
     }
+    if (forceToolUse) {
+      logger.info(`[AI_CHAT] Forcing tool_choice=required for categories=${(toolCategories || []).join(',')}`);
+    }
     // eslint-disable-next-line no-restricted-syntax
     for (let iteration = 0; iteration < MAX_TOOL_CALL_ITERATIONS; iteration += 1) {
       logger.debug(`[AI_CHAT] API call iteration=${iteration + 1}/${MAX_TOOL_CALL_ITERATIONS}`);
+      const toolChoice = resolveToolChoice({
+        forceToolUse,
+        hasTools: toolsForApi.length > 0,
+        hasCompletedToolIteration: toolIterations > 0,
+      });
       const aiChatRequest = {
         messages: messagesForApi,
         tools: toolsForApi,
-        tool_choice: 'auto',
+        tool_choice: toolChoice,
         purpose: AI_CHAT_PURPOSES.CHAT,
       };
       if (toolCategories) {
@@ -467,7 +525,7 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
       logger.info(
         `[AI_CHAT] Assistant turn iteration=${iteration + 1} tool_calls=${
           toolCalls.length
-        }${toolNamesSuffix} content=${assistantContentPreview}`,
+        } tool_choice=${toolChoice}${toolNamesSuffix} content=${assistantContentPreview}`,
       );
       logger.debug(
         `[AI_CHAT] Assistant turn details iteration=${iteration +
@@ -475,6 +533,18 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
       );
 
       if (!toolCalls || toolCalls.length === 0) {
+        // Some providers may ignore tool_choice=required. Retry once with an
+        // explicit nudge before accepting an ungrounded device answer/action.
+        if (forceToolUse && toolIterations === 0 && !forcedToolRetryUsed) {
+          forcedToolRetryUsed = true;
+          logger.warn('[AI_CHAT] Forced tool use expected but model returned no tool_calls, retrying once');
+          messagesForApi.push({
+            role: 'user',
+            content: FORCE_TOOL_RETRY_MESSAGE,
+          });
+          // eslint-disable-next-line no-continue
+          continue;
+        }
         break;
       }
 
@@ -673,6 +743,9 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
 module.exports = {
   forwardMessageToAiChat,
   buildSystemPromptWithCurrentTime,
+  shouldForceToolChoice,
+  resolveToolChoice,
+  FORCE_TOOL_RETRY_MESSAGE,
   debugPreview,
   extractAssistantMessage,
   extractMessageFilesFromToolResult,

--- a/server/lib/gateway/gateway.forwardMessageToAiChat.js
+++ b/server/lib/gateway/gateway.forwardMessageToAiChat.js
@@ -24,10 +24,13 @@ const MAX_TOOL_RESULT_CHARS = 4000;
 const MAX_FALLBACK_ANSWER_CHARS = 2000;
 const MAX_NESTED_VALUE_CHARS = 2000;
 
-// Categories where answering without a tool call risks hallucinating home state or actions.
+// Only pure "other" chat (general knowledge, greetings) may answer without tools.
+// Home actions, state queries, scenes and web/time lookups must call tools first.
 const FORCE_TOOL_CHOICE_CATEGORIES = new Set([
   AI_CHAT_TOOL_CATEGORIES.DEVICE_QUERY,
   AI_CHAT_TOOL_CATEGORIES.DEVICE_CONTROL,
+  AI_CHAT_TOOL_CATEGORIES.SCENES,
+  AI_CHAT_TOOL_CATEGORIES.WEB_AND_TIME,
 ]);
 
 const FORCE_TOOL_RETRY_MESSAGE =
@@ -63,7 +66,8 @@ function buildSystemPromptWithCurrentTime(timezoneName, now = new Date(), { incl
 }
 
 /**
- * @description Whether device query/control intents should force at least one tool call.
+ * @description Whether the classified intent should force at least one tool call.
+ * Forced for home/device/scene/web intents; not for pure "other" chat or unknown routing.
  * @param {Array<string>|null|undefined} toolCategories - Categories selected by the intent router.
  * @returns {boolean} True when tool use must be required on the first model turn.
  * @example
@@ -78,7 +82,7 @@ function shouldForceToolChoice(toolCategories) {
 
 /**
  * @description Resolve OpenAI-compatible tool_choice for the current AI chat iteration.
- * Force tools only before any tool has run for device_query/device_control intents.
+ * Force tools only before any tool has run when the intent requires tool use.
  * After tools have executed, switch back to auto so the model can produce a final answer.
  * @param {object} options - Resolution options.
  * @param {boolean} options.forceToolUse - Whether the intent requires a tool call.

--- a/server/lib/gateway/gateway.forwardMessageToAiChat.js
+++ b/server/lib/gateway/gateway.forwardMessageToAiChat.js
@@ -25,12 +25,13 @@ const MAX_FALLBACK_ANSWER_CHARS = 2000;
 const MAX_NESTED_VALUE_CHARS = 2000;
 
 // Only pure "other" chat (general knowledge, greetings) may answer without tools.
-// Home actions, state queries, scenes and web/time lookups must call tools first.
+// Home actions, state queries and scenes must call tools first.
+// web_and_time is not forced: current date/time is already in the system prompt,
+// and simple clock questions should not require a tool call.
 const FORCE_TOOL_CHOICE_CATEGORIES = new Set([
   AI_CHAT_TOOL_CATEGORIES.DEVICE_QUERY,
   AI_CHAT_TOOL_CATEGORIES.DEVICE_CONTROL,
   AI_CHAT_TOOL_CATEGORIES.SCENES,
-  AI_CHAT_TOOL_CATEGORIES.WEB_AND_TIME,
 ]);
 
 const FORCE_TOOL_RETRY_MESSAGE =
@@ -67,7 +68,7 @@ function buildSystemPromptWithCurrentTime(timezoneName, now = new Date(), { incl
 
 /**
  * @description Whether the classified intent should force at least one tool call.
- * Forced for home/device/scene/web intents; not for pure "other" chat or unknown routing.
+ * Forced for home/device/scene intents; not for web/time, pure "other" chat, or unknown routing.
  * @param {Array<string>|null|undefined} toolCategories - Categories selected by the intent router.
  * @returns {boolean} True when tool use must be required on the first model turn.
  * @example

--- a/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
+++ b/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
@@ -1091,7 +1091,26 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
     it('should only send tools of the classified categories and omit scene rules', async () => {
       const tools = buildRoutedTools();
       const { forwardMessageToAiChat } = getModule({ tools });
-      const aiChat = fake.resolves({
+      const aiChat = stub();
+      aiChat.onCall(0).resolves({
+        choices: [
+          {
+            message: {
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_1',
+                  function: {
+                    name: 'device_turn_on_off',
+                    arguments: '{"action":"off"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+      aiChat.onCall(1).resolves({
         choices: [{ message: { content: 'OK' } }],
       });
       const classifyAiChatToolCategories = fake.resolves(['device_control']);
@@ -1117,6 +1136,198 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
       expect(request.messages[0].content).to.not.include(scenesPromptMock);
       expect(request.purpose).to.equal('chat');
       expect(request.categories).to.deep.equal(['device_control']);
+      expect(request.tool_choice).to.equal('required');
+      expect(aiChat.getCall(1).args[0].tool_choice).to.equal('auto');
+    });
+
+    it('should force tool_choice=required for device_query then switch to auto after tools', async () => {
+      const tools = [
+        {
+          intent: 'device.get-state',
+          config: {
+            title: 'Get states',
+            description: 'Get device states',
+            categories: ['device_query', 'other'],
+            inputSchema: { room: z.enum(['Salon']).optional() },
+          },
+          cb: fake.resolves({ content: [{ type: 'text', text: 'Salon temperature: 25.3°C' }] }),
+        },
+      ];
+      const { forwardMessageToAiChat } = getModule({ tools });
+      const aiChat = stub();
+      aiChat.onCall(0).resolves({
+        choices: [
+          {
+            message: {
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_temp',
+                  function: {
+                    name: 'device_get_state',
+                    arguments: '{"device_type":"temperature-sensor","room":"Salon"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+      aiChat.onCall(1).resolves({
+        choices: [{ message: { content: 'La température dans le salon est de 25,3 °C.' } }],
+      });
+      const classifyAiChatToolCategories = fake.resolves(['device_query']);
+      const reply = fake.resolves(null);
+      const replyByIntent = fake.resolves(null);
+
+      const result = await forwardMessageToAiChat.call(
+        buildContext({ tools, aiChat, reply, replyByIntent, classifyAiChatToolCategories }),
+        {
+          message: { text: 'Et la température ?' },
+          previousQuestions: [],
+          context: {},
+        },
+      );
+
+      expect(result).to.deep.equal({ answer: 'La température dans le salon est de 25,3 °C.', imagesSent: 0 });
+      expect(aiChat.getCall(0).args[0].tool_choice).to.equal('required');
+      expect(aiChat.getCall(1).args[0].tool_choice).to.equal('auto');
+      assert.calledWith(
+        reply,
+        match.has('text', 'Et la température ?'),
+        'device_get_state({"device_type":"temperature-sensor","room":"Salon"})',
+        {},
+        null,
+        match({ messageType: 'tool_call', toolName: 'device_get_state', toolStatus: 'success' }),
+      );
+    });
+
+    it('should retry once when forced tool use returns no tool_calls', async () => {
+      const tools = buildRoutedTools();
+      const { forwardMessageToAiChat, FORCE_TOOL_RETRY_MESSAGE } = getModule({ tools });
+      const aiChat = stub();
+      aiChat.onCall(0).resolves({
+        choices: [{ message: { content: 'La température est de 25,3 °C.' } }],
+      });
+      aiChat.onCall(1).resolves({
+        choices: [
+          {
+            message: {
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_retry',
+                  function: {
+                    name: 'device_turn_on_off',
+                    arguments: '{"action":"off"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+      aiChat.onCall(2).resolves({
+        choices: [{ message: { content: 'Fait après retry.' } }],
+      });
+      const classifyAiChatToolCategories = fake.resolves(['device_control']);
+      const reply = fake.resolves(null);
+      const replyByIntent = fake.resolves(null);
+
+      const result = await forwardMessageToAiChat.call(
+        buildContext({ tools, aiChat, reply, replyByIntent, classifyAiChatToolCategories }),
+        {
+          message: { text: 'Éteins la lumière' },
+          previousQuestions: [],
+          context: {},
+        },
+      );
+
+      expect(result).to.deep.equal({ answer: 'Fait après retry.', imagesSent: 0 });
+      expect(aiChat.callCount).to.equal(3);
+      expect(aiChat.getCall(0).args[0].tool_choice).to.equal('required');
+      expect(aiChat.getCall(1).args[0].tool_choice).to.equal('required');
+      // messagesForApi is mutated in place after the call, so assert presence rather than last element.
+      expect(
+        aiChat
+          .getCall(1)
+          .args[0].messages.some((message) => message.role === 'user' && message.content === FORCE_TOOL_RETRY_MESSAGE),
+      ).to.equal(true);
+      expect(aiChat.getCall(2).args[0].tool_choice).to.equal('auto');
+    });
+
+    it('should accept the answer after a failed forced-tool retry', async () => {
+      const tools = buildRoutedTools();
+      const { forwardMessageToAiChat } = getModule({ tools });
+      const aiChat = stub();
+      aiChat.onCall(0).resolves({
+        choices: [{ message: { content: 'Il fait 22 °C.' } }],
+      });
+      aiChat.onCall(1).resolves({
+        choices: [{ message: { content: 'Il fait toujours 22 °C.' } }],
+      });
+      const classifyAiChatToolCategories = fake.resolves(['device_query']);
+      const reply = fake.resolves(null);
+      const replyByIntent = fake.resolves(null);
+
+      const result = await forwardMessageToAiChat.call(
+        buildContext({ tools, aiChat, reply, replyByIntent, classifyAiChatToolCategories }),
+        {
+          message: { text: 'Quelle température ?' },
+          previousQuestions: [],
+          context: {},
+        },
+      );
+
+      expect(result).to.deep.equal({ answer: 'Il fait toujours 22 °C.', imagesSent: 0 });
+      expect(aiChat.callCount).to.equal(2);
+      expect(aiChat.getCall(0).args[0].tool_choice).to.equal('required');
+      expect(aiChat.getCall(1).args[0].tool_choice).to.equal('required');
+    });
+
+    it('should keep tool_choice=auto for scenes and unclassified requests', async () => {
+      const tools = buildRoutedTools();
+      const { forwardMessageToAiChat } = getModule({ tools });
+      const scenesAiChat = fake.resolves({
+        choices: [{ message: { content: 'OK scenes' } }],
+      });
+      const nullAiChat = fake.resolves({
+        choices: [{ message: { content: 'OK null' } }],
+      });
+      const reply = fake.resolves(null);
+      const replyByIntent = fake.resolves(null);
+
+      await forwardMessageToAiChat.call(
+        buildContext({
+          tools,
+          aiChat: scenesAiChat,
+          reply,
+          replyByIntent,
+          classifyAiChatToolCategories: fake.resolves(['scenes']),
+        }),
+        {
+          message: { text: 'Crée une scène' },
+          previousQuestions: [],
+          context: {},
+        },
+      );
+      await forwardMessageToAiChat.call(
+        buildContext({
+          tools,
+          aiChat: nullAiChat,
+          reply,
+          replyByIntent,
+          classifyAiChatToolCategories: fake.resolves(null),
+        }),
+        {
+          message: { text: 'Bonjour' },
+          previousQuestions: [],
+          context: {},
+        },
+      );
+
+      expect(scenesAiChat.getCall(0).args[0].tool_choice).to.equal('auto');
+      expect(nullAiChat.getCall(0).args[0].tool_choice).to.equal('auto');
     });
 
     it('should send scene tools and scene rules when the request is classified as scenes', async () => {
@@ -1141,6 +1352,7 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
       const request = aiChat.getCall(0).args[0];
       expect(request.tools.map((tool) => tool.function.name)).to.deep.equal(['scene_create']);
       expect(request.messages[0].content).to.include(scenesPromptMock);
+      expect(request.tool_choice).to.equal('auto');
     });
 
     it('should fall back to all tools and scene rules when classification returns null', async () => {
@@ -1167,6 +1379,7 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
       expect(request.messages[0].content).to.include(scenesPromptMock);
       expect(request.purpose).to.equal('chat');
       expect(request).to.not.have.property('categories');
+      expect(request.tool_choice).to.equal('auto');
     });
 
     it('should not call the router when there is no tool to filter', async () => {
@@ -1189,6 +1402,7 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
 
       assert.notCalled(classifyAiChatToolCategories);
       assert.calledOnce(aiChat);
+      expect(aiChat.getCall(0).args[0].tool_choice).to.equal('auto');
     });
 
     it('should still execute a tool excluded by routing if the model calls it', async () => {
@@ -1233,5 +1447,31 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
       const toolMessage = aiChat.getCall(1).args[0].messages.find((m) => m.role === 'tool');
       expect(toolMessage.content).to.equal('done');
     });
+  });
+});
+
+describe('gateway.forwardMessageToAiChat tool choice helpers', () => {
+  it('shouldForceToolChoice should detect device query and control categories', () => {
+    const { shouldForceToolChoice } = getModule();
+    expect(shouldForceToolChoice(['device_query'])).to.equal(true);
+    expect(shouldForceToolChoice(['device_control', 'other'])).to.equal(true);
+    expect(shouldForceToolChoice(['scenes'])).to.equal(false);
+    expect(shouldForceToolChoice(['other'])).to.equal(false);
+    expect(shouldForceToolChoice(null)).to.equal(false);
+    expect(shouldForceToolChoice([])).to.equal(false);
+  });
+
+  it('resolveToolChoice should require tools only before the first tool iteration', () => {
+    const { resolveToolChoice } = getModule();
+    expect(resolveToolChoice({ forceToolUse: true, hasTools: true, hasCompletedToolIteration: false })).to.equal(
+      'required',
+    );
+    expect(resolveToolChoice({ forceToolUse: true, hasTools: true, hasCompletedToolIteration: true })).to.equal('auto');
+    expect(resolveToolChoice({ forceToolUse: true, hasTools: false, hasCompletedToolIteration: false })).to.equal(
+      'auto',
+    );
+    expect(resolveToolChoice({ forceToolUse: false, hasTools: true, hasCompletedToolIteration: false })).to.equal(
+      'auto',
+    );
   });
 });

--- a/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
+++ b/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
@@ -1285,11 +1285,14 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
       expect(aiChat.getCall(1).args[0].tool_choice).to.equal('required');
     });
 
-    it('should keep tool_choice=auto for other and unclassified requests', async () => {
+    it('should keep tool_choice=auto for other, web_and_time and unclassified requests', async () => {
       const tools = buildRoutedTools();
       const { forwardMessageToAiChat } = getModule({ tools });
       const otherAiChat = fake.resolves({
         choices: [{ message: { content: 'OK other' } }],
+      });
+      const webAndTimeAiChat = fake.resolves({
+        choices: [{ message: { content: 'Il est 20:38.' } }],
       });
       const nullAiChat = fake.resolves({
         choices: [{ message: { content: 'OK null' } }],
@@ -1314,6 +1317,20 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
       await forwardMessageToAiChat.call(
         buildContext({
           tools,
+          aiChat: webAndTimeAiChat,
+          reply,
+          replyByIntent,
+          classifyAiChatToolCategories: fake.resolves(['web_and_time']),
+        }),
+        {
+          message: { text: 'Quelle heure est-il ?' },
+          previousQuestions: [],
+          context: {},
+        },
+      );
+      await forwardMessageToAiChat.call(
+        buildContext({
+          tools,
           aiChat: nullAiChat,
           reply,
           replyByIntent,
@@ -1327,6 +1344,7 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
       );
 
       expect(otherAiChat.getCall(0).args[0].tool_choice).to.equal('auto');
+      expect(webAndTimeAiChat.getCall(0).args[0].tool_choice).to.equal('auto');
       expect(nullAiChat.getCall(0).args[0].tool_choice).to.equal('auto');
     });
 
@@ -1471,12 +1489,12 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
 });
 
 describe('gateway.forwardMessageToAiChat tool choice helpers', () => {
-  it('shouldForceToolChoice should force all tool-needing categories except pure other', () => {
+  it('shouldForceToolChoice should force home intents but not web/time or pure other', () => {
     const { shouldForceToolChoice } = getModule();
     expect(shouldForceToolChoice(['device_query'])).to.equal(true);
     expect(shouldForceToolChoice(['device_control', 'other'])).to.equal(true);
     expect(shouldForceToolChoice(['scenes'])).to.equal(true);
-    expect(shouldForceToolChoice(['web_and_time'])).to.equal(true);
+    expect(shouldForceToolChoice(['web_and_time'])).to.equal(false);
     expect(shouldForceToolChoice(['other'])).to.equal(false);
     expect(shouldForceToolChoice(null)).to.equal(false);
     expect(shouldForceToolChoice([])).to.equal(false);

--- a/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
+++ b/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
@@ -1285,11 +1285,11 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
       expect(aiChat.getCall(1).args[0].tool_choice).to.equal('required');
     });
 
-    it('should keep tool_choice=auto for scenes and unclassified requests', async () => {
+    it('should keep tool_choice=auto for other and unclassified requests', async () => {
       const tools = buildRoutedTools();
       const { forwardMessageToAiChat } = getModule({ tools });
-      const scenesAiChat = fake.resolves({
-        choices: [{ message: { content: 'OK scenes' } }],
+      const otherAiChat = fake.resolves({
+        choices: [{ message: { content: 'OK other' } }],
       });
       const nullAiChat = fake.resolves({
         choices: [{ message: { content: 'OK null' } }],
@@ -1300,13 +1300,13 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
       await forwardMessageToAiChat.call(
         buildContext({
           tools,
-          aiChat: scenesAiChat,
+          aiChat: otherAiChat,
           reply,
           replyByIntent,
-          classifyAiChatToolCategories: fake.resolves(['scenes']),
+          classifyAiChatToolCategories: fake.resolves(['other']),
         }),
         {
-          message: { text: 'Crée une scène' },
+          message: { text: "Quelle est la durée de cuisson d'un œuf ?" },
           previousQuestions: [],
           context: {},
         },
@@ -1326,14 +1326,33 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
         },
       );
 
-      expect(scenesAiChat.getCall(0).args[0].tool_choice).to.equal('auto');
+      expect(otherAiChat.getCall(0).args[0].tool_choice).to.equal('auto');
       expect(nullAiChat.getCall(0).args[0].tool_choice).to.equal('auto');
     });
 
     it('should send scene tools and scene rules when the request is classified as scenes', async () => {
       const tools = buildRoutedTools();
       const { forwardMessageToAiChat } = getModule({ tools });
-      const aiChat = fake.resolves({
+      const aiChat = stub();
+      aiChat.onCall(0).resolves({
+        choices: [
+          {
+            message: {
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_scene',
+                  function: {
+                    name: 'scene_create',
+                    arguments: '{}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+      aiChat.onCall(1).resolves({
         choices: [{ message: { content: 'OK' } }],
       });
       const classifyAiChatToolCategories = fake.resolves(['scenes']);
@@ -1352,7 +1371,8 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
       const request = aiChat.getCall(0).args[0];
       expect(request.tools.map((tool) => tool.function.name)).to.deep.equal(['scene_create']);
       expect(request.messages[0].content).to.include(scenesPromptMock);
-      expect(request.tool_choice).to.equal('auto');
+      expect(request.tool_choice).to.equal('required');
+      expect(aiChat.getCall(1).args[0].tool_choice).to.equal('auto');
     });
 
     it('should fall back to all tools and scene rules when classification returns null', async () => {
@@ -1451,11 +1471,12 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
 });
 
 describe('gateway.forwardMessageToAiChat tool choice helpers', () => {
-  it('shouldForceToolChoice should detect device query and control categories', () => {
+  it('shouldForceToolChoice should force all tool-needing categories except pure other', () => {
     const { shouldForceToolChoice } = getModule();
     expect(shouldForceToolChoice(['device_query'])).to.equal(true);
     expect(shouldForceToolChoice(['device_control', 'other'])).to.equal(true);
-    expect(shouldForceToolChoice(['scenes'])).to.equal(false);
+    expect(shouldForceToolChoice(['scenes'])).to.equal(true);
+    expect(shouldForceToolChoice(['web_and_time'])).to.equal(true);
     expect(shouldForceToolChoice(['other'])).to.equal(false);
     expect(shouldForceToolChoice(null)).to.equal(false);
     expect(shouldForceToolChoice([])).to.equal(false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- When the AI chat intent router classifies a request as `device_query`, `device_control`, or `scenes`, the first model turn now uses `tool_choice: "required"` so the model cannot invent sensor values, fake actions, or claim a scene was created without calling tools.
- After at least one tool iteration completes, `tool_choice` switches back to `auto` so the model can produce the final natural-language reply.
- If a provider ignores `required` and still returns no tool calls, Gladys retries once with an explicit nudge before accepting the answer.
- `web_and_time`, pure `other` (greetings / general knowledge), and failed/null routing keep `tool_choice: auto` — current date/time is already in the system prompt, so clock questions must not force a tool.

## Test plan
- [x] Unit tests for `shouldForceToolChoice` / `resolveToolChoice` (`scenes` forced, `web_and_time` not forced)
- [x] `device_query` / `device_control` / `scenes` force `required` then `auto` after tools
- [x] Retry once when forced tool use returns no `tool_calls`
- [x] Accept answer after a failed forced-tool retry
- [x] `other` / `web_and_time` / unclassified intents keep `tool_choice: auto`
- [x] `npm run prettier` / focused unit tests on server
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ec181ee-94ae-453f-9658-94bde1dffd5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ec181ee-94ae-453f-9658-94bde1dffd5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced AI tool-calling behavior by forcing tool usage for device query/control and scenes on the first turn, while allowing web/time intents to proceed without forced tool selection.
  * Added a single controlled retry when the model does not return the expected tool call, using a dedicated retry prompt.
  * Improved tool-choice handling to better align “required” vs “auto” behavior across iterations.

* **Tests**
  * Expanded and refined unit tests to cover forced vs non-forced tool selection (including web/time), retry flow, and correct tool-choice transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->