### PR TITLE
Add value age tracking to sensor readings for LLM context

### DIFF
--- a/server/config/prompts/aiChat.prompt.txt
+++ b/server/config/prompts/aiChat.prompt.txt
@@ -16,6 +16,10 @@ Rules:
 - To change the brightness, the color, or the white color temperature (warm/cool white) of a light, use the `device_set_light` tool with a brightness percentage (0-100), a hexadecimal RGB color (for example #0000FF for blue), or a Kelvin temperature (for example 2700 for warm white, 4000 for neutral white, 6500 for cool white). Use `device_turn_on_off` only to turn lights on or off.
 - When the user asks to save, store, or record a value in a virtual sensor (for example a value read from a camera image), use the `sensor_set_state` tool.
 - Use the tool names and arguments exactly as provided by the tool schema.
+- Only report rooms, devices and values that are present in the tool results of this turn. Never infer, estimate, or complete a measurement for a room or a device that is absent from the results, even when you know that room exists in the home.
+- If a room or a device has no sensor for what the user asked, say so explicitly (for example "there is no humidity sensor in the kitchen"). Never fill the gap with a plausible value.
+- Each state returned by the tools carries an `age` field telling how long ago the value was last updated. For measurements such as temperature, humidity, CO2 or power, a value older than a few hours means the sensor stopped reporting: say when it was last updated instead of presenting it as the current value.
+- If a tool result is truncated, answer with the part you received and say the list is incomplete. Never invent the missing entries.
 - After you receive tool results, provide a concise and accurate answer in plain language only.
 - Never reply with JSON, code blocks, or raw tool output: extract the relevant values from tool results and phrase them in a short natural-language sentence.
 - Never repeat tool names, arguments, or invocation syntax (for example `device_turn_on_off({...})`) in your reply text. Tool execution is shown separately in the chat UI.

--- a/server/config/prompts/aiChat.prompt.txt
+++ b/server/config/prompts/aiChat.prompt.txt
@@ -18,7 +18,8 @@ Rules:
 - Use the tool names and arguments exactly as provided by the tool schema.
 - Only report rooms, devices and values that are present in the tool results of this turn. Never infer, estimate, or complete a measurement for a room or a device that is absent from the results, even when you know that room exists in the home.
 - If a room or a device has no sensor for what the user asked, say so explicitly (for example "there is no humidity sensor in the kitchen"). Never fill the gap with a plausible value.
-- Each state returned by the tools carries an `age` field telling how long ago the value was last updated. For measurements such as temperature, humidity, CO2 or power, a value older than a few hours means the sensor stopped reporting: say when it was last updated instead of presenting it as the current value.
+- Each state returned by the tools carries an `age` field telling how long ago the value was last reported. Many sensors only report when their value changes, so an age of a few hours is normal for a healthy device: give the value as is.
+- Only treat a sensor as no longer reporting when its `age` reaches about two days or more. In that case, give the value together with when it was last updated, instead of presenting it as the current value. This does not apply to lights, switches, shutters, door or motion sensors, where a large age only means that nothing happened.
 - If a tool result is truncated, answer with the part you received and say the list is incomplete. Never invent the missing entries.
 - After you receive tool results, provide a concise and accurate answer in plain language only.
 - Never reply with JSON, code blocks, or raw tool output: extract the relevant values from tool results and phrase them in a short natural-language sentence.

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -555,6 +555,24 @@ async function getAllTools(userId) {
           }),
         );
 
