### PR TITLE
feat(homekit): expose fans as a Fanv2

### DIFF
--- a/server/services/homekit/lib/buildAccessory.js
+++ b/server/services/homekit/lib/buildAccessory.js
@@ -57,13 +57,28 @@ function buildAccessory(device) {
     const serviceConfigs = [];
 
     categories[category].forEach((cat) => {
-      if (
-        serviceConfigs.length > 0 &&
-        !serviceConfigs[serviceConfigs.length - 1].find(
-          (config) => config.category === cat.category && config.type === cat.type,
-        )
-      ) {
-        serviceConfigs[serviceConfigs.length - 1].push(cat);
+      const currentConfig = serviceConfigs[serviceConfigs.length - 1];
+      const sameFeature =
+        currentConfig && currentConfig.find((config) => config.category === cat.category && config.type === cat.type);
+
+      if (currentConfig && !sameFeature) {
+        currentConfig.push(cat);
+
+        return;
+      }
+
+      // Some integrations expose a writable feature and its read-only counterpart (for example the
+      // Matter fan speed setting and the speed actually reached). Those are the two halves of a
+      // single HomeKit characteristic, not two devices: keep the writable one and drop the other.
+      // Only the feature types declaring it are merged, because a read-only feature is not always
+      // the feedback of its writable namesake: Matter exposes both an OnOff relay and a BooleanState
+      // sensor as SWITCH.BINARY, and those two really are separate services.
+      const mergeReadOnlyTwin = mappings[cat.category].capabilities[cat.type].mergeReadOnlyTwin === true;
+
+      if (mergeReadOnlyTwin && sameFeature && sameFeature.read_only !== cat.read_only) {
+        if (sameFeature.read_only) {
+          currentConfig[currentConfig.indexOf(sameFeature)] = cat;
+        }
 
         return;
       }

--- a/server/services/homekit/lib/buildService.js
+++ b/server/services/homekit/lib/buildService.js
@@ -374,6 +374,16 @@ function buildService(device, features, categoryMapping, subtype) {
             callback(undefined, speed > readFeature.min ? 1 : 0);
           });
           activeCharacteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
+            // Snapshot the speed on the way down rather than relying on a GET having happened
+            // first: switching the fan off from the Home app without reading it beforehand would
+            // otherwise restore it at full speed instead of where the user had left it.
+            if (!value) {
+              const currentSpeed = this.gladys.stateManager.get('deviceFeature', writeFeature.selector).last_value;
+              if (currentSpeed > writeFeature.min) {
+                lastActiveSpeed = currentSpeed;
+              }
+            }
+
             const action = {
               type: ACTIONS.DEVICE.SET_VALUE,
               status: ACTIONS_STATUS.PENDING,

--- a/server/services/homekit/lib/buildService.js
+++ b/server/services/homekit/lib/buildService.js
@@ -7,6 +7,9 @@ const {
   ACTIONS_STATUS,
   EVENTS,
   DEVICE_FEATURE_UNITS,
+  FAN_MODE,
+  FAN_ROCK_SETTING,
+  FAN_AIRFLOW_DIRECTION,
 } = require('../../../utils/constants');
 const { normalize } = require('../../../utils/device');
 const { fahrenheitToCelsius } = require('../../../utils/units');
@@ -269,6 +272,157 @@ function buildService(device, features, categoryMapping, subtype) {
             undefined,
             aqiToAirQuality(this.gladys.stateManager.get('deviceFeature', feature.selector).last_value),
           );
+        });
+        break;
+      }
+      case `${DEVICE_FEATURE_CATEGORIES.FAN}:${DEVICE_FEATURE_TYPES.FAN.MODE}`: {
+        const activeCharacteristic = service.getCharacteristic(
+          Characteristic[categoryMapping.capabilities[feature.type].characteristics[0]],
+        );
+
+        // HomeKit only knows on/off, so turning the fan back on restores the last mode it ran at.
+        let lastActiveMode = Math.min(FAN_MODE.HIGH, feature.max === undefined ? FAN_MODE.HIGH : feature.max);
+
+        activeCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+          const mode = this.gladys.stateManager.get('deviceFeature', feature.selector).last_value;
+          if (mode !== FAN_MODE.OFF) {
+            lastActiveMode = mode;
+          }
+          callback(undefined, mode === FAN_MODE.OFF ? 0 : 1);
+        });
+        activeCharacteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
+          const mode = this.gladys.stateManager.get('deviceFeature', feature.selector).last_value;
+          if (mode !== FAN_MODE.OFF) {
+            lastActiveMode = mode;
+          }
+          const action = {
+            type: ACTIONS.DEVICE.SET_VALUE,
+            status: ACTIONS_STATUS.PENDING,
+            value: value ? lastActiveMode : FAN_MODE.OFF,
+            device: device.selector,
+            device_feature: feature.selector,
+          };
+          this.gladys.event.emit(EVENTS.ACTION.TRIGGERED, action);
+          callback();
+        });
+        break;
+      }
+      case `${DEVICE_FEATURE_CATEGORIES.FAN}:${DEVICE_FEATURE_TYPES.FAN.PERCENT}`:
+      case `${DEVICE_FEATURE_CATEGORIES.FAN}:${DEVICE_FEATURE_TYPES.FAN.SPEED}`: {
+        // A fan can expose both a percentage and a raw speed, HomeKit has a single RotationSpeed:
+        // the percentage wins because it already uses the HomeKit scale.
+        const hasPercentFeature = features.some((f) => f.type === DEVICE_FEATURE_TYPES.FAN.PERCENT);
+        if (feature.type === DEVICE_FEATURE_TYPES.FAN.SPEED && hasPercentFeature) {
+          break;
+        }
+
+        const [rotationSpeedName, activeName] = categoryMapping.capabilities[feature.type].characteristics;
+        const rotationSpeedCharacteristic = service.getCharacteristic(Characteristic[rotationSpeedName]);
+
+        rotationSpeedCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+          callback(
+            undefined,
+            normalize(
+              this.gladys.stateManager.get('deviceFeature', feature.selector).last_value,
+              feature.min,
+              feature.max,
+              rotationSpeedCharacteristic.props.minValue,
+              rotationSpeedCharacteristic.props.maxValue,
+            ),
+          );
+        });
+        rotationSpeedCharacteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
+          const action = {
+            type: ACTIONS.DEVICE.SET_VALUE,
+            status: ACTIONS_STATUS.PENDING,
+            value: Math.round(
+              normalize(
+                value,
+                rotationSpeedCharacteristic.props.minValue,
+                rotationSpeedCharacteristic.props.maxValue,
+                feature.min,
+                feature.max,
+              ),
+            ),
+            device: device.selector,
+            device_feature: feature.selector,
+          };
+          this.gladys.event.emit(EVENTS.ACTION.TRIGGERED, action);
+          callback();
+        });
+
+        // Fanv2 always requires Active. Without a mode feature, the speed is the only on/off signal.
+        if (!features.some((f) => f.type === DEVICE_FEATURE_TYPES.FAN.MODE)) {
+          let lastActiveSpeed = feature.max;
+          const activeCharacteristic = service.getCharacteristic(Characteristic[activeName]);
+
+          activeCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+            const speed = this.gladys.stateManager.get('deviceFeature', feature.selector).last_value;
+            if (speed > feature.min) {
+              lastActiveSpeed = speed;
+            }
+            callback(undefined, speed > feature.min ? 1 : 0);
+          });
+          activeCharacteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
+            const action = {
+              type: ACTIONS.DEVICE.SET_VALUE,
+              status: ACTIONS_STATUS.PENDING,
+              value: value ? lastActiveSpeed : feature.min,
+              device: device.selector,
+              device_feature: feature.selector,
+            };
+            this.gladys.event.emit(EVENTS.ACTION.TRIGGERED, action);
+            callback();
+          });
+        }
+        break;
+      }
+      case `${DEVICE_FEATURE_CATEGORIES.FAN}:${DEVICE_FEATURE_TYPES.FAN.ROCK_SETTING}`: {
+        const swingModeCharacteristic = service.getCharacteristic(
+          Characteristic[categoryMapping.capabilities[feature.type].characteristics[0]],
+        );
+
+        // Gladys stores a bitmap of the oscillation axes, HomeKit only has on/off. The feature max
+        // is the set of axes the device supports, so it is the value used to enable oscillation.
+        const enabledRockSetting = feature.max || FAN_ROCK_SETTING.LEFT_RIGHT;
+
+        swingModeCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+          const rockSetting = this.gladys.stateManager.get('deviceFeature', feature.selector).last_value;
+          callback(undefined, rockSetting === FAN_ROCK_SETTING.OFF ? 0 : 1);
+        });
+        swingModeCharacteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
+          const action = {
+            type: ACTIONS.DEVICE.SET_VALUE,
+            status: ACTIONS_STATUS.PENDING,
+            value: value ? enabledRockSetting : FAN_ROCK_SETTING.OFF,
+            device: device.selector,
+            device_feature: feature.selector,
+          };
+          this.gladys.event.emit(EVENTS.ACTION.TRIGGERED, action);
+          callback();
+        });
+        break;
+      }
+      case `${DEVICE_FEATURE_CATEGORIES.FAN}:${DEVICE_FEATURE_TYPES.FAN.AIRFLOW_DIRECTION}`: {
+        const rotationDirectionCharacteristic = service.getCharacteristic(
+          Characteristic[categoryMapping.capabilities[feature.type].characteristics[0]],
+        );
+
+        rotationDirectionCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+          const direction = this.gladys.stateManager.get('deviceFeature', feature.selector).last_value;
+          // HomeKit RotationDirection: 0 clockwise, 1 counter clockwise.
+          callback(undefined, direction === FAN_AIRFLOW_DIRECTION.REVERSE ? 1 : 0);
+        });
+        rotationDirectionCharacteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
+          const action = {
+            type: ACTIONS.DEVICE.SET_VALUE,
+            status: ACTIONS_STATUS.PENDING,
+            value: value ? FAN_AIRFLOW_DIRECTION.REVERSE : FAN_AIRFLOW_DIRECTION.FORWARD,
+            device: device.selector,
+            device_feature: feature.selector,
+          };
+          this.gladys.event.emit(EVENTS.ACTION.TRIGGERED, action);
+          callback();
         });
         break;
       }

