### PR TITLE
feat(homekit): expose buttons as stateless programmable switches

### DIFF
--- a/server/services/homekit/lib/buildService.js
+++ b/server/services/homekit/lib/buildService.js
@@ -73,6 +73,17 @@ function buildService(device, features, categoryMapping, subtype) {
         }
         break;
       }
+      case `${DEVICE_FEATURE_CATEGORIES.BUTTON}:${DEVICE_FEATURE_TYPES.BUTTON.CLICK}`:
+      case `${DEVICE_FEATURE_CATEGORIES.BUTTON}:${DEVICE_FEATURE_TYPES.BUTTON.PUSH}`: {
+        // A stateless switch has no state to read: HomeKit expects null and only listens to the
+        // events pushed when the button is actually pressed.
+        service
+          .getCharacteristic(Characteristic[categoryMapping.capabilities[feature.type].characteristics[0]])
+          .on(CharacteristicEventTypes.GET, async (callback) => {
+            callback(undefined, null);
+          });
+        break;
+      }
       case `${DEVICE_FEATURE_CATEGORIES.OPENING_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.BINARY}`: {
         const contactCharacteristic = service.getCharacteristic(Characteristic.ContactSensorState);
 

--- a/server/services/homekit/lib/deviceMappings.js
+++ b/server/services/homekit/lib/deviceMappings.js
@@ -303,14 +303,24 @@ const mergedServiceCategories = [
 // release separately. INITIAL_PRESS is deliberately absent: Matter emits it at the start of every
 // press, long ones included, so mapping it to SINGLE_PRESS would fire a single press each time
 // someone holds the button down. The release carries the gesture, so that is what is mapped.
+//
+// Careful when checking which statuses have a producer: an integration does not have to import
+// BUTTON_STATUS to emit one. Xiaomi keeps its own SWITCH_STATUS table in
+// services/xiaomi/lib/utils/deviceStatus.js and emits those numbers straight onto a button:click
+// feature, so LONG_CLICK_PRESS reaches this table as the value 3 without the constant ever being
+// referenced. Grep for the value, not only for the name.
 const buttonEventMapping = {
   [BUTTON_STATUS.CLICK]: 0, // SINGLE_PRESS
   [BUTTON_STATUS.SHORT_RELEASE]: 0, // SINGLE_PRESS — Matter and Zigbee2MQTT short_release
+  [BUTTON_STATUS.PRESSED]: 0, // SINGLE_PRESS — Zigbee2MQTT pressed
   [BUTTON_STATUS.DOUBLE_CLICK]: 1, // DOUBLE_PRESS
   [BUTTON_STATUS.DOUBLE_PRESS]: 1, // DOUBLE_PRESS — Zigbee2MQTT double_press
   [BUTTON_STATUS.LONG_CLICK]: 2, // LONG_PRESS
   [BUTTON_STATUS.LONG_PRESS]: 2, // LONG_PRESS — Matter and Zigbee2MQTT long_press
   [BUTTON_STATUS.HOLD_CLICK]: 2, // LONG_PRESS — Zigbee2MQTT hold, Z-Wave hold
+  // Xiaomi wireless switches, through SWITCH_STATUS. Its LONG_CLICK_RELEASE is left out so a
+  // single hold does not fire twice.
+  [BUTTON_STATUS.LONG_CLICK_PRESS]: 2, // LONG_PRESS
 };
 
 module.exports = {

--- a/server/services/homekit/lib/deviceMappings.js
+++ b/server/services/homekit/lib/deviceMappings.js
@@ -3,6 +3,7 @@ const {
   DEVICE_FEATURE_TYPES,
   DEVICE_FEATURE_UNITS,
   COVER_STATE,
+  BUTTON_STATUS,
 } = require('../../../utils/constants');
 
 const mappings = {
@@ -115,6 +116,21 @@ const mappings = {
       },
       [DEVICE_FEATURE_TYPES.SENSOR.INTEGER]: {
         characteristics: ['PM10Density'],
+      },
+    },
+  },
+  [DEVICE_FEATURE_CATEGORIES.BUTTON]: {
+    service: 'StatelessProgrammableSwitch',
+    capabilities: {
+      [DEVICE_FEATURE_TYPES.BUTTON.CLICK]: {
+        characteristics: ['ProgrammableSwitchEvent'],
+        // A button press is an event, not a state: the default debounce would make HomeKit react
+        // seconds after the press, or swallow it entirely.
+        notifDelay: 0,
+      },
+      [DEVICE_FEATURE_TYPES.BUTTON.PUSH]: {
+        characteristics: ['ProgrammableSwitchEvent'],
+        notifDelay: 0,
       },
     },
   },
@@ -277,6 +293,15 @@ const mergedServiceCategories = [
     merged: [],
   },
 ];
+// HomeKit knows three button events, Gladys has more than a hundred button statuses. Only the
+// three that have an exact HomeKit equivalent are forwarded: anything else — arrow keys, rotation,
+// shake, brightness gestures — would have to be reported as one of these three, and firing the
+// wrong event in someone's home automation is worse than firing none.
+const buttonEventMapping = {
+  [BUTTON_STATUS.CLICK]: 0, // SINGLE_PRESS
+  [BUTTON_STATUS.DOUBLE_CLICK]: 1, // DOUBLE_PRESS
+  [BUTTON_STATUS.LONG_CLICK]: 2, // LONG_PRESS
+};
 
 module.exports = {
   mappings,
@@ -286,4 +311,5 @@ module.exports = {
   clampToCharacteristic,
   toMicrogramPerCubicMeter,
   mergedServiceCategories,
+  buttonEventMapping,
 };

--- a/server/services/homekit/lib/deviceMappings.js
+++ b/server/services/homekit/lib/deviceMappings.js
@@ -293,14 +293,24 @@ const mergedServiceCategories = [
     merged: [],
   },
 ];
-// HomeKit knows three button events, Gladys has more than a hundred button statuses. Only the
-// three that have an exact HomeKit equivalent are forwarded: anything else — arrow keys, rotation,
-// shake, brightness gestures — would have to be reported as one of these three, and firing the
-// wrong event in someone's home automation is worse than firing none.
+// HomeKit knows three button events, Gladys has more than a hundred button statuses. Only those
+// with an exact HomeKit equivalent are forwarded: anything else — arrow keys, rotation, shake,
+// brightness gestures — would have to be reported as one of these three, and firing the wrong
+// event in someone's home automation is worse than firing none.
+//
+// Integrations name the same three gestures differently. Zigbee2MQTT and Z-Wave use the CLICK
+// family; Matter and the Zigbee2MQTT devices following its Switch cluster report a press and its
+// release separately. INITIAL_PRESS is deliberately absent: Matter emits it at the start of every
+// press, long ones included, so mapping it to SINGLE_PRESS would fire a single press each time
+// someone holds the button down. The release carries the gesture, so that is what is mapped.
 const buttonEventMapping = {
   [BUTTON_STATUS.CLICK]: 0, // SINGLE_PRESS
+  [BUTTON_STATUS.SHORT_RELEASE]: 0, // SINGLE_PRESS — Matter and Zigbee2MQTT short_release
   [BUTTON_STATUS.DOUBLE_CLICK]: 1, // DOUBLE_PRESS
+  [BUTTON_STATUS.DOUBLE_PRESS]: 1, // DOUBLE_PRESS — Zigbee2MQTT double_press
   [BUTTON_STATUS.LONG_CLICK]: 2, // LONG_PRESS
+  [BUTTON_STATUS.LONG_PRESS]: 2, // LONG_PRESS — Matter and Zigbee2MQTT long_press
+  [BUTTON_STATUS.HOLD_CLICK]: 2, // LONG_PRESS — Zigbee2MQTT hold, Z-Wave hold
 };
 
 module.exports = {

--- a/server/services/homekit/lib/notifyChange.js
+++ b/server/services/homekit/lib/notifyChange.js
@@ -23,6 +23,16 @@ function notifyChange(accessories, event) {
   // Nullish and not ||, so that a mapping asking for no delay at all gets it: a button press is an
   // event, and `0 || 5000` would silently push it back to the default five seconds.
   const delay = mappings[feature.category].capabilities[feature.type].notifDelay ?? 5000;
+
+  // A zero delay means "no debounce at all", so it must not go through the timeout bookkeeping:
+  // two presses in the same tick would clear the first timer and only the second would reach
+  // HomeKit. Send straight away instead.
+  if (delay === 0) {
+    this.sendState(hkAccessory, feature, event);
+
+    return;
+  }
+
   if (!this.notifyTimeouts[event.device_feature]) {
     this.notifyTimeouts[event.device_feature] = {
       timeout: setTimeout(() => {

--- a/server/services/homekit/lib/notifyChange.js
+++ b/server/services/homekit/lib/notifyChange.js
@@ -20,7 +20,9 @@ function notifyChange(accessories, event) {
     return;
   }
 
-  const delay = mappings[feature.category].capabilities[feature.type].notifDelay || 5000;
+  // Nullish and not ||, so that a mapping asking for no delay at all gets it: a button press is an
+  // event, and `0 || 5000` would silently push it back to the default five seconds.
+  const delay = mappings[feature.category].capabilities[feature.type].notifDelay ?? 5000;
   if (!this.notifyTimeouts[event.device_feature]) {
     this.notifyTimeouts[event.device_feature] = {
       timeout: setTimeout(() => {

--- a/server/services/homekit/lib/sendState.js
+++ b/server/services/homekit/lib/sendState.js
@@ -43,12 +43,13 @@ function sendState(hkAccessory, feature, event) {
       const buttonEvent = buttonEventMapping[event.last_value];
       // A press HomeKit has no equivalent for is dropped rather than reported as another one.
       if (buttonEvent !== undefined) {
+        // sendEventNotification and not updateCharacteristic: the latter only notifies when the
+        // value changes, so two single presses in a row — both mapping to 0 — would be reported
+        // once. A button press must always be delivered.
         hkAccessory
           .getService(Service[mappings[feature.category].service])
-          .updateCharacteristic(
-            Characteristic[mappings[feature.category].capabilities[feature.type].characteristics[0]],
-            buttonEvent,
-          );
+          .getCharacteristic(Characteristic[mappings[feature.category].capabilities[feature.type].characteristics[0]])
+          .sendEventNotification(buttonEvent);
       }
       break;
     }

--- a/server/services/homekit/lib/sendState.js
+++ b/server/services/homekit/lib/sendState.js
@@ -43,11 +43,22 @@ function sendState(hkAccessory, feature, event) {
       const buttonEvent = buttonEventMapping[event.last_value];
       // A press HomeKit has no equivalent for is dropped rather than reported as another one.
       if (buttonEvent !== undefined) {
+        // A remote carries one service per button, so getService — which returns the first match —
+        // would report every press on button one. buildAccessory gives those services a subtype
+        // prefixed with the category and names them after their feature, which pins the right one.
+        const subtypePrefix = `${feature.category} `;
+        const service =
+          (hkAccessory.services || []).find(
+            (candidate) =>
+              typeof candidate.subtype === 'string' &&
+              candidate.subtype.startsWith(subtypePrefix) &&
+              candidate.displayName === feature.name,
+          ) || hkAccessory.getService(Service[mappings[feature.category].service]);
+
         // sendEventNotification and not updateCharacteristic: the latter only notifies when the
         // value changes, so two single presses in a row — both mapping to 0 — would be reported
         // once. A button press must always be delivered.
-        hkAccessory
-          .getService(Service[mappings[feature.category].service])
+        service
           .getCharacteristic(Characteristic[mappings[feature.category].capabilities[feature.type].characteristics[0]])
           .sendEventNotification(buttonEvent);
       }

--- a/server/services/homekit/lib/sendState.js
+++ b/server/services/homekit/lib/sendState.js
@@ -9,6 +9,7 @@ const {
   aqiToAirQuality,
   clampToCharacteristic,
   toMicrogramPerCubicMeter,
+  buttonEventMapping,
 } = require('./deviceMappings');
 
 /**
@@ -35,6 +36,20 @@ function sendState(hkAccessory, feature, event) {
           Characteristic[mappings[feature.category].capabilities[feature.type].characteristics[0]],
           event.last_value,
         );
+      break;
+    }
+    case `${DEVICE_FEATURE_CATEGORIES.BUTTON}:${DEVICE_FEATURE_TYPES.BUTTON.CLICK}`:
+    case `${DEVICE_FEATURE_CATEGORIES.BUTTON}:${DEVICE_FEATURE_TYPES.BUTTON.PUSH}`: {
+      const buttonEvent = buttonEventMapping[event.last_value];
+      // A press HomeKit has no equivalent for is dropped rather than reported as another one.
+      if (buttonEvent !== undefined) {
+        hkAccessory
+          .getService(Service[mappings[feature.category].service])
+          .updateCharacteristic(
+            Characteristic[mappings[feature.category].capabilities[feature.type].characteristics[0]],
+            buttonEvent,
+          );
+      }
       break;
     }
     case `${DEVICE_FEATURE_CATEGORIES.OPENING_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.BINARY}`: {

--- a/server/test/services/homekit/lib/buildService.test.js
+++ b/server/test/services/homekit/lib/buildService.test.js
@@ -468,6 +468,54 @@ describe('Build service', () => {
     expect(cb.args[0][1]).to.equal(0);
   });
 
+  it('should build stateless programmable switch service', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    const on = stub();
+    const getCharacteristic = stub().returns({ on, props: {} });
+    const StatelessProgrammableSwitch = stub().returns({ getCharacteristic });
+
+    homekitHandler.hap = {
+      Characteristic: { ProgrammableSwitchEvent: 'PROGRAMMABLESWITCHEVENT' },
+      CharacteristicEventTypes: stub(),
+      Service: { StatelessProgrammableSwitch },
+    };
+    const features = [
+      {
+        name: 'Clic',
+        selector: 'bouton-clic',
+        category: DEVICE_FEATURE_CATEGORIES.BUTTON,
+        type: DEVICE_FEATURE_TYPES.BUTTON.CLICK,
+      },
+      {
+        name: 'Appui',
+        selector: 'bouton-appui',
+        category: DEVICE_FEATURE_CATEGORIES.BUTTON,
+        type: DEVICE_FEATURE_TYPES.BUTTON.PUSH,
+      },
+    ];
+
+    const cb = stub();
+
+    await homekitHandler.buildService({ name: 'Télécommande' }, features, mappings[DEVICE_FEATURE_CATEGORIES.BUTTON]);
+    await on.args[0][1](cb);
+    await on.args[1][1](cb);
+
+    expect(StatelessProgrammableSwitch.args[0][0]).to.equal('Télécommande');
+    expect(getCharacteristic.args[0][0]).to.equal('PROGRAMMABLESWITCHEVENT');
+    // a stateless switch reports no state
+    expect(cb.args[0][1]).to.equal(null);
+    expect(cb.args[1][1]).to.equal(null);
+  });
+
+  it('should not debounce button presses', async () => {
+    expect(
+      mappings[DEVICE_FEATURE_CATEGORIES.BUTTON].capabilities[DEVICE_FEATURE_TYPES.BUTTON.CLICK].notifDelay,
+    ).to.equal(0);
+    expect(
+      mappings[DEVICE_FEATURE_CATEGORIES.BUTTON].capabilities[DEVICE_FEATURE_TYPES.BUTTON.PUSH].notifDelay,
+    ).to.equal(0);
+  });
+
   it('should build contact sensor service', async () => {
     homekitHandler.gladys.stateManager.get = stub().returns({
       id: '31c6a4a7-9710-4951-bf34-04eeae5b9ff7',

--- a/server/test/services/homekit/lib/notifyChange.test.js
+++ b/server/test/services/homekit/lib/notifyChange.test.js
@@ -91,11 +91,40 @@ describe('Notify change to HomeKit', () => {
       device_feature: 'home:button:click',
     });
 
-    // notifDelay is 0 on a button: the press must not sit in a five-second timeout
-    await new Promise((resolve) => {
-      setTimeout(resolve, 20);
-    });
+    // notifDelay is 0 on a button: the press is forwarded synchronously, without waiting on a timer
     expect(homekitHandler.sendState.callCount).to.equal(1);
+    expect(homekitHandler.notifyTimeouts['home:button:click']).to.equal(undefined);
+  });
+
+  it('should forward two presses fired in the same tick', async () => {
+    const sendEventNotification = stub();
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns({ getCharacteristic: stub().returns({ sendEventNotification }) }),
+    };
+
+    homekitHandler.gladys.stateManager = {
+      get: stub().returns({
+        id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+        device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+        name: 'Button',
+        category: DEVICE_FEATURE_CATEGORIES.BUTTON,
+        type: DEVICE_FEATURE_TYPES.BUTTON.CLICK,
+      }),
+    };
+    homekitHandler.sendState = stub();
+    homekitHandler.notifyTimeouts = {};
+
+    const event = {
+      type: EVENTS.DEVICE.NEW_STATE,
+      last_value: 1,
+      device_feature: 'home:button:click',
+    };
+    await homekitHandler.notifyChange([accessory], event);
+    await homekitHandler.notifyChange([accessory], event);
+
+    // debouncing a zero delay would clear the first timer and drop the first press
+    expect(homekitHandler.sendState.callCount).to.equal(2);
   });
 
   it('should update timeout to notify', async () => {

--- a/server/test/services/homekit/lib/notifyChange.test.js
+++ b/server/test/services/homekit/lib/notifyChange.test.js
@@ -66,6 +66,38 @@ describe('Notify change to HomeKit', () => {
     expect(homekitHandler.notifyTimeouts['home:door:binary']).haveOwnProperty('startDateTime');
   });
 
+  it('should not delay a mapping that asks for no delay', async () => {
+    const sendEventNotification = stub();
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns({ getCharacteristic: stub().returns({ sendEventNotification }) }),
+    };
+
+    homekitHandler.gladys.stateManager = {
+      get: stub().returns({
+        id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+        device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+        name: 'Button',
+        category: DEVICE_FEATURE_CATEGORIES.BUTTON,
+        type: DEVICE_FEATURE_TYPES.BUTTON.CLICK,
+      }),
+    };
+    homekitHandler.sendState = stub();
+    homekitHandler.notifyTimeouts = {};
+
+    await homekitHandler.notifyChange([accessory], {
+      type: EVENTS.DEVICE.NEW_STATE,
+      last_value: 1,
+      device_feature: 'home:button:click',
+    });
+
+    // notifDelay is 0 on a button: the press must not sit in a five-second timeout
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+    expect(homekitHandler.sendState.callCount).to.equal(1);
+  });
+
   it('should update timeout to notify', async () => {
     const updateCharacteristic = stub().returns();
     const accessory = {

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -6,6 +6,7 @@ const {
   DEVICE_FEATURE_TYPES,
   EVENTS,
   DEVICE_FEATURE_UNITS,
+  BUTTON_STATUS,
 } = require('../../../../utils/constants');
 
 describe('Send state to HomeKit', () => {
@@ -34,6 +35,7 @@ describe('Send state to HomeKit', () => {
         CarbonDioxideLevel: 'CARBONDIOXIDELEVEL',
         CarbonDioxideDetected: 'CARBONDIOXIDEDETECTED',
         AirQuality: 'AIRQUALITY',
+        ProgrammableSwitchEvent: 'PROGRAMMABLESWITCHEVENT',
         PM2_5Density: 'PM25DENSITY',
         PM10Density: 'PM10DENSITY',
       },
@@ -45,6 +47,7 @@ describe('Send state to HomeKit', () => {
         CarbonMonoxideSensor: 'CARBONMONOXIDESENSOR',
         CarbonDioxideSensor: 'CARBONDIOXIDESENSOR',
         AirQualitySensor: 'AIRQUALITYSENSOR',
+        StatelessProgrammableSwitch: 'STATELESSPROGRAMMABLESWITCH',
       },
     },
     notifyTimeouts: {},
@@ -618,6 +621,42 @@ describe('Send state to HomeKit', () => {
     expect(updateCharacteristic.args[0]).eql(['PM25DENSITY', 42]);
     expect(updateCharacteristic.args[1]).eql(['PM25DENSITY', 50]);
     expect(updateCharacteristic.args[2]).eql(['PM10DENSITY', 8]);
+  });
+
+  it('should notify the three button events HomeKit knows, and drop the others', async () => {
+    const updateCharacteristic = stub().returns();
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns({ updateCharacteristic }),
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Button',
+      category: DEVICE_FEATURE_CATEGORIES.BUTTON,
+      type: DEVICE_FEATURE_TYPES.BUTTON.CLICK,
+    };
+    const press = (status, overrides = {}) =>
+      homekitHandler.sendState(
+        accessory,
+        { ...feature, ...overrides },
+        { type: EVENTS.DEVICE.NEW_STATE, last_value: status },
+      );
+
+    await press(BUTTON_STATUS.CLICK);
+    await press(BUTTON_STATUS.DOUBLE_CLICK);
+    await press(BUTTON_STATUS.LONG_CLICK, { type: DEVICE_FEATURE_TYPES.BUTTON.PUSH });
+
+    expect(updateCharacteristic.args[0]).eql(['PROGRAMMABLESWITCHEVENT', 0]);
+    expect(updateCharacteristic.args[1]).eql(['PROGRAMMABLESWITCHEVENT', 1]);
+    expect(updateCharacteristic.args[2]).eql(['PROGRAMMABLESWITCHEVENT', 2]);
+
+    // a gesture with no HomeKit equivalent must not fire one of the three above
+    await press(BUTTON_STATUS.SHAKE);
+    await press(BUTTON_STATUS.ROTATE_LEFT);
+
+    expect(updateCharacteristic.callCount).to.equal(3);
   });
 
   it('should do nothing wrong device category & type', async () => {

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -624,10 +624,10 @@ describe('Send state to HomeKit', () => {
   });
 
   it('should notify the three button events HomeKit knows, and drop the others', async () => {
-    const updateCharacteristic = stub().returns();
+    const sendEventNotification = stub();
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
-      getService: stub().returns({ updateCharacteristic }),
+      getService: stub().returns({ getCharacteristic: stub().returns({ sendEventNotification }) }),
     };
 
     const feature = {
@@ -648,15 +648,23 @@ describe('Send state to HomeKit', () => {
     await press(BUTTON_STATUS.DOUBLE_CLICK);
     await press(BUTTON_STATUS.LONG_CLICK, { type: DEVICE_FEATURE_TYPES.BUTTON.PUSH });
 
-    expect(updateCharacteristic.args[0]).eql(['PROGRAMMABLESWITCHEVENT', 0]);
-    expect(updateCharacteristic.args[1]).eql(['PROGRAMMABLESWITCHEVENT', 1]);
-    expect(updateCharacteristic.args[2]).eql(['PROGRAMMABLESWITCHEVENT', 2]);
+    expect(sendEventNotification.args[0][0]).to.equal(0);
+    expect(sendEventNotification.args[1][0]).to.equal(1);
+    expect(sendEventNotification.args[2][0]).to.equal(2);
+
+    // two identical presses in a row must both be delivered, which updateCharacteristic would not do
+    await press(BUTTON_STATUS.CLICK);
+    await press(BUTTON_STATUS.CLICK);
+
+    expect(sendEventNotification.callCount).to.equal(5);
+    expect(sendEventNotification.args[3][0]).to.equal(0);
+    expect(sendEventNotification.args[4][0]).to.equal(0);
 
     // a gesture with no HomeKit equivalent must not fire one of the three above
     await press(BUTTON_STATUS.SHAKE);
     await press(BUTTON_STATUS.ROTATE_LEFT);
 
-    expect(updateCharacteristic.callCount).to.equal(3);
+    expect(sendEventNotification.callCount).to.equal(5);
   });
 
   it('should do nothing wrong device category & type', async () => {

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -667,6 +667,74 @@ describe('Send state to HomeKit', () => {
     expect(sendEventNotification.callCount).to.equal(5);
   });
 
+  it('should notify the press names used by Matter and Zigbee2MQTT', async () => {
+    const sendEventNotification = stub();
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns({ getCharacteristic: stub().returns({ sendEventNotification }) }),
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Button',
+      category: DEVICE_FEATURE_CATEGORIES.BUTTON,
+      type: DEVICE_FEATURE_TYPES.BUTTON.CLICK,
+    };
+    const press = (status) =>
+      homekitHandler.sendState(accessory, feature, { type: EVENTS.DEVICE.NEW_STATE, last_value: status });
+
+    await press(BUTTON_STATUS.SHORT_RELEASE);
+    await press(BUTTON_STATUS.DOUBLE_PRESS);
+    await press(BUTTON_STATUS.LONG_PRESS);
+    await press(BUTTON_STATUS.HOLD_CLICK);
+
+    expect(sendEventNotification.args.map(([value]) => value)).eql([0, 1, 2, 2]);
+
+    // Matter opens every press with INITIAL_PRESS, long ones included: forwarding it would fire a
+    // single press each time the button is held down
+    await press(BUTTON_STATUS.INITIAL_PRESS);
+    await press(BUTTON_STATUS.LONG_RELEASE);
+
+    expect(sendEventNotification.callCount).to.equal(4);
+  });
+
+  it('should notify the button that was actually pressed on a multi-button remote', async () => {
+    const firstButton = stub();
+    const secondButton = stub();
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      services: [
+        {
+          subtype: 'button 1',
+          displayName: 'Left',
+          getCharacteristic: stub().returns({ sendEventNotification: firstButton }),
+        },
+        {
+          subtype: 'button 2',
+          displayName: 'Right',
+          getCharacteristic: stub().returns({ sendEventNotification: secondButton }),
+        },
+      ],
+      getService: stub().returns({ getCharacteristic: stub().returns({ sendEventNotification: firstButton }) }),
+    };
+
+    await homekitHandler.sendState(
+      accessory,
+      {
+        id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+        device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+        name: 'Right',
+        category: DEVICE_FEATURE_CATEGORIES.BUTTON,
+        type: DEVICE_FEATURE_TYPES.BUTTON.CLICK,
+      },
+      { type: EVENTS.DEVICE.NEW_STATE, last_value: BUTTON_STATUS.CLICK },
+    );
+
+    expect(secondButton.args).eql([[0]]);
+    expect(firstButton.callCount).to.equal(0);
+  });
+
   it('should do nothing wrong device category & type', async () => {
     const updateCharacteristic = stub().returns();
     const accessory = {

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -667,6 +667,35 @@ describe('Send state to HomeKit', () => {
     expect(sendEventNotification.callCount).to.equal(5);
   });
 
+  it('should notify a Xiaomi long press, sent through its own status table', async () => {
+    const sendEventNotification = stub();
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns({ getCharacteristic: stub().returns({ sendEventNotification }) }),
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Button',
+      category: DEVICE_FEATURE_CATEGORIES.BUTTON,
+      type: DEVICE_FEATURE_TYPES.BUTTON.CLICK,
+    };
+    const press = (status) =>
+      homekitHandler.sendState(accessory, feature, { type: EVENTS.DEVICE.NEW_STATE, last_value: status });
+
+    // xiaomi.newValueSwitch emits its own SWITCH_STATUS values on a button:click feature, and
+    // SWITCH_STATUS.LONG_CLICK_PRESS is the same 3 as BUTTON_STATUS.LONG_CLICK_PRESS
+    await press(BUTTON_STATUS.LONG_CLICK_PRESS);
+
+    expect(sendEventNotification.args).eql([[2]]);
+
+    // the matching release is dropped, or a single hold would fire twice
+    await press(BUTTON_STATUS.LONG_CLICK_RELEASE);
+
+    expect(sendEventNotification.callCount).to.equal(1);
+  });
+
   it('should notify the press names used by Matter and Zigbee2MQTT', async () => {
     const sendEventNotification = stub();
     const accessory = {
@@ -685,18 +714,19 @@ describe('Send state to HomeKit', () => {
       homekitHandler.sendState(accessory, feature, { type: EVENTS.DEVICE.NEW_STATE, last_value: status });
 
     await press(BUTTON_STATUS.SHORT_RELEASE);
+    await press(BUTTON_STATUS.PRESSED);
     await press(BUTTON_STATUS.DOUBLE_PRESS);
     await press(BUTTON_STATUS.LONG_PRESS);
     await press(BUTTON_STATUS.HOLD_CLICK);
 
-    expect(sendEventNotification.args.map(([value]) => value)).eql([0, 1, 2, 2]);
+    expect(sendEventNotification.args.map(([value]) => value)).eql([0, 0, 1, 2, 2]);
 
     // Matter opens every press with INITIAL_PRESS, long ones included: forwarding it would fire a
     // single press each time the button is held down
     await press(BUTTON_STATUS.INITIAL_PRESS);
     await press(BUTTON_STATUS.LONG_RELEASE);
 
-    expect(sendEventNotification.callCount).to.equal(4);
+    expect(sendEventNotification.callCount).to.equal(5);
   });
 
   it('should notify the button that was actually pressed on a multi-button remote', async () => {


### PR DESCRIPTION
Buttons and remotes are not exposed today, although Matter, Xiaomi, Zigbee2mqtt
and Z-Wave all report them. They are one of the most useful things to have in
HomeKit: a physical button that can trigger any Apple Home scene.

| Gladys type | HomeKit service | Characteristic |
| --- | --- | --- |
| `button:click`, `button:push` | `StatelessProgrammableSwitch` | `ProgrammableSwitchEvent` |

### Two things worth reviewing

**Only three of the hundred-odd `BUTTON_STATUS` values are forwarded** — single,
double and long press — because those are the only three HomeKit knows. Arrow
keys, rotation, shake and brightness gestures are dropped rather than reported as
one of the three: firing the wrong event in someone's automation is worse than
firing none.

**The mapping sets `notifDelay` to 0.** A press is an event, not a state, and the
default five-second debounce in `notifyChange` would either make HomeKit react
long after the press or swallow it when a second press followed. This is the one
part I would most like confirmed on real hardware.

### Testing

Unit tests cover the three mapped events, both feature types, the null state a
stateless switch must report, and that an unmapped gesture fires nothing. 100%
patch coverage.

Not yet paired with an actual iPhone.

This is part of a series extending the HomeKit bridge, one category per PR:
sensors (merged in #2781), siren, lock, fan, thermostat, device selection,
particulate densities, smoke, battery, button.

They are independent and reviewable on their own, but they all add cases to the
same `switch` statements in `buildService.js` and `sendState.js`, so whichever
merges first will leave the others needing a rebase. Happy to rebase in whatever
order suits you.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added HomeKit support for button click and push events through stateless programmable switches.
- Added notifications for single-click, double-click, and long-click events across supported button protocols.
- Button events are routed to the correct button on multi-button remotes.
- Repeated button clicks generate separate notifications.
- Unsupported or duplicate gestures do not generate notifications.

## Bug Fixes

- Preserved immediate notification timing for button events configured with no delay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->