### PR TITLE
Fix disarming an alarm while it is arming

### DIFF
--- a/server/lib/house/house.disarm.js
+++ b/server/lib/house/house.disarm.js
@@ -13,8 +13,9 @@ const { NotFoundError, ConflictError } = require('../../utils/coreErrors');
  */
 async function disarm(selector) {
   // In case there is a timeout to arm this house, we clear it
-  clearTimeout(this.armingHouseTimeout.get(selector));
-  if (this.armingHouseTimeout.get(selector)) {
+  const armingWasInProgress = this.armingHouseTimeout.has(selector);
+  if (armingWasInProgress) {
+    clearTimeout(this.armingHouseTimeout.get(selector));
     this.armingHouseTimeout.delete(selector);
   }
   // Delete all rate limit associated to this house
@@ -30,7 +31,10 @@ async function disarm(selector) {
     throw new NotFoundError('House not found');
   }
 
-  if (house.alarm_mode === ALARM_MODES.DISARMED) {
+  // While a house is arming, its alarm mode is still "disarmed" in DB: it only switches
+  // to "armed" at the end of the delay. So we only consider the house already disarmed
+  // when there was no arming in progress to cancel.
+  if (house.alarm_mode === ALARM_MODES.DISARMED && !armingWasInProgress) {
     throw new ConflictError('House is already disarmed');
   }
   // Update database

--- a/server/lib/house/house.disarmWithCode.js
+++ b/server/lib/house/house.disarmWithCode.js
@@ -45,8 +45,11 @@ async function disarmWithCode(selector, code) {
   // If code is right, delete all rate limit associated to this house
   await this.alarmCodeRateLimit.delete(selector);
 
-  // In this case, we don't throw an error if the house is already disarmed
-  if (house.alarm_mode === ALARM_MODES.DISARMED) {
+  // In this case, we don't throw an error if the house is already disarmed.
+  // A house currently arming is still "disarmed" in DB, so we let it go through
+  // disarm to cancel the pending arming.
+  const armingInProgress = this.armingHouseTimeout.has(selector);
+  if (house.alarm_mode === ALARM_MODES.DISARMED && !armingInProgress) {
     return house.get({ plain: true });
   }
 

--- a/server/test/lib/house/house.disarm.test.js
+++ b/server/test/lib/house/house.disarm.test.js
@@ -1,6 +1,7 @@
 const { expect } = require('chai');
 const assertChai = require('chai').assert;
 const sinon = require('sinon');
+const Promise = require('bluebird');
 
 const { fake, assert } = sinon;
 
@@ -54,10 +55,40 @@ describe('house.disarm', () => {
       alarm_mode: ALARM_MODES.DISARMED,
     });
     await house.arm('test-house');
-    const promise = house.disarm('test-house');
-    await assertChai.isRejected(promise);
+    sinon.reset();
+    await house.disarm('test-house');
     // Timeout should be deleted
     expect(house.armingHouseTimeout.size).to.equal(0);
+    // The UI & the scenes should be notified the house is disarmed
+    assert.calledTwice(event.emit);
+    expect(event.emit.firstCall.args).to.deep.equal([
+      EVENTS.TRIGGERS.CHECK,
+      {
+        type: EVENTS.ALARM.DISARM,
+        house: 'test-house',
+      },
+    ]);
+    expect(event.emit.secondCall.args).to.deep.equal([
+      EVENTS.WEBSOCKET.SEND_ALL,
+      {
+        type: WEBSOCKET_MESSAGE_TYPES.ALARM.DISARMED,
+        payload: {
+          house: 'test-house',
+        },
+      },
+    ]);
+  });
+  it('should not arm the house after the delay when arming was cancelled', async () => {
+    await house.update('test-house', {
+      alarm_delay_before_arming: 0.001,
+      alarm_mode: ALARM_MODES.DISARMED,
+    });
+    await house.arm('test-house');
+    await house.disarm('test-house');
+    // Wait for the arming delay to be over
+    await Promise.delay(20);
+    const houseInDb = await house.getBySelector('test-house');
+    expect(houseInDb.alarm_mode).to.equal(ALARM_MODES.DISARMED);
   });
   it('should return house not found', async () => {
     const promise = house.disarm('house-not-found');

--- a/server/test/lib/house/house.disarmWithCode.test.js
+++ b/server/test/lib/house/house.disarmWithCode.test.js
@@ -74,4 +74,33 @@ describe('house.disarmWithCode', () => {
     await house.disarmWithCode('test-house', '123456');
     await house.disarmWithCode('test-house', '123456');
   });
+  it('should cancel the arming in progress', async () => {
+    await house.update('test-house', {
+      alarm_code: '123456',
+      alarm_delay_before_arming: 5,
+      alarm_mode: ALARM_MODES.DISARMED,
+    });
+    await house.arm('test-house');
+    sinon.reset();
+    await house.disarmWithCode('test-house', '123456');
+    // Timeout should be deleted
+    expect(house.armingHouseTimeout.size).to.equal(0);
+    assert.calledTwice(event.emit);
+    expect(event.emit.firstCall.args).to.deep.equal([
+      EVENTS.TRIGGERS.CHECK,
+      {
+        type: EVENTS.ALARM.DISARM,
+        house: 'test-house',
+      },
+    ]);
+    expect(event.emit.secondCall.args).to.deep.equal([
+      EVENTS.WEBSOCKET.SEND_ALL,
+      {
+        type: WEBSOCKET_MESSAGE_TYPES.ALARM.DISARMED,
+        payload: {
+          house: 'test-house',
+        },
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
### Description

While a house is arming, its alarm mode stays `disarmed` in DB until the arming delay is over (it only switches to `armed` inside the `setTimeout` callback). Disarming during that window cleared the pending timeout, but then threw a `ConflictError` ("House is already disarmed") before emitting anything — so neither the `alarm disarmed` scene trigger nor the `alarm.disarmed` websocket event were sent. The alarm was effectively not armed anymore, but the UI stayed stuck on the arming countdown at 0.

This is what a user hit on the forum: a scene triggered by "alarm is arming" that disarms the house when an opening sensor is still open. The arming was correctly cancelled, but the countdown never went away.

Changes:

- `house.disarm` now succeeds when there is a pending arming to cancel, and emits the usual `ALARM.DISARM` trigger + `ALARM.DISARMED` websocket event. It still throws `ConflictError` when the house is genuinely already disarmed.
- `house.disarmWithCode` no longer returns early when the house is arming — entering the alarm code on a tablet during the countdown now cancels the arming, instead of silently resolving and letting the house arm anyway.

## Forum

Forum: ``https://community.gladysassistant.com/t/armer-lalarme-si-tous-les-detecteurs-douverture-et-ou-de-mouvement-sont-en-bonne-position``/10437

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

Tests run locally: `test/lib/house`, `test/controllers/house` and `test/lib/scene` are green (297 passing). No UI change, so Cypress was not run.

New/updated tests:
- `house.disarm`: cancelling an arming resolves and emits the disarm trigger + websocket event, and the house is still disarmed after the delay would have elapsed.
- `house.disarmWithCode`: entering the code during the countdown cancels the pending arming.

---
_Generated by [Claude Code](https://claude.ai/code/session_013A5enXXRuGRnwayS8TYJ2X)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed disarming during an active arming delay.
  * Disarm requests now cancel pending arming operations and complete successfully.
  * Prevented a house from arming after its pending arming delay has been canceled.
  * Ensured disarm notifications are sent when cancellation occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->