### PR TITLE
AI chat: retry once when the final answer is raw data instead of natural language

### DIFF
--- a/server/config/prompts/aiChat.prompt.txt
+++ b/server/config/prompts/aiChat.prompt.txt
@@ -17,6 +17,7 @@ Rules:
 - When the user asks to save, store, or record a value in a virtual sensor (for example a value read from a camera image), use the `sensor_set_state` tool.
 - Use the tool names and arguments exactly as provided by the tool schema.
 - After you receive tool results, provide a concise and accurate answer in plain language only.
+- Never reply with JSON, code blocks, or raw tool output: extract the relevant values from tool results and phrase them in a short natural-language sentence.
 - Never repeat tool names, arguments, or invocation syntax (for example `device_turn_on_off({...})`) in your reply text. Tool execution is shown separately in the chat UI.
 - Reply exactly with NO_RESPONSE only when the user explicitly asks for no reply (for example: "do not reply", "say nothing", "don't answer", "ne réponds pas", "ne dis rien", "ne fais rien"). In all other cases, provide a normal concise reply.
 - When a camera image tool succeeds, Gladys displays the image in the chat for the user. Do not invent image URLs or use markdown image syntax (![]()); you may reply with a short confirmation or stay silent.

--- a/server/lib/gateway/gateway.forwardMessageToAiChat.js
+++ b/server/lib/gateway/gateway.forwardMessageToAiChat.js
@@ -418,7 +418,7 @@ function looksLikeRawDataAnswer(text) {
     return false;
   }
   let candidate = text.trim();
