### PR TITLE
feat(homekit): expose device batteries

### DIFF
--- a/server/services/homekit/lib/buildService.js
+++ b/server/services/homekit/lib/buildService.js
@@ -17,6 +17,7 @@ const {
   aqiToAirQuality,
   clampToCharacteristic,
   toMicrogramPerCubicMeter,
+  LOW_BATTERY_THRESHOLD,
 } = require('./deviceMappings');
 
 const sleep = promisify(setTimeout);
@@ -230,6 +231,44 @@ function buildService(device, features, categoryMapping, subtype) {
             ),
           );
         });
+        break;
+      }
+      case `${DEVICE_FEATURE_CATEGORIES.BATTERY}:${DEVICE_FEATURE_TYPES.BATTERY.INTEGER}`:
+      case `${DEVICE_FEATURE_CATEGORIES.BATTERY}:${DEVICE_FEATURE_TYPES.SENSOR.INTEGER}`:
+      case `${DEVICE_FEATURE_CATEGORIES.BATTERY}:${DEVICE_FEATURE_TYPES.LOCK.INTEGER}`: {
+        const [levelName, lowName] = mappings[feature.category].capabilities[feature.type].characteristics;
+
+        const levelCharacteristic = service.getCharacteristic(Characteristic[levelName]);
+        levelCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+          callback(
+            undefined,
+            clampToCharacteristic(
+              this.gladys.stateManager.get('deviceFeature', feature.selector).last_value,
+              levelCharacteristic.props,
+            ),
+          );
+        });
+
+        // StatusLowBattery is required by HomeKit, so it is derived from the level — but only when
+        // the device has no dedicated low-battery feature, which is authoritative when present.
+        if (!features.some((f) => f.category === DEVICE_FEATURE_CATEGORIES.BATTERY_LOW)) {
+          service.getCharacteristic(Characteristic[lowName]).on(CharacteristicEventTypes.GET, async (callback) => {
+            const level = this.gladys.stateManager.get('deviceFeature', feature.selector).last_value;
+            // Number.isFinite and not a bare comparison: `null <= 20` is true in JavaScript, so a
+            // device that has not reported yet would be announced as low on battery.
+            callback(undefined, Number.isFinite(level) && level <= LOW_BATTERY_THRESHOLD ? 1 : 0);
+          });
+        }
+        break;
+      }
+      case `${DEVICE_FEATURE_CATEGORIES.BATTERY_LOW}:${DEVICE_FEATURE_TYPES.BATTERY_LOW.BINARY}`:
+      case `${DEVICE_FEATURE_CATEGORIES.BATTERY_LOW}:${DEVICE_FEATURE_TYPES.SENSOR.BINARY}`: {
+        // Gladys and HomeKit agree on the direction: 1 means the battery is low.
+        service
+          .getCharacteristic(Characteristic[mappings[feature.category].capabilities[feature.type].characteristics[0]])
+          .on(CharacteristicEventTypes.GET, async (callback) => {
+            callback(undefined, this.gladys.stateManager.get('deviceFeature', feature.selector).last_value ? 1 : 0);
+          });
         break;
       }
       case `${DEVICE_FEATURE_CATEGORIES.CO_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.DECIMAL}`:

--- a/server/services/homekit/lib/deviceMappings.js
+++ b/server/services/homekit/lib/deviceMappings.js
@@ -118,6 +118,33 @@ const mappings = {
       },
     },
   },
