### PR TITLE
Fix container select alignment in logs page

### DIFF
--- a/front/src/routes/integration/all/external-integration/logs-page/LogsTab.jsx
+++ b/front/src/routes/integration/all/external-integration/logs-page/LogsTab.jsx
@@ -14,7 +14,7 @@ const LogsTab = ({ logs, logsStatus, getLogs, subContainers = [], selectedContai
         {subContainers.length > 0 && (
           <Localizer>
             <select
-              class="form-control form-control-sm custom-select w-auto mr-2"
+              class={cx('form-control form-control-sm custom-select w-auto mr-2', style.containerSelect)}
               value={selectedContainer}
               onChange={selectContainer}
               aria-label={<Text id="integration.externalIntegration.logs.containerSelectLabel" />}

--- a/front/src/routes/integration/all/external-integration/logs-page/style.css
+++ b/front/src/routes/integration/all/external-integration/logs-page/style.css
@@ -1,3 +1,16 @@
+/*
+ * `.custom-select` keeps the full-size vertical padding (0.5rem) and line-height (1.5),
+ * while `.form-control-sm` shrinks the select down to the small height. The text no longer
+ * fits in the content box and ends up pushed down and cut off, so realign it with the
+ * small sizing used by the neighbouring `.btn-sm`.
+ */
+select.containerSelect {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  padding-left: 0.5rem;
+  line-height: 1.33333333;
+}
+
 .logs {
   max-height: 65vh;
   overflow: auto;


### PR DESCRIPTION
### Description

Fixes the vertical alignment of the container select dropdown in the logs page. The select element was using both `.custom-select` (which applies full-size padding) and `.form-control-sm` (which shrinks the height), causing text to be misaligned and cut off.

Added custom CSS styling to the `.containerSelect` class that adjusts padding and line-height to properly align the text with the small button sizing used by neighboring elements.

### Checklist

- [ ] Tests pass: `cd server && npm run coverage` and Cypress (`npm run cypress:run`)
- [ ] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [ ] No undocumented breaking change

https://claude.ai/code/session_01KxWZEYkxpz63zeZg7g8FCY