### PR TITLE
Fix device edit page showing a broken category selector on binary sensors

### DIFF
--- a/front/src/components/device/UpdateDeviceFeature.jsx
+++ b/front/src/components/device/UpdateDeviceFeature.jsx
@@ -32,8 +32,15 @@ class UpdateDeviceFeature extends Component {
   deleteFeature = () => this.props.deleteFeature(this.props.featureIndex);
 
   render({ feature, featureIndex, canEditCategory, device, ...props }) {
+    // The current category must belong to the compatible list: types are not unique across
+    // categories (SWITCH.BINARY and SENSOR.BINARY are both 'binary'), so checking the type
+    // alone would display the selector on read-only binary sensors and wipe their category.
+    const compatibleCategories = DEVICE_FEATURE_COMPATIBLE_CATEGORY[feature.type];
     const allowModifyCategory =
-      canEditCategory && canEditCategory(device, feature) && DEVICE_FEATURE_COMPATIBLE_CATEGORY[feature.type];
+      canEditCategory &&
+      canEditCategory(device, feature) &&
+      compatibleCategories &&
+      compatibleCategories.includes(feature.category);
     const availableUnits =
       get(DEVICE_FEATURE_UNITS_BY_CATEGORY_AND_TYPE, `${feature.category}.${feature.type}`) ||
       DEVICE_FEATURE_UNITS_BY_CATEGORY[feature.category];
@@ -74,9 +81,6 @@ class UpdateDeviceFeature extends Component {
                     onChange={this.updateCategory}
                     class="form-control"
                   >
-                    <option value="">
-                      <Text id="global.emptySelectOption" />
-                    </option>
                     {DEVICE_FEATURE_COMPATIBLE_CATEGORY[feature.type].map(type => (
                       <option value={type}>
                         <Text id={`deviceFeatureCategory.${type}.shortCategoryName`}>{type}</Text>


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests? — no front unit-test infrastructure for this component; the change is a 2-line rendering condition, covered by Cypress E2E in CI
- [x] Are server tests passing with coverage? (`cd server && npm run coverage`) — no server change
- [x] Did Cypress E2E tests pass? (`npm run cypress:run` from repo root, if UI changed) — run by CI
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new feature/service, did you run the integration comparator? — no new service, no translation change
- [x] Did you test this pull request in real life? With real devices? — reproduced from the device data reported on the [forum](https://community.gladysassistant.com/t/moes-porte-de-garage-ts0601-par-tze204-jktmrpoj/10362/21)
- [x] If your changes modify the API (REST or Node.js), did you modify the API documentation? — no API change
- [x] If you are adding a new features/services which needs explanation, did you modify the user documentation? — bug fix, no doc change
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.js`)? — not needed

### Description of change

Follow-up to #2721, reported on the forum ([post #21](https://community.gladysassistant.com/t/moes-porte-de-garage-ts0601-par-tze204-jktmrpoj/10362/21)): after saving the Moes garage door opener, the user's `garage_door_contact` opening-sensor feature ended up with an **empty category** — blank chip in the features list, blank card header (no icon, no label), and a "Catégorie" dropdown stuck on the empty `---------` option.

**Root cause** — in `UpdateDeviceFeature.jsx`, the category selector visibility relies on `canEditCategory` callbacks (Zigbee2MQTT, Tasmota) that test `feature.type === DEVICE_FEATURE_TYPES.SWITCH.BINARY`. But `SWITCH.BINARY` and `SENSOR.BINARY` are the same string (`'binary'`), so the selector also appeared on **read-only binary sensors** (opening sensor, leak sensor, smoke sensor…). For those features the dropdown only offered Light/Switch plus an empty option, displayed as `---------` since the current category wasn't in the list — and interacting with it then saving wiped the feature's category, breaking the feature's display and its use in dashboards/scenes.

Two changes in `front/src/components/device/UpdateDeviceFeature.jsx`:

- Only render the category selector when the feature's **current category belongs to the compatible list** for its type (`light`/`switch` for binary, `shutter`/`curtain` for state). Binary sensors no longer show the selector; the switch ↔ light and shutter ↔ curtain reclassification behavior is unchanged.
- Remove the empty `---------` option from the category selector, so a feature category can no longer be saved empty from this page.

Users affected by the bug (empty category on a feature) can fix their device by deleting it in Gladys and re-saving it from the Zigbee discovery page — features are recreated with the correct categories, no Zigbee re-pairing needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMkbyfpQSryxVRnKPnjitK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved category editing by restricting selections to categories compatible with the device feature type.
  * Ensured the current category remains valid before allowing edits.
  * Removed the empty category option from the selector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->