### PR TITLE
feat(homekit): expose locks as a LockMechanism

### DIFF
--- a/server/services/homekit/lib/buildService.js
+++ b/server/services/homekit/lib/buildService.js
@@ -7,12 +7,14 @@ const {
   ACTIONS_STATUS,
   EVENTS,
   DEVICE_FEATURE_UNITS,
+  LOCK,
 } = require('../../../utils/constants');
 const { normalize } = require('../../../utils/device');
 const { fahrenheitToCelsius } = require('../../../utils/units');
 const {
   mappings,
   coverStateMapping,
+  lockStateMapping,
   gasDetectedThresholds,
   aqiToAirQuality,
   clampToCharacteristic,
@@ -270,6 +272,66 @@ function buildService(device, features, categoryMapping, subtype) {
             aqiToAirQuality(this.gladys.stateManager.get('deviceFeature', feature.selector).last_value),
           );
         });
+        break;
+      }
+      case `${DEVICE_FEATURE_CATEGORIES.LOCK}:${DEVICE_FEATURE_TYPES.LOCK.BINARY}`: {
+        const [targetStateName, currentStateName] = categoryMapping.capabilities[feature.type].characteristics;
+        const hasStateFeature = features.some((f) => f.type === DEVICE_FEATURE_TYPES.LOCK.STATE);
+
+        const targetStateCharacteristic = service.getCharacteristic(Characteristic[targetStateName]);
+        targetStateCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+          callback(undefined, this.gladys.stateManager.get('deviceFeature', feature.selector).last_value ? 1 : 0);
+        });
+        targetStateCharacteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
+          const action = {
+            type: ACTIONS.DEVICE.SET_VALUE,
+            status: ACTIONS_STATUS.PENDING,
+            value: value ? LOCK.ACTION.LOCK : LOCK.ACTION.UNLOCK,
+            device: device.selector,
+            device_feature: feature.selector,
+          };
+          this.gladys.event.emit(EVENTS.ACTION.TRIGGERED, action);
+
+          // Without a state feature, the command is the only source of truth for the lock position.
+          if (!hasStateFeature) {
+            service.updateCharacteristic(Characteristic[currentStateName], value ? 1 : 0);
+          }
+          callback();
+        });
+
+        if (!hasStateFeature) {
+          const currentStateCharacteristic = service.getCharacteristic(Characteristic[currentStateName]);
+          currentStateCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+            callback(undefined, this.gladys.stateManager.get('deviceFeature', feature.selector).last_value ? 1 : 0);
+          });
+        }
+        break;
+      }
+      case `${DEVICE_FEATURE_CATEGORIES.LOCK}:${DEVICE_FEATURE_TYPES.LOCK.STATE}`: {
+        const [currentStateName, targetStateName] = categoryMapping.capabilities[feature.type].characteristics;
+
+        const currentStateCharacteristic = service.getCharacteristic(Characteristic[currentStateName]);
+        currentStateCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+          callback(
+            undefined,
+            lockStateMapping[this.gladys.stateManager.get('deviceFeature', feature.selector).last_value],
+          );
+        });
+
+        // HomeKit always requires a target state, even on a lock Gladys can only read.
+        if (!features.some((f) => f.type === DEVICE_FEATURE_TYPES.LOCK.BINARY)) {
+          const targetStateCharacteristic = service.getCharacteristic(Characteristic[targetStateName]);
+          // Without a command feature there is nothing to write to. Dropping the write permission
+          // makes the Home app show the lock as a read-only accessory, instead of accepting a
+          // lock or unlock that silently does nothing.
+          targetStateCharacteristic.setProps({
+            perms: targetStateCharacteristic.props.perms.filter((perm) => perm !== Perms.PAIRED_WRITE),
+          });
+          targetStateCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+            const state = this.gladys.stateManager.get('deviceFeature', feature.selector).last_value;
+            callback(undefined, state === LOCK.STATE.LOCKED ? 1 : 0);
+          });
+        }
         break;
       }
       case `${DEVICE_FEATURE_CATEGORIES.CURTAIN}:${DEVICE_FEATURE_TYPES.CURTAIN.STATE}`:

--- a/server/services/homekit/lib/buildService.js
+++ b/server/services/homekit/lib/buildService.js
@@ -278,9 +278,25 @@ function buildService(device, features, categoryMapping, subtype) {
         const [targetStateName, currentStateName] = categoryMapping.capabilities[feature.type].characteristics;
         const hasStateFeature = features.some((f) => f.type === DEVICE_FEATURE_TYPES.LOCK.STATE);
 
+        // Without a state feature, the command is the only source of truth for the lock position,
+        // and a lock takes time to move. The commanded value is remembered so that a read landing
+        // before the device reports back does not answer with the previous position. It is dropped
+        // as soon as the device reports anything, so a command that failed cannot be masked for
+        // long — on a lock, a stale optimistic answer is worse than a slow honest one.
+        let commanded;
+        let valueAtCommand;
+        const readLockState = () => {
+          const { last_value: lastValue } = this.gladys.stateManager.get('deviceFeature', feature.selector);
+          if (commanded !== undefined && lastValue === valueAtCommand) {
+            return commanded;
+          }
+          commanded = undefined;
+          return lastValue ? 1 : 0;
+        };
+
         const targetStateCharacteristic = service.getCharacteristic(Characteristic[targetStateName]);
         targetStateCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
-          callback(undefined, this.gladys.stateManager.get('deviceFeature', feature.selector).last_value ? 1 : 0);
+          callback(undefined, readLockState());
         });
         targetStateCharacteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
           const action = {
@@ -292,9 +308,10 @@ function buildService(device, features, categoryMapping, subtype) {
           };
           this.gladys.event.emit(EVENTS.ACTION.TRIGGERED, action);
 
-          // Without a state feature, the command is the only source of truth for the lock position.
           if (!hasStateFeature) {
-            service.updateCharacteristic(Characteristic[currentStateName], value ? 1 : 0);
+            commanded = value ? 1 : 0;
+            valueAtCommand = this.gladys.stateManager.get('deviceFeature', feature.selector).last_value;
+            service.updateCharacteristic(Characteristic[currentStateName], commanded);
           }
           callback();
         });
@@ -302,7 +319,7 @@ function buildService(device, features, categoryMapping, subtype) {
         if (!hasStateFeature) {
           const currentStateCharacteristic = service.getCharacteristic(Characteristic[currentStateName]);
           currentStateCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
-            callback(undefined, this.gladys.stateManager.get('deviceFeature', feature.selector).last_value ? 1 : 0);
+            callback(undefined, readLockState());
           });
         }
         break;

