### PR TITLE
Fix external integration install on kernels without CPU CFS scheduler (Synology)

### DIFF
--- a/docs/specs/external-integrations.md
+++ b/docs/specs/external-integrations.md
@@ -750,7 +750,7 @@ Field-by-field justification:
 | `CapDrop` | `ALL` | no Linux capabilities |
 | `SecurityOpt` | `no-new-privileges` | no escalation via setuid binaries |
 | `Memory`/`MemorySwap` | 256 MB (same values) | swap = memory ⇒ **no swap**; OOM kill → supervised restart |
-| `NanoCpus` | `500000000` (0.5 CPU) | an integration cannot starve Gladys on a Raspberry Pi |
+| `NanoCpus` | `500000000` (0.5 CPU) | an integration cannot starve Gladys on a Raspberry Pi; **omitted** when `docker info` reports `CPUCfsQuota: false` (e.g. Synology DSM kernels without the CFS scheduler), otherwise the daemon rejects the creation with an HTTP 400 |
 | `PidsLimit` | 100 | anti fork-bomb |
 | `Binds` | a single one: `<basePath>/external-integrations/<selector>:/data` | the integration's local persistence; survives container recreations, removed at uninstall |
 | `Tmpfs /tmp` | `noexec,nosuid,64m` | scratch in RAM, no execution of dropped binaries |
@@ -769,7 +769,7 @@ Field-by-field justification:
 | Ports | `PortBindings` only for the declared `ports[]` — host port **chosen by Gladys** (free at first start, then persisted), bound to `0.0.0.0` (LAN access assumed and displayed at install, see B.14.8) |
 | Devices | `Devices` = intersection **requested (manifest) ∩ granted (`granted_devices`, UI toggles) ∩ present (detection)** — classes resolved by the supervisor: `coral-usb` → `/dev/bus/usb`, `coral-pcie` → `/dev/apex_*`, `gpu` → `/dev/dri`, `video` → `/dev/video*`; recomputed at every container creation |
 | Rootfs | `ReadonlyRootfs` per the manifest's `read_only` (default `true`) |
-| Limits | `Memory`/`MemorySwap` = `memory_mb` (default 256), `NanoCpus` = `cpu` (default 0.5), `ShmSize` = `shm_mb` (default 64) — manifest values, displayed at install |
+| Limits | `Memory`/`MemorySwap` = `memory_mb` (default 256), `NanoCpus` = `cpu` (default 0.5, omitted like on the main container when the kernel has no CFS scheduler), `ShmSize` = `shm_mb` (default 64) — manifest values, displayed at install |
 | Labels | `io.gladysassistant.external-integration: <selector>` (same reconciliation key as the main one — a single filter catches the whole group) + `io.gladysassistant.container: <name>` |
 
 The private network `gladys-int-<selector>` is created at install and carries the same label — uninstall and boot-time reconciliation remove containers **and** network through the same filter.