--- a/server/services/homekit/lib/buildService.js
+++ b/server/services/homekit/lib/buildService.js
@@ -309,12 +309,20 @@ function buildService(device, features, categoryMapping, subtype) {
       }
       case `${DEVICE_FEATURE_CATEGORIES.FAN}:${DEVICE_FEATURE_TYPES.FAN.PERCENT}`:
       case `${DEVICE_FEATURE_CATEGORIES.FAN}:${DEVICE_FEATURE_TYPES.FAN.SPEED}`: {
-        // A fan can expose both a percentage and a raw speed, HomeKit has a single RotationSpeed:
-        // the percentage wins because it already uses the HomeKit scale.
-        const hasPercentFeature = features.some((f) => f.type === DEVICE_FEATURE_TYPES.FAN.PERCENT);
-        if (feature.type === DEVICE_FEATURE_TYPES.FAN.SPEED && hasPercentFeature) {
+        // A fan can expose both a percentage and a raw speed, HomeKit has a single RotationSpeed.
+        // They are wired once, on whichever comes first, so the handlers are not registered twice.
+        const speedFeatures = features.filter(
+          (f) => f.type === DEVICE_FEATURE_TYPES.FAN.PERCENT || f.type === DEVICE_FEATURE_TYPES.FAN.SPEED,
+        );
+        if (speedFeatures[0] !== feature) {
           break;
         }
+
+        // Reads prefer the percentage, which already uses the HomeKit scale. Writes must go to a
+        // feature that accepts them: an integration can expose a read-only percentage as the
+        // feedback of a writable speed, and commanding the percentage would go nowhere.
+        const readFeature = speedFeatures.find((f) => f.type === DEVICE_FEATURE_TYPES.FAN.PERCENT) || speedFeatures[0];
+        const writeFeature = speedFeatures.find((f) => !f.read_only) || readFeature;
 
         const [rotationSpeedName, activeName] = categoryMapping.capabilities[feature.type].characteristics;
         const rotationSpeedCharacteristic = service.getCharacteristic(Characteristic[rotationSpeedName]);
@@ -323,9 +331,9 @@ function buildService(device, features, categoryMapping, subtype) {
           callback(
             undefined,
             normalize(
-              this.gladys.stateManager.get('deviceFeature', feature.selector).last_value,
-              feature.min,
-              feature.max,
+              this.gladys.stateManager.get('deviceFeature', readFeature.selector).last_value,
+              readFeature.min,
+              readFeature.max,
               rotationSpeedCharacteristic.props.minValue,
               rotationSpeedCharacteristic.props.maxValue,
             ),
@@ -340,12 +348,12 @@ function buildService(device, features, categoryMapping, subtype) {
                 value,
                 rotationSpeedCharacteristic.props.minValue,
                 rotationSpeedCharacteristic.props.maxValue,
-                feature.min,
-                feature.max,
+                writeFeature.min,
+                writeFeature.max,
               ),
             ),
             device: device.selector,
-            device_feature: feature.selector,
+            device_feature: writeFeature.selector,
           };
           this.gladys.event.emit(EVENTS.ACTION.TRIGGERED, action);
           callback();
@@ -353,23 +361,25 @@ function buildService(device, features, categoryMapping, subtype) {
 
         // Fanv2 always requires Active. Without a mode feature, the speed is the only on/off signal.
         if (!features.some((f) => f.type === DEVICE_FEATURE_TYPES.FAN.MODE)) {
-          let lastActiveSpeed = feature.max;
+          let lastActiveSpeed = writeFeature.max;
           const activeCharacteristic = service.getCharacteristic(Characteristic[activeName]);
 
           activeCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
-            const speed = this.gladys.stateManager.get('deviceFeature', feature.selector).last_value;
-            if (speed > feature.min) {
-              lastActiveSpeed = speed;
+            const speed = this.gladys.stateManager.get('deviceFeature', readFeature.selector).last_value;
+            if (speed > readFeature.min) {
+              // The speed to restore is remembered on the feature it will be written back to, since
+              // the read and write features can use different scales.
+              lastActiveSpeed = this.gladys.stateManager.get('deviceFeature', writeFeature.selector).last_value;
             }
-            callback(undefined, speed > feature.min ? 1 : 0);
+            callback(undefined, speed > readFeature.min ? 1 : 0);
           });
           activeCharacteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
             const action = {
               type: ACTIONS.DEVICE.SET_VALUE,
               status: ACTIONS_STATUS.PENDING,
-              value: value ? lastActiveSpeed : feature.min,
+              value: value ? lastActiveSpeed : writeFeature.min,
               device: device.selector,
-              device_feature: feature.selector,
+              device_feature: writeFeature.selector,
             };
             this.gladys.event.emit(EVENTS.ACTION.TRIGGERED, action);
             callback();

--- a/server/services/homekit/lib/deviceMappings.js
+++ b/server/services/homekit/lib/deviceMappings.js
@@ -150,6 +150,28 @@ const mappings = {
       },
     },
   },
+  [DEVICE_FEATURE_CATEGORIES.FAN]: {
+    service: 'Fanv2',
+    capabilities: {
+      [DEVICE_FEATURE_TYPES.FAN.MODE]: {
+        characteristics: ['Active'],
+      },
+      [DEVICE_FEATURE_TYPES.FAN.PERCENT]: {
+        characteristics: ['RotationSpeed', 'Active'],
+        mergeReadOnlyTwin: true,
+      },
+      [DEVICE_FEATURE_TYPES.FAN.SPEED]: {
+        characteristics: ['RotationSpeed', 'Active'],
+        mergeReadOnlyTwin: true,
+      },
+      [DEVICE_FEATURE_TYPES.FAN.ROCK_SETTING]: {
+        characteristics: ['SwingMode'],
+      },
+      [DEVICE_FEATURE_TYPES.FAN.AIRFLOW_DIRECTION]: {
+        characteristics: ['RotationDirection'],
+      },
+    },
+  },
   [DEVICE_FEATURE_CATEGORIES.SHUTTER]: {
     service: 'WindowCovering',
     capabilities: {

--- a/server/services/homekit/lib/sendState.js
+++ b/server/services/homekit/lib/sendState.js
@@ -1,5 +1,12 @@
 const { intToRgb, rgbToHsb } = require('../../../utils/colors');
-const { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES, DEVICE_FEATURE_UNITS } = require('../../../utils/constants');
+const {
+  DEVICE_FEATURE_CATEGORIES,
+  DEVICE_FEATURE_TYPES,
+  DEVICE_FEATURE_UNITS,
+  FAN_MODE,
+  FAN_ROCK_SETTING,
+  FAN_AIRFLOW_DIRECTION,
+} = require('../../../utils/constants');
 const { normalize } = require('../../../utils/device');
 const { fahrenheitToCelsius } = require('../../../utils/units');
 const {
@@ -147,6 +154,51 @@ function sendState(hkAccessory, feature, event) {
         .updateCharacteristic(
           Characteristic[mappings[feature.category].capabilities[feature.type].characteristics[0]],
           aqiToAirQuality(event.last_value),
+        );
+      break;
+    }
+    case `${DEVICE_FEATURE_CATEGORIES.FAN}:${DEVICE_FEATURE_TYPES.FAN.MODE}`: {
+      hkAccessory
+        .getService(Service[mappings[feature.category].service])
+        .updateCharacteristic(
+          Characteristic[mappings[feature.category].capabilities[feature.type].characteristics[0]],
+          event.last_value === FAN_MODE.OFF ? 0 : 1,
+        );
+      break;
+    }
+    case `${DEVICE_FEATURE_CATEGORIES.FAN}:${DEVICE_FEATURE_TYPES.FAN.PERCENT}`:
+    case `${DEVICE_FEATURE_CATEGORIES.FAN}:${DEVICE_FEATURE_TYPES.FAN.SPEED}`: {
+      const service = hkAccessory.getService(Service[mappings[feature.category].service]);
+      const [rotationSpeedName] = mappings[feature.category].capabilities[feature.type].characteristics;
+      const rotationSpeedCharacteristic = service.getCharacteristic(Characteristic[rotationSpeedName]);
+
+      service.updateCharacteristic(
+        Characteristic[rotationSpeedName],
+        normalize(
+          event.last_value,
+          feature.min,
+          feature.max,
+          rotationSpeedCharacteristic.props.minValue,
+          rotationSpeedCharacteristic.props.maxValue,
+        ),
+      );
+      break;
+    }
+    case `${DEVICE_FEATURE_CATEGORIES.FAN}:${DEVICE_FEATURE_TYPES.FAN.ROCK_SETTING}`: {
+      hkAccessory
+        .getService(Service[mappings[feature.category].service])
+        .updateCharacteristic(
+          Characteristic[mappings[feature.category].capabilities[feature.type].characteristics[0]],
+          event.last_value === FAN_ROCK_SETTING.OFF ? 0 : 1,
+        );
+      break;
+    }
+    case `${DEVICE_FEATURE_CATEGORIES.FAN}:${DEVICE_FEATURE_TYPES.FAN.AIRFLOW_DIRECTION}`: {
+      hkAccessory
+        .getService(Service[mappings[feature.category].service])
+        .updateCharacteristic(
+          Characteristic[mappings[feature.category].capabilities[feature.type].characteristics[0]],
+          event.last_value === FAN_AIRFLOW_DIRECTION.REVERSE ? 1 : 0,
         );
       break;
     }

--- a/server/services/homekit/lib/sendState.js
+++ b/server/services/homekit/lib/sendState.js
@@ -168,6 +168,21 @@ function sendState(hkAccessory, feature, event) {
     }
     case `${DEVICE_FEATURE_CATEGORIES.FAN}:${DEVICE_FEATURE_TYPES.FAN.PERCENT}`:
     case `${DEVICE_FEATURE_CATEGORIES.FAN}:${DEVICE_FEATURE_TYPES.FAN.SPEED}`: {
+      // buildService reads RotationSpeed from the percentage when the fan exposes one, since it
+      // already uses the HomeKit scale. A fan reporting both would otherwise emit two events per
+      // change and the raw speed, rescaled, would overwrite the percentage HomeKit is showing.
+      if (feature.type === DEVICE_FEATURE_TYPES.FAN.SPEED) {
+        const device = this.gladys.stateManager.get('deviceById', feature.device_id);
+        const hasPercentFeature = ((device && device.features) || []).some(
+          (deviceFeature) =>
+            deviceFeature.category === DEVICE_FEATURE_CATEGORIES.FAN &&
+            deviceFeature.type === DEVICE_FEATURE_TYPES.FAN.PERCENT,
+        );
+        if (hasPercentFeature) {
+          break;
+        }
+      }
+
       const service = hkAccessory.getService(Service[mappings[feature.category].service]);
       const [rotationSpeedName] = mappings[feature.category].capabilities[feature.type].characteristics;
       const rotationSpeedCharacteristic = service.getCharacteristic(Characteristic[rotationSpeedName]);

--- a/server/test/services/homekit/lib/buildAccessory.test.js
+++ b/server/test/services/homekit/lib/buildAccessory.test.js
@@ -99,4 +99,148 @@ describe('Build accessory', () => {
     expect(homekitHandler.buildService.callCount).to.equal(1);
     expect(homekitHandler.buildService.args[0][1]).to.have.deep.members(device.features);
   });
+  it('should keep the writable feature when a read-only twin exists', async () => {
+    homekitHandler.buildService = sinon.stub().returns('builded-service');
+    const addService = sinon.stub();
+    homekitHandler.hap = {
+      Accessory: sinon.stub().returns({ addService, services: ['service1', 'service2'] }),
+    };
+
+    const device = {
+      id: 'c22a4d4b-e261-4b22-a2be-309baf12c3ca',
+      name: 'Ventilateur',
+      features: [
+        {
+          name: 'Speed %',
+          category: 'fan',
+          type: 'percent',
+          read_only: false,
+        },
+        {
+          name: 'Speed % current',
+          category: 'fan',
+          type: 'percent',
+          read_only: true,
+        },
+        {
+          name: 'Oscillation',
+          category: 'fan',
+          type: 'rock-setting',
+          read_only: false,
+        },
+      ],
+    };
+
+    await homekitHandler.buildAccessory(device);
+
+    // a single Fanv2 service, built from the writable percent feature
+    expect(homekitHandler.buildService.callCount).to.equal(1);
+    expect(homekitHandler.buildService.args[0][1]).to.have.deep.members([
+      { name: 'Speed %', category: 'fan', type: 'percent', read_only: false },
+      { name: 'Oscillation', category: 'fan', type: 'rock-setting', read_only: false },
+    ]);
+    expect(addService.callCount).to.equal(1);
+  });
+
+  it('should keep the writable feature whichever order the twins come in', async () => {
+    homekitHandler.buildService = sinon.stub().returns('builded-service');
+    const addService = sinon.stub();
+    homekitHandler.hap = {
+      Accessory: sinon.stub().returns({ addService, services: ['service1', 'service2'] }),
+    };
+
+    // the read-only counterpart comes first this time
+    const device = {
+      id: 'c22a4d4b-e261-4b22-a2be-309baf12c3ca',
+      name: 'Ventilateur',
+      features: [
+        {
+          name: 'Speed % current',
+          category: 'fan',
+          type: 'percent',
+          read_only: true,
+        },
+        {
+          name: 'Speed %',
+          category: 'fan',
+          type: 'percent',
+          read_only: false,
+        },
+      ],
+    };
+
+    await homekitHandler.buildAccessory(device);
+
+    expect(homekitHandler.buildService.callCount).to.equal(1);
+    expect(homekitHandler.buildService.args[0][1]).to.have.deep.members([device.features[1]]);
+    expect(addService.callCount).to.equal(1);
+  });
+
+  it('should not merge a read-only twin of a feature type that did not ask for it', async () => {
+    homekitHandler.buildService = sinon.stub().returns('builded-service');
+    const addService = sinon.stub();
+    homekitHandler.hap = {
+      Accessory: sinon.stub().returns({ addService, services: ['service1', 'service2'] }),
+    };
+
+    // Matter exposes an OnOff relay and a BooleanState sensor as the same category and type, but
+    // they are two separate things and must stay two services.
+    const device = {
+      id: 'c22a4d4b-e261-4b22-a2be-309baf12c3ca',
+      name: 'Matter',
+      features: [
+        {
+          name: 'OnOff',
+          category: 'switch',
+          type: 'binary',
+          read_only: false,
+        },
+        {
+          name: 'BooleanState',
+          category: 'switch',
+          type: 'binary',
+          read_only: true,
+        },
+      ],
+    };
+
+    await homekitHandler.buildAccessory(device);
+
+    expect(homekitHandler.buildService.callCount).to.equal(2);
+    expect(homekitHandler.buildService.args[0][1]).to.have.deep.members([device.features[0]]);
+    expect(homekitHandler.buildService.args[1][1]).to.have.deep.members([device.features[1]]);
+    expect(addService.callCount).to.equal(2);
+  });
+
+  it('should still split identical features into several services', async () => {
+    homekitHandler.buildService = sinon.stub().returns('builded-service');
+    const addService = sinon.stub();
+    homekitHandler.hap = {
+      Accessory: sinon.stub().returns({ addService, services: ['service1', 'service2'] }),
+    };
+
+    const device = {
+      id: 'c22a4d4b-e261-4b22-a2be-309baf12c3ca',
+      name: 'Double interrupteur',
+      features: [
+        {
+          name: 'Switch 1',
+          category: 'switch',
+          type: 'binary',
+          read_only: false,
+        },
+        {
+          name: 'Switch 2',
+          category: 'switch',
+          type: 'binary',
+          read_only: false,
+        },
+      ],
+    };
+
+    await homekitHandler.buildAccessory(device);
+
+    expect(homekitHandler.buildService.callCount).to.equal(2);
+    expect(addService.callCount).to.equal(2);
+  });
 });

--- a/server/test/services/homekit/lib/buildService.test.js
+++ b/server/test/services/homekit/lib/buildService.test.js
@@ -1383,6 +1383,55 @@ describe('Build service', () => {
     });
   });
 
+  it('should send fan speed commands to the writable feature, not the read-only one', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'ventilo-percent').returns({ last_value: 50 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'ventilo-speed').returns({ last_value: 3 });
+    homekitHandler.gladys.event.emit = stub();
+    const on = stub();
+    const getCharacteristic = stub().returns({ on, props: { minValue: 0, maxValue: 100 } });
+    const Fanv2 = stub().returns({ getCharacteristic });
+
+    homekitHandler.hap = {
+      Characteristic: { RotationSpeed: 'ROTATIONSPEED', Active: 'ACTIVE' },
+      CharacteristicEventTypes: stub(),
+      Service: { Fanv2 },
+    };
+    // Matter can expose the reached percentage read-only, and the speed setting as the command
+    const features = [
+      {
+        name: 'Pourcentage',
+        selector: 'ventilo-percent',
+        category: DEVICE_FEATURE_CATEGORIES.FAN,
+        type: DEVICE_FEATURE_TYPES.FAN.PERCENT,
+        read_only: true,
+        min: 0,
+        max: 100,
+      },
+      {
+        name: 'Vitesse',
+        selector: 'ventilo-speed',
+        category: DEVICE_FEATURE_CATEGORIES.FAN,
+        type: DEVICE_FEATURE_TYPES.FAN.SPEED,
+        read_only: false,
+        min: 0,
+        max: 5,
+      },
+    ];
+
+    const cb = stub();
+
+    await homekitHandler.buildService({ name: 'Ventilateur' }, features, mappings[DEVICE_FEATURE_CATEGORIES.FAN]);
+    // reads come from the percentage, which is already on the HomeKit scale
+    await on.args[0][1](cb);
+    expect(cb.args[0][1]).to.equal(50);
+
+    // writes must reach the speed feature, rescaled to its own bounds
+    await on.args[1][1](60, cb);
+    expect(homekitHandler.gladys.event.emit.args[0][1].device_feature).to.equal('ventilo-speed');
+    expect(homekitHandler.gladys.event.emit.args[0][1].value).to.equal(3);
+  });
+
   it('should build shutter/curtain service', async () => {
     homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'shutter-state').returns({
       id: '31c6a4a7-9710-4951-bf34-04eeae5b9ff7',

--- a/server/test/services/homekit/lib/buildService.test.js
+++ b/server/test/services/homekit/lib/buildService.test.js
@@ -8,6 +8,9 @@ const {
   ACTIONS,
   ACTIONS_STATUS,
   DEVICE_FEATURE_UNITS,
+  FAN_MODE,
+  FAN_ROCK_SETTING,
+  FAN_AIRFLOW_DIRECTION,
 } = require('../../../../utils/constants');
 
 describe('Build service', () => {
@@ -1041,6 +1044,343 @@ describe('Build service', () => {
     expect(cb.args[2][1]).to.equal(8);
     // no unit declared, the value is taken as µg/m³ and only clamped
     expect(cb.args[3][1]).to.equal(1000);
+  });
+
+  it('should build fan service', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get
+      .withArgs('deviceFeature', 'ventilateur-mode')
+      .returns({ last_value: FAN_MODE.MEDIUM });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'ventilateur-percent').returns({ last_value: 40 });
+    homekitHandler.gladys.stateManager.get
+      .withArgs('deviceFeature', 'ventilateur-rock')
+      .returns({ last_value: FAN_ROCK_SETTING.OFF });
+    homekitHandler.gladys.stateManager.get
+      .withArgs('deviceFeature', 'ventilateur-airflow')
+      .returns({ last_value: FAN_AIRFLOW_DIRECTION.REVERSE });
+    homekitHandler.gladys.event.emit = stub();
+    const on = stub();
+    const getCharacteristic = stub()
+      .returns({ on })
+      .onCall(1)
+      .returns({
+        on,
+        props: {
+          minValue: 0,
+          maxValue: 100,
+        },
+      });
+    const Fanv2 = stub().returns({
+      getCharacteristic,
+    });
+
+    homekitHandler.hap = {
+      Characteristic: {
+        Active: 'ACTIVE',
+        RotationSpeed: 'ROTATIONSPEED',
+        SwingMode: 'SWINGMODE',
+        RotationDirection: 'ROTATIONDIRECTION',
+      },
+      CharacteristicEventTypes: stub(),
+      Service: {
+        Fanv2,
+      },
+    };
+    const device = {
+      name: 'Ventilateur',
+      selector: 'ventilateur',
+    };
+    const features = [
+      {
+        name: 'Mode',
+        selector: 'ventilateur-mode',
+        category: DEVICE_FEATURE_CATEGORIES.FAN,
+        type: DEVICE_FEATURE_TYPES.FAN.MODE,
+        min: FAN_MODE.OFF,
+        max: FAN_MODE.AUTO,
+      },
+      {
+        name: 'Vitesse %',
+        selector: 'ventilateur-percent',
+        category: DEVICE_FEATURE_CATEGORIES.FAN,
+        type: DEVICE_FEATURE_TYPES.FAN.PERCENT,
+        min: 0,
+        max: 100,
+      },
+      {
+        name: 'Vitesse',
+        selector: 'ventilateur-speed',
+        category: DEVICE_FEATURE_CATEGORIES.FAN,
+        type: DEVICE_FEATURE_TYPES.FAN.SPEED,
+        min: 0,
+        max: 10,
+      },
+      {
+        name: 'Oscillation',
+        selector: 'ventilateur-rock',
+        category: DEVICE_FEATURE_CATEGORIES.FAN,
+        type: DEVICE_FEATURE_TYPES.FAN.ROCK_SETTING,
+        min: FAN_ROCK_SETTING.OFF,
+        max: FAN_ROCK_SETTING.LEFT_RIGHT_AND_UP_DOWN,
+      },
+      {
+        name: 'Direction',
+        selector: 'ventilateur-airflow',
+        category: DEVICE_FEATURE_CATEGORIES.FAN,
+        type: DEVICE_FEATURE_TYPES.FAN.AIRFLOW_DIRECTION,
+        min: FAN_AIRFLOW_DIRECTION.FORWARD,
+        max: FAN_AIRFLOW_DIRECTION.REVERSE,
+      },
+    ];
+
+    const cb = stub();
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.FAN]);
+    await on.args[0][1](cb);
+    await on.args[1][1](0, cb);
+    await on.args[2][1](cb);
+    await on.args[3][1](60, cb);
+    await on.args[4][1](cb);
+    await on.args[5][1](1, cb);
+    await on.args[6][1](cb);
+    await on.args[7][1](0, cb);
+
+    expect(Fanv2.args[0][0]).to.equal('Ventilateur');
+    // the raw speed feature is ignored, the percentage already drives RotationSpeed
+    expect(getCharacteristic.callCount).to.equal(4);
+    expect(on.callCount).to.equal(8);
+    expect(getCharacteristic.args[0][0]).to.equal('ACTIVE');
+    expect(getCharacteristic.args[1][0]).to.equal('ROTATIONSPEED');
+    expect(getCharacteristic.args[2][0]).to.equal('SWINGMODE');
+    expect(getCharacteristic.args[3][0]).to.equal('ROTATIONDIRECTION');
+    expect(cb.args[0][1]).to.equal(1);
+    expect(homekitHandler.gladys.event.emit.args[0][1]).to.eql({
+      type: ACTIONS.DEVICE.SET_VALUE,
+      status: ACTIONS_STATUS.PENDING,
+      value: FAN_MODE.OFF,
+      device: device.selector,
+      device_feature: features[0].selector,
+    });
+    expect(cb.args[2][1]).to.equal(40);
+    expect(homekitHandler.gladys.event.emit.args[1][1]).to.eql({
+      type: ACTIONS.DEVICE.SET_VALUE,
+      status: ACTIONS_STATUS.PENDING,
+      value: 60,
+      device: device.selector,
+      device_feature: features[1].selector,
+    });
+    expect(cb.args[4][1]).to.equal(0);
+    // enabling oscillation uses every axis the device supports
+    expect(homekitHandler.gladys.event.emit.args[2][1]).to.eql({
+      type: ACTIONS.DEVICE.SET_VALUE,
+      status: ACTIONS_STATUS.PENDING,
+      value: FAN_ROCK_SETTING.LEFT_RIGHT_AND_UP_DOWN,
+      device: device.selector,
+      device_feature: features[3].selector,
+    });
+    expect(cb.args[6][1]).to.equal(1);
+    expect(homekitHandler.gladys.event.emit.args[3][1]).to.eql({
+      type: ACTIONS.DEVICE.SET_VALUE,
+      status: ACTIONS_STATUS.PENDING,
+      value: FAN_AIRFLOW_DIRECTION.FORWARD,
+      device: device.selector,
+      device_feature: features[4].selector,
+    });
+
+    // same characteristics read and written the other way round
+    homekitHandler.gladys.stateManager.get
+      .withArgs('deviceFeature', 'ventilateur-mode')
+      .returns({ last_value: FAN_MODE.OFF });
+    homekitHandler.gladys.stateManager.get
+      .withArgs('deviceFeature', 'ventilateur-rock')
+      .returns({ last_value: FAN_ROCK_SETTING.UP_DOWN });
+    homekitHandler.gladys.stateManager.get
+      .withArgs('deviceFeature', 'ventilateur-airflow')
+      .returns({ last_value: FAN_AIRFLOW_DIRECTION.FORWARD });
+
+    await on.args[0][1](cb);
+    await on.args[4][1](cb);
+    await on.args[5][1](0, cb);
+    await on.args[6][1](cb);
+    await on.args[7][1](1, cb);
+
+    expect(cb.args[8][1]).to.equal(0);
+    expect(cb.args[9][1]).to.equal(1);
+    expect(homekitHandler.gladys.event.emit.args[4][1].value).to.equal(FAN_ROCK_SETTING.OFF);
+    expect(cb.args[11][1]).to.equal(0);
+    expect(homekitHandler.gladys.event.emit.args[5][1].value).to.equal(FAN_AIRFLOW_DIRECTION.REVERSE);
+  });
+
+  it('should fall back to sane defaults when the fan declares no bounds', async () => {
+    homekitHandler.gladys.stateManager.get = stub().returns({ last_value: 0 });
+    homekitHandler.gladys.event.emit = stub();
+    const on = stub();
+    const getCharacteristic = stub().returns({ on });
+    const Fanv2 = stub().returns({
+      getCharacteristic,
+    });
+
+    homekitHandler.hap = {
+      Characteristic: {
+        Active: 'ACTIVE',
+        SwingMode: 'SWINGMODE',
+      },
+      CharacteristicEventTypes: stub(),
+      Service: {
+        Fanv2,
+      },
+    };
+    const device = {
+      name: 'Ventilateur',
+      selector: 'ventilateur',
+    };
+    // neither feature declares a max
+    const features = [
+      {
+        name: 'Mode',
+        selector: 'ventilateur-mode',
+        category: DEVICE_FEATURE_CATEGORIES.FAN,
+        type: DEVICE_FEATURE_TYPES.FAN.MODE,
+      },
+      {
+        name: 'Oscillation',
+        selector: 'ventilateur-rock',
+        category: DEVICE_FEATURE_CATEGORIES.FAN,
+        type: DEVICE_FEATURE_TYPES.FAN.ROCK_SETTING,
+      },
+    ];
+
+    const cb = stub();
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.FAN]);
+    // the fan is off, turning it on falls back to the highest standard mode
+    await on.args[1][1](1, cb);
+    // no supported axis bitmap, oscillation falls back to left/right
+    await on.args[3][1](1, cb);
+
+    expect(homekitHandler.gladys.event.emit.args[0][1].value).to.equal(FAN_MODE.HIGH);
+    expect(homekitHandler.gladys.event.emit.args[1][1].value).to.equal(FAN_ROCK_SETTING.LEFT_RIGHT);
+  });
+
+  it('should restore the last fan mode when switched back on', async () => {
+    const modeState = { last_value: FAN_MODE.LOW };
+    homekitHandler.gladys.stateManager.get = stub().returns(modeState);
+    homekitHandler.gladys.event.emit = stub();
+    const on = stub();
+    const getCharacteristic = stub().returns({ on });
+    const Fanv2 = stub().returns({
+      getCharacteristic,
+    });
+
+    homekitHandler.hap = {
+      Characteristic: {
+        Active: 'ACTIVE',
+      },
+      CharacteristicEventTypes: stub(),
+      Service: {
+        Fanv2,
+      },
+    };
+    const device = {
+      name: 'Ventilateur',
+      selector: 'ventilateur',
+    };
+    const features = [
+      {
+        name: 'Mode',
+        selector: 'ventilateur-mode',
+        category: DEVICE_FEATURE_CATEGORIES.FAN,
+        type: DEVICE_FEATURE_TYPES.FAN.MODE,
+        min: FAN_MODE.OFF,
+        max: FAN_MODE.AUTO,
+      },
+    ];
+
+    const cb = stub();
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.FAN]);
+    // the fan is running in LOW, then HomeKit turns it off and back on
+    await on.args[0][1](cb);
+    modeState.last_value = FAN_MODE.OFF;
+    await on.args[1][1](1, cb);
+
+    expect(homekitHandler.gladys.event.emit.args[0][1]).to.eql({
+      type: ACTIONS.DEVICE.SET_VALUE,
+      status: ACTIONS_STATUS.PENDING,
+      value: FAN_MODE.LOW,
+      device: device.selector,
+      device_feature: features[0].selector,
+    });
+  });
+
+  it('should build fan service without mode feature', async () => {
+    homekitHandler.gladys.stateManager.get = stub().returns({ last_value: 0 });
+    homekitHandler.gladys.event.emit = stub();
+    const on = stub();
+    const getCharacteristic = stub()
+      .returns({ on })
+      .onCall(0)
+      .returns({
+        on,
+        props: {
+          minValue: 0,
+          maxValue: 100,
+        },
+      });
+    const Fanv2 = stub().returns({
+      getCharacteristic,
+    });
+
+    homekitHandler.hap = {
+      Characteristic: {
+        Active: 'ACTIVE',
+        RotationSpeed: 'ROTATIONSPEED',
+      },
+      CharacteristicEventTypes: stub(),
+      Service: {
+        Fanv2,
+      },
+    };
+    const device = {
+      name: 'Ventilateur',
+      selector: 'ventilateur',
+    };
+    const features = [
+      {
+        name: 'Vitesse',
+        selector: 'ventilateur-speed',
+        category: DEVICE_FEATURE_CATEGORIES.FAN,
+        type: DEVICE_FEATURE_TYPES.FAN.SPEED,
+        min: 0,
+        max: 10,
+      },
+    ];
+
+    const cb = stub();
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.FAN]);
+    await on.args[2][1](cb);
+    await on.args[3][1](1, cb);
+    // running at speed 6, then switched off from HomeKit
+    homekitHandler.gladys.stateManager.get = stub().returns({ last_value: 6 });
+    await on.args[2][1](cb);
+    await on.args[3][1](0, cb);
+
+    expect(getCharacteristic.args[0][0]).to.equal('ROTATIONSPEED');
+    expect(getCharacteristic.args[1][0]).to.equal('ACTIVE');
+    expect(on.callCount).to.equal(4);
+    expect(cb.args[0][1]).to.equal(0);
+    expect(cb.args[2][1]).to.equal(1);
+    // switching off writes the minimum speed
+    expect(homekitHandler.gladys.event.emit.args[1][1].value).to.equal(0);
+    // no mode feature, so turning the fan on falls back to the top speed
+    expect(homekitHandler.gladys.event.emit.args[0][1]).to.eql({
+      type: ACTIONS.DEVICE.SET_VALUE,
+      status: ACTIONS_STATUS.PENDING,
+      value: 10,
+      device: device.selector,
+      device_feature: features[0].selector,
+    });
   });
 
   it('should build shutter/curtain service', async () => {

--- a/server/test/services/homekit/lib/buildService.test.js
+++ b/server/test/services/homekit/lib/buildService.test.js
@@ -1432,6 +1432,41 @@ describe('Build service', () => {
     expect(homekitHandler.gladys.event.emit.args[0][1].value).to.equal(3);
   });
 
+  it('should remember the fan speed when switched off without a prior read', async () => {
+    homekitHandler.gladys.stateManager.get = stub().returns({ last_value: 40 });
+    homekitHandler.gladys.event.emit = stub();
+    const on = stub();
+    const getCharacteristic = stub().returns({ on, props: { minValue: 0, maxValue: 100 } });
+    const Fanv2 = stub().returns({ getCharacteristic });
+
+    homekitHandler.hap = {
+      Characteristic: { RotationSpeed: 'ROTATIONSPEED', Active: 'ACTIVE' },
+      CharacteristicEventTypes: stub(),
+      Service: { Fanv2 },
+    };
+    const features = [
+      {
+        name: 'Vitesse',
+        selector: 'ventilo-percent',
+        category: DEVICE_FEATURE_CATEGORIES.FAN,
+        type: DEVICE_FEATURE_TYPES.FAN.PERCENT,
+        min: 0,
+        max: 100,
+      },
+    ];
+
+    const cb = stub();
+
+    await homekitHandler.buildService({ name: 'Ventilateur' }, features, mappings[DEVICE_FEATURE_CATEGORIES.FAN]);
+    // switch off straight away, with no GET beforehand
+    await on.args[3][1](0, cb);
+    expect(homekitHandler.gladys.event.emit.args[0][1].value).to.equal(0);
+
+    // switching back on must restore the speed it had, not jump to full
+    await on.args[3][1](1, cb);
+    expect(homekitHandler.gladys.event.emit.args[1][1].value).to.equal(40);
+  });
+
   it('should build shutter/curtain service', async () => {
     homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'shutter-state').returns({
       id: '31c6a4a7-9710-4951-bf34-04eeae5b9ff7',

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -6,6 +6,9 @@ const {
   DEVICE_FEATURE_TYPES,
   EVENTS,
   DEVICE_FEATURE_UNITS,
+  FAN_MODE,
+  FAN_ROCK_SETTING,
+  FAN_AIRFLOW_DIRECTION,
 } = require('../../../../utils/constants');
 
 describe('Send state to HomeKit', () => {
@@ -28,6 +31,10 @@ describe('Send state to HomeKit', () => {
         CurrentPosition: 'CURRENTPOSITION',
         PositionState: 'POSITIONSTATE',
         TargetPosition: 'TARGETPOSITION',
+        Active: 'ACTIVE',
+        RotationSpeed: 'ROTATIONSPEED',
+        SwingMode: 'SWINGMODE',
+        RotationDirection: 'ROTATIONDIRECTION',
         CurrentAmbientLightLevel: 'CURRENTAMBIENTLIGHTLEVEL',
         CarbonMonoxideDetected: 'CARBONMONOXIDEDETECTED',
         CarbonMonoxideLevel: 'CARBONMONOXIDELEVEL',
@@ -41,6 +48,7 @@ describe('Send state to HomeKit', () => {
         ContactSensor: 'CONTACTSENSOR',
         MotionSensor: 'MOTIONSENSOR',
         WindowCovering: 'WINDOWCOVERING',
+        Fanv2: 'FANV2',
         LightSensor: 'LIGHTSENSOR',
         CarbonMonoxideSensor: 'CARBONMONOXIDESENSOR',
         CarbonDioxideSensor: 'CARBONDIOXIDESENSOR',
@@ -618,6 +626,83 @@ describe('Send state to HomeKit', () => {
     expect(updateCharacteristic.args[0]).eql(['PM25DENSITY', 42]);
     expect(updateCharacteristic.args[1]).eql(['PM25DENSITY', 50]);
     expect(updateCharacteristic.args[2]).eql(['PM10DENSITY', 8]);
+  });
+
+  it('should notify fan mode, speed, oscillation and direction', async () => {
+    const updateCharacteristic = stub().returns();
+    const getCharacteristic = stub().returns({
+      props: {
+        minValue: 0,
+        maxValue: 100,
+      },
+    });
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns({ updateCharacteristic, getCharacteristic }),
+    };
+
+    const baseFeature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Fan',
+      category: DEVICE_FEATURE_CATEGORIES.FAN,
+    };
+
+    await homekitHandler.sendState(
+      accessory,
+      { ...baseFeature, type: DEVICE_FEATURE_TYPES.FAN.MODE },
+      { type: EVENTS.DEVICE.NEW_STATE, last_value: FAN_MODE.HIGH },
+    );
+    await homekitHandler.sendState(
+      accessory,
+      { ...baseFeature, type: DEVICE_FEATURE_TYPES.FAN.SPEED, min: 0, max: 10 },
+      { type: EVENTS.DEVICE.NEW_STATE, last_value: 5 },
+    );
+    await homekitHandler.sendState(
+      accessory,
+      { ...baseFeature, type: DEVICE_FEATURE_TYPES.FAN.ROCK_SETTING },
+      { type: EVENTS.DEVICE.NEW_STATE, last_value: FAN_ROCK_SETTING.UP_DOWN },
+    );
+    await homekitHandler.sendState(
+      accessory,
+      { ...baseFeature, type: DEVICE_FEATURE_TYPES.FAN.AIRFLOW_DIRECTION },
+      { type: EVENTS.DEVICE.NEW_STATE, last_value: FAN_AIRFLOW_DIRECTION.FORWARD },
+    );
+
+    expect(updateCharacteristic.args[0]).eql(['ACTIVE', 1]);
+    expect(updateCharacteristic.args[1]).eql(['ROTATIONSPEED', 50]);
+    expect(updateCharacteristic.args[2]).eql(['SWINGMODE', 1]);
+    expect(updateCharacteristic.args[3]).eql(['ROTATIONDIRECTION', 0]);
+
+    // and the opposite value of each
+    await homekitHandler.sendState(
+      accessory,
+      { ...baseFeature, type: DEVICE_FEATURE_TYPES.FAN.MODE },
+      { type: EVENTS.DEVICE.NEW_STATE, last_value: FAN_MODE.OFF },
+    );
+    await homekitHandler.sendState(
+      accessory,
+      { ...baseFeature, type: DEVICE_FEATURE_TYPES.FAN.ROCK_SETTING },
+      { type: EVENTS.DEVICE.NEW_STATE, last_value: FAN_ROCK_SETTING.OFF },
+    );
+    await homekitHandler.sendState(
+      accessory,
+      { ...baseFeature, type: DEVICE_FEATURE_TYPES.FAN.AIRFLOW_DIRECTION },
+      { type: EVENTS.DEVICE.NEW_STATE, last_value: FAN_AIRFLOW_DIRECTION.REVERSE },
+    );
+
+    expect(updateCharacteristic.args[4]).eql(['ACTIVE', 0]);
+    expect(updateCharacteristic.args[5]).eql(['SWINGMODE', 0]);
+    expect(updateCharacteristic.args[6]).eql(['ROTATIONDIRECTION', 1]);
+
+    // a fan exposing a percentage rather than a raw speed
+    await homekitHandler.sendState(
+      accessory,
+      { ...baseFeature, type: DEVICE_FEATURE_TYPES.FAN.PERCENT, min: 0, max: 100 },
+      { type: EVENTS.DEVICE.NEW_STATE, last_value: 30 },
+    );
+
+    expect(updateCharacteristic.args[7]).eql(['ROTATIONSPEED', 30]);
   });
 
   it('should do nothing wrong device category & type', async () => {

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -648,6 +648,13 @@ describe('Send state to HomeKit', () => {
       category: DEVICE_FEATURE_CATEGORIES.FAN,
     };
 
+    homekitHandler.gladys.stateManager = {
+      get: stub().returns({
+        id: '4756151c-369e-4772-8bf7-943a6ac70583',
+        features: [{ ...baseFeature, type: DEVICE_FEATURE_TYPES.FAN.SPEED }],
+      }),
+    };
+
     await homekitHandler.sendState(
       accessory,
       { ...baseFeature, type: DEVICE_FEATURE_TYPES.FAN.MODE },
@@ -703,6 +710,52 @@ describe('Send state to HomeKit', () => {
     );
 
     expect(updateCharacteristic.args[7]).eql(['ROTATIONSPEED', 30]);
+  });
+
+  it('should ignore the raw speed of a fan that also reports a percentage', async () => {
+    const updateCharacteristic = stub().returns();
+    const getCharacteristic = stub().returns({ props: { minValue: 0, maxValue: 100 } });
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns({ updateCharacteristic, getCharacteristic }),
+    };
+
+    const baseFeature = {
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Fan',
+      category: DEVICE_FEATURE_CATEGORIES.FAN,
+    };
+    const percentFeature = {
+      ...baseFeature,
+      id: 'e9ba4c39-4e8c-4dd1-9a4f-1a5c3b3f9b4d',
+      type: DEVICE_FEATURE_TYPES.FAN.PERCENT,
+      min: 0,
+      max: 100,
+    };
+    const speedFeature = {
+      ...baseFeature,
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      type: DEVICE_FEATURE_TYPES.FAN.SPEED,
+      min: 0,
+      max: 10,
+    };
+
+    homekitHandler.gladys.stateManager = {
+      get: stub().returns({
+        id: '4756151c-369e-4772-8bf7-943a6ac70583',
+        features: [percentFeature, speedFeature],
+      }),
+    };
+
+    await homekitHandler.sendState(accessory, speedFeature, { type: EVENTS.DEVICE.NEW_STATE, last_value: 5 });
+
+    // buildService reads RotationSpeed from the percentage, so rescaling the raw speed here would
+    // overwrite it with a value HomeKit is not showing
+    expect(updateCharacteristic.callCount).to.equal(0);
+
+    await homekitHandler.sendState(accessory, percentFeature, { type: EVENTS.DEVICE.NEW_STATE, last_value: 30 });
+
+    expect(updateCharacteristic.args).eql([['ROTATIONSPEED', 30]]);
   });
 
   it('should do nothing wrong device category & type', async () => {


### PR DESCRIPTION
Fans are not exposed to HomeKit today. This maps them to `Fanv2`, which covers
on/off, speed, oscillation and airflow direction.

| Gladys feature type | HomeKit characteristics |
| --- | --- |
| `mode` | `Active` |
| `percent` | `RotationSpeed`, `Active` |
| `speed` | `RotationSpeed`, `Active` |
| `rock-setting` | `SwingMode` |
| `airflow-direction` | `RotationDirection` |

### Read-only twin merge

Some integrations — Matter in particular — expose the same physical capability
twice: one writable feature for the command and one read-only feature reporting the
current value. Built naively, that produced **three separate `Fanv2` services** for
a single fan in the Home app.

`buildAccessory` now merges a read-only feature into its writable twin when both
map to the same characteristics. The rule is opt-in per feature type via a
`mergeReadOnlyTwin` flag in the mapping, rather than applied globally: an earlier
version of this branch merged on characteristic overlap alone, which incorrectly
merged a Matter OnOff relay with a BooleanState sensor, since both surface as
`switch:binary`. The flag keeps the merge to the cases where it is actually
correct (`fan:percent` and `fan:speed`).

### Testing

Unit tests cover every feature type, the twin merge (including the case that must
*not* merge), and both the pull and push paths. `npm run coverage` is green with
100% patch coverage.

The bridge has been smoke-tested against the real `hap-nodejs` library, but **not
yet paired with an actual iPhone**. The twin merge is the part I would most like
confirmed on real hardware — feedback very welcome.

This is part of a series extending the HomeKit bridge, one category per PR:
sensors (merged in #2781), siren, lock, fan, thermostat, device selection,
particulate densities, smoke, battery, button.

They are independent and reviewable on their own, but they all add cases to the
same `switch` statements in `buildService.js` and `sendState.js`, so whichever
merges first will leave the others needing a rebase. Happy to rebase in whatever
order suits you.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added HomeKit support for fan controls, including operating mode, speed, percentage, oscillation, and airflow direction.
* Fan speed uses percentage values when available and restores the previous active setting when turned back on.
* Fan state changes are synchronized between the app and HomeKit.

## Bug Fixes
* Improved handling of duplicate read-only and writable fan controls by presenting a single accurate HomeKit service.
* Preserved separate services for unrelated or intentionally duplicated features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->