### PR TITLE
Make the release workflow work with the master branch protection

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,7 +1,9 @@
 name: Create release tag
 
 # Tags master as soon as the version in package.json changes, whether the bump
-# came from the "Prepare release" workflow or was pushed by hand.
+# came from the "Prepare release" workflow or was pushed by hand. Editing the
+# version field in an unrelated pull request therefore ships a release: it is
+# not a casually editable field.
 on:
   push:
     branches:
@@ -34,18 +36,26 @@ jobs:
           # package.json also changes for plain dependency updates: only an
           # unreleased version is worth tagging. An empty output skips the
           # remaining steps.
-          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
-            echo "Tag ${TAG} already exists, nothing to release."
-          else
+          TAGGED_COMMIT=$(git rev-parse -q --verify "refs/tags/${TAG}^{commit}" || true)
+          if [ -z "${TAGGED_COMMIT}" ]; then
             echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+            echo "create=true" >> "$GITHUB_OUTPUT"
+          elif [ "${TAGGED_COMMIT}" = "${GITHUB_SHA}" ]; then
+            # The tag was created by an earlier attempt on this very commit, which
+            # then failed. Keep going, without recreating it, so re-running the job
+            # replays the dispatches it never reached.
+            echo "Tag ${TAG} already points at this commit, replaying the dispatches."
+            echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag ${TAG} already exists on another commit, nothing to release."
           fi
       - name: 🔧 Configure git
-        if: steps.version.outputs.tag
+        if: steps.version.outputs.create
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: 🔖 Create and push the tag
-        if: steps.version.outputs.tag
+        if: steps.version.outputs.create
         env:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
@@ -64,7 +74,18 @@ jobs:
           # start from a GITHUB_TOKEN, which is why no PAT is needed here.
           for workflow in docker-release-build.yml build-demo-website.yml build-apidoc-documentation.yml; do
             echo "Triggering ${workflow} on ${TAG}"
-            gh workflow run "${workflow}" --ref "${TAG}"
+            # The tag was pushed a second ago and may not be visible to the API yet.
+            for attempt in 1 2 3; do
+              if gh workflow run "${workflow}" --ref "${TAG}"; then
+                break
+              fi
+              if [ "${attempt}" = 3 ]; then
+                echo "::error::Could not dispatch ${workflow} on ${TAG}. Re-run this job to replay the dispatches."
+                exit 1
+              fi
+              echo "Dispatch failed, retrying in 5s (attempt ${attempt}/3)"
+              sleep 5
+            done
           done
       - name: 📝 Job summary
         if: steps.version.outputs.tag

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,91 +1,80 @@
 name: Create release tag
-run-name: Create ${{ inputs.release_type }} release tag
 
+# Tags master as soon as the version in package.json changes, whether the bump
+# came from the "Prepare release" workflow or was pushed by hand.
 on:
-  workflow_dispatch:
-    inputs:
-      release_type:
-        description: 'Type of version bump'
-        required: true
-        default: 'patch'
-        type: choice
-        options:
-          - patch
-          - minor
+  push:
+    branches:
+      - master
+    paths:
+      - package.json
 
 permissions:
   contents: write
   # Needed to dispatch the release workflows on the new tag.
   actions: write
 
-# Two overlapping runs would bump from the same tip and race on the same tag.
 concurrency:
   group: create-release-tag
   cancel-in-progress: false
 
 jobs:
   create-release-tag:
-    name: Bump version and push tag
+    name: Tag the new version
     runs-on: ubuntu-latest
     steps:
-      - name: 🛑 Ensure workflow runs on master
-        if: github.ref != 'refs/heads/master'
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          echo "::error::This workflow can only be run on master, got ${REF_NAME}."
-          exit 1
       - name: ⬇️ Checkout Gladys code
         uses: actions/checkout@v4
         with:
-          # Always release from the current tip of master, not from the commit
-          # master pointed at when the workflow was dispatched.
-          ref: master
           fetch-depth: 0
