### PR TITLE
Add GitHub label automation (area labeler, LLM type classification) and PR template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -47,6 +47,20 @@ Then, follow our guide:
 
 ---
 
+## 🏷️ Labels & Forum Link
+
+Most labels are applied automatically, you don't need to set them yourself:
+
+- `type:feature` / `type:fix` / `type:chore` — set automatically when the PR is opened (you can pre-set one manually, it won't be overwritten)
+- `area:*` (server, front, integration, ai, infra) — set automatically from the files changed
+- `risk:high` / `needs:human-review` — set by the automated review
+
+Labels for contributors: look for [`good first issue`](https://github.com/gladysassistant/Gladys/labels/good%20first%20issue) and [`help wanted`](https://github.com/gladysassistant/Gladys/labels/help%20wanted) to find issues to work on.
+
+If your PR implements a forum request, add a line `Forum: https://community.gladysassistant.com/t/...` in the PR description (see the PR template): the release pipeline uses it to notify the forum topic when the feature ships.
+
+---
+
 ## 📜 Licensing
 
 All contributions to Gladys are submitted under the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).  

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,28 @@
-### Pull Request check-list
+### Description
 
-To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:
+<!-- A short description of the change. Screenshots are always welcome! -->
 
-- [ ] If your changes affect the code, did you write the tests?
-- [ ] Are server tests passing with coverage? (`cd server && npm run coverage`) — Codecov requires **100% coverage on lines changed in this PR**
-- [ ] Did Cypress E2E tests pass? (`npm run cypress:run` from repo root, if UI changed)
-- [ ] Is the linter passing? (`npm run eslint` on both front/server)
-- [ ] Did you run prettier? (`npm run prettier` on both front/server)
-- [ ] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front)
-- [ ] Did you test this pull request in real life? With real devices? If this development is a big feature or a new service, we recommend that you provide a Docker image to the community ([forum](https://community.gladysassistant.com/)) for testing before merging. An AMD64 preview image is built automatically for non-draft PRs; for ARM64, comment `/build-arm64` on the PR.
-- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
-- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
-- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).
+## Forum
 
-NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.
+<!--
+If this pull request implements a feature requested on the community forum,
+paste the topic URL on a single line using this exact format:
 
-### Description of change
+Forum: https://community.gladysassistant.com/t/...
 
-Please provide a description of the change here. It's always best with screenshots, so don't hesitate to add some!
+This link is what allows the release pipeline to automatically notify the
+forum topic when the feature ships.
+-->
+
+### Checklist
+
+- [ ] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
+- [ ] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
+- [ ] No undocumented breaking change
+
+<!--
+More details in the contribution guide: .github/CONTRIBUTING.md
+Testing in real life with real devices is always appreciated. An AMD64 preview
+Docker image is built automatically for non-draft PRs; for ARM64, comment
+/build-arm64 on the PR.
+-->

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -31,6 +31,13 @@
           - 'server/lib/gateway/gateway.getAiChatModels.js'
           - 'server/lib/gateway/gateway.getOpenAIQuota.js'
 
+'area:database':
+  - changed-files:
+      - any-glob-to-any-file:
+          # DB migrations run on every user install at upgrade: review carefully
+          - 'server/migrations/**'
+          - 'server/models/**'
+
 'area:infra':
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -30,6 +30,7 @@
           - 'server/lib/gateway/gateway.getAiChatDebugContext.js'
           - 'server/lib/gateway/gateway.getAiChatModels.js'
           - 'server/lib/gateway/gateway.getOpenAIQuota.js'
+          - 'server/utils/aiChatModels.js'
 
 'area:database':
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,39 @@
+# Configuration for actions/labeler@v5 (area labels).
+# A PR can receive several area labels: a change in server/services/** gets
+# both area:integration and area:server, which is expected.
+
+'area:server':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'server/**'
+
+'area:front':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'front/**'
+
+'area:integration':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'server/services/**'
+
+'area:ai':
+  - changed-files:
+      - any-glob-to-any-file:
+          # NLP brain: message routing to intents
+          - 'server/lib/brain/**'
+          - 'server/test/lib/brain/**'
+          # Gladys Plus gateway AI chat (LLM forwarding, tool classification, prompts)
+          - 'server/lib/gateway/gateway.aiChat.js'
+          - 'server/lib/gateway/gateway.classifyAiChatToolCategories.js'
+          - 'server/lib/gateway/gateway.forwardMessageToAiChat.js'
+          - 'server/lib/gateway/gateway.getAiChatDebugContext.js'
+          - 'server/lib/gateway/gateway.getAiChatModels.js'
+          - 'server/lib/gateway/gateway.getOpenAIQuota.js'
+
+'area:infra':
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+          - 'docker/**'
+          - 'codecov.yml'

--- a/.github/workflows/pr-classify.yml
+++ b/.github/workflows/pr-classify.yml
@@ -41,7 +41,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: gh pr edit "$PR_NUMBER" --add-label "type:chore"
 
-      - name: Classify PR type with Claude
+      - name: Classify PR type with Scaleway Generative APIs
         if: |
           steps.check.outputs.has_type == 'false' &&
           !startsWith(github.event.pull_request.user.login, 'dependabot') &&
@@ -49,7 +49,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           # PR title/body are untrusted input: passed through env vars only,
           # never interpolated into the script.
@@ -70,14 +70,30 @@ jobs:
           DIFF=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER" -H "Accept: application/vnd.github.diff" | head -c 20000) \
             || fail_soft "could not fetch the PR diff"
 
+          # Scaleway Generative APIs (serverless, OpenAI-compatible). The
+          # json_schema response format constrains the model output to one of
+          # the three allowed types; defensive parsing below is kept as backup.
           REQUEST=$(jq -n \
             --arg title "$PR_TITLE" \
             --arg body "$PR_BODY" \
             --arg files "$FILES" \
             --arg diff "$DIFF" \
             '{
-              model: "claude-haiku-4-5-20251001",
+              model: "mistral-small-3.2-24b-instruct-2506",
               max_tokens: 64,
+              temperature: 0,
+              response_format: {
+                type: "json_schema",
+                json_schema: {
+                  name: "pr_type",
+                  schema: {
+                    type: "object",
+                    properties: {type: {type: "string", enum: ["feature", "fix", "chore"]}},
+                    required: ["type"],
+                    additionalProperties: false
+                  }
+                }
+              },
               messages: [{
                 role: "user",
                 content: ("You are classifying a GitHub pull request of the Gladys Assistant home automation project.\n\nClassify the pull request as exactly one of these three types:\n- \"feature\": a new user-visible feature\n- \"fix\": a bug fix\n- \"chore\": dependencies, CI, refactoring, documentation - anything invisible in the user-facing changelog\n\nAnswer with strict JSON only, without any other text, in this exact format:\n{\"type\": \"feature\" | \"fix\" | \"chore\"}\n\nPR title:\n" + $title + "\n\nPR description:\n" + $body + "\n\nChanged files:\n" + $files + "\n\nDiff (truncated to 20000 characters):\n" + $diff)
@@ -86,13 +102,12 @@ jobs:
 
           RESPONSE=$(curl -sS --fail \
             --max-time 120 \
-            https://api.anthropic.com/v1/messages \
-            -H "x-api-key: $ANTHROPIC_API_KEY" \
-            -H "anthropic-version: 2023-06-01" \
+            https://api.scaleway.ai/v1/chat/completions \
+            -H "Authorization: Bearer $SCW_SECRET_KEY" \
             -H "content-type: application/json" \
-            -d "$REQUEST") || fail_soft "Anthropic API call failed"
+            -d "$REQUEST") || fail_soft "Scaleway API call failed"
 
-          TEXT=$(echo "$RESPONSE" | jq -r '.content[0].text // empty') \
+          TEXT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty') \
             || fail_soft "could not read the API response"
           [ -n "$TEXT" ] || fail_soft "empty model response"
 

--- a/.github/workflows/pr-classify.yml
+++ b/.github/workflows/pr-classify.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
+          SCALEWAY_API_KEY: ${{ secrets.SCALEWAY_API_KEY }}
           PR_NUMBERS: ${{ steps.prs.outputs.numbers }}
         run: |
           set -uo pipefail
@@ -142,7 +142,7 @@ jobs:
             RESPONSE=$(curl -sS --fail \
               --max-time 120 \
               https://api.scaleway.ai/v1/chat/completions \
-              -H "Authorization: Bearer $SCW_SECRET_KEY" \
+              -H "Authorization: Bearer $SCALEWAY_API_KEY" \
               -H "content-type: application/json" \
               -d "$REQUEST") || { warn "$PR" "Scaleway API call failed"; continue; }
 

--- a/.github/workflows/pr-classify.yml
+++ b/.github/workflows/pr-classify.yml
@@ -9,6 +9,16 @@ on:
     # "opened" only: no re-classification during the PR lifetime, and a manual
     # label fix is never overwritten on synchronize.
     types: [opened]
+  # Manual backfill for existing PRs. Idempotent: PRs that already carry a
+  # type label are always skipped.
+  workflow_dispatch:
+    inputs:
+      pr_numbers:
+        description: >-
+          PR number(s) to classify, one per line. Leave empty to classify all
+          open PRs without a type label.
+        required: false
+        default: ''
 
 permissions:
   pull-requests: write
@@ -18,109 +28,147 @@ jobs:
   classify:
     runs-on: ubuntu-latest
     steps:
-      - name: Check for an existing type label
-        id: check
-        env:
-          LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
-        run: |
-          if echo "$LABELS_JSON" | jq -e 'map(select(startswith("type:"))) | length > 0' > /dev/null; then
-            echo "PR already has a type label, skipping classification."
-            echo "has_type=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_type=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Label dependency-bot PRs as chore
-        if: |
-          steps.check.outputs.has_type == 'false' &&
-          (startsWith(github.event.pull_request.user.login, 'dependabot') ||
-           startsWith(github.event.pull_request.user.login, 'renovate'))
+      - name: Resolve PR numbers
+        id: prs
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh pr edit "$PR_NUMBER" --add-label "type:chore"
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+          INPUT_PRS: ${{ inputs.pr_numbers }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request_target" ]; then
+            PRS="$EVENT_PR"
+          elif [ -n "$INPUT_PRS" ]; then
+            PRS="$INPUT_PRS"
+          else
+            PRS=$(gh pr list --state open --limit 1000 --json number --jq '.[].number')
+          fi
+          {
+            echo "numbers<<PRS_EOF"
+            echo "$PRS"
+            echo "PRS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Classify PR type with Scaleway Generative APIs
-        if: |
-          steps.check.outputs.has_type == 'false' &&
-          !startsWith(github.event.pull_request.user.login, 'dependabot') &&
-          !startsWith(github.event.pull_request.user.login, 'renovate')
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          # PR title/body are untrusted input: passed through env vars only,
-          # never interpolated into the script.
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBERS: ${{ steps.prs.outputs.numbers }}
         run: |
           set -uo pipefail
 
-          fail_soft() {
-            echo "::warning::PR type classification failed: $1. No label was applied."
-            exit 1
+          FAILED=0
+          warn() {
+            echo "::warning::PR #$1: $2. No label applied."
+            FAILED=1
           }
 
-          # PR data is fetched through the GitHub API: no checkout of the fork,
-          # no execution of untrusted code.
-          FILES=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename') \
-            || fail_soft "could not fetch the list of changed files"
-          DIFF=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER" -H "Accept: application/vnd.github.diff" | head -c 20000) \
-            || fail_soft "could not fetch the PR diff"
+          while IFS= read -r PR; do
+            PR=$(echo "$PR" | tr -d '[:space:]')
+            [ -n "$PR" ] || continue
+            case "$PR" in
+              *[!0-9]*)
+                echo "::warning::Skipping invalid PR number '$PR'."
+                FAILED=1
+                continue
+                ;;
+            esac
 
-          # Scaleway Generative APIs (serverless, OpenAI-compatible). The
-          # json_schema response format constrains the model output to one of
-          # the three allowed types; defensive parsing below is kept as backup.
-          REQUEST=$(jq -n \
-            --arg title "$PR_TITLE" \
-            --arg body "$PR_BODY" \
-            --arg files "$FILES" \
-            --arg diff "$DIFF" \
-            '{
-              model: "mistral-small-3.2-24b-instruct-2506",
-              max_tokens: 64,
-              temperature: 0,
-              response_format: {
-                type: "json_schema",
-                json_schema: {
-                  name: "pr_type",
-                  schema: {
-                    type: "object",
-                    properties: {type: {type: "string", enum: ["feature", "fix", "chore"]}},
-                    required: ["type"],
-                    additionalProperties: false
+            # All PR data is fetched through the GitHub API: no checkout of
+            # the fork, no execution of untrusted code. Title and body are
+            # untrusted input: they only ever transit through shell variables
+            # and jq --arg, never interpolated into code.
+            PR_DATA=$(gh api "repos/$GH_REPO/pulls/$PR") \
+              || { warn "$PR" "could not fetch PR data"; continue; }
+
+            if echo "$PR_DATA" | jq -e '.labels | map(select(.name | startswith("type:"))) | length > 0' > /dev/null; then
+              echo "PR #$PR already has a type label, skipping."
+              continue
+            fi
+
+            LOGIN=$(echo "$PR_DATA" | jq -r '.user.login // empty')
+            case "$LOGIN" in
+              dependabot* | renovate*)
+                gh pr edit "$PR" --add-label "type:chore" \
+                  || { warn "$PR" "could not apply type:chore"; continue; }
+                echo "PR #$PR: dependency-bot author, applied type:chore."
+                continue
+                ;;
+            esac
+
+            PR_TITLE=$(echo "$PR_DATA" | jq -r '.title // ""')
+            PR_BODY=$(echo "$PR_DATA" | jq -r '.body // ""')
+            FILES=$(gh api "repos/$GH_REPO/pulls/$PR/files" --paginate --jq '.[].filename') \
+              || { warn "$PR" "could not fetch the list of changed files"; continue; }
+            DIFF=$(gh api "repos/$GH_REPO/pulls/$PR" -H "Accept: application/vnd.github.diff") \
+              || { warn "$PR" "could not fetch the PR diff"; continue; }
+            # Truncate in bash: piping into `head -c` would kill gh with
+            # SIGPIPE on large diffs and fail the step under pipefail
+            DIFF=${DIFF:0:20000}
+
+            # Scaleway Generative APIs (serverless, OpenAI-compatible). The
+            # json_schema response format constrains the model output to one
+            # of the three allowed types; defensive parsing below is kept as
+            # backup.
+            REQUEST=$(jq -n \
+              --arg title "$PR_TITLE" \
+              --arg body "$PR_BODY" \
+              --arg files "$FILES" \
+              --arg diff "$DIFF" \
+              '{
+                model: "mistral-small-3.2-24b-instruct-2506",
+                max_tokens: 64,
+                temperature: 0,
+                response_format: {
+                  type: "json_schema",
+                  json_schema: {
+                    name: "pr_type",
+                    schema: {
+                      type: "object",
+                      properties: {type: {type: "string", enum: ["feature", "fix", "chore"]}},
+                      required: ["type"],
+                      additionalProperties: false
+                    }
                   }
-                }
-              },
-              messages: [{
-                role: "user",
-                content: ("You are classifying a GitHub pull request of the Gladys Assistant home automation project.\n\nClassify the pull request as exactly one of these three types:\n- \"feature\": a new user-visible feature\n- \"fix\": a bug fix\n- \"chore\": dependencies, CI, refactoring, documentation - anything invisible in the user-facing changelog\n\nAnswer with strict JSON only, without any other text, in this exact format:\n{\"type\": \"feature\" | \"fix\" | \"chore\"}\n\nPR title:\n" + $title + "\n\nPR description:\n" + $body + "\n\nChanged files:\n" + $files + "\n\nDiff (truncated to 20000 characters):\n" + $diff)
-              }]
-            }') || fail_soft "could not build the API request"
+                },
+                messages: [{
+                  role: "user",
+                  content: ("You are classifying a GitHub pull request of the Gladys Assistant home automation project.\n\nClassify the pull request as exactly one of these three types:\n- \"feature\": a new user-visible feature\n- \"fix\": a bug fix\n- \"chore\": dependencies, CI, refactoring, documentation - anything invisible in the user-facing changelog\n\nAnswer with strict JSON only, without any other text, in this exact format:\n{\"type\": \"feature\" | \"fix\" | \"chore\"}\n\nPR title:\n" + $title + "\n\nPR description:\n" + $body + "\n\nChanged files:\n" + $files + "\n\nDiff (truncated to 20000 characters):\n" + $diff)
+                }]
+              }') || { warn "$PR" "could not build the API request"; continue; }
 
-          RESPONSE=$(curl -sS --fail \
-            --max-time 120 \
-            https://api.scaleway.ai/v1/chat/completions \
-            -H "Authorization: Bearer $SCW_SECRET_KEY" \
-            -H "content-type: application/json" \
-            -d "$REQUEST") || fail_soft "Scaleway API call failed"
+            RESPONSE=$(curl -sS --fail \
+              --max-time 120 \
+              https://api.scaleway.ai/v1/chat/completions \
+              -H "Authorization: Bearer $SCW_SECRET_KEY" \
+              -H "content-type: application/json" \
+              -d "$REQUEST") || { warn "$PR" "Scaleway API call failed"; continue; }
 
-          TEXT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty') \
-            || fail_soft "could not read the API response"
-          [ -n "$TEXT" ] || fail_soft "empty model response"
+            TEXT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty')
+            [ -n "$TEXT" ] || { warn "$PR" "empty model response"; continue; }
 
-          # Defensive parsing: strip potential markdown fences before parsing.
-          CLEANED=$(echo "$TEXT" | sed -e 's/^[[:space:]]*```[a-zA-Z]*//' -e 's/```[[:space:]]*$//')
-          TYPE=$(echo "$CLEANED" | jq -r '.type // empty' 2> /dev/null) \
-            || fail_soft "model response is not valid JSON"
+            # Defensive parsing: strip potential markdown fences before
+            # parsing.
+            CLEANED=$(echo "$TEXT" | sed -e 's/^[[:space:]]*```[a-zA-Z]*//' -e 's/```[[:space:]]*$//')
+            TYPE=$(echo "$CLEANED" | jq -r '.type // empty' 2> /dev/null) \
+              || { warn "$PR" "model response is not valid JSON"; continue; }
 
-          case "$TYPE" in
-            feature | fix | chore) ;;
-            *) fail_soft "unexpected type value: '$TYPE'" ;;
-          esac
+            case "$TYPE" in
+              feature | fix | chore) ;;
+              *)
+                warn "$PR" "unexpected type value: '$TYPE'"
+                continue
+                ;;
+            esac
 
-          gh pr edit "$PR_NUMBER" --add-label "type:$TYPE" \
-            || fail_soft "could not apply the label type:$TYPE"
-          echo "Applied label type:$TYPE"
+            gh pr edit "$PR" --add-label "type:$TYPE" \
+              || { warn "$PR" "could not apply the label type:$TYPE"; continue; }
+            echo "PR #$PR: applied type:$TYPE"
+
+            # Be gentle with API rate limits during backfills
+            sleep 1
+          done <<< "$PR_NUMBERS"
+
+          exit "$FAILED"

--- a/.github/workflows/pr-classify.yml
+++ b/.github/workflows/pr-classify.yml
@@ -1,0 +1,111 @@
+name: PR Type Classification
+
+# pull_request_target (not pull_request) so that secrets are available for PRs
+# coming from forks. SECURITY: this workflow must NEVER check out or execute
+# code from the PR head. It only reads PR metadata and the diff through the
+# GitHub API, and it does not check out anything at all.
+on:
+  pull_request_target:
+    # "opened" only: no re-classification during the PR lifetime, and a manual
+    # label fix is never overwritten on synchronize.
+    types: [opened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for an existing type label
+        id: check
+        env:
+          LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          if echo "$LABELS_JSON" | jq -e 'map(select(startswith("type:"))) | length > 0' > /dev/null; then
+            echo "PR already has a type label, skipping classification."
+            echo "has_type=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_type=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Label dependency-bot PRs as chore
+        if: |
+          steps.check.outputs.has_type == 'false' &&
+          (startsWith(github.event.pull_request.user.login, 'dependabot') ||
+           startsWith(github.event.pull_request.user.login, 'renovate'))
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr edit "$PR_NUMBER" --add-label "type:chore"
+
+      - name: Classify PR type with Claude
+        if: |
+          steps.check.outputs.has_type == 'false' &&
+          !startsWith(github.event.pull_request.user.login, 'dependabot') &&
+          !startsWith(github.event.pull_request.user.login, 'renovate')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # PR title/body are untrusted input: passed through env vars only,
+          # never interpolated into the script.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -uo pipefail
+
+          fail_soft() {
+            echo "::warning::PR type classification failed: $1. No label was applied."
+            exit 1
+          }
+
+          # PR data is fetched through the GitHub API: no checkout of the fork,
+          # no execution of untrusted code.
+          FILES=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename') \
+            || fail_soft "could not fetch the list of changed files"
+          DIFF=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER" -H "Accept: application/vnd.github.diff" | head -c 20000) \
+            || fail_soft "could not fetch the PR diff"
+
+          REQUEST=$(jq -n \
+            --arg title "$PR_TITLE" \
+            --arg body "$PR_BODY" \
+            --arg files "$FILES" \
+            --arg diff "$DIFF" \
+            '{
+              model: "claude-haiku-4-5-20251001",
+              max_tokens: 64,
+              messages: [{
+                role: "user",
+                content: ("You are classifying a GitHub pull request of the Gladys Assistant home automation project.\n\nClassify the pull request as exactly one of these three types:\n- \"feature\": a new user-visible feature\n- \"fix\": a bug fix\n- \"chore\": dependencies, CI, refactoring, documentation - anything invisible in the user-facing changelog\n\nAnswer with strict JSON only, without any other text, in this exact format:\n{\"type\": \"feature\" | \"fix\" | \"chore\"}\n\nPR title:\n" + $title + "\n\nPR description:\n" + $body + "\n\nChanged files:\n" + $files + "\n\nDiff (truncated to 20000 characters):\n" + $diff)
+              }]
+            }') || fail_soft "could not build the API request"
+
+          RESPONSE=$(curl -sS --fail \
+            --max-time 120 \
+            https://api.anthropic.com/v1/messages \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            -d "$REQUEST") || fail_soft "Anthropic API call failed"
+
+          TEXT=$(echo "$RESPONSE" | jq -r '.content[0].text // empty') \
+            || fail_soft "could not read the API response"
+          [ -n "$TEXT" ] || fail_soft "empty model response"
+
+          # Defensive parsing: strip potential markdown fences before parsing.
+          CLEANED=$(echo "$TEXT" | sed -e 's/^[[:space:]]*```[a-zA-Z]*//' -e 's/```[[:space:]]*$//')
+          TYPE=$(echo "$CLEANED" | jq -r '.type // empty' 2> /dev/null) \
+            || fail_soft "model response is not valid JSON"
+
+          case "$TYPE" in
+            feature | fix | chore) ;;
+            *) fail_soft "unexpected type value: '$TYPE'" ;;
+          esac
+
+          gh pr edit "$PR_NUMBER" --add-label "type:$TYPE" \
+            || fail_soft "could not apply the label type:$TYPE"
+          echo "Applied label type:$TYPE"

--- a/.github/workflows/pr-classify.yml
+++ b/.github/workflows/pr-classify.yml
@@ -42,7 +42,7 @@ jobs:
           elif [ -n "$INPUT_PRS" ]; then
             PRS="$INPUT_PRS"
           else
-            PRS=$(gh pr list --state open --limit 1000 --json number --jq '.[].number')
+            PRS=$(gh api --paginate "repos/$GH_REPO/pulls?state=open&per_page=100" --jq '.[].number')
           fi
           {
             echo "numbers<<PRS_EOF"
@@ -88,9 +88,11 @@ jobs:
               continue
             fi
 
+            # Exact logins only: a user named e.g. "dependabot-fan" must not
+            # be treated as a trusted dependency bot
             LOGIN=$(echo "$PR_DATA" | jq -r '.user.login // empty')
             case "$LOGIN" in
-              dependabot* | renovate*)
+              'dependabot[bot]' | 'renovate[bot]')
                 gh pr edit "$PR" --add-label "type:chore" \
                   || { warn "$PR" "could not apply type:chore"; continue; }
                 echo "PR #$PR: dependency-bot author, applied type:chore."