-  const fenced = candidate.match(/^```[a-z]*\s*([\s\S]*?)\s*```$/i);
+  const fenced = candidate.match(/^```[^\n`]*\n([\s\S]*?)\s*```$/);
   if (fenced) {
     candidate = fenced[1].trim();
   }

--- a/server/lib/gateway/gateway.forwardMessageToAiChat.js
+++ b/server/lib/gateway/gateway.forwardMessageToAiChat.js
@@ -37,6 +37,9 @@ const FORCE_TOOL_CHOICE_CATEGORIES = new Set([
 const FORCE_TOOL_RETRY_MESSAGE =
   'You must call a tool before answering. Use the available tools to fetch live data or perform the requested action.';
 
+const RAW_DATA_ANSWER_RETRY_MESSAGE =
+  'Your previous reply was raw data. Reply again with a short natural-language sentence in the language of the user, without JSON, code blocks, or raw tool output.';
+
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
@@ -402,6 +405,35 @@ function stripToolTraceEchoFromAnswer(answer) {
 }
 
 /**
+ * @description Detect a final answer that is raw structured data instead of natural language.
+ * Small models sometimes echo tool data (JSON) as their reply after a tool turn.
+ * Matches answers that are entirely a JSON object or array, optionally wrapped in a code fence.
+ * @param {string} text - Assistant final answer text.
+ * @returns {boolean} True when the answer looks like raw data.
+ * @example
+ * looksLikeRawDataAnswer('{"state": {"value": 850}}');
+ */
+function looksLikeRawDataAnswer(text) {
+  if (!text || typeof text !== 'string') {
+    return false;
+  }
+  let candidate = text.trim();
+  const fenced = candidate.match(/^```[a-z]*\s*([\s\S]*?)\s*```$/i);
+  if (fenced) {
+    candidate = fenced[1].trim();
+  }
+  if (!candidate.startsWith('{') && !candidate.startsWith('[')) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(candidate);
+    return typeof parsed === 'object' && parsed !== null;
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
  * @public
  * @description Handle a new chat message sent by a user to Gladys Plus.
  * Tool calling loop is executed on the Gladys instance using MCP callbacks.
@@ -488,6 +520,7 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
     let toolIterations = 0;
     const forceToolUse = shouldForceToolChoice(toolCategories) && toolsForApi.length > 0;
     let forcedToolRetryUsed = false;
+    let rawDataAnswerRetryUsed = false;
     const selectedModel = resolveAiChatModel(message?.model);
     if (message?.model && selectedModel === null) {
       logger.warn(`[AI_CHAT] Ignoring invalid model=${message.model}`);
@@ -546,6 +579,28 @@ async function forwardMessageToAiChat({ message, image, previousQuestions, conte
           messagesForApi.push({
             role: 'user',
             content: FORCE_TOOL_RETRY_MESSAGE,
+          });
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+        // Small models sometimes echo tool data (raw JSON) as their final reply
+        // instead of natural language. Retry once with an explicit reformulation
+        // request. Only after tool results exist in the conversation: without
+        // tools, a JSON answer may be intentional (the user asked for JSON).
+        if (
+          !rawDataAnswerRetryUsed &&
+          hadToolResultsInConversation(messagesForApi) &&
+          looksLikeRawDataAnswer(assistantMessage?.content)
+        ) {
+          rawDataAnswerRetryUsed = true;
+          logger.warn('[AI_CHAT] Assistant replied with raw data instead of natural language, retrying once');
+          messagesForApi.push({
+            role: 'assistant',
+            content: assistantMessage.content,
+          });
+          messagesForApi.push({
+            role: 'user',
+            content: RAW_DATA_ANSWER_RETRY_MESSAGE,
           });
           // eslint-disable-next-line no-continue
           continue;
@@ -751,6 +806,8 @@ module.exports = {
   shouldForceToolChoice,
   resolveToolChoice,
   FORCE_TOOL_RETRY_MESSAGE,
+  RAW_DATA_ANSWER_RETRY_MESSAGE,
+  looksLikeRawDataAnswer,
   debugPreview,
   extractAssistantMessage,
   extractMessageFilesFromToolResult,

--- a/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
+++ b/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
@@ -1285,6 +1285,130 @@ describe('gateway.forwardMessageToAiChat helpers', () => {
       expect(aiChat.getCall(1).args[0].tool_choice).to.equal('required');
     });
 
+    it('should retry once with a reformulation request when the final answer is raw JSON after a tool call', async () => {
+      const tools = buildRoutedTools();
+      const { forwardMessageToAiChat, RAW_DATA_ANSWER_RETRY_MESSAGE } = getModule({ tools });
+      const rawJsonAnswer = '{"state": {"value": 850, "timestamp": "2026-07-30T20:38:00.000Z"}}';
+      const aiChat = stub();
+      aiChat.onCall(0).resolves({
+        choices: [
+          {
+            message: {
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_co2',
+                  function: {
+                    name: 'device_turn_on_off',
+                    arguments: '{"action":"off"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+      aiChat.onCall(1).resolves({
+        choices: [{ message: { content: rawJsonAnswer } }],
+      });
+      aiChat.onCall(2).resolves({
+        choices: [{ message: { content: 'Le taux de CO2 est de 850 ppm.' } }],
+      });
+      const classifyAiChatToolCategories = fake.resolves(['device_control']);
+      const reply = fake.resolves(null);
+      const replyByIntent = fake.resolves(null);
+
+      const result = await forwardMessageToAiChat.call(
+        buildContext({ tools, aiChat, reply, replyByIntent, classifyAiChatToolCategories }),
+        {
+          message: { text: 'Quel est le niveau de CO2 ?' },
+          previousQuestions: [],
+          context: {},
+        },
+      );
+
+      expect(result).to.deep.equal({ answer: 'Le taux de CO2 est de 850 ppm.', imagesSent: 0 });
+      expect(aiChat.callCount).to.equal(3);
+      const retryMessages = aiChat.getCall(2).args[0].messages;
+      expect(
+        retryMessages.some((message) => message.role === 'assistant' && message.content === rawJsonAnswer),
+      ).to.equal(true);
+      expect(
+        retryMessages.some((message) => message.role === 'user' && message.content === RAW_DATA_ANSWER_RETRY_MESSAGE),
+      ).to.equal(true);
+      expect(aiChat.getCall(2).args[0].tool_choice).to.equal('auto');
+    });
+
+    it('should accept the raw JSON answer after a failed reformulation retry', async () => {
+      const tools = buildRoutedTools();
+      const { forwardMessageToAiChat } = getModule({ tools });
+      const rawJsonAnswer = '{"state": {"value": 850}}';
+      const aiChat = stub();
+      aiChat.onCall(0).resolves({
+        choices: [
+          {
+            message: {
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_co2',
+                  function: {
+                    name: 'device_turn_on_off',
+                    arguments: '{"action":"off"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+      aiChat.onCall(1).resolves({
+        choices: [{ message: { content: rawJsonAnswer } }],
+      });
+      aiChat.onCall(2).resolves({
+        choices: [{ message: { content: rawJsonAnswer } }],
+      });
+      const classifyAiChatToolCategories = fake.resolves(['device_control']);
+      const reply = fake.resolves(null);
+      const replyByIntent = fake.resolves(null);
+
+      const result = await forwardMessageToAiChat.call(
+        buildContext({ tools, aiChat, reply, replyByIntent, classifyAiChatToolCategories }),
+        {
+          message: { text: 'Quel est le niveau de CO2 ?' },
+          previousQuestions: [],
+          context: {},
+        },
+      );
+
+      expect(result).to.deep.equal({ answer: rawJsonAnswer, imagesSent: 0 });
+      expect(aiChat.callCount).to.equal(3);
+    });
+
+    it('should not retry a JSON answer when no tool result exists in the conversation', async () => {
+      const tools = buildRoutedTools();
+      const { forwardMessageToAiChat } = getModule({ tools });
+      const rawJsonAnswer = '{"example": "value"}';
+      const aiChat = fake.resolves({
+        choices: [{ message: { content: rawJsonAnswer } }],
+      });
+      const classifyAiChatToolCategories = fake.resolves(['other']);
+      const reply = fake.resolves(null);
+      const replyByIntent = fake.resolves(null);
+
+      const result = await forwardMessageToAiChat.call(
+        buildContext({ tools, aiChat, reply, replyByIntent, classifyAiChatToolCategories }),
+        {
+          message: { text: 'Donne-moi un exemple de JSON' },
+          previousQuestions: [],
+          context: {},
+        },
+      );
+
+      expect(result).to.deep.equal({ answer: rawJsonAnswer, imagesSent: 0 });
+      expect(aiChat.callCount).to.equal(1);
+    });
+
     it('should keep tool_choice=auto for other, web_and_time and unclassified requests', async () => {
       const tools = buildRoutedTools();
       const { forwardMessageToAiChat } = getModule({ tools });
@@ -1512,5 +1636,21 @@ describe('gateway.forwardMessageToAiChat tool choice helpers', () => {
     expect(resolveToolChoice({ forceToolUse: false, hasTools: true, hasCompletedToolIteration: false })).to.equal(
       'auto',
     );
+  });
+
+  it('looksLikeRawDataAnswer should only match answers that are entirely raw JSON data', () => {
+    const { looksLikeRawDataAnswer } = getModule();
+    expect(looksLikeRawDataAnswer('{"state": {"value": 850, "timestamp": "2026-07-30T20:38:00.000Z"}}')).to.equal(true);
+    expect(looksLikeRawDataAnswer('[{"room": "Salon", "value": 25.3}]')).to.equal(true);
+    expect(looksLikeRawDataAnswer('```json\n{"value": 850}\n```')).to.equal(true);
+    expect(looksLikeRawDataAnswer('```\n{"value": 850}\n```')).to.equal(true);
+    expect(looksLikeRawDataAnswer('  {"value": 850}  ')).to.equal(true);
+    expect(looksLikeRawDataAnswer('Le taux de CO2 est de 850 ppm.')).to.equal(false);
+    expect(looksLikeRawDataAnswer('Voici la valeur : {"value": 850}')).to.equal(false);
+    expect(looksLikeRawDataAnswer('850')).to.equal(false);
+    expect(looksLikeRawDataAnswer('{invalid json')).to.equal(false);
+    expect(looksLikeRawDataAnswer('')).to.equal(false);
+    expect(looksLikeRawDataAnswer(null)).to.equal(false);
+    expect(looksLikeRawDataAnswer(undefined)).to.equal(false);
   });
 });

--- a/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
+++ b/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
@@ -1643,6 +1643,7 @@ describe('gateway.forwardMessageToAiChat tool choice helpers', () => {
     expect(looksLikeRawDataAnswer('{"state": {"value": 850, "timestamp": "2026-07-30T20:38:00.000Z"}}')).to.equal(true);
     expect(looksLikeRawDataAnswer('[{"room": "Salon", "value": 25.3}]')).to.equal(true);
     expect(looksLikeRawDataAnswer('```json\n{"value": 850}\n```')).to.equal(true);
+    expect(looksLikeRawDataAnswer('```json5\n{"value": 850}\n```')).to.equal(true);
     expect(looksLikeRawDataAnswer('```\n{"value": 850}\n```')).to.equal(true);
     expect(looksLikeRawDataAnswer('  {"value": 850}  ')).to.equal(true);
     expect(looksLikeRawDataAnswer('Le taux de CO2 est de 850 ppm.')).to.equal(false);
@@ -1650,6 +1651,7 @@ describe('gateway.forwardMessageToAiChat tool choice helpers', () => {
     expect(looksLikeRawDataAnswer('850')).to.equal(false);
     expect(looksLikeRawDataAnswer('{invalid json')).to.equal(false);
     expect(looksLikeRawDataAnswer('')).to.equal(false);
+    expect(looksLikeRawDataAnswer(123)).to.equal(false);
     expect(looksLikeRawDataAnswer(null)).to.equal(false);
     expect(looksLikeRawDataAnswer(undefined)).to.equal(false);
   });


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests?
- [x] Are server tests passing with coverage? (`cd server && npm run coverage`) — 100% line coverage on `gateway.forwardMessageToAiChat.js` with the focused test file
- [ ] Did Cypress E2E tests pass? (no UI change)
- [x] Is the linter passing? (`npm run eslint` on server — only a pre-existing JSDoc warning remains)
- [x] Did you run prettier? (`npm run prettier` on server)
- [ ] If you are adding a new feature/service, did you run the integration comparator? (not applicable)
- [ ] Did you test this pull request in real life? With real devices?
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (not applicable)
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? (not applicable)
- [ ] Did you add fake requests data for the demo mode? (not applicable)

### Description of change

Follow-up to #2724. That PR fixed the case where a small/fast model answers a device question **without** calling a tool. This PR fixes the mirror failure mode: the model calls the tool correctly, but then replies to the user with **raw data instead of natural language**, and Gladys forwards it verbatim:

```
user:      très bien, quelle est le niveau de Co2
tool_call: device_get_state({"device_type":"co2-sensor","room":"Salon"})
assistant: {"state": {"value": 850, "timestamp": "2026-07-30T20:38:00.000Z"}}
```

This JSON is not the tool result (which is a TOON table of `room, device, feature, category, value, unit` rows) — it is a structure invented by the model, which mimics the "data register" of the conversation after a tool turn instead of switching back to natural language. Nothing in the final-answer pipeline filtered it: only the `NO_RESPONSE` sentinel, tool-trace echo lines and image URLs are stripped.

Two complementary measures, following the same bounded-retry pattern introduced in #2724:

**1. Deterministic guard + single retry** (`gateway.forwardMessageToAiChat.js`)
- New helper `looksLikeRawDataAnswer(text)`: matches answers that are *entirely* a JSON object or array, optionally wrapped in a code fence (```` ```json ````). Conservative on purpose: sentences containing JSON, bare numbers, or invalid JSON are not matched.
- When the model returns a final answer (no tool calls) that looks like raw data **and** tool results already exist in the conversation, Gladys pushes the raw answer plus an explicit reformulation request (`RAW_DATA_ANSWER_RETRY_MESSAGE`) and retries once. If the retry still returns raw data, the answer is accepted as-is (graceful degradation, one extra call max).
- The guard is scoped to conversations that had tool results: a JSON answer without any tool call may be intentional (user explicitly asking for a JSON example) and is left untouched.

**2. Explicit prompt rule** (`config/prompts/aiChat.prompt.txt`)
- New rule: never reply with JSON, code blocks, or raw tool output; extract the relevant values and phrase them in a short natural-language sentence.

**Tests**
- Retries once with the reformulation request (raw answer + nudge visible in the retry messages, `tool_choice` stays `auto` after a tool turn)
- Accepts the raw JSON answer after a failed retry (no infinite loop)
- Does not retry a JSON answer when no tool result exists in the conversation
- Unit tests for `looksLikeRawDataAnswer` (objects, arrays, code fences, prose, bare numbers, invalid JSON, null/empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155QowwTDY9xtY2nMXETVtb

---
_Generated by [Claude Code](https://claude.ai/code/session_0155QowwTDY9xtY2nMXETVtb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the AI chat behavior to avoid returning raw JSON, code blocks, or unprocessed tool output.
  * After tool use, the system now more reliably detects when an assistant response is wrapped raw JSON and triggers a one-time attempt to convert it into a short natural-language answer.
  * If the conversion attempt fails, the original response is kept.
* **Tests**
  * Expanded coverage for raw-JSON detection and the post-tool retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->