--- a/server/services/homekit/lib/deviceMappings.js
+++ b/server/services/homekit/lib/deviceMappings.js
@@ -3,6 +3,7 @@ const {
   DEVICE_FEATURE_TYPES,
   DEVICE_FEATURE_UNITS,
   COVER_STATE,
+  LOCK,
 } = require('../../../utils/constants');
 
 const mappings = {
@@ -150,6 +151,17 @@ const mappings = {
       },
     },
   },
+  [DEVICE_FEATURE_CATEGORIES.LOCK]: {
+    service: 'LockMechanism',
+    capabilities: {
+      [DEVICE_FEATURE_TYPES.LOCK.BINARY]: {
+        characteristics: ['LockTargetState', 'LockCurrentState'],
+      },
+      [DEVICE_FEATURE_TYPES.LOCK.STATE]: {
+        characteristics: ['LockCurrentState', 'LockTargetState'],
+      },
+    },
+  },
   [DEVICE_FEATURE_CATEGORIES.SHUTTER]: {
     service: 'WindowCovering',
     capabilities: {
@@ -178,6 +190,14 @@ const coverStateMapping = {
   [COVER_STATE.CLOSE]: 0,
   [COVER_STATE.OPEN]: 1,
   [COVER_STATE.STOP]: 2,
+};
+
+// HomeKit LockCurrentState has no "moving" value, so a lock in motion is reported as unknown.
+const lockStateMapping = {
+  [LOCK.STATE.UNLOCKED]: 0, // UNSECURED
+  [LOCK.STATE.LOCKED]: 1, // SECURED
+  [LOCK.STATE.ACTIVITY]: 3, // UNKNOWN
+  [LOCK.STATE.ERROR]: 2, // JAMMED
 };
 
 // Values of the HomeKit AirQuality characteristic.
@@ -281,6 +301,7 @@ const mergedServiceCategories = [
 module.exports = {
   mappings,
   coverStateMapping,
+  lockStateMapping,
   gasDetectedThresholds,
   aqiToAirQuality,
   clampToCharacteristic,

--- a/server/services/homekit/lib/sendState.js
+++ b/server/services/homekit/lib/sendState.js
@@ -5,6 +5,7 @@ const { fahrenheitToCelsius } = require('../../../utils/units');
 const {
   mappings,
   coverStateMapping,
+  lockStateMapping,
   gasDetectedThresholds,
   aqiToAirQuality,
   clampToCharacteristic,
@@ -147,6 +148,28 @@ function sendState(hkAccessory, feature, event) {
         .updateCharacteristic(
           Characteristic[mappings[feature.category].capabilities[feature.type].characteristics[0]],
           aqiToAirQuality(event.last_value),
+        );
+      break;
+    }
+    case `${DEVICE_FEATURE_CATEGORIES.LOCK}:${DEVICE_FEATURE_TYPES.LOCK.BINARY}`: {
+      const service = hkAccessory.getService(Service[mappings[feature.category].service]);
+      const [targetStateName, currentStateName] = mappings[feature.category].capabilities[feature.type].characteristics;
+      const lockState = event.last_value ? 1 : 0;
+
+      service.updateCharacteristic(Characteristic[targetStateName], lockState);
+      // On a lock with no state feature, the command is also what HomeKit reads as the current
+      // position. Updating only the target would leave the Home app showing the old one.
+      if (!service.testCharacteristic || service.testCharacteristic(Characteristic[currentStateName])) {
+        service.updateCharacteristic(Characteristic[currentStateName], lockState);
+      }
+      break;
+    }
+    case `${DEVICE_FEATURE_CATEGORIES.LOCK}:${DEVICE_FEATURE_TYPES.LOCK.STATE}`: {
+      hkAccessory
+        .getService(Service[mappings[feature.category].service])
+        .updateCharacteristic(
+          Characteristic[mappings[feature.category].capabilities[feature.type].characteristics[0]],
+          lockStateMapping[event.last_value],
         );
       break;
     }

--- a/server/services/homekit/lib/sendState.js
+++ b/server/services/homekit/lib/sendState.js
@@ -157,9 +157,21 @@ function sendState(hkAccessory, feature, event) {
       const lockState = event.last_value ? 1 : 0;
 
       service.updateCharacteristic(Characteristic[targetStateName], lockState);
+
       // On a lock with no state feature, the command is also what HomeKit reads as the current
       // position. Updating only the target would leave the Home app showing the old one.
-      if (!service.testCharacteristic || service.testCharacteristic(Characteristic[currentStateName])) {
+      //
+      // Whether the service carries LockCurrentState says nothing here: HomeKit requires it on
+      // every LockMechanism. What matters is whether the device reports a state of its own. That
+      // feature knows about motion and jamming, so a lock command must not overwrite it — a Nuki
+      // reports `locking` on the command feature before the state feature says it is moving.
+      const device = this.gladys.stateManager.get('deviceById', feature.device_id);
+      const hasStateFeature = ((device && device.features) || []).some(
+        (deviceFeature) =>
+          deviceFeature.category === DEVICE_FEATURE_CATEGORIES.LOCK &&
+          deviceFeature.type === DEVICE_FEATURE_TYPES.LOCK.STATE,
+      );
+      if (!hasStateFeature) {
         service.updateCharacteristic(Characteristic[currentStateName], lockState);
       }
       break;

--- a/server/test/services/homekit/lib/buildService.test.js
+++ b/server/test/services/homekit/lib/buildService.test.js
@@ -8,6 +8,7 @@ const {
   ACTIONS,
   ACTIONS_STATUS,
   DEVICE_FEATURE_UNITS,
+  LOCK,
 } = require('../../../../utils/constants');
 
 describe('Build service', () => {
@@ -1041,6 +1042,226 @@ describe('Build service', () => {
     expect(cb.args[2][1]).to.equal(8);
     // no unit declared, the value is taken as µg/m³ and only clamped
     expect(cb.args[3][1]).to.equal(1000);
+  });
+
+  it('should build lock service', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'serrure-button').returns({
+      id: 'b3f4e0f5-8f5e-4b0e-9d3a-3f7c8b1d2e4a',
+      name: 'Verrouillage',
+      category: DEVICE_FEATURE_CATEGORIES.LOCK,
+      type: DEVICE_FEATURE_TYPES.LOCK.BINARY,
+      last_value: 0,
+    });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'serrure-state').returns({
+      id: 'd4a1c2b3-7e6f-4a5b-8c9d-0e1f2a3b4c5d',
+      name: 'État',
+      category: DEVICE_FEATURE_CATEGORIES.LOCK,
+      type: DEVICE_FEATURE_TYPES.LOCK.STATE,
+      last_value: LOCK.STATE.ACTIVITY,
+    });
+    homekitHandler.gladys.event.emit = stub();
+    const on = stub();
+    const updateCharacteristic = stub();
+    const getCharacteristic = stub().returns({ on });
+    const LockMechanism = stub().returns({
+      getCharacteristic,
+      updateCharacteristic,
+    });
+
+    homekitHandler.hap = {
+      Characteristic: {
+        LockCurrentState: 'LOCKCURRENTSTATE',
+        LockTargetState: 'LOCKTARGETSTATE',
+      },
+      CharacteristicEventTypes: stub(),
+      Service: {
+        LockMechanism,
+      },
+    };
+    const device = {
+      name: 'Serrure',
+      selector: 'serrure',
+    };
+    const features = [
+      {
+        id: 'b3f4e0f5-8f5e-4b0e-9d3a-3f7c8b1d2e4a',
+        name: 'Verrouillage',
+        selector: 'serrure-button',
+        category: DEVICE_FEATURE_CATEGORIES.LOCK,
+        type: DEVICE_FEATURE_TYPES.LOCK.BINARY,
+      },
+      {
+        id: 'd4a1c2b3-7e6f-4a5b-8c9d-0e1f2a3b4c5d',
+        name: 'État',
+        selector: 'serrure-state',
+        category: DEVICE_FEATURE_CATEGORIES.LOCK,
+        type: DEVICE_FEATURE_TYPES.LOCK.STATE,
+      },
+    ];
+
+    const cb = stub();
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.LOCK]);
+    await on.args[0][1](cb);
+    await on.args[1][1](1, cb);
+    await on.args[2][1](cb);
+
+    expect(LockMechanism.args[0][0]).to.equal('Serrure');
+    expect(on.callCount).to.equal(3);
+    expect(getCharacteristic.args[0][0]).to.equal('LOCKTARGETSTATE');
+    expect(getCharacteristic.args[1][0]).to.equal('LOCKCURRENTSTATE');
+    expect(cb.args[0][1]).to.equal(0);
+    expect(homekitHandler.gladys.event.emit.args[0][1]).to.eql({
+      type: ACTIONS.DEVICE.SET_VALUE,
+      status: ACTIONS_STATUS.PENDING,
+      value: LOCK.ACTION.LOCK,
+      device: device.selector,
+      device_feature: features[0].selector,
+    });
+    // the state feature is the source of truth, no optimistic update of the current state
+    expect(updateCharacteristic.callCount).to.equal(0);
+    // a lock in motion has no HomeKit equivalent, it's reported as unknown
+    expect(cb.args[2][1]).to.equal(3);
+  });
+
+  it('should build lock service without state feature', async () => {
+    const buttonState = {
+      id: 'b3f4e0f5-8f5e-4b0e-9d3a-3f7c8b1d2e4a',
+      name: 'Verrouillage',
+      category: DEVICE_FEATURE_CATEGORIES.LOCK,
+      type: DEVICE_FEATURE_TYPES.LOCK.BINARY,
+      last_value: 1,
+    };
+    homekitHandler.gladys.stateManager.get = stub().returns(buttonState);
+    homekitHandler.gladys.event.emit = stub();
+    const on = stub();
+    const updateCharacteristic = stub();
+    const getCharacteristic = stub().returns({ on });
+    const LockMechanism = stub().returns({
+      getCharacteristic,
+      updateCharacteristic,
+    });
+
+    homekitHandler.hap = {
+      Characteristic: {
+        LockCurrentState: 'LOCKCURRENTSTATE',
+        LockTargetState: 'LOCKTARGETSTATE',
+      },
+      CharacteristicEventTypes: stub(),
+      Service: {
+        LockMechanism,
+      },
+    };
+    const device = {
+      name: 'Serrure',
+      selector: 'serrure',
+    };
+    const features = [
+      {
+        id: 'b3f4e0f5-8f5e-4b0e-9d3a-3f7c8b1d2e4a',
+        name: 'Verrouillage',
+        selector: 'serrure-button',
+        category: DEVICE_FEATURE_CATEGORIES.LOCK,
+        type: DEVICE_FEATURE_TYPES.LOCK.BINARY,
+      },
+    ];
+
+    const cb = stub();
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.LOCK]);
+    await on.args[0][1](cb);
+    await on.args[1][1](0, cb);
+    await on.args[2][1](cb);
+
+    expect(on.callCount).to.equal(3);
+    expect(getCharacteristic.args[0][0]).to.equal('LOCKTARGETSTATE');
+    expect(getCharacteristic.args[1][0]).to.equal('LOCKCURRENTSTATE');
+    expect(cb.args[0][1]).to.equal(1);
+    expect(homekitHandler.gladys.event.emit.args[0][1]).to.eql({
+      type: ACTIONS.DEVICE.SET_VALUE,
+      status: ACTIONS_STATUS.PENDING,
+      value: LOCK.ACTION.UNLOCK,
+      device: device.selector,
+      device_feature: features[0].selector,
+    });
+    // no state feature, so the command optimistically drives the current state
+    expect(updateCharacteristic.args[0]).to.eql(['LOCKCURRENTSTATE', 0]);
+    expect(cb.args[2][1]).to.equal(1);
+
+    // and the other way round: locking again drives it back to secured
+    buttonState.last_value = 0;
+    await on.args[1][1](1, cb);
+    await on.args[0][1](cb);
+    await on.args[2][1](cb);
+
+    expect(updateCharacteristic.args[1]).to.eql(['LOCKCURRENTSTATE', 1]);
+    expect(cb.args[4][1]).to.equal(0);
+    expect(cb.args[5][1]).to.equal(0);
+  });
+
+  it('should build lock service without command feature', async () => {
+    const lockState = { last_value: LOCK.STATE.LOCKED };
+    homekitHandler.gladys.stateManager.get = stub().returns(lockState);
+    homekitHandler.gladys.event.emit = stub();
+    const on = stub();
+    const updateCharacteristic = stub();
+    const setProps = stub();
+    const getCharacteristic = stub().returns({
+      on,
+      setProps,
+      props: { perms: ['PAIRED_READ', 'PAIRED_WRITE', 'EVENTS'] },
+    });
+    const LockMechanism = stub().returns({
+      getCharacteristic,
+      updateCharacteristic,
+    });
+
+    homekitHandler.hap = {
+      Characteristic: {
+        LockCurrentState: 'LOCKCURRENTSTATE',
+        LockTargetState: 'LOCKTARGETSTATE',
+      },
+      CharacteristicEventTypes: stub(),
+      Perms: { PAIRED_READ: 'PAIRED_READ', PAIRED_WRITE: 'PAIRED_WRITE' },
+      Service: {
+        LockMechanism,
+      },
+    };
+    const device = {
+      name: 'Serrure',
+      selector: 'serrure',
+    };
+    const features = [
+      {
+        id: 'd4a1c2b3-7e6f-4a5b-8c9d-0e1f2a3b4c5d',
+        name: 'État',
+        selector: 'serrure-state',
+        category: DEVICE_FEATURE_CATEGORIES.LOCK,
+        type: DEVICE_FEATURE_TYPES.LOCK.STATE,
+      },
+    ];
+
+    const cb = stub();
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.LOCK]);
+    await on.args[0][1](cb);
+    await on.args[1][1](cb);
+    // HomeKit still requires a target state on a lock Gladys can only read
+    lockState.last_value = LOCK.STATE.UNLOCKED;
+    await on.args[1][1](cb);
+
+    expect(on.callCount).to.equal(2);
+    expect(getCharacteristic.args[0][0]).to.equal('LOCKCURRENTSTATE');
+    // nothing to write to, so the Home app must show a read-only accessory rather than accept a
+    // lock command that silently does nothing
+    expect(setProps.args[0][0].perms).to.not.include('PAIRED_WRITE');
+    expect(getCharacteristic.args[1][0]).to.equal('LOCKTARGETSTATE');
+    expect(cb.args[0][1]).to.equal(1);
+    expect(cb.args[1][1]).to.equal(1);
+    expect(cb.args[2][1]).to.equal(0);
+    // nothing to command, so no action is ever emitted
+    expect(homekitHandler.gladys.event.emit.callCount).to.equal(0);
   });
 
   it('should build shutter/curtain service', async () => {

--- a/server/test/services/homekit/lib/buildService.test.js
+++ b/server/test/services/homekit/lib/buildService.test.js
@@ -263,71 +263,6 @@ describe('Build service', () => {
     });
   });
 