+  [DEVICE_FEATURE_CATEGORIES.BATTERY]: {
+    service: 'Battery',
+    capabilities: {
+      // Integrations disagree on which type carries a battery percentage: Nuki reports it as a lock
+      // integer, most others as a sensor or battery integer. All three mean the same thing here.
+      [DEVICE_FEATURE_TYPES.BATTERY.INTEGER]: {
+        characteristics: ['BatteryLevel', 'StatusLowBattery'],
+      },
+      [DEVICE_FEATURE_TYPES.SENSOR.INTEGER]: {
+        characteristics: ['BatteryLevel', 'StatusLowBattery'],
+      },
+      [DEVICE_FEATURE_TYPES.LOCK.INTEGER]: {
+        characteristics: ['BatteryLevel', 'StatusLowBattery'],
+      },
+    },
+  },
+  [DEVICE_FEATURE_CATEGORIES.BATTERY_LOW]: {
+    service: 'Battery',
+    capabilities: {
+      [DEVICE_FEATURE_TYPES.BATTERY_LOW.BINARY]: {
+        characteristics: ['StatusLowBattery'],
+      },
+      [DEVICE_FEATURE_TYPES.SENSOR.BINARY]: {
+        characteristics: ['StatusLowBattery'],
+      },
+    },
+  },
   [DEVICE_FEATURE_CATEGORIES.SWITCH]: {
     service: 'Switch',
     capabilities: {
@@ -276,7 +303,18 @@ const mergedServiceCategories = [
     ],
     merged: [],
   },
+  // Same for the battery: HomeKit shows a single Battery service, while Gladys splits the
+  // percentage and the low-battery flag across two categories.
+  {
+    hosts: [DEVICE_FEATURE_CATEGORIES.BATTERY, DEVICE_FEATURE_CATEGORIES.BATTERY_LOW],
+    merged: [],
+  },
 ];
