### PR TITLE
Exclude integration-only changes from area:server label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,11 +1,15 @@
 # Configuration for actions/labeler@v5 (area labels).
-# A PR can receive several area labels: a change in server/services/** gets
-# both area:integration and area:server, which is expected.
+# A PR can receive several area labels.
 
 'area:server':
   - changed-files:
-      - any-glob-to-any-file:
+      # At least one changed file in server/** outside the integrations code:
+      # a PR only touching an integration gets area:integration, not
+      # area:server
+      - all-globs-to-any-file:
           - 'server/**'
+          - '!server/services/**'
+          - '!server/test/services/**'
 
 'area:front':
   - changed-files:
@@ -16,6 +20,7 @@
   - changed-files:
       - any-glob-to-any-file:
           - 'server/services/**'
+          - 'server/test/services/**'
 
 'area:ai':
   - changed-files:


### PR DESCRIPTION
### Description

Follow-up to #2728. A PR that only touches an integration (like #2725) was getting both `area:integration` and `area:server`, which dilutes the signal: an integration PR is an integration PR.

- `area:server` now uses `all-globs-to-any-file` with negated globs: it requires at least one changed file in `server/**` **outside** `server/services/**` and `server/test/services/**`. An integration-only PR no longer gets `area:server`; a PR touching both an integration and core server code still gets both labels.
- `area:integration` now also covers `server/test/services/**`, so integration test changes map to the right label.

The negated-glob semantics were verified against minimatch (the matcher used by `actions/labeler`): `server/services/mqtt/index.js` and `server/test/services/mqtt/mqtt.test.js` no longer match `area:server`, while `server/lib/device/index.js` and `server/models/device.js` still do.

## Forum

### Checklist

- [x] Tests pass: not applicable (labeler configuration only, no runtime code touched)
- [x] Linter and prettier pass: not applicable (YAML validated, `actionlint` not affected)
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHBVeH8X83JF48gnPSLiTr

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHBVeH8X83JF48gnPSLiTr)_