### PR TITLE
fix(front): render the jobs link in the "too much states to delete" alert

### DIFF
--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -66,7 +66,7 @@
     "searchPlaceHolder": "Chercher un appareil",
     "noRoom": "Sans pièce",
     "noFeatures": "Aucune fonctionnalité",
-    "tooMuchStatesToDelete": "Cet appareil a {{count}} états dans la base de données et ne peut être supprimé immédiatement. Gladys a lancé une suppression lente en arrière-plan de tous les états de cet appareil afin d'éviter qu'elle ne soit bloquée pendant la suppression de ceux-ci. Cette suppression peut durer quelques minutes ou quelques heures (selon la rapidité de votre disque). Vous pouvez suivre la progression de la suppression <a href=\"/dashboard/settings/jobs\"> ici</a>. Lorsque ce processus sera terminé, nous vous invitons à revenir sur cet onglet pour effectuer la suppression définitive de cet appareil.",
+    "tooMuchStatesToDelete": "Cet appareil a {{count}} états dans la base de données et ne peut être supprimé immédiatement. Gladys a lancé une suppression lente en arrière-plan de tous les états de cet appareil afin d'éviter qu'elle ne soit bloquée pendant la suppression de ceux-ci. Cette suppression peut durer quelques minutes ou quelques heures (selon la rapidité de votre disque). Vous pouvez suivre la progression de la suppression <a href=\"/dashboard/settings/jobs\">ici</a>. Lorsque ce processus sera terminé, nous vous invitons à revenir sur cet onglet pour effectuer la suppression définitive de cet appareil.",
     "migrate": {
       "button": "Migrer",
       "modalTitle": "Migrer « {{name}} »",

--- a/front/src/routes/integration/all/matter/MatterDeviceBox.jsx
+++ b/front/src/routes/integration/all/matter/MatterDeviceBox.jsx
@@ -1,5 +1,5 @@
 import { Component } from 'preact';
-import { Text, Localizer } from 'preact-i18n';
+import { Text, MarkupText, Localizer } from 'preact-i18n';
 import cx from 'classnames';
 import get from 'get-value';
 
@@ -144,7 +144,7 @@ class MatterDeviceBox extends Component {
                 )}
                 {tooMuchStatesError && (
                   <div class="alert alert-warning">
-                    <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
+                    <MarkupText id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
                   </div>
                 )}
                 <div class="form-group">

--- a/front/src/routes/integration/all/mqtt/device-page/DeviceListItem.jsx
+++ b/front/src/routes/integration/all/mqtt/device-page/DeviceListItem.jsx
@@ -1,4 +1,4 @@
-import { Text } from 'preact-i18n';
+import { Text, MarkupText } from 'preact-i18n';
 import { Component } from 'preact';
 import { Link } from 'preact-router/match';
 import cx from 'classnames';
@@ -79,7 +79,7 @@ class DeviceListItem extends Component {
 
         {tooMuchStatesError && (
           <div class={cx('alert alert-warning mt-2 mb-0', style.deviceListItemAlert)}>
-            <Text id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
+            <MarkupText id="device.tooMuchStatesToDelete" fields={{ count: statesNumber }} />
           </div>
         )}
         {error && (


### PR DESCRIPTION
The MQTT device list and the Matter device box displayed the
device.tooMuchStatesToDelete translation with <Text>, which escapes HTML.
The link to the background jobs page was therefore printed as raw markup
instead of being rendered as a clickable link.

Use <MarkupText> like every other integration does, and drop a stray
leading space inside the French link label.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GDJ9X5B24E2EWmMztLQRWP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device-deletion warnings so localized messages display links and dynamic details correctly.
  * Fixed spacing in the French deletion warning.
  * Updated Matter and MQTT device deletion prompts to render formatted text consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->