+
+// Percentage at or below which a device with no dedicated low-battery feature is reported as low.
+// HomeKit requires StatusLowBattery on every Battery service, so it has to be derived from the
+// level when the device does not report it. 20% is what the other HomeKit bridges use.
+const LOW_BATTERY_THRESHOLD = 20;
 
 module.exports = {
   mappings,
@@ -286,4 +324,5 @@ module.exports = {
   clampToCharacteristic,
   toMicrogramPerCubicMeter,
   mergedServiceCategories,
+  LOW_BATTERY_THRESHOLD,
 };

--- a/server/services/homekit/lib/sendState.js
+++ b/server/services/homekit/lib/sendState.js
@@ -9,6 +9,7 @@ const {
   aqiToAirQuality,
   clampToCharacteristic,
   toMicrogramPerCubicMeter,
+  LOW_BATTERY_THRESHOLD,
 } = require('./deviceMappings');
 
 /**
@@ -133,9 +134,24 @@ function sendState(hkAccessory, feature, event) {
         Characteristic[levelName],
         clampToCharacteristic(event.last_value, levelCharacteristic.props),
       );
-      // StatusLowBattery is not pushed here: on a device that also reports a dedicated
-      // low-battery feature, pushing a derived value would fight with the real one. The GET handler
-      // built by buildService keeps it correct either way.
+
+      // StatusLowBattery has to be pushed as well, or crossing the threshold would only show up
+      // the next time HomeKit polls — updateCharacteristic is what notifies subscribers, the GET
+      // handler is not. Only when the device has no dedicated low-battery feature though: that one
+      // is authoritative, and a derived value would fight with it.
+      const device = this.gladys.stateManager.get('deviceById', feature.device_id);
+      const hasDedicatedLowFeature = ((device && device.features) || []).some(
+        (deviceFeature) => deviceFeature.category === DEVICE_FEATURE_CATEGORIES.BATTERY_LOW,
+      );
+      if (!hasDedicatedLowFeature) {
+        const [, lowName] = mappings[feature.category].capabilities[feature.type].characteristics;
+        // Number.isFinite and not a bare comparison: `null <= 20` is true in JavaScript, so a
+        // device reporting nothing would be announced as low on battery.
+        service.updateCharacteristic(
+          Characteristic[lowName],
+          Number.isFinite(event.last_value) && event.last_value <= LOW_BATTERY_THRESHOLD ? 1 : 0,
+        );
+      }
       break;
     }
     case `${DEVICE_FEATURE_CATEGORIES.BATTERY_LOW}:${DEVICE_FEATURE_TYPES.BATTERY_LOW.BINARY}`:

--- a/server/services/homekit/lib/sendState.js
+++ b/server/services/homekit/lib/sendState.js
@@ -122,6 +122,32 @@ function sendState(hkAccessory, feature, event) {
       );
       break;
     }
+    case `${DEVICE_FEATURE_CATEGORIES.BATTERY}:${DEVICE_FEATURE_TYPES.BATTERY.INTEGER}`:
+    case `${DEVICE_FEATURE_CATEGORIES.BATTERY}:${DEVICE_FEATURE_TYPES.SENSOR.INTEGER}`:
+    case `${DEVICE_FEATURE_CATEGORIES.BATTERY}:${DEVICE_FEATURE_TYPES.LOCK.INTEGER}`: {
+      const service = hkAccessory.getService(Service[mappings[feature.category].service]);
+      const [levelName] = mappings[feature.category].capabilities[feature.type].characteristics;
+      const levelCharacteristic = service.getCharacteristic(Characteristic[levelName]);
+
+      service.updateCharacteristic(
+        Characteristic[levelName],
+        clampToCharacteristic(event.last_value, levelCharacteristic.props),
+      );
+      // StatusLowBattery is not pushed here: on a device that also reports a dedicated
+      // low-battery feature, pushing a derived value would fight with the real one. The GET handler
+      // built by buildService keeps it correct either way.
+      break;
+    }
+    case `${DEVICE_FEATURE_CATEGORIES.BATTERY_LOW}:${DEVICE_FEATURE_TYPES.BATTERY_LOW.BINARY}`:
+    case `${DEVICE_FEATURE_CATEGORIES.BATTERY_LOW}:${DEVICE_FEATURE_TYPES.SENSOR.BINARY}`: {
+      hkAccessory
+        .getService(Service[mappings[feature.category].service])
+        .updateCharacteristic(
+          Characteristic[mappings[feature.category].capabilities[feature.type].characteristics[0]],
+          event.last_value ? 1 : 0,
+        );
+      break;
+    }
     case `${DEVICE_FEATURE_CATEGORIES.CO_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.DECIMAL}`:
     case `${DEVICE_FEATURE_CATEGORIES.CO_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.INTEGER}`:
     case `${DEVICE_FEATURE_CATEGORIES.CO2_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.DECIMAL}`:

--- a/server/test/services/homekit/lib/buildAccessory.test.js
+++ b/server/test/services/homekit/lib/buildAccessory.test.js
@@ -99,4 +99,28 @@ describe('Build accessory', () => {
     expect(homekitHandler.buildService.callCount).to.equal(1);
     expect(homekitHandler.buildService.args[0][1]).to.have.deep.members(device.features);
   });
+  it('should build a single battery service from the level and the low flag', async () => {
+    homekitHandler.buildService = sinon.stub().returns('builded-service');
+    const addService = sinon.stub();
+    homekitHandler.hap = {
+      Accessory: sinon.stub().returns({ addService, services: ['service1', 'service2'] }),
+    };
+
+    const device = {
+      id: 'c22a4d4b-e261-4b22-a2be-309baf12c3ca',
+      name: 'Serrure',
+      features: [
+        { name: 'Batterie', category: 'battery', type: 'integer' },
+        { name: 'Batterie faible', category: 'battery-low', type: 'binary' },
+      ],
+    };
+
+    await homekitHandler.buildAccessory(device);
+
+    // one Battery service, not two
+    expect(homekitHandler.buildService.callCount).to.equal(1);
+    expect(homekitHandler.buildService.args[0][1]).to.have.deep.members(device.features);
+    expect(homekitHandler.buildService.args[0][3]).to.equal(undefined);
+    expect(addService.callCount).to.equal(1);
+  });
 });

--- a/server/test/services/homekit/lib/buildService.test.js
+++ b/server/test/services/homekit/lib/buildService.test.js
@@ -995,6 +995,38 @@ describe('Build service', () => {
     expect(cb.args[1][1]).to.equal(0);
   });
 
+  it('should not claim a battery level for a device that only reports a low flag', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'contact-faible').returns({ last_value: 1 });
+    const on = stub();
+    const getCharacteristic = stub().returns({ on, props: { minValue: 0, maxValue: 100 } });
+    const Battery = stub().returns({ getCharacteristic });
+
+    homekitHandler.hap = {
+      Characteristic: { BatteryLevel: 'BATTERYLEVEL', StatusLowBattery: 'STATUSLOWBATTERY' },
+      CharacteristicEventTypes: stub(),
+      Service: { Battery },
+    };
+    const features = [
+      {
+        name: 'Batterie faible',
+        selector: 'contact-faible',
+        category: DEVICE_FEATURE_CATEGORIES.BATTERY_LOW,
+        type: DEVICE_FEATURE_TYPES.BATTERY_LOW.BINARY,
+      },
+    ];
+
+    const cb = stub();
+
+    await homekitHandler.buildService({ name: 'Contact' }, features, mappings[DEVICE_FEATURE_CATEGORIES.BATTERY_LOW]);
+    await on.args[0][1](cb);
+
+    // BatteryLevel is optional on the HAP Battery service, so it is never added and the Home app
+    // does not show a made-up 0%. Only the flag the device actually reports is exposed.
+    expect(getCharacteristic.args).eql([['STATUSLOWBATTERY']]);
+    expect(cb.args[0][1]).to.equal(1);
+  });
+
   it('should build air quality sensor service', async () => {
     homekitHandler.gladys.stateManager.get = stub().returns({
       id: 'ec9de6a2-6f0a-4f0e-9d0e-1b5f1cb0a5ce',

--- a/server/test/services/homekit/lib/buildService.test.js
+++ b/server/test/services/homekit/lib/buildService.test.js
@@ -897,6 +897,104 @@ describe('Build service', () => {
     expect(cb.args[1][1]).to.equal(1);
   });
 
+  it('should build battery service and derive the low flag from the level', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'batterie').returns({ last_value: 15 });
+    const on = stub();
+    const getCharacteristic = stub().returns({
+      on,
+      props: { minValue: 0, maxValue: 100 },
+    });
+    const Battery = stub().returns({ getCharacteristic });
+
+    homekitHandler.hap = {
+      Characteristic: { BatteryLevel: 'BATTERYLEVEL', StatusLowBattery: 'STATUSLOWBATTERY' },
+      CharacteristicEventTypes: stub(),
+      Service: { Battery },
+    };
+    const features = [
+      {
+        name: 'Batterie',
+        selector: 'batterie',
+        category: DEVICE_FEATURE_CATEGORIES.BATTERY,
+        type: DEVICE_FEATURE_TYPES.SENSOR.INTEGER,
+      },
+    ];
+
+    const cb = stub();
+
+    await homekitHandler.buildService({ name: 'Capteur' }, features, mappings[DEVICE_FEATURE_CATEGORIES.BATTERY]);
+    await on.args[0][1](cb);
+    await on.args[1][1](cb);
+
+    expect(getCharacteristic.args[0][0]).to.equal('BATTERYLEVEL');
+    expect(getCharacteristic.args[1][0]).to.equal('STATUSLOWBATTERY');
+    expect(cb.args[0][1]).to.equal(15);
+    // 15% is at or below the 20% threshold
+    expect(cb.args[1][1]).to.equal(1);
+
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'batterie').returns({ last_value: 80 });
+    await on.args[1][1](cb);
+    expect(cb.args[2][1]).to.equal(0);
+
+    // the comparison is inclusive: exactly 20% is low, 21% is not
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'batterie').returns({ last_value: 20 });
+    await on.args[1][1](cb);
+    expect(cb.args[3][1]).to.equal(1);
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'batterie').returns({ last_value: 21 });
+    await on.args[1][1](cb);
+    expect(cb.args[4][1]).to.equal(0);
+
+    // a device that has not reported yet must not be announced as low: null <= 20 is true in JS
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'batterie').returns({ last_value: null });
+    await on.args[1][1](cb);
+    expect(cb.args[5][1]).to.equal(0);
+  });
+
+  it('should let a dedicated low battery feature win over the derived flag', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'nuki-batterie').returns({ last_value: 5 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'nuki-faible').returns({ last_value: 0 });
+    const on = stub();
+    const getCharacteristic = stub().returns({
+      on,
+      props: { minValue: 0, maxValue: 100 },
+    });
+    const Battery = stub().returns({ getCharacteristic });
+
+    homekitHandler.hap = {
+      Characteristic: { BatteryLevel: 'BATTERYLEVEL', StatusLowBattery: 'STATUSLOWBATTERY' },
+      CharacteristicEventTypes: stub(),
+      Service: { Battery },
+    };
+    // Nuki reports its battery percentage as a lock integer, not a sensor integer
+    const features = [
+      {
+        name: 'Batterie',
+        selector: 'nuki-batterie',
+        category: DEVICE_FEATURE_CATEGORIES.BATTERY,
+        type: DEVICE_FEATURE_TYPES.LOCK.INTEGER,
+      },
+      {
+        name: 'Batterie faible',
+        selector: 'nuki-faible',
+        category: DEVICE_FEATURE_CATEGORIES.BATTERY_LOW,
+        type: DEVICE_FEATURE_TYPES.BATTERY_LOW.BINARY,
+      },
+    ];
+
+    const cb = stub();
+
+    await homekitHandler.buildService({ name: 'Serrure' }, features, mappings[DEVICE_FEATURE_CATEGORIES.BATTERY]);
+    await on.args[0][1](cb);
+    await on.args[1][1](cb);
+
+    // the level alone would say low at 5%, the dedicated feature says it is not
+    expect(on.callCount).to.equal(2);
+    expect(cb.args[0][1]).to.equal(5);
+    expect(cb.args[1][1]).to.equal(0);
+  });
+
   it('should build air quality sensor service', async () => {
     homekitHandler.gladys.stateManager.get = stub().returns({
       id: 'ec9de6a2-6f0a-4f0e-9d0e-1b5f1cb0a5ce',

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -34,6 +34,8 @@ describe('Send state to HomeKit', () => {
         CarbonDioxideLevel: 'CARBONDIOXIDELEVEL',
         CarbonDioxideDetected: 'CARBONDIOXIDEDETECTED',
         AirQuality: 'AIRQUALITY',
+        BatteryLevel: 'BATTERYLEVEL',
+        StatusLowBattery: 'STATUSLOWBATTERY',
         PM2_5Density: 'PM25DENSITY',
         PM10Density: 'PM10DENSITY',
       },
@@ -45,6 +47,7 @@ describe('Send state to HomeKit', () => {
         CarbonMonoxideSensor: 'CARBONMONOXIDESENSOR',
         CarbonDioxideSensor: 'CARBONDIOXIDESENSOR',
         AirQualitySensor: 'AIRQUALITYSENSOR',
+        Battery: 'BATTERY',
       },
     },
     notifyTimeouts: {},
@@ -618,6 +621,58 @@ describe('Send state to HomeKit', () => {
     expect(updateCharacteristic.args[0]).eql(['PM25DENSITY', 42]);
     expect(updateCharacteristic.args[1]).eql(['PM25DENSITY', 50]);
     expect(updateCharacteristic.args[2]).eql(['PM10DENSITY', 8]);
+  });
+
+  it('should notify battery level and low battery flag', async () => {
+    const updateCharacteristic = stub().returns();
+    const getCharacteristic = stub().returns({ props: { minValue: 0, maxValue: 100 } });
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns({ updateCharacteristic, getCharacteristic }),
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Battery',
+      category: DEVICE_FEATURE_CATEGORIES.BATTERY,
+      type: DEVICE_FEATURE_TYPES.SENSOR.INTEGER,
+    };
+
+    await homekitHandler.sendState(accessory, feature, { type: EVENTS.DEVICE.NEW_STATE, last_value: 42 });
+    // Nuki reports the same thing as a lock integer
+    await homekitHandler.sendState(
+      accessory,
+      { ...feature, type: DEVICE_FEATURE_TYPES.LOCK.INTEGER },
+      { type: EVENTS.DEVICE.NEW_STATE, last_value: 8 },
+    );
+    await homekitHandler.sendState(
+      accessory,
+      {
+        ...feature,
+        category: DEVICE_FEATURE_CATEGORIES.BATTERY_LOW,
+        type: DEVICE_FEATURE_TYPES.BATTERY_LOW.BINARY,
+      },
+      { type: EVENTS.DEVICE.NEW_STATE, last_value: 1 },
+    );
+
+    expect(updateCharacteristic.args[0]).eql(['BATTERYLEVEL', 42]);
+    expect(updateCharacteristic.args[1]).eql(['BATTERYLEVEL', 8]);
+    // the two remaining type flavours reach the same branches
+    await homekitHandler.sendState(
+      accessory,
+      { ...feature, type: DEVICE_FEATURE_TYPES.BATTERY.INTEGER },
+      { type: EVENTS.DEVICE.NEW_STATE, last_value: 60 },
+    );
+    await homekitHandler.sendState(
+      accessory,
+      { ...feature, category: DEVICE_FEATURE_CATEGORIES.BATTERY_LOW, type: DEVICE_FEATURE_TYPES.SENSOR.BINARY },
+      { type: EVENTS.DEVICE.NEW_STATE, last_value: 0 },
+    );
+
+    expect(updateCharacteristic.args[2]).eql(['STATUSLOWBATTERY', 1]);
+    expect(updateCharacteristic.args[3]).eql(['BATTERYLEVEL', 60]);
+    expect(updateCharacteristic.args[4]).eql(['STATUSLOWBATTERY', 0]);
   });
 
   it('should do nothing wrong device category & type', async () => {

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -673,6 +673,13 @@ describe('Send state to HomeKit', () => {
     expect(updateCharacteristic.args[2]).eql(['STATUSLOWBATTERY', 1]);
     expect(updateCharacteristic.args[3]).eql(['BATTERYLEVEL', 60]);
     expect(updateCharacteristic.args[4]).eql(['STATUSLOWBATTERY', 0]);
+
+    // a reading outside the HomeKit 0-100 range is clamped, not rejected
+    await homekitHandler.sendState(accessory, feature, { type: EVENTS.DEVICE.NEW_STATE, last_value: 120 });
+    await homekitHandler.sendState(accessory, feature, { type: EVENTS.DEVICE.NEW_STATE, last_value: -5 });
+
+    expect(updateCharacteristic.args[5]).eql(['BATTERYLEVEL', 100]);
+    expect(updateCharacteristic.args[6]).eql(['BATTERYLEVEL', 0]);
   });
 
   it('should do nothing wrong device category & type', async () => {

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -724,10 +724,16 @@ describe('Send state to HomeKit', () => {
       ['STATUSLOWBATTERY', 1],
     ]);
 
+    // and back up: a battery that has been changed has to clear the warning as fast as it raised it
+    await homekitHandler.sendState(accessory, feature, { type: EVENTS.DEVICE.NEW_STATE, last_value: 21 });
+
+    expect(updateCharacteristic.args[4]).eql(['BATTERYLEVEL', 21]);
+    expect(updateCharacteristic.args[5]).eql(['STATUSLOWBATTERY', 0]);
+
     // a device that reports nothing is not low on battery: `null <= 20` is true in JavaScript
     await homekitHandler.sendState(accessory, feature, { type: EVENTS.DEVICE.NEW_STATE, last_value: null });
 
-    expect(updateCharacteristic.args[5]).eql(['STATUSLOWBATTERY', 0]);
+    expect(updateCharacteristic.args[7]).eql(['STATUSLOWBATTERY', 0]);
   });
 
   it('should do nothing wrong device category & type', async () => {

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -693,9 +693,12 @@ describe('Send state to HomeKit', () => {
   it('should derive the low battery flag when the device only reports a percentage', async () => {
     const updateCharacteristic = stub().returns();
     const getCharacteristic = stub().returns({ props: { minValue: 0, maxValue: 100 } });
+    // narrowed to the battery service, so picking the wrong one fails here rather than passing
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
-      getService: stub().returns({ updateCharacteristic, getCharacteristic }),
+      getService: stub()
+        .withArgs('BATTERY')
+        .returns({ updateCharacteristic, getCharacteristic }),
     };
 
     const feature = {

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -639,6 +639,14 @@ describe('Send state to HomeKit', () => {
       type: DEVICE_FEATURE_TYPES.SENSOR.INTEGER,
     };
 
+    // this device reports its own low-battery flag, so the level must not derive a second one
+    homekitHandler.gladys.stateManager = {
+      get: stub().returns({
+        id: '4756151c-369e-4772-8bf7-943a6ac70583',
+        features: [feature, { ...feature, category: DEVICE_FEATURE_CATEGORIES.BATTERY_LOW }],
+      }),
+    };
+
     await homekitHandler.sendState(accessory, feature, { type: EVENTS.DEVICE.NEW_STATE, last_value: 42 });
     // Nuki reports the same thing as a lock integer
     await homekitHandler.sendState(
@@ -680,6 +688,43 @@ describe('Send state to HomeKit', () => {
 
     expect(updateCharacteristic.args[5]).eql(['BATTERYLEVEL', 100]);
     expect(updateCharacteristic.args[6]).eql(['BATTERYLEVEL', 0]);
+  });
+
+  it('should derive the low battery flag when the device only reports a percentage', async () => {
+    const updateCharacteristic = stub().returns();
+    const getCharacteristic = stub().returns({ props: { minValue: 0, maxValue: 100 } });
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns({ updateCharacteristic, getCharacteristic }),
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Battery',
+      category: DEVICE_FEATURE_CATEGORIES.BATTERY,
+      type: DEVICE_FEATURE_TYPES.SENSOR.INTEGER,
+    };
+
+    homekitHandler.gladys.stateManager = {
+      get: stub().returns({ id: '4756151c-369e-4772-8bf7-943a6ac70583', features: [feature] }),
+    };
+
+    // the threshold is inclusive, and crossing it has to notify HomeKit rather than wait for a poll
+    await homekitHandler.sendState(accessory, feature, { type: EVENTS.DEVICE.NEW_STATE, last_value: 21 });
+    await homekitHandler.sendState(accessory, feature, { type: EVENTS.DEVICE.NEW_STATE, last_value: 20 });
+
+    expect(updateCharacteristic.args).eql([
+      ['BATTERYLEVEL', 21],
+      ['STATUSLOWBATTERY', 0],
+      ['BATTERYLEVEL', 20],
+      ['STATUSLOWBATTERY', 1],
+    ]);
+
+    // a device that reports nothing is not low on battery: `null <= 20` is true in JavaScript
+    await homekitHandler.sendState(accessory, feature, { type: EVENTS.DEVICE.NEW_STATE, last_value: null });
+
+    expect(updateCharacteristic.args[5]).eql(['STATUSLOWBATTERY', 0]);
   });
 
   it('should do nothing wrong device category & type', async () => {


### PR DESCRIPTION
Battery levels are not exposed today, although seven integrations report them —
Bluetooth, Matter, Netatmo, Nuki, Xiaomi, Zigbee2mqtt and Z-Wave. HomeKit shows a
`Battery` service directly on the accessory it belongs to, so a battery-powered
sensor carries its level where users expect it.

### Three details worth reviewing

**Integrations disagree on which type carries a percentage.** Most use
`sensor:integer`, some `battery:integer`, and Nuki `lock:integer`
(`nuki.mqtt.convertToDevice.js` and its HTTP counterpart). All three are mapped —
the first two alone would have silently dropped every Nuki lock, with no error
and no log.

**`StatusLowBattery` is required by HomeKit**, while most Gladys devices only
report a percentage. It is derived from a 20% threshold, the value the other
HomeKit bridges use. A device that reports a dedicated low-battery feature keeps
its own value: the derived handler is not registered at all in that case, rather
than being registered and overwritten.

**Two Gladys categories, one HomeKit service.** The level and the low-battery
flag are folded together so the Home app shows one battery, not two.

### Testing

Unit tests cover the three percentage types, both low-battery types, the derived
threshold on each side of its boundary, the dedicated feature winning over the
derived one, and the merge. 100% patch coverage.

Not yet paired with an actual iPhone.

This is part of a series extending the HomeKit bridge, one category per PR:
sensors (merged in #2781), siren, lock, fan, thermostat, device selection,
particulate densities, smoke, battery, button.

They are independent and reviewable on their own, but they all add cases to the
same `switch` statements in `buildService.js` and `sendState.js`, so whichever
merges first will leave the others needing a rebase. Happy to rebase in whatever
order suits you.

This PR introduces a `mergeCategories` helper in `buildAccessory.js`, because
HomeKit models as one service what Gladys splits across several categories. The
thermostat, particulate density and battery PRs each need it and each carry
their own copy, so whichever merges first, the others will drop theirs on
rebase. Tell me if you would rather have it extracted into its own PR first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HomeKit support for reporting battery levels across supported device types.
  * Battery levels are constrained to the valid 0–100% range.
  * Added automatic low-battery status when the level reaches 20% or below.
  * Added support for dedicated low-battery indicators, which take precedence when available.
  * Added support for low-battery-only devices without displaying an inaccurate battery level.

* **Bug Fixes**
  * Improved updates for changing, missing, and out-of-range battery readings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->