### PR TITLE
Add value list selector for device feature conditions

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -2978,6 +2978,8 @@
         "removeLabel": "Entfernen",
         "orText": "ODER",
         "orButton": "+ ODER",
+        "useCustomValue": "Eigenen Wert eingeben",
+        "useValueList": "Aus der Werteliste auswählen",
         "logicExplanationText": "Die Bedingungen in diesem Block sind mit ODER verknüpft: Der Block ist erfüllt, sobald eine davon zutrifft. Für ein UND fügst du mehrere Blöcke \"Nur fortsetzen, wenn\" hinzu: Dann müssen alle erfüllt sein.",
         "explanationText": "Anstelle eines festen Werts kannst du hier eine Berechnung auf Basis einer Szenenvariable eingeben. Um eine Variable in den Text einzufügen, gib \"{{\" ein. Um einen Variablenwert festzulegen, musst du zuerst das Feld \"Gerätewert abrufen\" verwenden."
       },
@@ -4546,6 +4548,20 @@
           "other": "Kein Wert empfangen",
           "zero": "Geöffnet",
           "one": "Geschlossen"
+        }
+      },
+      "motion-sensor": {
+        "binary": {
+          "other": "Kein Wert empfangen",
+          "zero": "Keine Bewegung",
+          "one": "Bewegung erkannt"
+        }
+      },
+      "smoke-sensor": {
+        "binary": {
+          "other": "Kein Wert empfangen",
+          "zero": "Kein Rauch",
+          "one": "Rauch erkannt"
         }
       },
       "co-sensor": {

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -2978,6 +2978,8 @@
         "removeLabel": "Remove",
         "orText": "OR",
         "orButton": "+ OR",
+        "useCustomValue": "Enter a custom value",
+        "useValueList": "Choose from the list of values",
         "logicExplanationText": "The conditions in this box are combined with an OR: the box is satisfied as soon as one of them is met. To make an AND, add several \"Condition on variables\" boxes: they will then all have to be satisfied.",
         "explanationText": "Instead of a fixed value, you can enter here a calculation based on a scene variable. To inject a variable in the text, press '{{'. To set a variable value, you need to use the 'Get device value' box before this one."
       },
@@ -4546,6 +4548,20 @@
           "other": "No value received",
           "zero": "Opened",
           "one": "Closed"
+        }
+      },
+      "motion-sensor": {
+        "binary": {
+          "other": "No value received",
+          "zero": "No motion",
+          "one": "Motion detected"
+        }
+      },
+      "smoke-sensor": {
+        "binary": {
+          "other": "No value received",
+          "zero": "Clear",
+          "one": "Smoke detected"
         }
       },
       "co-sensor": {

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -2978,6 +2978,8 @@
         "removeLabel": "Effacer",
         "orText": "OU",
         "orButton": "+ OU",
+        "useCustomValue": "Saisir une valeur personnalisée",
+        "useValueList": "Choisir dans la liste des valeurs",
         "logicExplanationText": "Les conditions de ce bloc sont reliées par un OU : le bloc est validé dès qu'une seule d'entre elles est réalisée. Pour faire un ET, ajoutez plusieurs blocs « Condition sur variables » : ils devront alors tous être validés.",
         "explanationText": "Dans le champ de valeur, entrez soit une valeur brute soit un calcul basé sur une variable de scène. Pour injecter une variable, tapez '{{'. Attention, vous devez avoir défini une variable auparavant dans une action 'Récupérer le dernier état' placé avant ce bloc condition."
       },
@@ -4546,6 +4548,20 @@
           "other": "Aucune valeur reçue",
           "zero": "Ouvert",
           "one": "Fermé"