-      - name: 💽 Setup nodejs
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: './package.json'
+      - name: 🔍 Read the version to tag
+        id: version
+        run: |
+          TAG="v$(node -p "require('./package.json').version")"
+          # package.json also changes for plain dependency updates: only an
+          # unreleased version is worth tagging. An empty output skips the
+          # remaining steps.
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} already exists, nothing to release."
+          else
+            echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          fi
       - name: 🔧 Configure git
+        if: steps.version.outputs.tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - name: 🔖 Bump version and create tag
-        id: bump
+      - name: 🔖 Create and push the tag
+        if: steps.version.outputs.tag
         env:
-          RELEASE_TYPE: ${{ inputs.release_type }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          NEW_VERSION=$(npm version "${RELEASE_TYPE}")
-          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Created tag ${NEW_VERSION}"
-      - name: 🚀 Push commit and tag
-        env:
-          NEW_VERSION: ${{ steps.bump.outputs.version }}
-        run: |
-          git push --atomic origin master "refs/tags/${NEW_VERSION}"
+          git tag -a "${TAG}" -m "${TAG}"
+          git push origin "refs/tags/${TAG}"
       - name: 🎬 Trigger the release workflows
+        if: steps.version.outputs.tag
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          NEW_VERSION: ${{ steps.bump.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
           # A tag pushed with the default GITHUB_TOKEN does not trigger the
           # workflows listening on `push: tags`, so they are dispatched explicitly
           # on the new tag. workflow_dispatch is one of the two events GitHub does
           # start from a GITHUB_TOKEN, which is why no PAT is needed here.
           for workflow in docker-release-build.yml build-demo-website.yml build-apidoc-documentation.yml; do
-            echo "Triggering ${workflow} on ${NEW_VERSION}"
-            gh workflow run "${workflow}" --ref "${NEW_VERSION}"
+            echo "Triggering ${workflow} on ${TAG}"
+            gh workflow run "${workflow}" --ref "${TAG}"
           done
       - name: 📝 Job summary
+        if: steps.version.outputs.tag
         env:
-          NEW_VERSION: ${{ steps.bump.outputs.version }}
-          RELEASE_TYPE: ${{ inputs.release_type }}
+          TAG: ${{ steps.version.outputs.tag }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
         run: |
           {
-            echo "### 🚀 Release ${NEW_VERSION} created"
+            echo "### 🚀 Release ${TAG} created"
             echo ""
-            echo "- Bump type: \`${RELEASE_TYPE}\`"
-            echo "- Tag: [\`${NEW_VERSION}\`](${{ github.server_url }}/${{ github.repository }}/releases/tag/${NEW_VERSION})"
+            echo "- Tag: [\`${TAG}\`](${REPO_URL}/releases/tag/${TAG})"
             echo "- Release workflows dispatched on the tag: production images, demo website, apidoc"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -61,6 +61,11 @@ jobs:
             exit 1
           fi
           BRANCH="release/${TAG}"
+          if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+            echo "::error::Branch ${BRANCH} already exists, from an abandoned release."
+            echo "::error::Reuse its pull request, or delete the branch and run this workflow again."
+            exit 1
+          fi
           git switch -c "${BRANCH}"
           git add package.json package-lock.json
           # Version-only commit message, as every release commit before it.

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,95 @@
+name: Prepare release
+run-name: Prepare ${{ inputs.release_type }} release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Type of version bump'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+
+permissions:
+  contents: write
+
+# Two overlapping runs would bump from the same tip and race on the same version.
+concurrency:
+  group: prepare-release
+  cancel-in-progress: false
+
+jobs:
+  prepare-release:
+    name: Bump version on a release branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛑 Ensure workflow runs on master
+        if: github.ref != 'refs/heads/master'
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          echo "::error::This workflow can only be run on master, got ${REF_NAME}."
+          exit 1
+      - name: ⬇️ Checkout Gladys code
+        uses: actions/checkout@v4
+        with:
+          # Always release from the current tip of master, not from the commit
+          # master pointed at when the workflow was dispatched.
+          ref: master
+          fetch-depth: 0
+      - name: 💽 Setup nodejs
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: './package.json'
+      - name: 🔧 Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: 🔖 Bump version on a release branch
+        id: bump
+        env:
+          RELEASE_TYPE: ${{ inputs.release_type }}
+        run: |
+          npm version "${RELEASE_TYPE}" --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v${VERSION}"
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "::error::Tag ${TAG} already exists, master may not have been released yet."
+            exit 1
+          fi
+          BRANCH="release/${TAG}"
+          git switch -c "${BRANCH}"
+          git add package.json package-lock.json
+          # Version-only commit message, as every release commit before it.
+          git commit -m "${VERSION}"
+          git push origin "${BRANCH}"
+          {
+            echo "version=${VERSION}"
+            echo "tag=${TAG}"
+            echo "branch=${BRANCH}"
+          } >> "$GITHUB_OUTPUT"
+      - name: 📝 Job summary
+        env:
+          TAG: ${{ steps.bump.outputs.tag }}
+          BRANCH: ${{ steps.bump.outputs.branch }}
+          RELEASE_TYPE: ${{ inputs.release_type }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          {
+            echo "### 📦 Release ${TAG} ready for review"
+            echo ""
+            echo "- Bump type: \`${RELEASE_TYPE}\`"
+            echo "- Branch: [\`${BRANCH}\`](${REPO_URL}/tree/${BRANCH})"
+            echo ""
+            echo "**[👉 Open the release pull request](${REPO_URL}/compare/master...${BRANCH}?expand=1)**"
+            echo ""
+            echo "The pull request has to be opened by a human: GitHub does not run the"
+            echo "required checks on a pull request opened by the \`GITHUB_TOKEN\`, so an"
+            echo "automatically opened one would stay blocked on them forever."
+            echo ""
+            echo "Once it is merged, the \`Create release tag\` workflow tags \`${TAG}\` on"
+            echo "master and starts the production images, demo website and apidoc builds."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Description

Follow-up to #2753. The workflow it added could not actually run a release: pushing the version commit to `master` failed with `GH006`, because the branch requires a pull request and 6 status checks, and `github-actions[bot]` has no bypass.

Having the workflow open that pull request itself does not solve it either — GitHub does not run checks on a pull request created with the `GITHUB_TOKEN`, so it would stay blocked on the required checks forever. A one-click release would need an identity allowed to bypass the protection (a GitHub App token or an admin PAT). Instead, this splits the release in two so it works with the protection as it stands, and with no secret to configure.

**`prepare-release.yml`** — manual dispatch, `patch` or `minor`. Bumps the version with `npm version --no-git-tag-version`, commits it on a `release/vX.Y.Z` branch, pushes that branch, and links to the pull request to open from the job summary. Because a human opens it, the required checks run — so the release commit is tested before it is tagged.

**`create-release-tag.yml`** — now triggered by a push on `master` touching `package.json`. It reads the version, and if no matching tag exists, creates `vX.Y.Z` and dispatches the production images, demo website and apidoc builds. Tags are not covered by the branch protection, so the `GITHUB_TOKEN` is enough. It is idempotent: a `package.json` change without a version bump does nothing.

Side effect worth noting: this also covers the current manual process. A bump commit pushed by hand to `master` now gets tagged and released automatically, without going through `prepare-release`.

The explicit dispatch of the downstream builds is kept from #2753: a tag pushed with the `GITHUB_TOKEN` does not trigger workflows listening on `push: tags`, and `workflow_dispatch` is one of the two events GitHub does start from that token.

## Forum

N/A

### Checklist

- [x] Tests pass — no application code changed, only GitHub Actions workflows
- [x] Linter and prettier pass on both front and server — no front or server file changed
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpWWjywQsozhFp7pgsz1Cy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a guided release-preparation workflow supporting patch and minor releases.
  - Release preparation now creates a dedicated release branch and provides clear next steps and release details.
- **Bug Fixes**
  - Prevented duplicate release tags from being created.
  - Automated release tagging now uses the package version and skips tags that already exist.
- **Chores**
  - Improved release automation with safer validation, serialized runs, and clearer status summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->