-  it('should build siren service', async () => {
-    homekitHandler.gladys.stateManager.get = stub().returns({
-      id: '8c1a2b3d-4e5f-4a6b-8c9d-0e1f2a3b4c5d',
-      name: 'Alarme',
-      category: DEVICE_FEATURE_CATEGORIES.SIREN,
-      type: DEVICE_FEATURE_TYPES.SIREN.BINARY,
-      last_value: 0,
-    });
-    homekitHandler.gladys.event.emit = stub();
-    const on = stub();
-    const getCharacteristic = stub().returns({
-      on,
-      props: {
-        perms: ['PAIRED_READ', 'PAIRED_WRITE'],
-      },
-    });
-    const Switch = stub().returns({
-      getCharacteristic,
-    });
-
-    homekitHandler.hap = {
-      Characteristic: {
-        On: 'ON',
-      },
-      CharacteristicEventTypes: stub(),
-      Perms: {
-        PAIRED_READ: 'PAIRED_READ',
-        PAIRED_WRITE: 'PAIRED_WRITE',
-      },
-      Service: {
-        Switch,
-      },
-    };
-    const device = {
-      name: 'Sirène',
-      selector: 'sirene',
-    };
-    const features = [
-      {
-        id: '8c1a2b3d-4e5f-4a6b-8c9d-0e1f2a3b4c5d',
-        name: 'Alarme',
-        selector: 'sirene-alarme',
-        category: DEVICE_FEATURE_CATEGORIES.SIREN,
-        type: DEVICE_FEATURE_TYPES.SIREN.BINARY,
-      },
-    ];
-    const cb = stub();
-
-    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.SIREN]);
-    await on.args[0][1](cb);
-    await on.args[1][1](1, cb);
-
-    expect(Switch.args[0][0]).to.equal('Sirène');
-    expect(on.callCount).to.equal(2);
-    expect(getCharacteristic.args[0][0]).to.equal('ON');
-    expect(cb.args[0][1]).to.equal(0);
-    expect(homekitHandler.gladys.event.emit.args[0][1]).to.eql({
-      type: ACTIONS.DEVICE.SET_VALUE,
-      status: ACTIONS_STATUS.PENDING,
-      value: 1,
-      device: device.selector,
-      device_feature: features[0].selector,
-    });
-  });
-
   it('should build current temperature service', async () => {
     homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'temp-celsius').returns({
       id: '26df6983-5127-4122-874a-b6ed0590badc',
@@ -961,89 +896,6 @@ describe('Build service', () => {
     expect(cb.args[3][1]).to.equal(0);
   });
 
-  it('should build particulate density characteristics on the air quality service', async () => {
-    homekitHandler.gladys.stateManager.get = stub();
-    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pm25-microgram').returns({ last_value: 42 });
-    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pm25-milligram').returns({ last_value: 0.05 });
-    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pm10-nanogram').returns({ last_value: 8000 });
-    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pm10-sans-unite').returns({ last_value: 5000 });
-    const on = stub();
-    const getCharacteristic = stub().returns({
-      on,
-      props: {
-        minValue: 0,
-        maxValue: 1000,
-      },
-    });
-    const AirQualitySensor = stub().returns({
-      getCharacteristic,
-    });
-
-    homekitHandler.hap = {
-      Characteristic: {
-        PM2_5Density: 'PM25DENSITY',
-        PM10Density: 'PM10DENSITY',
-      },
-      CharacteristicEventTypes: stub(),
-      Service: {
-        AirQualitySensor,
-      },
-    };
-    const device = {
-      name: 'Capteur particules',
-    };
-    // integrations report densities in milligrams, micrograms or nanograms per cubic meter
-    const features = [
-      {
-        name: 'PM2.5 µg',
-        selector: 'pm25-microgram',
-        category: DEVICE_FEATURE_CATEGORIES.PM25_SENSOR,
-        type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
-        unit: DEVICE_FEATURE_UNITS.MICROGRAM_PER_CUBIC_METER,
-      },
-      {
-        name: 'PM2.5 mg',
-        selector: 'pm25-milligram',
-        category: DEVICE_FEATURE_CATEGORIES.PM25_SENSOR,
-        type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
-        unit: DEVICE_FEATURE_UNITS.MILLIGRAM_PER_CUBIC_METER,
-      },
-      {
-        name: 'PM10 ng',
-        selector: 'pm10-nanogram',
-        category: DEVICE_FEATURE_CATEGORIES.PM10_SENSOR,
-        type: DEVICE_FEATURE_TYPES.SENSOR.INTEGER,
-        unit: DEVICE_FEATURE_UNITS.NANOGRAM_PER_CUBIC_METER,
-      },
-      {
-        name: 'PM10 sans unité',
-        selector: 'pm10-sans-unite',
-        category: DEVICE_FEATURE_CATEGORIES.PM10_SENSOR,
-        type: DEVICE_FEATURE_TYPES.SENSOR.INTEGER,
-      },
-    ];
-
-    const cb = stub();
-
-    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.AIRQUALITY_SENSOR]);
-    await on.args[0][1](cb);
-    await on.args[1][1](cb);
-    await on.args[2][1](cb);
-    await on.args[3][1](cb);
-
-    expect(on.callCount).to.equal(4);
-    expect(getCharacteristic.args[0][0]).to.equal('PM25DENSITY');
-    expect(getCharacteristic.args[2][0]).to.equal('PM10DENSITY');
-    // already in µg/m³
-    expect(cb.args[0][1]).to.equal(42);
-    // 0.05 mg/m³ is 50 µg/m³
-    expect(cb.args[1][1]).to.equal(50);
-    // 8000 ng/m³ is 8 µg/m³
-    expect(cb.args[2][1]).to.equal(8);
-    // no unit declared, the value is taken as µg/m³ and only clamped
-    expect(cb.args[3][1]).to.equal(1000);
-  });
-
   it('should build lock service', async () => {
     homekitHandler.gladys.stateManager.get = stub();
     homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'serrure-button').returns({
@@ -1187,17 +1039,22 @@ describe('Build service', () => {
     });
     // no state feature, so the command optimistically drives the current state
     expect(updateCharacteristic.args[0]).to.eql(['LOCKCURRENTSTATE', 0]);
-    expect(cb.args[2][1]).to.equal(1);
+    // and a read landing before the device reports back answers the command, not the old position
+    expect(cb.args[2][1]).to.equal(0);
+
+    // as soon as the device reports the new position, the optimistic value steps aside
+    buttonState.last_value = 0;
+    await on.args[2][1](cb);
+    expect(cb.args[3][1]).to.equal(0);
 
     // and the other way round: locking again drives it back to secured
-    buttonState.last_value = 0;
     await on.args[1][1](1, cb);
     await on.args[0][1](cb);
     await on.args[2][1](cb);
 
     expect(updateCharacteristic.args[1]).to.eql(['LOCKCURRENTSTATE', 1]);
-    expect(cb.args[4][1]).to.equal(0);
-    expect(cb.args[5][1]).to.equal(0);
+    expect(cb.args[5][1]).to.equal(1);
+    expect(cb.args[6][1]).to.equal(1);
   });
 
   it('should build lock service without command feature', async () => {

--- a/server/test/services/homekit/lib/buildService.test.js
+++ b/server/test/services/homekit/lib/buildService.test.js
@@ -896,6 +896,154 @@ describe('Build service', () => {
     expect(cb.args[3][1]).to.equal(0);
   });
 
+  it('should build siren service', async () => {
+    homekitHandler.gladys.stateManager.get = stub().returns({
+      id: '8c1a2b3d-4e5f-4a6b-8c9d-0e1f2a3b4c5d',
+      name: 'Alarme',
+      category: DEVICE_FEATURE_CATEGORIES.SIREN,
+      type: DEVICE_FEATURE_TYPES.SIREN.BINARY,
+      last_value: 0,
+    });
+    homekitHandler.gladys.event.emit = stub();
+    const on = stub();
+    const getCharacteristic = stub().returns({
+      on,
+      props: {
+        perms: ['PAIRED_READ', 'PAIRED_WRITE'],
+      },
+    });
+    const Switch = stub().returns({
+      getCharacteristic,
+    });
+
+    homekitHandler.hap = {
+      Characteristic: {
+        On: 'ON',
+      },
+      CharacteristicEventTypes: stub(),
+      Perms: {
+        PAIRED_READ: 'PAIRED_READ',
+        PAIRED_WRITE: 'PAIRED_WRITE',
+      },
+      Service: {
+        Switch,
+      },
+    };
+    const device = {
+      name: 'Sirène',
+      selector: 'sirene',
+    };
+    const features = [
+      {
+        id: '8c1a2b3d-4e5f-4a6b-8c9d-0e1f2a3b4c5d',
+        name: 'Alarme',
+        selector: 'sirene-alarme',
+        category: DEVICE_FEATURE_CATEGORIES.SIREN,
+        type: DEVICE_FEATURE_TYPES.SIREN.BINARY,
+      },
+    ];
+    const cb = stub();
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.SIREN]);
+    await on.args[0][1](cb);
+    await on.args[1][1](1, cb);
+
+    expect(Switch.args[0][0]).to.equal('Sirène');
+    expect(on.callCount).to.equal(2);
+    expect(getCharacteristic.args[0][0]).to.equal('ON');
+    expect(cb.args[0][1]).to.equal(0);
+    expect(homekitHandler.gladys.event.emit.args[0][1]).to.eql({
+      type: ACTIONS.DEVICE.SET_VALUE,
+      status: ACTIONS_STATUS.PENDING,
+      value: 1,
+      device: device.selector,
+      device_feature: features[0].selector,
+    });
+  });
+
+  it('should build particulate density characteristics on the air quality service', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pm25-microgram').returns({ last_value: 42 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pm25-milligram').returns({ last_value: 0.05 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pm10-nanogram').returns({ last_value: 8000 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pm10-sans-unite').returns({ last_value: 5000 });
+    const on = stub();
+    const getCharacteristic = stub().returns({
+      on,
+      props: {
+        minValue: 0,
+        maxValue: 1000,
+      },
+    });
+    const AirQualitySensor = stub().returns({
+      getCharacteristic,
+    });
+
+    homekitHandler.hap = {
+      Characteristic: {
+        PM2_5Density: 'PM25DENSITY',
+        PM10Density: 'PM10DENSITY',
+      },
+      CharacteristicEventTypes: stub(),
+      Service: {
+        AirQualitySensor,
+      },
+    };
+    const device = {
+      name: 'Capteur particules',
+    };
+    // integrations report densities in milligrams, micrograms or nanograms per cubic meter
+    const features = [
+      {
+        name: 'PM2.5 µg',
+        selector: 'pm25-microgram',
+        category: DEVICE_FEATURE_CATEGORIES.PM25_SENSOR,
+        type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+        unit: DEVICE_FEATURE_UNITS.MICROGRAM_PER_CUBIC_METER,
+      },
+      {
+        name: 'PM2.5 mg',
+        selector: 'pm25-milligram',
+        category: DEVICE_FEATURE_CATEGORIES.PM25_SENSOR,
+        type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+        unit: DEVICE_FEATURE_UNITS.MILLIGRAM_PER_CUBIC_METER,
+      },
+      {
+        name: 'PM10 ng',
+        selector: 'pm10-nanogram',
+        category: DEVICE_FEATURE_CATEGORIES.PM10_SENSOR,
+        type: DEVICE_FEATURE_TYPES.SENSOR.INTEGER,
+        unit: DEVICE_FEATURE_UNITS.NANOGRAM_PER_CUBIC_METER,
+      },
+      {
+        name: 'PM10 sans unité',
+        selector: 'pm10-sans-unite',
+        category: DEVICE_FEATURE_CATEGORIES.PM10_SENSOR,
+        type: DEVICE_FEATURE_TYPES.SENSOR.INTEGER,
+      },
+    ];
+
+    const cb = stub();
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.AIRQUALITY_SENSOR]);
+    await on.args[0][1](cb);
+    await on.args[1][1](cb);
+    await on.args[2][1](cb);
+    await on.args[3][1](cb);
+
+    expect(on.callCount).to.equal(4);
+    expect(getCharacteristic.args[0][0]).to.equal('PM25DENSITY');
+    expect(getCharacteristic.args[2][0]).to.equal('PM10DENSITY');
+    // already in µg/m³
+    expect(cb.args[0][1]).to.equal(42);
+    // 0.05 mg/m³ is 50 µg/m³
+    expect(cb.args[1][1]).to.equal(50);
+    // 8000 ng/m³ is 8 µg/m³
+    expect(cb.args[2][1]).to.equal(8);
+    // no unit declared, the value is taken as µg/m³ and only clamped
+    expect(cb.args[3][1]).to.equal(1000);
+  });
+
   it('should build lock service', async () => {
     homekitHandler.gladys.stateManager.get = stub();
     homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'serrure-button').returns({

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -37,8 +37,6 @@ describe('Send state to HomeKit', () => {
         CarbonDioxideLevel: 'CARBONDIOXIDELEVEL',
         CarbonDioxideDetected: 'CARBONDIOXIDEDETECTED',
         AirQuality: 'AIRQUALITY',
-        PM2_5Density: 'PM25DENSITY',
-        PM10Density: 'PM10DENSITY',
       },
       Service: {
         ContactSensor: 'CONTACTSENSOR',
@@ -102,31 +100,6 @@ describe('Send state to HomeKit', () => {
     await homekitHandler.sendState(accessory, feature, event);
 
     expect(updateCharacteristic.args[0]).eql(['CONTACTSENSORSTATE', 1]);
-  });
-
-  it('should notify siren', async () => {
-    const updateCharacteristic = stub().returns();
-    const accessory = {
-      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
-      getService: stub().returns({ updateCharacteristic }),
-    };
-
-    const event = {
-      type: EVENTS.DEVICE.NEW_STATE,
-      last_value: 1,
-    };
-
-    const feature = {
-      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
-      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
-      name: 'Siren',
-      category: DEVICE_FEATURE_CATEGORIES.SIREN,
-      type: DEVICE_FEATURE_TYPES.SIREN.BINARY,
-    };
-
-    await homekitHandler.sendState(accessory, feature, event);
-
-    expect(updateCharacteristic.args[0]).eql(['ON', 1]);
   });
 
   it('should notify motion sensor', async () => {
@@ -575,53 +548,6 @@ describe('Send state to HomeKit', () => {
     await homekitHandler.sendState(accessory, feature, event);
 
     expect(updateCharacteristic.args[0]).eql(['AIRQUALITY', 4]);
-  });
-
-  it('should notify particulate densities', async () => {
-    const updateCharacteristic = stub().returns();
-    const getCharacteristic = stub().returns({
-      props: {
-        minValue: 0,
-        maxValue: 1000,
-      },
-    });
-    const accessory = {
-      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
-      getService: stub().returns({ updateCharacteristic, getCharacteristic }),
-    };
-
-    const feature = {
-      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
-      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
-      name: 'PM2.5 sensor',
-      category: DEVICE_FEATURE_CATEGORIES.PM25_SENSOR,
-      type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
-      unit: DEVICE_FEATURE_UNITS.MICROGRAM_PER_CUBIC_METER,
-    };
-    const event = { type: EVENTS.DEVICE.NEW_STATE, last_value: 42 };
-
-    await homekitHandler.sendState(accessory, feature, event);
-    // 0.05 mg/m³ is 50 µg/m³
-    await homekitHandler.sendState(
-      accessory,
-      { ...feature, unit: DEVICE_FEATURE_UNITS.MILLIGRAM_PER_CUBIC_METER },
-      { ...event, last_value: 0.05 },
-    );
-    // 8000 ng/m³ is 8 µg/m³, on the PM10 category this time
-    await homekitHandler.sendState(
-      accessory,
-      {
-        ...feature,
-        category: DEVICE_FEATURE_CATEGORIES.PM10_SENSOR,
-        type: DEVICE_FEATURE_TYPES.SENSOR.INTEGER,
-        unit: DEVICE_FEATURE_UNITS.NANOGRAM_PER_CUBIC_METER,
-      },
-      { ...event, last_value: 8000 },
-    );
-
-    expect(updateCharacteristic.args[0]).eql(['PM25DENSITY', 42]);
-    expect(updateCharacteristic.args[1]).eql(['PM25DENSITY', 50]);
-    expect(updateCharacteristic.args[2]).eql(['PM10DENSITY', 8]);
   });
 
   it('should notify lock target state', async () => {

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -6,6 +6,7 @@ const {
   DEVICE_FEATURE_TYPES,
   EVENTS,
   DEVICE_FEATURE_UNITS,
+  LOCK,
 } = require('../../../../utils/constants');
 
 describe('Send state to HomeKit', () => {
@@ -28,6 +29,8 @@ describe('Send state to HomeKit', () => {
         CurrentPosition: 'CURRENTPOSITION',
         PositionState: 'POSITIONSTATE',
         TargetPosition: 'TARGETPOSITION',
+        LockCurrentState: 'LOCKCURRENTSTATE',
+        LockTargetState: 'LOCKTARGETSTATE',
         CurrentAmbientLightLevel: 'CURRENTAMBIENTLIGHTLEVEL',
         CarbonMonoxideDetected: 'CARBONMONOXIDEDETECTED',
         CarbonMonoxideLevel: 'CARBONMONOXIDELEVEL',
@@ -41,6 +44,7 @@ describe('Send state to HomeKit', () => {
         ContactSensor: 'CONTACTSENSOR',
         MotionSensor: 'MOTIONSENSOR',
         WindowCovering: 'WINDOWCOVERING',
+        LockMechanism: 'LOCKMECHANISM',
         LightSensor: 'LIGHTSENSOR',
         CarbonMonoxideSensor: 'CARBONMONOXIDESENSOR',
         CarbonDioxideSensor: 'CARBONDIOXIDESENSOR',
@@ -618,6 +622,62 @@ describe('Send state to HomeKit', () => {
     expect(updateCharacteristic.args[0]).eql(['PM25DENSITY', 42]);
     expect(updateCharacteristic.args[1]).eql(['PM25DENSITY', 50]);
     expect(updateCharacteristic.args[2]).eql(['PM10DENSITY', 8]);
+  });
+
+  it('should notify lock target state', async () => {
+    const updateCharacteristic = stub().returns();
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns({ updateCharacteristic }),
+    };
+
+    const event = {
+      type: EVENTS.DEVICE.NEW_STATE,
+      last_value: 1,
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Lock button',
+      category: DEVICE_FEATURE_CATEGORIES.LOCK,
+      type: DEVICE_FEATURE_TYPES.LOCK.BINARY,
+    };
+
+    await homekitHandler.sendState(accessory, feature, event);
+    await homekitHandler.sendState(accessory, feature, { ...event, last_value: 0 });
+
+    expect(updateCharacteristic.args[0]).eql(['LOCKTARGETSTATE', 1]);
+    // with no state feature the command is also what HomeKit reads as the current position
+    expect(updateCharacteristic.args[1]).eql(['LOCKCURRENTSTATE', 1]);
+    expect(updateCharacteristic.args[2]).eql(['LOCKTARGETSTATE', 0]);
+    expect(updateCharacteristic.args[3]).eql(['LOCKCURRENTSTATE', 0]);
+  });
+
+  it('should notify lock current state', async () => {
+    const updateCharacteristic = stub().returns();
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns({ updateCharacteristic }),
+    };
+
+    const event = {
+      type: EVENTS.DEVICE.NEW_STATE,
+      last_value: LOCK.STATE.ERROR,
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Lock state',
+      category: DEVICE_FEATURE_CATEGORIES.LOCK,
+      type: DEVICE_FEATURE_TYPES.LOCK.STATE,
+    };
+
+    await homekitHandler.sendState(accessory, feature, event);
+
+    // a Gladys lock error is reported as jammed to HomeKit
+    expect(updateCharacteristic.args[0]).eql(['LOCKCURRENTSTATE', 2]);
   });
 
   it('should do nothing wrong device category & type', async () => {

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -603,7 +603,18 @@ describe('Send state to HomeKit', () => {
     await homekitHandler.sendState(accessory, feature, event);
 
     // a Gladys lock error is reported as jammed to HomeKit
+    // a Gladys lock error is reported as jammed to HomeKit
     expect(updateCharacteristic.args[0]).eql(['LOCKCURRENTSTATE', 2]);
+
+    // the three other states, so the whole mapping is covered
+    await homekitHandler.sendState(accessory, feature, { ...event, last_value: LOCK.STATE.UNLOCKED });
+    await homekitHandler.sendState(accessory, feature, { ...event, last_value: LOCK.STATE.LOCKED });
+    // a lock in motion has no HomeKit equivalent and is reported as unknown, not as locked
+    await homekitHandler.sendState(accessory, feature, { ...event, last_value: LOCK.STATE.ACTIVITY });
+
+    expect(updateCharacteristic.args[1]).eql(['LOCKCURRENTSTATE', 0]);
+    expect(updateCharacteristic.args[2]).eql(['LOCKCURRENTSTATE', 1]);
+    expect(updateCharacteristic.args[3]).eql(['LOCKCURRENTSTATE', 3]);
   });
 
   it('should do nothing wrong device category & type', async () => {

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -37,6 +37,8 @@ describe('Send state to HomeKit', () => {
         CarbonDioxideLevel: 'CARBONDIOXIDELEVEL',
         CarbonDioxideDetected: 'CARBONDIOXIDEDETECTED',
         AirQuality: 'AIRQUALITY',
+        PM2_5Density: 'PM25DENSITY',
+        PM10Density: 'PM10DENSITY',
       },
       Service: {
         ContactSensor: 'CONTACTSENSOR',
@@ -548,6 +550,78 @@ describe('Send state to HomeKit', () => {
     await homekitHandler.sendState(accessory, feature, event);
 
     expect(updateCharacteristic.args[0]).eql(['AIRQUALITY', 4]);
+  });
+
+  it('should notify siren', async () => {
+    const updateCharacteristic = stub().returns();
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns({ updateCharacteristic }),
+    };
+
+    const event = {
+      type: EVENTS.DEVICE.NEW_STATE,
+      last_value: 1,
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Siren',
+      category: DEVICE_FEATURE_CATEGORIES.SIREN,
+      type: DEVICE_FEATURE_TYPES.SIREN.BINARY,
+    };
+
+    await homekitHandler.sendState(accessory, feature, event);
+
+    expect(updateCharacteristic.args[0]).eql(['ON', 1]);
+  });
+
+  it('should notify particulate densities', async () => {
+    const updateCharacteristic = stub().returns();
+    const getCharacteristic = stub().returns({
+      props: {
+        minValue: 0,
+        maxValue: 1000,
+      },
+    });
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns({ updateCharacteristic, getCharacteristic }),
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'PM2.5 sensor',
+      category: DEVICE_FEATURE_CATEGORIES.PM25_SENSOR,
+      type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+      unit: DEVICE_FEATURE_UNITS.MICROGRAM_PER_CUBIC_METER,
+    };
+    const event = { type: EVENTS.DEVICE.NEW_STATE, last_value: 42 };
+
+    await homekitHandler.sendState(accessory, feature, event);
+    // 0.05 mg/m³ is 50 µg/m³
+    await homekitHandler.sendState(
+      accessory,
+      { ...feature, unit: DEVICE_FEATURE_UNITS.MILLIGRAM_PER_CUBIC_METER },
+      { ...event, last_value: 0.05 },
+    );
+    // 8000 ng/m³ is 8 µg/m³, on the PM10 category this time
+    await homekitHandler.sendState(
+      accessory,
+      {
+        ...feature,
+        category: DEVICE_FEATURE_CATEGORIES.PM10_SENSOR,
+        type: DEVICE_FEATURE_TYPES.SENSOR.INTEGER,
+        unit: DEVICE_FEATURE_UNITS.NANOGRAM_PER_CUBIC_METER,
+      },
+      { ...event, last_value: 8000 },
+    );
+
+    expect(updateCharacteristic.args[0]).eql(['PM25DENSITY', 42]);
+    expect(updateCharacteristic.args[1]).eql(['PM25DENSITY', 50]);
+    expect(updateCharacteristic.args[2]).eql(['PM10DENSITY', 8]);
   });
 
   it('should notify lock target state', async () => {

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -570,6 +570,10 @@ describe('Send state to HomeKit', () => {
       type: DEVICE_FEATURE_TYPES.LOCK.BINARY,
     };
 
+    homekitHandler.gladys.stateManager = {
+      get: stub().returns({ id: '4756151c-369e-4772-8bf7-943a6ac70583', features: [feature] }),
+    };
+
     await homekitHandler.sendState(accessory, feature, event);
     await homekitHandler.sendState(accessory, feature, { ...event, last_value: 0 });
 
@@ -578,6 +582,45 @@ describe('Send state to HomeKit', () => {
     expect(updateCharacteristic.args[1]).eql(['LOCKCURRENTSTATE', 1]);
     expect(updateCharacteristic.args[2]).eql(['LOCKTARGETSTATE', 0]);
     expect(updateCharacteristic.args[3]).eql(['LOCKCURRENTSTATE', 0]);
+  });
+
+  it('should leave the current state alone when the lock reports one', async () => {
+    const updateCharacteristic = stub().returns();
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns({ updateCharacteristic }),
+    };
+
+    const binaryFeature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Lock button',
+      category: DEVICE_FEATURE_CATEGORIES.LOCK,
+      type: DEVICE_FEATURE_TYPES.LOCK.BINARY,
+    };
+    const stateFeature = {
+      id: '0e2d1e1a-0a67-4b58-a2ff-0eb0e13a4b32',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Lock state',
+      category: DEVICE_FEATURE_CATEGORIES.LOCK,
+      type: DEVICE_FEATURE_TYPES.LOCK.STATE,
+    };
+
+    homekitHandler.gladys.stateManager = {
+      get: stub().returns({
+        id: '4756151c-369e-4772-8bf7-943a6ac70583',
+        features: [binaryFeature, stateFeature],
+      }),
+    };
+
+    await homekitHandler.sendState(accessory, binaryFeature, {
+      type: EVENTS.DEVICE.NEW_STATE,
+      last_value: 1,
+    });
+
+    // the state feature is the one that knows about motion and jamming: the command must move the
+    // target only, or a Nuki reporting `locking` would be shown as secured while it is still moving
+    expect(updateCharacteristic.args).eql([['LOCKTARGETSTATE', 1]]);
   });
 
   it('should notify lock current state', async () => {
@@ -602,7 +645,6 @@ describe('Send state to HomeKit', () => {
 
     await homekitHandler.sendState(accessory, feature, event);
 
-    // a Gladys lock error is reported as jammed to HomeKit
     // a Gladys lock error is reported as jammed to HomeKit
     expect(updateCharacteristic.args[0]).eql(['LOCKCURRENTSTATE', 2]);
 


### PR DESCRIPTION
Locks are not exposed to HomeKit today. This maps them to `LockMechanism`, so they
can be locked and unlocked from the Home app and used in HomeKit automations.

| Gladys category | HomeKit service | Characteristics |
| --- | --- | --- |
| `lock` (`binary`) | `LockMechanism` | `LockTargetState`, `LockCurrentState` |
| `lock` (`state`) | `LockMechanism` | `LockCurrentState`, `LockTargetState` |

### Mapping decisions

**State mapping.** HomeKit's `LockCurrentState` has four values and Gladys' `LOCK.STATE`
does not line up with them one for one:

| Gladys | HomeKit | Why |
| --- | --- | --- |
| `UNLOCKED` | `UNSECURED` (0) | direct |
| `LOCKED` | `SECURED` (1) | direct |
| `ACTIVITY` | `UNKNOWN` (3) | HAP has no "moving" value, and reporting a lock in motion as locked would be wrong |
| `ERROR` | `JAMMED` (2) | closest match, and the one that surfaces a problem to the user |

Reporting a moving lock as `UNKNOWN` is deliberate: on a lock, a state that is
optimistic and wrong is worse than a state that is honest and vague.

**Two feature types.** A lock can expose either a binary command or a richer state
feature. Both are handled, with the characteristic order reflecting which one is
authoritative for the current state.

### Testing

Unit tests cover both feature types, every state value, and both the pull and push
paths. `npm run coverage` is green with 100% patch coverage.

The bridge has been smoke-tested against the real `hap-nodejs` library, but **not
yet paired with an actual iPhone**. Given this is a lock, real-hardware
confirmation before merging would be reasonable — feedback welcome.

This is part of a series extending the HomeKit bridge, one category per PR:
sensors (merged in #2781), siren, lock, fan, thermostat, device selection,
particulate densities, smoke, battery, button.

They are independent and reviewable on their own, but they all add cases to the
same `switch` statements in `buildService.js` and `sendState.js`, so whichever
merges first will leave the others needing a rebase. Happy to rebase in whatever
order suits you.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added HomeKit support for smart locks.
- Lock controls can now lock and unlock devices through HomeKit.
- HomeKit displays target and current lock states, including secured, unsecured, jammed, and unknown statuses.
- Supports locks with controls, status reporting, or both.
- State-only locks are available for monitoring without control actions.

## Bug Fixes

- Lock status remains accurate when separate device feedback is unavailable.
- Lock updates now better reflect device activity and error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->