### PR TITLE
fix: upgrade handlebars to 4.7.9 (CVE-2026-33937)

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -26,7 +26,7 @@
         "form-data": "^2.3.3",
         "fs-extra": "^11.1.0",
         "get-value": "^3.0.1",
-        "handlebars": "^4.7.7",
+        "handlebars": "^4.7.9",
         "joi": "^17.7.0",
         "jsonwebtoken": "^8.5.1",
         "lodash.chunk": "^4.2.0",
@@ -5526,12 +5526,13 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
+        "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
         "wordwrap": "^1.0.0"
       },
@@ -15590,12 +15591,12 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "requires": {
         "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
+        "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"

--- a/server/package.json
+++ b/server/package.json
@@ -93,7 +93,7 @@
     "form-data": "^2.3.3",
     "fs-extra": "^11.1.0",
     "get-value": "^3.0.1",
-    "handlebars": "^4.7.7",
+    "handlebars": "^4.7.9",
     "joi": "^17.7.0",
     "jsonwebtoken": "^8.5.1",
     "lodash.chunk": "^4.2.0",


### PR DESCRIPTION
## Summary
Upgrade handlebars from 4.7.7 to 4.7.9 to fix CVE-2026-33937.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-33937 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-33937` |
| **File** | `server/package-lock.json` (dependency: `handlebars`) |
| **Assessment** | Likely exploitable |

**Description**: handlebars.js: Handlebars: Remote Code Execution via crafted Abstract Syntax Tree object in compile()

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-33937` flagged this pattern.

## Changes
- `server/package.json`
- `server/package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Handlebars package version constraint to support the latest compatible release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->