+        // An empty list is an ambiguous signal for the model, which tends to fill the
+        // gap with a plausible value. Say explicitly that nothing is configured.
+        if (states.length === 0) {
+          const typeLabel = deviceType && deviceType.length > 0 ? ` of type "${deviceType}"` : '';
+          const roomLabel = room && room !== '' ? ` in room "${room}"` : '';
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text:
+                  `device.get-state: no device${typeLabel} is configured${roomLabel}. ` +
+                  'No measurement exists for this query, do not report any value.',
+              },
+            ],
+          };
+        }
+
         return {
           content: [
             {

--- a/server/services/mcp/lib/formatValue.js
+++ b/server/services/mcp/lib/formatValue.js
@@ -23,11 +23,14 @@ const ONE_DAY_IN_MS = 24 * ONE_HOUR_IN_MS;
  * formatAge({ last_value_changed: new Date() }, Date.now());
  */
 function formatAge(feature, now) {
-  if (!feature.last_value_changed) {
+  const { last_value_changed: lastValueChanged } = feature;
+
+  // Only an absent value means "unknown": 0 is the Unix epoch, a valid date.
+  if (lastValueChanged === null || lastValueChanged === undefined) {
     return null;
   }
 
-  const lastValueChangedTimestamp = new Date(feature.last_value_changed).getTime();
+  const lastValueChangedTimestamp = new Date(lastValueChanged).getTime();
   if (Number.isNaN(lastValueChangedTimestamp)) {
     return null;
   }

--- a/server/services/mcp/lib/formatValue.js
+++ b/server/services/mcp/lib/formatValue.js
@@ -7,14 +7,52 @@ const coverStateLabels = {
   [COVER_STATE.STOP]: 'stopped',
 };
 
+const ONE_MINUTE_IN_MS = 60 * 1000;
+const ONE_HOUR_IN_MS = 60 * ONE_MINUTE_IN_MS;
+const ONE_DAY_IN_MS = 24 * ONE_HOUR_IN_MS;
+
 /**
- * @description Format feature value for llm.
+ * @description Format how long ago a feature value was last updated.
+ * The LLM has no other way to tell a live reading from the last value of a
+ * sensor that stopped reporting (dead battery, unplugged, sensor removed),
+ * so every state we expose carries its age.
+ * @param {object} feature - Feature to format.
+ * @param {number} now - Current timestamp in ms.
+ * @returns {string|null} Compact age such as '12min', '3h', '6d', or null when unknown.
+ * @example
+ * formatAge({ last_value_changed: new Date() }, Date.now());
+ */
+function formatAge(feature, now) {
+  if (!feature.last_value_changed) {
+    return null;
+  }
+
+  const lastValueChangedTimestamp = new Date(feature.last_value_changed).getTime();
+  if (Number.isNaN(lastValueChangedTimestamp)) {
+    return null;
+  }
+
+  // A value dated in the future means a clock skew, report it as fresh.
+  const ageInMs = Math.max(0, now - lastValueChangedTimestamp);
+
+  if (ageInMs < ONE_HOUR_IN_MS) {
+    return `${Math.floor(ageInMs / ONE_MINUTE_IN_MS)}min`;
+  }
+  if (ageInMs < ONE_DAY_IN_MS) {
+    return `${Math.floor(ageInMs / ONE_HOUR_IN_MS)}h`;
+  }
+
+  return `${Math.floor(ageInMs / ONE_DAY_IN_MS)}d`;
+}
+
+/**
+ * @description Format the raw feature value into something readable by the llm.
  * @param {object} feature - Feature to format.
  * @returns {object} Value formated and unit if necessary.
  * @example
- * formatValue(feature)
+ * formatRawValue(feature)
  */
-function formatValue(feature) {
+function formatRawValue(feature) {
   switch (`${feature.category}:${feature.type}`) {
     case 'opening-sensor:binary':
       return {
@@ -47,6 +85,22 @@ function formatValue(feature) {
   }
 }
 
+/**
+ * @description Format feature value for llm.
+ * @param {object} feature - Feature to format.
+ * @param {number} [now] - Current timestamp in ms, mainly for tests.
+ * @returns {object} Value formated, unit if necessary, and age of the value.
+ * @example
+ * formatValue(feature)
+ */
+function formatValue(feature, now = Date.now()) {
+  return {
+    ...formatRawValue(feature),
+    age: formatAge(feature, now),
+  };
+}
+
 module.exports = {
   formatValue,
+  formatAge,
 };

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -3261,4 +3261,83 @@ describe('build schemas', () => {
       'device.set-light: brightness 20% command sent for Brightness Only Light; could not dispatch for Brightness Only Light (missing color feature)',
     );
   });
+
+  it('should tell device.get-state that no device is configured instead of returning an empty list', async () => {
+    const rooms = [
+      { id: 'room-1', name: 'Salon', selector: 'salon' },
+      { id: 'room-2', name: 'Cuisine', selector: 'cuisine' },
+    ];
+
+    // The humidity sensor lives in the living room, the kitchen has none.
+    const humiditySensor = {
+      selector: 'capteur-salon',
+      name: 'Capteur salon',
+      room: { selector: 'salon', name: 'Salon' },
+      features: [
+        {
+          id: 'feature-humidity',
+          selector: 'capteur-salon-humidity',
+          name: 'Humidité',
+          category: 'humidity-sensor',
+          type: 'decimal',
+          unit: '%',
+          last_value: 52,
+        },
+      ],
+    };
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isLightControlFeature,
+      isShutterFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      formatValue: stub().callsFake((feature) => ({
+        value: feature.last_value,
+        unit: feature.unit,
+        age: '2min',
+      })),
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves(rooms) },
+        user: { get: stub().resolves([]) },
+        house: { get: stub().resolves([]) },
+        calendar: { get: stub().resolves([]) },
+        area: { get: stub().resolves([]) },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves([humiditySensor]),
+          getBySelector: stub().resolves(humiditySensor),
+          setValue: stub().resolves(),
+          getDeviceFeaturesAggregates: stub().resolves({ values: [] }),
+          camera: { getImagesInRoom: stub().resolves([]) },
+        },
+        event: { emit: fake() },
+      },
+      levenshtein: { distance: stub().returns(10) },
+      toon: stub().returns('toonmockdata'),
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    const getStateTool = tools.find((tool) => tool.intent === 'device.get-state');
+
+    const noSensorInRoom = await getStateTool.cb({ room: 'Cuisine', device_type: 'humidity-sensor' });
+    expect(noSensorInRoom.content[0].text).to.eq(
+      'device.get-state: no device of type "humidity-sensor" is configured in room "Cuisine". ' +
+        'No measurement exists for this query, do not report any value.',
+    );
+
+    const noSensorAtAll = await getStateTool.cb({ room: undefined, device_type: 'co2-sensor' });
+    expect(noSensorAtAll.content[0].text).to.eq(
+      'device.get-state: no device of type "co2-sensor" is configured. ' +
+        'No measurement exists for this query, do not report any value.',
+    );
+
+    // A room that does have the sensor still returns the regular payload.
+    const withSensor = await getStateTool.cb({ room: 'Salon', device_type: 'humidity-sensor' });
+    expect(withSensor.content[0].text).to.eq('toonmockdata');
+  });
 });

--- a/server/test/services/mcp/lib/formatValue.test.js
+++ b/server/test/services/mcp/lib/formatValue.test.js
@@ -174,6 +174,19 @@ describe('formatValue', () => {
     ).to.eq(null);
   });
 
+  it('should treat a Unix epoch timestamp as a date, not as a missing value', () => {
+    const feature = {
+      category: 'humidity-sensor',
+      type: 'decimal',
+      last_value: 52,
+      unit: '%',
+      last_value_changed: 0,
+    };
+
+    expect(formatValue(feature, 0).age).to.eq('0min');
+    expect(formatValue(feature, new Date('1970-01-03T00:00:00.000Z').getTime()).age).to.eq('2d');
+  });
+
   it('should keep the age of a stale sensor that stopped reporting', () => {
     const now = new Date('2026-07-12T12:00:00.000Z').getTime();
     const feature = {

--- a/server/test/services/mcp/lib/formatValue.test.js
+++ b/server/test/services/mcp/lib/formatValue.test.js
@@ -15,6 +15,7 @@ describe('formatValue', () => {
     expect(result).to.deep.equal({
       value: 'open',
       unit: null,
+      age: null,
     });
   });
 
@@ -30,6 +31,7 @@ describe('formatValue', () => {
     expect(result).to.deep.equal({
       value: 'off',
       unit: null,
+      age: null,
     });
   });
 
@@ -37,14 +39,17 @@ describe('formatValue', () => {
     expect(formatValue({ category: 'shutter', type: 'state', last_value: COVER_STATE.OPEN })).to.deep.equal({
       value: 'open',
       unit: null,
+      age: null,
     });
     expect(formatValue({ category: 'shutter', type: 'state', last_value: COVER_STATE.CLOSE })).to.deep.equal({
       value: 'closed',
       unit: null,
+      age: null,
     });
     expect(formatValue({ category: 'shutter', type: 'state', last_value: COVER_STATE.STOP })).to.deep.equal({
       value: 'stopped',
       unit: null,
+      age: null,
     });
   });
 
@@ -58,6 +63,7 @@ describe('formatValue', () => {
     expect(result).to.deep.equal({
       value: 'closed',
       unit: null,
+      age: null,
     });
   });
 
@@ -65,6 +71,7 @@ describe('formatValue', () => {
     expect(formatValue({ category: 'switch', type: 'binary', last_value: 1 })).to.deep.equal({
       value: 'on',
       unit: null,
+      age: null,
     });
   });
 
@@ -72,10 +79,12 @@ describe('formatValue', () => {
     expect(formatValue({ category: 'curtain', type: 'state', last_value: COVER_STATE.OPEN })).to.deep.equal({
       value: 'open',
       unit: null,
+      age: null,
     });
     expect(formatValue({ category: 'shutter', type: 'state', last_value: 42 })).to.deep.equal({
       value: 42,
       unit: null,
+      age: null,
     });
   });
 
@@ -83,14 +92,17 @@ describe('formatValue', () => {
     expect(formatValue({ category: 'light', type: 'color', last_value: 255 })).to.deep.equal({
       value: '#0000ff',
       unit: null,
+      age: null,
     });
     expect(formatValue({ category: 'light', type: 'color', last_value: 16711680 })).to.deep.equal({
       value: '#ff0000',
       unit: null,
+      age: null,
     });
     expect(formatValue({ category: 'light', type: 'color', last_value: null })).to.deep.equal({
       value: null,
       unit: null,
+      age: null,
     });
   });
 
@@ -107,6 +119,75 @@ describe('formatValue', () => {
     expect(result).to.deep.equal({
       value: 22.5,
       unit: '°C',
+      age: null,
+    });
+  });
+
+  it('should report the age of the value in minutes, hours and days', () => {
+    const now = new Date('2026-07-12T12:00:00.000Z').getTime();
+    const buildFeature = (lastValueChanged) => ({
+      category: 'temperature-sensor',
+      type: 'decimal',
+      last_value: 22.5,
+      unit: '°C',
+      last_value_changed: lastValueChanged,
+    });
+
+    expect(formatValue(buildFeature('2026-07-12T11:48:00.000Z'), now).age).to.eq('12min');
+    expect(formatValue(buildFeature('2026-07-12T09:00:00.000Z'), now).age).to.eq('3h');
+    expect(formatValue(buildFeature('2026-07-06T12:00:00.000Z'), now).age).to.eq('6d');
+  });
+
+  it('should report a fresh value as 0min', () => {
+    const now = new Date('2026-07-12T12:00:00.000Z').getTime();
+    const feature = {
+      category: 'humidity-sensor',
+      type: 'decimal',
+      last_value: 52,
+      unit: '%',
+      last_value_changed: new Date('2026-07-12T12:00:00.000Z'),
+    };
+
+    expect(formatValue(feature, now).age).to.eq('0min');
+  });
+
+  it('should report a value dated in the future as fresh', () => {
+    const now = new Date('2026-07-12T12:00:00.000Z').getTime();
+    const feature = {
+      category: 'humidity-sensor',
+      type: 'decimal',
+      last_value: 52,
+      unit: '%',
+      last_value_changed: '2026-07-12T14:00:00.000Z',
+    };
+
+    expect(formatValue(feature, now).age).to.eq('0min');
+  });
+
+  it('should return a null age when last_value_changed is missing or invalid', () => {
+    const now = new Date('2026-07-12T12:00:00.000Z').getTime();
+
+    expect(formatValue({ category: 'humidity-sensor', type: 'decimal', last_value: 52 }, now).age).to.eq(null);
+    expect(
+      formatValue({ category: 'humidity-sensor', type: 'decimal', last_value: 52, last_value_changed: 'nope' }, now)
+        .age,
+    ).to.eq(null);
+  });
+
+  it('should keep the age of a stale sensor that stopped reporting', () => {
+    const now = new Date('2026-07-12T12:00:00.000Z').getTime();
+    const feature = {
+      category: 'humidity-sensor',
+      type: 'decimal',
+      last_value: 52.2,
+      unit: '%',
+      last_value_changed: '2026-06-12T12:00:00.000Z',
+    };
+
+    expect(formatValue(feature, now)).to.deep.equal({
+      value: 52.2,
+      unit: '%',
+      age: '30d',
     });
   });
 });


### PR DESCRIPTION
### Description

This PR adds age tracking to sensor readings exposed to the LLM, helping it distinguish between live measurements and stale values from sensors that have stopped reporting (dead batteries, unplugged devices, etc.).

**Key changes:**

1. **New `formatAge()` function** in `formatValue.js` that calculates how long ago a sensor value was last updated, returning compact formats like `'12min'`, `'3h'`, or `'6d'`. Returns `null` when the timestamp is missing or invalid.

2. **Updated `formatValue()` function** to include an `age` field in its output alongside `value` and `unit`. This provides the LLM with temporal context for every sensor reading.

3. **Improved empty state handling** in `buildSchemas.js` for the `device.get-state` tool. When no devices match the query, the tool now explicitly tells the LLM "no device is configured" instead of returning an empty list, preventing the model from hallucinating plausible values.

4. **Updated AI chat prompt** to clarify that the LLM should only report values present in tool results and never infer or estimate missing data.

All existing tests have been updated to expect the new `age` field, and comprehensive new tests cover:
- Age calculation in minutes, hours, and days
- Fresh values (0min)
- Future-dated values (treated as fresh due to clock skew)
- Missing or invalid timestamps (null age)
- Stale sensor tracking

### Checklist

- [x] Tests pass: All unit tests updated and new tests added for age tracking functionality
- [x] Linter and prettier pass
- [x] No breaking changes: The `age` field is additive; existing code consuming `value` and `unit` continues to work

https://claude.ai/code/session_01YHsCQc8ttFMpWzZAaYSwwn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sensor readings now display how long ago they were recorded.
  - Clear messages appear when no matching devices or measurements are found.
  - AI responses identify missing sensors, account for stale readings, and disclose incomplete tool results.

- **Bug Fixes**
  - Prevented empty or misleading device-state responses when no results are available.
  - Improved handling of missing, invalid, future, and outdated measurement timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->