--- a/server/lib/external-integration/externalIntegration.buildContainerDescriptor.js
+++ b/server/lib/external-integration/externalIntegration.buildContainerDescriptor.js
@@ -25,6 +25,7 @@ async function buildContainerDescriptor(service, integrationToken) {
   const { basePathOnHost } = await this.system.getGladysBasePath();
   const hostApiUrl = await this.getHostApiUrl();
   const networkMode = await this.system.getNetworkMode();
+  const cpuCfsSupported = await this.system.hasCpuCfsSupport();
   const timezone = (await this.variable.getValue(SYSTEM_VARIABLE_NAMES.TIMEZONE)) || 'UTC';
   // When Gladys runs as a host process, the integration reaches its API
   // through `host.docker.internal`. Docker Desktop resolves it out of the
@@ -59,7 +60,9 @@ async function buildContainerDescriptor(service, integrationToken) {
       SecurityOpt: ['no-new-privileges'],
       Memory: MEMORY_LIMIT_IN_BYTES,
       MemorySwap: MEMORY_LIMIT_IN_BYTES,
-      NanoCpus: NANO_CPUS,
+      // omitted on kernels without the CPU CFS scheduler (Synology DSM):
+      // the daemon would reject the creation with an HTTP 400
+      ...(cpuCfsSupported ? { NanoCpus: NANO_CPUS } : {}),
       PidsLimit: PIDS_LIMIT,
       // the only writable bind: local persistence of the integration,
       // survives container recreations, removed at uninstall

--- a/server/lib/external-integration/externalIntegration.buildSubContainerDescriptor.js
+++ b/server/lib/external-integration/externalIntegration.buildSubContainerDescriptor.js
@@ -31,6 +31,7 @@ const PIDS_LIMIT = 100;
 async function buildSubContainerDescriptor(service, entry, { env = {} } = {}) {
   const { basePathOnHost } = await this.system.getGladysBasePath();
   const timezone = (await this.variable.getValue(SYSTEM_VARIABLE_NAMES.TIMEZONE)) || 'UTC';
+  const cpuCfsSupported = await this.system.hasCpuCfsSupport();
   const networkName = `${PRIVATE_NETWORK_PREFIX}${service.selector}`;
   const finalEnv = { ...(entry.env || {}), ...env, TZ: timezone };
   // devices: requested ∩ granted ∩ present, resolved at every creation —
@@ -89,7 +90,9 @@ async function buildSubContainerDescriptor(service, entry, { env = {} } = {}) {
       SecurityOpt: ['no-new-privileges'],
       Memory: memoryInBytes,
       MemorySwap: memoryInBytes,
-      NanoCpus: Math.round((entry.cpu || SUB_CONTAINER_CPU_DEFAULT) * 1e9),
+      // omitted on kernels without the CPU CFS scheduler (Synology DSM):
+      // the daemon would reject the creation with an HTTP 400
+      ...(cpuCfsSupported ? { NanoCpus: Math.round((entry.cpu || SUB_CONTAINER_CPU_DEFAULT) * 1e9) } : {}),
       ShmSize: (entry.shm_mb || SUB_CONTAINER_SHM_DEFAULT_MB) * BYTES_PER_MB,
       PidsLimit: PIDS_LIMIT,
       ...(binds.length > 0 ? { Binds: binds } : {}),

--- a/server/lib/system/index.js
+++ b/server/lib/system/index.js
@@ -30,6 +30,7 @@ const { restartContainer } = require('./system.restartContainer');
 const { removeContainer } = require('./system.removeContainer');
 const { stopContainer } = require('./system.stopContainer');
 const { getNetworkMode } = require('./system.getNetworkMode');
+const { hasCpuCfsSupport } = require('./system.hasCpuCfsSupport');
 const { vacuum } = require('./system.vacuum');
 const { checkIfGladysUpgraded } = require('./system.checkIfGladysUpgraded');
 const { setDuckDbTimezone } = require('./system.setDuckDbTimezone');
@@ -56,6 +57,7 @@ const System = function System(sequelize, event, config, job, variable, user, me
   // on timezone change, reset DuckDB timezone
   this.event.on(EVENTS.SYSTEM.TIMEZONE_CHANGED, eventFunctionWrapper(this.setDuckDbTimezone.bind(this)));
   this.networkMode = null;
+  this.cpuCfsSupport = null;
   this.gladysLogsCache = null;
 };
 
@@ -88,6 +90,7 @@ System.prototype.restartContainer = restartContainer;
 System.prototype.removeContainer = removeContainer;
 System.prototype.stopContainer = stopContainer;
 System.prototype.getNetworkMode = getNetworkMode;
+System.prototype.hasCpuCfsSupport = hasCpuCfsSupport;
 System.prototype.vacuum = vacuum;
 System.prototype.setDuckDbTimezone = setDuckDbTimezone;
 System.prototype.shutdown = shutdown;

--- a/server/lib/system/system.hasCpuCfsSupport.js
+++ b/server/lib/system/system.hasCpuCfsSupport.js
@@ -1,0 +1,33 @@
+const logger = require('../../utils/logger');
+const { PlatformNotCompatible } = require('../../utils/coreErrors');
+
+/**
+ * @description Check if the Docker host kernel supports the CPU CFS scheduler.
+ * Some kernels (Synology DSM among others) are compiled without CFS bandwidth
+ * control: setting NanoCpus there makes the daemon reject container creation
+ * with "NanoCPUs can not be set" (HTTP 400).
+ * @returns {Promise<boolean>} Resolve with true if CPU limits can be set.
+ * @example
+ * const cpuCfsSupported = await this.hasCpuCfsSupport();
+ */
+async function hasCpuCfsSupport() {
+  if (!this.dockerode) {
+    throw new PlatformNotCompatible('SYSTEM_NOT_RUNNING_DOCKER');
+  }
+  if (this.cpuCfsSupport === null) {
+    try {
+      const dockerInfo = await this.dockerode.info();
+      // only an explicit false means unsupported: on any doubt keep the
+      // CPU limit, the kernels concerned always report the field
+      this.cpuCfsSupport = dockerInfo.CPUCfsQuota !== false;
+    } catch (e) {
+      logger.warn(`hasCpuCfsSupport: unable to read Docker info, assuming CPU CFS support. ${e}`);
+      return true;
+    }
+  }
+  return this.cpuCfsSupport;
+}
+
+module.exports = {
+  hasCpuCfsSupport,
+};

--- a/server/test/lib/external-integration/externalIntegration.buildContainerDescriptor.test.js
+++ b/server/test/lib/external-integration/externalIntegration.buildContainerDescriptor.test.js
@@ -66,6 +66,18 @@ describe('externalIntegration.buildContainerDescriptor', () => {
     );
   });
 
+  it('should omit NanoCpus when the kernel has no CPU CFS support', async () => {
+    const { externalIntegration } = buildSupervisor({
+      system: {
+        hasCpuCfsSupport: fake.resolves(false),
+      },
+    });
+    const service = await seedExternalService();
+    const descriptor = await externalIntegration.buildContainerDescriptor(service, 'token');
+    expect(descriptor.HostConfig).to.not.have.property('NanoCpus');
+    expect(descriptor.HostConfig.Memory).to.equal(268435456);
+  });
+
   it('should not add ExtraHosts when Gladys runs in a container', async () => {
     const { externalIntegration } = buildSupervisor();
     const service = await seedExternalService();

--- a/server/test/lib/external-integration/externalIntegration.buildSubContainerDescriptor.test.js
+++ b/server/test/lib/external-integration/externalIntegration.buildSubContainerDescriptor.test.js
@@ -1,4 +1,5 @@
 const { expect } = require('chai');
+const { fake } = require('sinon');
 
 const { buildSupervisor, seedExternalService, TEST_CONTAINERS_MANIFEST } = require('./testUtils.test');
 const { SUB_CONTAINER_PORTS_VARIABLE } = require('../../../lib/external-integration/constants');
@@ -79,6 +80,19 @@ describe('externalIntegration.buildSubContainerDescriptor', () => {
       '/var/lib/gladysassistant/external-integrations/ext-dev-open-meteo-demo/containers/mqtt/mosquitto/config:/mosquitto/config',
       '/var/lib/gladysassistant/external-integrations/ext-dev-open-meteo-demo/containers/mqtt/mosquitto/data:/mosquitto/data',
     ]);
+  });
+
+  it('should omit NanoCpus when the kernel has no CPU CFS support', async () => {
+    const { externalIntegration } = buildSupervisor({
+      system: {
+        hasCpuCfsSupport: fake.resolves(false),
+      },
+    });
+    const service = await seedExternalService({ manifest: TEST_CONTAINERS_MANIFEST });
+    const entry = TEST_CONTAINERS_MANIFEST.containers[0];
+    const descriptor = await externalIntegration.buildSubContainerDescriptor(service, entry);
+    expect(descriptor.HostConfig).to.not.have.property('NanoCpus');
+    expect(descriptor.HostConfig.Memory).to.equal(128 * 1024 * 1024);
   });
 
   it('should not mount a granted class that is not detected', async () => {

--- a/server/test/lib/external-integration/testUtils.test.js
+++ b/server/test/lib/external-integration/testUtils.test.js
@@ -182,6 +182,7 @@ function buildFakeSystem(overrides = {}) {
     connectToNetwork: fake.resolves(true),
     inspectNetwork: fake.resolves({ IPAM: { Config: [{ Gateway: '172.30.0.1' }] } }),
     getNetworkMode: fake.resolves('host'),
+    hasCpuCfsSupport: fake.resolves(true),
     getGladysBasePath: fake.resolves({
       basePathOnContainer: '/var/lib/gladysassistant',
       basePathOnHost: '/var/lib/gladysassistant',

--- a/server/test/lib/system/DockerodeMock.test.js
+++ b/server/test/lib/system/DockerodeMock.test.js
@@ -14,6 +14,7 @@ class Docker {
 }
 
 Docker.prototype.listContainers = fake.resolves(containers);
+Docker.prototype.info = fake.resolves({ CPUCfsQuota: true });
 Docker.prototype.listImages = fake.resolves(images);
 
 const container = {

--- a/server/test/lib/system/system.hasCpuCfsSupport.test.js
+++ b/server/test/lib/system/system.hasCpuCfsSupport.test.js
@@ -1,0 +1,89 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const { fake, assert } = sinon;
+
+const proxyquire = require('proxyquire').noCallThru();
+
+const { PlatformNotCompatible } = require('../../../utils/coreErrors');
+const DockerodeMock = require('./DockerodeMock.test');
+
+const System = proxyquire('../../../lib/system', {
+  dockerode: DockerodeMock,
+});
+const Job = require('../../../lib/job');
+
+const sequelize = {
+  close: fake.resolves(null),
+};
+
+const event = {
+  on: fake.resolves(null),
+  emit: fake.resolves(null),
+};
+
+const job = new Job(event);
+
+const config = {
+  tempFolder: '/tmp/gladys',
+};
+
+describe('system.hasCpuCfsSupport', () => {
+  let system;
+
+  beforeEach(async () => {
+    system = new System(sequelize, event, config, job);
+    await system.init();
+    // Reset all fakes invoked within init call
+    sinon.reset();
+  });
+
+  afterEach(() => {
+    sinon.reset();
+  });
+
+  it('should failed as not on docker env', async () => {
+    system.dockerode = undefined;
+
+    try {
+      await system.hasCpuCfsSupport();
+      assert.fail('should have fail');
+    } catch (e) {
+      expect(e).be.instanceOf(PlatformNotCompatible);
+    }
+  });
+
+  it('should return true when the kernel supports CPU CFS', async () => {
+    system.dockerode.info = fake.resolves({ CPUCfsQuota: true });
+    const cpuCfsSupported = await system.hasCpuCfsSupport();
+    expect(cpuCfsSupported).to.equal(true);
+  });
+
+  it('should return false when the kernel has no CPU CFS support', async () => {
+    system.dockerode.info = fake.resolves({ CPUCfsQuota: false });
+    const cpuCfsSupported = await system.hasCpuCfsSupport();
+    expect(cpuCfsSupported).to.equal(false);
+  });
+
+  it('should cache the result', async () => {
+    const info = fake.resolves({ CPUCfsQuota: false });
+    system.dockerode.info = info;
+    await system.hasCpuCfsSupport();
+    const cpuCfsSupported = await system.hasCpuCfsSupport();
+    expect(cpuCfsSupported).to.equal(false);
+    assert.calledOnce(info);
+  });
+
+  it('should default to true when the field is missing', async () => {
+    system.dockerode.info = fake.resolves({});
+    const cpuCfsSupported = await system.hasCpuCfsSupport();
+    expect(cpuCfsSupported).to.equal(true);
+  });
+
+  it('should default to true when Docker info fails, without caching', async () => {
+    system.dockerode.info = fake.rejects(new Error('socket error'));
+    const cpuCfsSupported = await system.hasCpuCfsSupport();
+    expect(cpuCfsSupported).to.equal(true);
+    expect(system.cpuCfsSupport).to.equal(null);
+  });
+});


### PR DESCRIPTION
On Synology DSM (e.g. DS920+), the kernel is compiled without CFS
bandwidth control, so Docker rejects container creation with an HTTP 400
"NanoCPUs can not be set" when the descriptor includes NanoCpus.

Add System.hasCpuCfsSupport(), which reads CPUCfsQuota from docker info
(cached), and omit NanoCpus from the main and sub-container descriptors
when the kernel does not support it. Memory, pids and log limits are
kept in all cases.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qkety8pE7SttcMH8MovUbG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container creation on systems where Docker CPU quota controls are unavailable.
  * CPU limits are now applied only when supported, while memory and other resource settings remain unchanged.
  * Applies to both primary and secondary containers.

* **Tests**
  * Added coverage for supported, unsupported, unavailable, and cached CPU capability detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->