@@ -104,8 +106,12 @@ jobs:
               || { warn "$PR" "could not fetch the list of changed files"; continue; }
             DIFF=$(gh api "repos/$GH_REPO/pulls/$PR" -H "Accept: application/vnd.github.diff") \
               || { warn "$PR" "could not fetch the PR diff"; continue; }
-            # Truncate in bash: piping into `head -c` would kill gh with
-            # SIGPIPE on large diffs and fail the step under pipefail
+            # Bound every free-form field so a huge PR can never overflow the
+            # model context. Truncate in bash: piping into `head -c` would
+            # kill gh with SIGPIPE on large payloads and fail the step under
+            # pipefail
+            [ ${#PR_BODY} -le 5000 ] || PR_BODY="${PR_BODY:0:5000}"$'\n[description truncated]'
+            [ ${#FILES} -le 10000 ] || FILES="${FILES:0:10000}"$'\n[file list truncated]'
             DIFF=${DIFF:0:20000}
 
             # Scaleway Generative APIs (serverless, OpenAI-compatible). The

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,17 @@
+name: PR Area Labeler
+
+on:
+  - pull_request_target
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          # Never remove labels that were added manually
+          sync-labels: false

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,14 @@
 name: PR Area Labeler
 
 on:
-  - pull_request_target
+  pull_request_target:
+  # Manual backfill for existing PRs
+  workflow_dispatch:
+    inputs:
+      pr_numbers:
+        description: 'PR number(s) to label, one per line. Leave empty to label all open PRs.'
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -11,7 +18,29 @@ jobs:
   labeler:
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve PR numbers (manual runs only)
+        id: prs
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          INPUT_PRS: ${{ inputs.pr_numbers }}
+        run: |
+          if [ -n "$INPUT_PRS" ]; then
+            PRS="$INPUT_PRS"
+          else
+            PRS=$(gh pr list --state open --limit 1000 --json number --jq '.[].number')
+          fi
+          {
+            echo "numbers<<PRS_EOF"
+            echo "$PRS"
+            echo "PRS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - uses: actions/labeler@v5
         with:
           # Never remove labels that were added manually
           sync-labels: false
+          # Empty on pull_request_target events: the PR is detected from the
+          # workflow context
+          pr-number: ${{ steps.prs.outputs.numbers }}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -29,7 +29,7 @@ jobs:
           if [ -n "$INPUT_PRS" ]; then
             PRS="$INPUT_PRS"
           else
-            PRS=$(gh pr list --state open --limit 1000 --json number --jq '.[].number')
+            PRS=$(gh api --paginate "repos/$GH_REPO/pulls?state=open&per_page=100" --jq '.[].number')
           fi
           {
             echo "numbers<<PRS_EOF"
@@ -37,7 +37,7 @@ jobs:
             echo "PRS_EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           # Never remove labels that were added manually
           sync-labels: false


### PR DESCRIPTION
### Description

Implements the label automation for the new label taxonomy (labels already exist on GitHub, none are created here). One commit per deliverable:

1. **`.github/labeler.yml` + `.github/workflows/pr-labeler.yml`** — area labels via `actions/labeler@v5` (`changed-files` / `any-glob-to-any-file` syntax), triggered on `pull_request_target` so it works for fork PRs. `sync-labels: false` so manually added labels are never removed. A PR touching `server/services/**` gets both `area:integration` and `area:server` (expected, not exclusive). Includes `area:database` for `server/migrations/**` and `server/models/**`.
2. **`.github/workflows/pr-classify.yml`** — LLM type classification on `opened` only (no re-classification, manual fixes never overwritten). Skips if a `type:*` label is already present; dependabot/renovate PRs get `type:chore` directly without an LLM call; otherwise calls the Scaleway Generative APIs serverless endpoint (`https://api.scaleway.ai/v1/chat/completions`, OpenAI-compatible, model `mistral-small-3.2-24b-instruct-2506`, key in the `SCALEWAY_API_KEY` secret) with title, description, changed files and the diff truncated to 20,000 characters. The request uses a `json_schema` structured output constraining the answer to the three allowed types, plus defensive parsing as backup; on any API or parsing error the job fails with a warning and applies no label. Minimal permissions (`pull-requests: write`, `contents: read`).
3. **`.github/PULL_REQUEST_TEMPLATE.md`** — simplified template merged with the existing one: short description, `## Forum` section with the `Forum: https://community.gladysassistant.com/t/...` convention for the release pipeline, short checklist.
4. **`.github/CONTRIBUTING.md`** — short "Labels & Forum Link" section documenting the taxonomy.

### Backfill for existing PRs

Both workflows have a `workflow_dispatch` trigger with an optional `pr_numbers` input (one PR number per line). Left empty, the labeler processes all open PRs and the classifier processes all open PRs without a `type:*` label. Both are idempotent: manually set labels are never removed and PRs already carrying a type label are always skipped, so re-running is safe. The classification job fails soft per PR (a warning per failed PR, remaining PRs still processed).

### Security model for fork PRs

Both workflows use `pull_request_target` so labels can be applied and secrets are available for fork PRs. Neither workflow checks out any code at all: the labeler reads its config from the base branch via the API, and the classifier fetches PR metadata, file list and diff through the GitHub API only. PR title/body are untrusted input and only transit through shell variables and `jq --arg` (never interpolated into code), and the model output can only result in one of three fixed label names. No fork code is ever executed.

### Assumptions

- **LLM provider**: Scaleway Generative APIs (serverless). Model `mistral-small-3.2-24b-instruct-2506` — the current small serverless instruct model, more than enough for a 3-class classification and cheap. The plain model name (without `mistral/` prefix or `:fp8` suffix) is the serverless naming; the prefixed forms are for Managed Inference deployments. The `SCALEWAY_API_KEY` secret must contain a Scaleway IAM secret key with access to Generative APIs.
- **`area:ai` paths**: there is no single AI directory in `server/lib`, so the label maps to `server/lib/brain/**` (NLP intent routing) + its tests, the six `gateway.*AiChat*` / `gateway.getOpenAIQuota.js` files in `server/lib/gateway` (LLM chat forwarding, tool classification), and `server/utils/aiChatModels.js`. If AI code is later consolidated into a dedicated folder, only `labeler.yml` needs updating.
- **`area:database` paths**: `server/migrations/**` and `server/models/**` (seeders excluded: demo/test data only).
- **`area:infra` paths**: `.github/**`, `docker/**` (contains both Dockerfiles and docker-compose) and `codecov.yml`. Root `package.json` was deliberately left out to avoid tagging every dependency bump as infra.
- **"Fail the job as a warning"** is implemented as a `::warning::` annotation plus a failing job; since the check is not required by branch protection it never blocks the PR.
- Both workflows were validated with `actionlint` v1.7.7 (no findings), and the defensive parsing was tested against fenced JSON, plain JSON and prose-wrapped output.

### Checklist

- [x] Workflow syntax validated with `actionlint`
- [x] No undocumented breaking change (automation only, no runtime code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHBVeH8X83JF48gnPSLiTr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic pull request labeling by change area and contribution type.
  * Added support for linking forum discussions to pull requests for release notifications.
  * Added manual options for labeling selected or all open pull requests.

* **Documentation**
  * Updated contribution guidance with label descriptions and forum-linking instructions.
  * Simplified the pull request template with clearer descriptions and essential validation checks.

* **Chores**
  * Added automated workflows to classify pull requests and preserve manually assigned labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->