### PR TITLE
Fix Bluetooth scan timer cleanup and test isolation

### DIFF
--- a/server/services/bluetooth/lib/commands/bluetooth.scan.js
+++ b/server/services/bluetooth/lib/commands/bluetooth.scan.js
@@ -51,13 +51,17 @@ async function scan(state, peripheralUuid = undefined) {
         }
       };
 
-      const scanStop = () => {
-        this.bluetooth.removeListener('discover', onDiscover);
-
+      const clearScanTimer = () => {
         if (this.scanTimer) {
           clearTimeout(this.scanTimer);
           this.scanTimer = undefined;
         }
+      };
+
+      const scanStop = () => {
+        this.bluetooth.removeListener('discover', onDiscover);
+
+        clearScanTimer();
 
         if (peripheralUuid) {
           if (peripherals[peripheralUuid]) {
@@ -79,8 +83,18 @@ async function scan(state, peripheralUuid = undefined) {
         this.bluetooth.stopScanning();
       }, TIMERS.SCAN);
 
-      if (!this.scanning) {
-        this.bluetooth.startScanning([], true);
+      try {
+        if (!this.scanning) {
+          this.bluetooth.startScanning([], true);
+        }
+      } catch (e) {
+        // Scan never started: release listeners, timer and counter.
+        this.bluetooth.removeListener('discover', onDiscover);
+        this.bluetooth.removeListener('scanStop', scanStop);
+        clearScanTimer();
+        this.scanCounter -= 1;
+
+        reject(e);
       }
     });
   }

--- a/server/services/bluetooth/lib/commands/bluetooth.scan.js
+++ b/server/services/bluetooth/lib/commands/bluetooth.scan.js
@@ -54,6 +54,11 @@ async function scan(state, peripheralUuid = undefined) {
       const scanStop = () => {
         this.bluetooth.removeListener('discover', onDiscover);
 
+        if (this.scanTimer) {
+          clearTimeout(this.scanTimer);
+          this.scanTimer = undefined;
+        }
+
         if (peripheralUuid) {
           if (peripherals[peripheralUuid]) {
             resolve(peripherals[peripheralUuid]);
@@ -68,13 +73,15 @@ async function scan(state, peripheralUuid = undefined) {
       this.bluetooth.on('discover', onDiscover);
       this.bluetooth.once('scanStop', scanStop);
 
-      if (!this.scanning) {
-        this.bluetooth.startScanning([], true);
-      }
-
+      // Timer is set before scanning starts, so it is always cleared by the
+      // "scanStop" event, even if scanning stops immediately.
       this.scanTimer = setTimeout(() => {
         this.bluetooth.stopScanning();
       }, TIMERS.SCAN);
+
+      if (!this.scanning) {
+        this.bluetooth.startScanning([], true);
+      }
     });
   }
 

--- a/server/test/services/bluetooth/BluetoothMock.test.js
+++ b/server/test/services/bluetooth/BluetoothMock.test.js
@@ -6,12 +6,13 @@ class BluetoothMock extends EventEmitter {
     super();
     // eslint-disable-next-line no-underscore-dangle
     this._peripherals = {};
+
+    // Fakes are per instance, so calls from another test (or a leaked timer)
+    // never pollute the call count checked in the current one.
+    this.startScanning = fake.returns(null);
+    this.stopScanning = fake.returns(null);
+    this.stopScanningAsync = fake.resolves(null);
   }
 }
-
-BluetoothMock.prototype.startScanning = fake.returns(null);
-
-BluetoothMock.prototype.stopScanning = fake.returns(null);
-BluetoothMock.prototype.stopScanningAsync = fake.resolves(null);
 
 module.exports = BluetoothMock;

--- a/server/test/services/bluetooth/lib/commands/bluetooth.scan.test.js
+++ b/server/test/services/bluetooth/lib/commands/bluetooth.scan.test.js
@@ -4,6 +4,7 @@ const sinon = require('sinon');
 const { fake, assert } = sinon;
 
 const BluetoothManager = require('../../../../../services/bluetooth/lib');
+const { TIMERS } = require('../../../../../services/bluetooth/lib/utils/bluetooth.constants');
 const { NotFoundError } = require('../../../../../utils/coreErrors');
 const BluetoothMock = require('../../BluetoothMock.test');
 
@@ -123,6 +124,44 @@ describe('bluetooth.scan command', () => {
     bluetooth.emit('scanStop');
     const result = await scanTimer;
     expect(result).to.be.deep.equal({});
+  });
+
+  it('should clear scan timer when scan stops right away', async () => {
+    bluetoothManager.ready = true;
+    // Scanning stops as soon as it starts
+    bluetooth.startScanning = fake(() => bluetooth.emit('scanStop'));
+
+    const peripherals = await bluetoothManager.scan(true);
+
+    expect(peripherals).to.be.deep.equal({});
+    expect(bluetoothManager.scanTimer).to.be.equal(undefined);
+    // No more listener
+    expect(bluetooth.eventNames()).is.lengthOf(0);
+
+    // No leaked timer stopping a scan started later
+    clock.tick(TIMERS.SCAN * 2);
+    assert.notCalled(bluetooth.stopScanning);
+  });
+
+  it('should clean up scan if scanning fails to start', async () => {
+    bluetoothManager.ready = true;
+    bluetooth.startScanning = fake.throws(new Error('Could not start scanning'));
+
+    try {
+      await bluetoothManager.scan(true);
+      assert.fail('Should have fail');
+    } catch (e) {
+      expect(e.message).to.be.equal('Could not start scanning');
+    }
+
+    expect(bluetoothManager.scanTimer).to.be.equal(undefined);
+    expect(bluetoothManager.scanCounter).to.be.equal(0);
+    // No more listener
+    expect(bluetooth.eventNames()).is.lengthOf(0);
+
+    // No leaked timer stopping a scan started later
+    clock.tick(TIMERS.SCAN * 2);
+    assert.notCalled(bluetooth.stopScanning);
   });
 
   it('should stop discover and reject if specific device is not found', async () => {


### PR DESCRIPTION
### Description of change

This PR fixes two related issues in the Bluetooth scanning functionality:

1. **Timer cleanup in scan function**: The scan timer was not being properly cleared when the scan stopped, which could cause the timer to fire after the scan had already completed. The fix ensures the timer is always cleared in the `scanStop` callback, even if scanning stops immediately.

2. **Test isolation in BluetoothMock**: Moved fake method definitions from the prototype to the instance constructor. This ensures each test instance has its own fake methods with independent call counts, preventing test pollution from leaked timers or concurrent tests.

The timer is now set before `startScanning()` is called, guaranteeing it will be cleared by the `scanStop` event listener regardless of when scanning actually stops.

### Changes made

- **server/services/bluetooth/lib/commands/bluetooth.scan.js**:
  - Added timer cleanup logic in the `scanStop` callback
  - Reordered timer setup to occur before `startScanning()` call
  - Added clarifying comments about timer lifecycle

- **server/test/services/bluetooth/BluetoothMock.test.js**:
  - Moved `startScanning`, `stopScanning`, and `stopScanningAsync` fake definitions from prototype to instance constructor
  - Added comment explaining why per-instance fakes are necessary for test isolation

### Testing

Existing unit tests cover these changes. The test isolation fix ensures that Bluetooth scan tests will not be affected by timer leaks or concurrent test execution.

### Checklist

- [x] Tests pass with 100% coverage on changed lines
- [x] Linter passing
- [x] No API changes

https://claude.ai/code/session_01C2nGCKwKz8DWi85KdiCo2G

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth scanning cleanup so timers and event listeners are cleared reliably when scanning stops.
  * Prevented lingering timeout behavior when scanning ends immediately.
  * Improved error handling when scanning fails to start, including proper counter reset and error reporting.

* **Tests**
  * Added coverage for immediate scan stops and startup failures.
  * Improved Bluetooth test isolation to prevent scan-related timers from affecting other test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->