### PR TITLE
Fix date validation and clamping in energy consumption tool

### DIFF
--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -1297,6 +1297,16 @@ async function getAllTools(userId) {
         const formatDateInput = ({ year, month, day }) =>
           `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
 
+        // new Date(year, ...) maps years 0 to 99 to 1900 to 1999, so a 4-digit year
+        // below 0100 would query a period two millennia away from the one asked for.
+        // Setting the year explicitly keeps it, and still rolls the day over the
+        // month boundary as the exclusive end date needs.
+        const createLocalDate = ({ year, month, day }) => {
+          const date = new Date(2000, 0, 1);
+          date.setFullYear(year, month - 1, day);
+          return date;
+        };
+
         const parsedStart = parseDateInput(startDate);
         const parsedEnd = parseDateInput(endDate);
         if (!parsedStart || !parsedEnd) {
@@ -1348,8 +1358,8 @@ async function getAllTools(userId) {
         }
 
         // Same date boundaries as the energy dashboard: local midnight, end exclusive.
-        const from = new Date(parsedStart.year, parsedStart.month - 1, parsedStart.day);
-        const to = new Date(parsedEnd.year, parsedEnd.month - 1, parsedEnd.day + 1);
+        const from = createLocalDate(parsedStart);
+        const to = createLocalDate({ ...parsedEnd, day: parsedEnd.day + 1 });
         if (!(from < to)) {
           return {
             content: [

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -1246,6 +1246,9 @@ async function getAllTools(userId) {
           'of an energy monitoring device over a date range. ' +
           'Dates are inclusive: for a single day use the same start_date and end_date, ' +
           'for a full month use the first and last day of the month. ' +
+          'A day past the end of its month (for example 2026-02-30) is clamped to the last day of that month. ' +
+          'To cover several months or a whole year, make a single call over the whole range with group_by month ' +
+          'instead of one call per month. ' +
           'The result contains the total over the period and the detail per group_by period. ' +
           'In currency mode, a separate home_subscription entry may be present: it is the fixed subscription cost ' +
           'of the whole home electricity contract, and is not part of the device consumption cost.',
@@ -1272,19 +1275,27 @@ async function getAllTools(userId) {
         },
       },
       cb: async ({ device, start_date: startDate, end_date: endDate, unit, group_by: groupBy }) => {
+        const DAYS_PER_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+        const isLeapYear = (year) => (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+
         const parseDateInput = (value) => {
           if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
             return null;
           }
           const [year, month, day] = value.split('-').map(Number);
-          // Reject calendar-invalid dates (2026-02-30, 2026-13-01) that the
-          // Date constructor would silently roll over to another day.
-          const date = new Date(year, month - 1, day);
-          if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+          if (month < 1 || month > 12 || day < 1 || day > 31) {
             return null;
           }
-          return { year, month, day };
+          // "Last day of February" is a date a model has to compute, and it gets it
+          // wrong on non-leap years (2026-02-29) or on 30-day months (2026-04-31).
+          // That intent is unambiguous, so clamp to the end of the month instead of
+          // failing: the Date constructor would silently roll over to the next month.
+          const lastDayOfMonth = month === 2 && isLeapYear(year) ? 29 : DAYS_PER_MONTH[month - 1];
+          return { year, month, day: Math.min(day, lastDayOfMonth) };
         };
+
+        const formatDateInput = ({ year, month, day }) =>
+          `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
 
         const parsedStart = parseDateInput(startDate);
         const parsedEnd = parseDateInput(endDate);
@@ -1293,7 +1304,9 @@ async function getAllTools(userId) {
             content: [
               {
                 type: 'text',
-                text: 'device.get-energy-consumption: start_date and end_date must be valid dates in YYYY-MM-DD format',
+                text:
+                  'device.get-energy-consumption: start_date and end_date must be in YYYY-MM-DD format, ' +
+                  'with a month between 01 and 12 and a day between 01 and 31',
               },
             ],
           };
@@ -1366,8 +1379,10 @@ async function getAllTools(userId) {
           device: selectedDevice.name,
           feature: selectedFeature.name,
           unit: displayMode === 'currency' ? deviceResult?.deviceFeature?.currency_unit || 'currency' : 'kWh',
-          start_date: startDate,
-          end_date: endDate,
+          // Echo the effective period, not the raw input: a clamped date must not be
+          // reported back as the day the caller asked for.
+          start_date: formatDateInput(parsedStart),
+          end_date: formatDateInput(parsedEnd),
           group_by: groupBy || 'day',
           total: roundValue(deviceValues.reduce((acc, value) => acc + value.sum_value, 0)),
           values: deviceValues.map((value) => ({

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -1323,20 +1323,75 @@ describe('build schemas', () => {
       unit: 'kwh',
     });
     expect(invalidDateResult.content[0].text).to.eq(
-      'device.get-energy-consumption: start_date and end_date must be valid dates in YYYY-MM-DD format',
+      'device.get-energy-consumption: start_date and end_date must be in YYYY-MM-DD format, ' +
+        'with a month between 01 and 12 and a day between 01 and 31',
     );
 
-    // Calendar-invalid date that would roll over in the Date constructor.
-    const rolledOverDateResult = await energyTool.cb({
+    // Out-of-range month and day are still rejected.
+    const invalidMonthResult = await energyTool.cb({
       device: 'Prise onduleur',
-      start_date: '2026-02-30',
-      end_date: '2026-03-02',
+      start_date: '2026-13-01',
+      end_date: '2026-13-31',
       unit: 'kwh',
     });
-    expect(rolledOverDateResult.content[0].text).to.eq(
-      'device.get-energy-consumption: start_date and end_date must be valid dates in YYYY-MM-DD format',
-    );
+    expect(invalidMonthResult.content[0].text).to.contain('must be in YYYY-MM-DD format');
+    const invalidDayResult = await energyTool.cb({
+      device: 'Prise onduleur',
+      start_date: '2026-07-00',
+      end_date: '2026-07-32',
+      unit: 'kwh',
+    });
+    expect(invalidDayResult.content[0].text).to.contain('must be in YYYY-MM-DD format');
 
+    // February 29th on a non-leap year: the model means "end of February", the day
+    // is clamped to the last day of the month instead of failing the whole call.
+    getConsumptionByDates.resetHistory();
+    getConsumptionByDates.resolves([
+      {
+        device: { name: 'Prise onduleur' },
+        deviceFeature: {
+          name: 'Consommation',
+          selector: 'prise-onduleur-thirty-minutes-consumption',
+          currency_unit: null,
+        },
+        values: [{ created_at: '2026-02-01T00:00:00.000Z', value: 12, sum_value: 12 }],
+      },
+    ]);
+    const clampedFebruaryResult = await energyTool.cb({
+      device: 'Prise onduleur',
+      start_date: '2026-02-01',
+      end_date: '2026-02-29',
+      unit: 'kwh',
+      group_by: 'month',
+    });
+    expect(getConsumptionByDates.callCount).to.eq(1);
+    expect(getConsumptionByDates.firstCall.args[1]).to.deep.equal({
+      from: new Date(2026, 1, 1),
+      to: new Date(2026, 2, 1),
+      group_by: 'month',
+      display_mode: 'kwh',
+    });
+    expect(clampedFebruaryResult.content[0].text).to.eq('toonmockdata');
+    // The effective period is echoed back, not the out-of-range input.
+    expect(mcpHandler.toon.lastCall.args[0].start_date).to.eq('2026-02-01');
+    expect(mcpHandler.toon.lastCall.args[0].end_date).to.eq('2026-02-28');
+
+    // Same clamping on a leap year keeps February 29th, and on a 30-day month.
+    getConsumptionByDates.resetHistory();
+    await energyTool.cb({
+      device: 'Prise onduleur',
+      start_date: '2024-02-29',
+      end_date: '2024-04-31',
+      unit: 'kwh',
+    });
+    expect(getConsumptionByDates.firstCall.args[1]).to.deep.include({
+      from: new Date(2024, 1, 29),
+      to: new Date(2024, 4, 1),
+    });
+    expect(mcpHandler.toon.lastCall.args[0].start_date).to.eq('2024-02-29');
+    expect(mcpHandler.toon.lastCall.args[0].end_date).to.eq('2024-04-30');
+
+    getConsumptionByDates.resetHistory();
     const reversedDatesResult = await energyTool.cb({
       device: 'Prise onduleur',
       start_date: '2026-07-12',

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -1391,6 +1391,26 @@ describe('build schemas', () => {
     expect(mcpHandler.toon.lastCall.args[0].start_date).to.eq('2024-02-29');
     expect(mcpHandler.toon.lastCall.args[0].end_date).to.eq('2024-04-30');
 
+    // Years below 0100 keep their century: new Date(year, ...) would map them to
+    // 1900-1999 and query a period two millennia away from the one asked for.
+    getConsumptionByDates.resetHistory();
+    await energyTool.cb({
+      device: 'Prise onduleur',
+      start_date: '0000-02-29',
+      end_date: '0000-03-01',
+      unit: 'kwh',
+    });
+    const expectedYearZeroFrom = new Date(2000, 0, 1);
+    expectedYearZeroFrom.setFullYear(0, 1, 29);
+    const expectedYearZeroTo = new Date(2000, 0, 1);
+    expectedYearZeroTo.setFullYear(0, 2, 2);
+    expect(getConsumptionByDates.firstCall.args[1]).to.deep.include({
+      from: expectedYearZeroFrom,
+      to: expectedYearZeroTo,
+    });
+    expect(getConsumptionByDates.firstCall.args[1].from.getFullYear()).to.eq(0);
+    expect(mcpHandler.toon.lastCall.args[0].start_date).to.eq('0000-02-29');
+
     getConsumptionByDates.resetHistory();
     const reversedDatesResult = await energyTool.cb({
       device: 'Prise onduleur',


### PR DESCRIPTION
### Description

This PR improves the date handling in the `device.get-energy-consumption` MCP tool to be more lenient and user-friendly:

**Changes:**
1. **Relaxed date validation**: Instead of rejecting dates with invalid months (13+) or days (32+), the tool now only validates that months are 01-12 and days are 01-31. This allows the tool to accept dates that models commonly generate incorrectly.

2. **Smart date clamping**: Out-of-range days are now clamped to the last valid day of their month:
   - February 29th on non-leap years → February 28th
   - April 31st → April 30th
   - February 29th on leap years → February 29th (preserved)
   
   This handles the common case where models try to specify "end of month" but get the day wrong.

3. **Improved error messages**: When dates fail validation (e.g., month 13, day 0), the error message now clearly explains the constraints.

4. **Echo effective dates**: The response now reports the actual dates used (after clamping), not the raw input, so users see what period was queried.

5. **Updated documentation**: The tool description now explains the clamping behavior and recommends using `group_by: month` for multi-month queries instead of multiple calls.

**Why:** LLMs frequently generate invalid dates like "2026-02-30" when trying to specify month-end ranges. Rather than failing the entire request, we now interpret the intent and clamp to valid dates, making the tool more robust and user-friendly.

### Checklist

- [x] Tests pass: Added comprehensive test cases covering invalid months, invalid days, leap year handling, and 30-day month clamping
- [x] Linter and prettier pass
- [x] No breaking changes: The tool is more permissive; existing valid inputs work identically

https://claude.ai/code/session_01C7nwArkBMo29eZn6o3o87f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Energy-consumption date ranges now accept day values from 1–31.
  * Dates beyond a month’s final day are automatically adjusted to that month’s last valid day.
  * Leap-year February 29 remains supported, including for years before 0100.

* **Bug Fixes**
  * Improved date validation messages to clarify accepted formats and numeric ranges.
  * Returned periods now reflect the normalized, effective dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->