### PR TITLE
Add workflow_dispatch to trigger Cursor automation webhooks

### DIFF
--- a/.github/workflows/cursor-automation-webhook.yml
+++ b/.github/workflows/cursor-automation-webhook.yml
@@ -1,0 +1,104 @@
+name: Trigger Cursor automation
+
+# Manual button to start a Cursor Automation webhook for a given PR.
+# Useful for fork PRs, which native Cursor PR triggers cannot run on.
+#
+# Required repository secrets:
+#   CURSOR_AUTOMATION_WEBHOOK_URL   - full webhook URL from the automation page
+#                                     (https://api2.cursor.sh/automations/webhook/<id>)
+#   CURSOR_AUTOMATION_WEBHOOK_TOKEN - API key from "Generate auth header"
+#                                     (crsr_... value only, without "Bearer ")
+#
+# SECURITY: this workflow never checks out or executes PR head code. It only
+# reads PR metadata through the GitHub API, then POSTs to Cursor.
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to pass to the Cursor automation
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate secrets
+        env:
+          WEBHOOK_URL: ${{ secrets.CURSOR_AUTOMATION_WEBHOOK_URL }}
+          WEBHOOK_TOKEN: ${{ secrets.CURSOR_AUTOMATION_WEBHOOK_TOKEN }}
+        run: |
+          if [ -z "$WEBHOOK_URL" ]; then
+            echo "::error::Missing secret CURSOR_AUTOMATION_WEBHOOK_URL"
+            exit 1
+          fi
+          if [ -z "$WEBHOOK_TOKEN" ]; then
+            echo "::error::Missing secret CURSOR_AUTOMATION_WEBHOOK_TOKEN"
+            exit 1
+          fi
+
+      - name: Fetch PR metadata and call Cursor webhook
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          WEBHOOK_URL: ${{ secrets.CURSOR_AUTOMATION_WEBHOOK_URL }}
+          WEBHOOK_TOKEN: ${{ secrets.CURSOR_AUTOMATION_WEBHOOK_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER=$(echo "$PR_NUMBER" | tr -d '[:space:]')
+          case "$PR_NUMBER" in
+            ''|*[!0-9]*)
+              echo "::error::Invalid PR number '$PR_NUMBER'"
+              exit 1
+              ;;
+          esac
+
+          # REST payload is stable for fork and same-repo PRs.
+          PR_JSON=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}")
+
+          PAYLOAD=$(jq -n \
+            --argjson pr "$PR_JSON" \
+            --arg repo "$GH_REPO" \
+            '{
+              pr_number: $pr.number,
+              pr_url: $pr.html_url,
+              repo: $repo,
+              title: $pr.title,
+              body: ($pr.body // ""),
+              state: $pr.state,
+              base_ref: $pr.base.ref,
+              head_ref: $pr.head.ref,
+              head_sha: $pr.head.sha,
+              is_fork: ($pr.head.repo.full_name != $repo),
+              author: $pr.user.login,
+              head_repository: ($pr.head.repo.full_name // $repo)
+            }')
+
+          echo "Triggering Cursor automation for PR #${PR_NUMBER}"
+          echo "$PAYLOAD" | jq '{pr_number, pr_url, repo, title, head_ref, head_sha, is_fork, author, head_repository}'
+
+          HTTP_CODE=$(curl -sS -o /tmp/cursor-webhook-response.txt -w "%{http_code}" \
+            -X POST "$WEBHOOK_URL" \
+            -H "Authorization: Bearer ${WEBHOOK_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+
+          echo "Cursor webhook HTTP status: ${HTTP_CODE}"
+          cat /tmp/cursor-webhook-response.txt
+          echo
+
+          case "$HTTP_CODE" in
+            2*)
+              echo "Cursor automation triggered successfully."
+              ;;
+            *)
+              echo "::error::Cursor webhook failed with HTTP ${HTTP_CODE}"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/cursor-automation-webhook.yml
+++ b/.github/workflows/cursor-automation-webhook.yml
@@ -83,6 +83,8 @@ jobs:
           echo "Triggering Cursor automation for PR #${PR_NUMBER}"
           echo "$PAYLOAD" | jq '{pr_number, pr_url, repo, title, head_ref, head_sha, is_fork, author, head_repository}'
 
+          # Response body is only printed on failure: Actions logs are public
+          # on this repo, and Cursor error payloads may include internal ids.
           HTTP_CODE=$(curl -sS -o /tmp/cursor-webhook-response.txt -w "%{http_code}" \
             -X POST "$WEBHOOK_URL" \
             -H "Authorization: Bearer ${WEBHOOK_TOKEN}" \
@@ -90,8 +92,6 @@ jobs:
             -d "$PAYLOAD")
 
           echo "Cursor webhook HTTP status: ${HTTP_CODE}"
-          cat /tmp/cursor-webhook-response.txt
-          echo
 
           case "$HTTP_CODE" in
             2*)
@@ -99,6 +99,8 @@ jobs:
               ;;
             *)
               echo "::error::Cursor webhook failed with HTTP ${HTTP_CODE}"
+              head -c 2000 /tmp/cursor-webhook-response.txt
+              echo
               exit 1
               ;;
           esac


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Adds a manual GitHub Actions workflow (`Trigger Cursor automation`) that posts PR metadata to a Cursor Automation webhook.

This is a practical workaround for **fork PRs**, which native Cursor PR triggers cannot run on (`Fork pull requests not supported`).

**How to use after merge:**

1. Create a Cursor Automation with a **Webhook** trigger
2. Add these repository secrets:
   - `CURSOR_AUTOMATION_WEBHOOK_URL` — full webhook URL from the automation page
   - `CURSOR_AUTOMATION_WEBHOOK_TOKEN` — API key from “Generate auth header” (`crsr_…` only, without `Bearer `)
3. In Actions → **Trigger Cursor automation** → Run workflow → enter the PR number

The workflow never checks out PR head code; it only reads PR metadata via the GitHub API, then POSTs JSON (`pr_number`, `pr_url`, `title`, `head_sha`, `is_fork`, etc.) to Cursor. That payload is appended to the automation prompt.

On success it only logs the HTTP status. On failure it prints a truncated (2KB) response body, since Actions logs are public on this repo.

### Checklist

- [x] Tests pass: N/A (workflow-only change)
- [x] Linter and prettier pass on both front and server: N/A
- [x] No undocumented breaking change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c293c576-40db-48b6-96eb-731e64d7d327?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c293c576-40db-48b6-96eb-731e64d7d327&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered workflow for sending pull request metadata to Cursor automation.
  * Supports specifying and validating a pull request number and required configuration.
  * Retrieves pull request details and securely forwards them to the automation service.
  * Detects pull requests from forks and uses read-only access without running pull request code.
  * Reports unsuccessful webhook responses and clearly surfaces configuration or validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->