### PR TITLE
fix French plural: « tableaux de bord » (not « tableaux de bords »)

### DIFF
--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -268,7 +268,7 @@
     "gatewayInstanceNotFoundError": "Votre instance Gladys n'est pas connectée à Gladys Plus.",
     "editDashboardNameLabel": "Nom",
     "editDashboardVisibility": "Visibilité",
-    "editDashboardVisibilityDescription": "Les tableaux de bords publics seront visible par tous les membres de l'installation Gladys.",
+    "editDashboardVisibilityDescription": "Les tableaux de bord publics seront visible par tous les membres de l'installation Gladys.",
     "editDashboardVisibilityNotEditableNotCreator": "Vous ne pouvez pas éditer le partage car vous n'êtes pas le créateur de ce tableau de bord.",
     "visibilities": {
       "private": "privé",
@@ -276,7 +276,7 @@
     },
     "editDashboardAddColumnButton": "Ajouter une colonne au tableau de bord",
     "editDashboardBoxNotEmpty": "Vous ne pouvez pas supprimer cette colonne car elle contient des widgets.",
-    "editDashboardMyDashboards": "Mes tableaux de bords",
+    "editDashboardMyDashboards": "Mes tableaux de bord",
     "editDashboardExplanation": "Chaque tableau de bord comporte 3 colonnes, que vous pouvez remplir selon vos préférences. Cliquez sur le bouton + pour ajouter un nouveau widget. Vous pouvez déplacer ce widget en l'attrapant et en le déplaçant.",
     "reorderDashboardButton": "Re-ordonner",
     "stopReorderingDashboardButton": "Arrêter de réordonner",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -268,7 +268,7 @@
     "gatewayInstanceNotFoundError": "Votre instance Gladys n'est pas connectée à Gladys Plus.",
     "editDashboardNameLabel": "Nom",
     "editDashboardVisibility": "Visibilité",
-    "editDashboardVisibilityDescription": "Les tableaux de bord publics seront visible par tous les membres de l'installation Gladys.",
+    "editDashboardVisibilityDescription": "Les tableaux de bord publics seront visibles par tous les membres de l'installation Gladys.",
     "editDashboardVisibilityNotEditableNotCreator": "Vous ne pouvez pas éditer le partage car vous n'êtes pas le créateur de ce tableau de bord.",
     "visibilities": {
       "private": "privé",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Corrects French grammar on the dashboard edit page:

- « Mes tableaux de bords » → « Mes tableaux de bord »
- « Les tableaux de bords publics seront visible… » → « Les tableaux de bord publics seront visibles… »

Only « bord » is invariable in this compound noun; the plural mark goes on « tableau ». The adjective « visibles » agrees with the plural subject.

## Test plan

- [x] Spot-check wording in `front/src/config/i18n/fr.json`
- [ ] Spot-check the dashboard edit page header and visibility description in French UI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb893-778c-7ccd-a8a4-79c9f377a23b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb893-778c-7ccd-a8a4-79c9f377a23b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected French dashboard translations for improved grammar and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->