+        }
+      },
+      "motion-sensor": {
+        "binary": {
+          "other": "Aucune valeur reçue",
+          "zero": "Pas de mouvement",
+          "one": "Mouvement détecté"
+        }
+      },
+      "smoke-sensor": {
+        "binary": {
+          "other": "Aucune valeur reçue",
+          "zero": "Sain",
+          "one": "Fumée détectée"
         }
       },
       "co-sensor": {

--- a/front/src/routes/scene/edit-scene/actions/only-continue-if/Condition.jsx
+++ b/front/src/routes/scene/edit-scene/actions/only-continue-if/Condition.jsx
@@ -14,15 +14,21 @@ const getDeviceFeature = option => (option && option.data ? option.data.deviceFe
 const isSameValue = (optionValue, conditionValue) => `${optionValue}` === `${conditionValue}`;
 
 class Condition extends Component {
+  // The current value can be displayed in the list only if it's a raw value present in that list
+  isValueInValueOptions = valueOptions => {
+    const { value, evaluate_value: evaluateValue } = this.props.condition;
+    return Boolean(
+      valueOptions &&
+        evaluateValue === undefined &&
+        value !== undefined &&
+        valueOptions.some(option => isSameValue(option.value, value))
+    );
+  };
+
   handleChange = selectedOption => {
     const valueOptions = getDeviceFeatureValueOptions(this.props.intl.dictionary, getDeviceFeature(selectedOption));
     // If the new variable only accepts a list of values, we drop the previous value if it's not in that list
-    const shouldResetValue =
-      valueOptions &&
-      !(
-        this.props.condition.value !== undefined &&
-        valueOptions.some(option => isSameValue(option.value, this.props.condition.value))
-      );
+    const shouldResetValue = Boolean(valueOptions) && !this.isValueInValueOptions(valueOptions);
 
     const newCondition = update(this.props.condition, {
       variable: {
@@ -61,6 +67,10 @@ class Condition extends Component {
   displayValueOptions = e => {
     e.preventDefault();
     this.setState({ customValue: false });
+    // We keep the current value if it can be pre-selected in the list
+    if (this.isValueInValueOptions(this.getValueOptions(this.getSelectedOption()))) {
+      return;
+    }
     const newCondition = update(this.props.condition, {
       value: {
         $set: undefined
@@ -159,7 +169,7 @@ class Condition extends Component {
     if (value === undefined || value === '') {
       return true;
     }
-    return valueOptions.some(option => isSameValue(option.value, value));
+    return this.isValueInValueOptions(valueOptions);
   };
 
   render(props, { customValue }) {

--- a/front/src/routes/scene/edit-scene/actions/only-continue-if/Condition.jsx
+++ b/front/src/routes/scene/edit-scene/actions/only-continue-if/Condition.jsx
@@ -4,14 +4,69 @@ import Select from 'react-select';
 import update from 'immutability-helper';
 
 import TextWithVariablesInjected from '../../../../../components/scene/TextWithVariablesInjected';
+import getDeviceFeatureValueOptions from '../../../../../utils/deviceFeatureValueOptions';
+import withIntlAsProp from '../../../../../utils/withIntlAsProp';
 
 import style from './Condition.css';
 
+const getDeviceFeature = option => (option && option.data ? option.data.deviceFeature : null);
+
+const isSameValue = (optionValue, conditionValue) => `${optionValue}` === `${conditionValue}`;
+
 class Condition extends Component {
   handleChange = selectedOption => {
+    const valueOptions = getDeviceFeatureValueOptions(this.props.intl.dictionary, getDeviceFeature(selectedOption));
+    // If the new variable only accepts a list of values, we drop the previous value if it's not in that list
+    const shouldResetValue =
+      valueOptions &&
+      !(
+        this.props.condition.value !== undefined &&
+        valueOptions.some(option => isSameValue(option.value, this.props.condition.value))
+      );
+
     const newCondition = update(this.props.condition, {
       variable: {
         $set: selectedOption && selectedOption.value ? selectedOption.value : null
+      },
+      ...(shouldResetValue
+        ? {
+            value: { $set: undefined },
+            evaluate_value: { $set: undefined }
+          }
+        : {})
+    });
+    if (shouldResetValue) {
+      this.setState({ customValue: false });
+    }
+    this.props.handleConditionChange(this.props.index, newCondition);
+  };
+
+  handleValueOptionChange = selectedOption => {
+    const newCondition = update(this.props.condition, {
+      value: {
+        $set: selectedOption ? selectedOption.value : undefined
+      },
+      evaluate_value: {
+        $set: undefined
+      }
+    });
+    this.props.handleConditionChange(this.props.index, newCondition);
+  };
+
+  displayCustomValue = e => {
+    e.preventDefault();
+    this.setState({ customValue: true });
+  };
+
+  displayValueOptions = e => {
+    e.preventDefault();
+    this.setState({ customValue: false });
+    const newCondition = update(this.props.condition, {
+      value: {
+        $set: undefined
+      },
+      evaluate_value: {
+        $set: undefined
       }
     });
     this.props.handleConditionChange(this.props.index, newCondition);
@@ -87,8 +142,33 @@ class Condition extends Component {
     return selectedOption;
   };
 
-  render(props, {}) {
+  getValueOptions = selectedOption =>
+    getDeviceFeatureValueOptions(this.props.intl.dictionary, getDeviceFeature(selectedOption));
+
+  // We display the list of values only if the variable is a device feature holding constants,
+  // and if the current value can be represented in that list (it's not a scene variable or
+  // a value saved before this list existed)
+  shouldDisplayValueOptions = (valueOptions, customValue) => {
+    if (!valueOptions || customValue) {
+      return false;
+    }
+    const { value, evaluate_value: evaluateValue } = this.props.condition;
+    if (evaluateValue !== undefined) {
+      return false;
+    }
+    if (value === undefined || value === '') {
+      return true;
+    }
+    return valueOptions.some(option => isSameValue(option.value, value));
+  };
+
+  render(props, { customValue }) {
     const selectedOption = this.getSelectedOption();
+    const valueOptions = this.getValueOptions(selectedOption);
+    const showValueOptions = this.shouldDisplayValueOptions(valueOptions, customValue);
+    const selectedValueOption = showValueOptions
+      ? valueOptions.find(option => isSameValue(option.value, props.condition.value)) || null
+      : null;
     return (
       <div>
         <div class="row">
@@ -151,22 +231,46 @@ class Condition extends Component {
                   <Text id="global.requiredField" />
                 </span>
               </label>
-              <Localizer>
-                <TextWithVariablesInjected
-                  text={
-                    props.condition.value !== undefined
-                      ? props.condition.value.toString()
-                      : props.condition.evaluate_value
-                  }
-                  triggersVariables={props.triggersVariables}
-                  actionsGroupsBefore={props.actionsGroupsBefore}
-                  variables={props.variables}
-                  path={props.path}
-                  updateText={this.handleValueChange}
-                  singleLineInput
-                  class={`${style.conditionTagify}`}
+              {showValueOptions && (
+                <Select
+                  value={selectedValueOption}
+                  onChange={this.handleValueOptionChange}
+                  options={valueOptions}
+                  className="react-select-container"
+                  classNamePrefix="react-select"
                 />
-              </Localizer>
+              )}
+              {!showValueOptions && (
+                <Localizer>
+                  <TextWithVariablesInjected
+                    text={
+                      props.condition.value !== undefined
+                        ? props.condition.value.toString()
+                        : props.condition.evaluate_value
+                    }
+                    triggersVariables={props.triggersVariables}
+                    actionsGroupsBefore={props.actionsGroupsBefore}
+                    variables={props.variables}
+                    path={props.path}
+                    updateText={this.handleValueChange}
+                    singleLineInput
+                    class={`${style.conditionTagify}`}
+                  />
+                </Localizer>
+              )}
+              {valueOptions && (
+                <small class="form-text">
+                  <a href="#" onClick={showValueOptions ? this.displayCustomValue : this.displayValueOptions}>
+                    <Text
+                      id={
+                        showValueOptions
+                          ? 'editScene.actionsCard.onlyContinueIf.useCustomValue'
+                          : 'editScene.actionsCard.onlyContinueIf.useValueList'
+                      }
+                    />
+                  </a>
+                </small>
+              )}
             </div>
           </div>
           <div class="col-md-2">
@@ -201,4 +305,4 @@ class Condition extends Component {
   }
 }
 
-export default Condition;
+export default withIntlAsProp(Condition);

--- a/front/src/utils/deviceFeatureValueOptions.js
+++ b/front/src/utils/deviceFeatureValueOptions.js
@@ -40,10 +40,12 @@ function getDeviceFeatureValueOptions(dictionary, deviceFeature) {
   const { category, type, min, max } = deviceFeature;
 
   if (category === DEVICE_FEATURE_CATEGORIES.FAN && FAN_LABELED_FEATURE_TYPES.includes(type)) {
-    return getFanFeatureOptions(type, min, max).map(value => ({
+    // The device can declare min/max bounds outside of the enum, in that case there is no value to propose
+    const fanOptions = getFanFeatureOptions(type, min, max).map(value => ({
       value,
       label: getValueLabel(dictionary, `deviceFeatureValue.category.${category}.${type}`, value)
     }));
+    return fanOptions.length > 0 ? fanOptions : null;
   }
 
   if (MATTER_INDEX_SENSOR_CATEGORIES.includes(category)) {

--- a/front/src/utils/deviceFeatureValueOptions.js
+++ b/front/src/utils/deviceFeatureValueOptions.js
@@ -1,0 +1,86 @@
+import get from 'get-value';
+
+import {
+  DEVICE_FEATURE_CATEGORIES,
+  DEVICE_FEATURE_TYPES,
+  LEVEL_MATTER_STATE,
+  getFanFeatureOptions
+} from '../../../server/utils/constants';
+
+const NUMERIC_VALUE = /^-?\d+$/;
+
+// Those fan features are bitmaps, the device tells us which values it supports with min/max
+const FAN_LABELED_FEATURE_TYPES = [
+  DEVICE_FEATURE_TYPES.FAN.ROCK_SETTING,
+  DEVICE_FEATURE_TYPES.FAN.WIND_SETTING,
+  DEVICE_FEATURE_TYPES.FAN.AIRFLOW_DIRECTION
+];
+
+// Matter index sensors all share the same level scale
+const MATTER_INDEX_SENSOR_CATEGORIES = [
+  DEVICE_FEATURE_CATEGORIES.VOC_MATTER_INDEX_SENSOR,
+  DEVICE_FEATURE_CATEGORIES.NO2_MATTER_INDEX_SENSOR
+];
+
+const getValueLabel = (dictionary, path, value) => get(dictionary, `${path}.${value}`, { default: `${value}` });
+
+/**
+ * @description Get the list of values a device feature can take, with their translated label.
+ * @param {Object} dictionary - The i18n dictionary.
+ * @param {Object} deviceFeature - The device feature.
+ * @returns {Array} The list of { label, value } options, or null if the feature is not a constant.
+ * @example
+ * const options = getDeviceFeatureValueOptions(dictionary, { category: 'opening-sensor', type: 'binary' });
+ */
+function getDeviceFeatureValueOptions(dictionary, deviceFeature) {
+  if (!deviceFeature) {
+    return null;
+  }
+
+  const { category, type, min, max } = deviceFeature;
+
+  if (category === DEVICE_FEATURE_CATEGORIES.FAN && FAN_LABELED_FEATURE_TYPES.includes(type)) {
+    return getFanFeatureOptions(type, min, max).map(value => ({
+      value,
+      label: getValueLabel(dictionary, `deviceFeatureValue.category.${category}.${type}`, value)
+    }));
+  }
+
+  if (MATTER_INDEX_SENSOR_CATEGORIES.includes(category)) {
+    return Object.values(LEVEL_MATTER_STATE).map(value => ({
+      value,
+      label: getValueLabel(dictionary, 'deviceFeatureValue.category.level-matter-index-sensor.level-state', value)
+    }));
+  }
+
+  // Binary features have their own labels per category (ex: Opened/Closed for an opening sensor),
+  // with a generic Active/Inactive fallback
+  if (type === DEVICE_FEATURE_TYPES.SENSOR.BINARY) {
+    const labels =
+      get(dictionary, `deviceFeatureValue.category.${category}.binary`) ||
+      get(dictionary, 'deviceFeatureValue.type.binary');
+    if (!labels) {
+      return null;
+    }
+    return [
+      { value: 1, label: labels.one },
+      { value: 0, label: labels.zero }
+    ];
+  }
+
+  // For all other features, the translations are the source of truth: a feature holding
+  // constants (button click, shutter state, pilot wire mode...) has one label per value.
+  const valueLabels = get(dictionary, `deviceFeatureValue.category.${category}.${type}`);
+  if (!valueLabels) {
+    return null;
+  }
+
+  const options = Object.keys(valueLabels)
+    .filter(key => NUMERIC_VALUE.test(key))
+    .map(key => ({ value: Number(key), label: valueLabels[key] }))
+    .sort((optionA, optionB) => optionA.value - optionB.value);
+
+  return options.length > 0 ? options : null;
+}
+
+export default getDeviceFeatureValueOptions;


### PR DESCRIPTION
### Description

This PR enhances the "Only continue if" condition editor to support selecting values from a predefined list when the device feature has constant values (e.g., binary sensors, fan settings, pilot wire modes).

**Key changes:**
- Created `getDeviceFeatureValueOptions` utility to extract and translate available values for device features based on their category and type
- Enhanced the Condition component to:
  - Display a dropdown selector when the device feature has a fixed set of values
  - Allow toggling between the dropdown list and custom value input via a link
  - Automatically reset the value when switching to a device feature with a different value set
  - Preserve backward compatibility with existing custom values and scene variables
- Added i18n strings for motion-sensor and smoke-sensor binary states in English, French, and German
- Added UI labels for toggling between custom value and value list modes

The implementation intelligently determines when to show the value list based on:
- Whether the device feature supports constant values
- Whether the current value can be represented in that list
- User preference (custom value vs. list mode)

This improves UX by providing guided selection for common device states while maintaining flexibility for advanced use cases.

### Checklist

- [ ] Tests pass: `cd server && npm run coverage` and Cypress (`npm run cypress:run`)
- [ ] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [ ] No undocumented breaking change

https://claude.ai/code/session_01SPxWgwcYrP5vQ3wZ2uXQV1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized options for selecting custom values or predefined value lists in scene conditions.
  * Added translated motion and smoke sensor states, including unknown and no-value labels.
  * Added support for device-specific value options, including fan levels, binary states, and numeric values.

* **Bug Fixes**
  * Scene condition values now reset when switching to incompatible variables, with improved validation for custom inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->