### PR TITLE
feat(homekit): expose PM2.5 and PM10 densities on the air quality sensor

### DIFF
--- a/server/services/homekit/lib/buildAccessory.js
+++ b/server/services/homekit/lib/buildAccessory.js
@@ -1,4 +1,32 @@
-const { mappings } = require('./deviceMappings');
+const { mappings, mergedServiceCategories } = require('./deviceMappings');
+
+/**
+ * @description Move the features of categories HomeKit models as a single service into their host
+ * category, so they end up in the same HomeKit service instead of one service per Gladys category.
+ * @param {object} categories - Device features grouped by Gladys category.
+ * @returns {object} The same grouping, with merged categories folded into their host.
+ * @example
+ * mergeCategories({ 'airquality-sensor': [aqi], 'pm25-sensor': [density] });
+ */
+function mergeCategories(categories) {
+  const mergedCategories = { ...categories };
+
+  mergedServiceCategories.forEach(({ hosts }) => {
+    const hostCategory = hosts.find((category) => mergedCategories[category]);
+    if (!hostCategory) {
+      return;
+    }
+
+    hosts
+      .filter((category) => category !== hostCategory && mergedCategories[category])
+      .forEach((category) => {
+        mergedCategories[hostCategory] = [...mergedCategories[hostCategory], ...mergedCategories[category]];
+        delete mergedCategories[category];
+      });
+  });
+
+  return mergedCategories;
+}
 
 /**
  * @description Create HomeKit accessory.
@@ -8,7 +36,7 @@ const { mappings } = require('./deviceMappings');
  * buildAccessory(device)
  */
 function buildAccessory(device) {
-  const categories = device.features.reduce((previousValue, currentValue) => {
+  const featuresByCategory = device.features.reduce((previousValue, currentValue) => {
     if (!mappings[currentValue.category] || !mappings[currentValue.category].capabilities[currentValue.type]) {
       return {
         ...previousValue,
@@ -21,6 +49,8 @@ function buildAccessory(device) {
         : [currentValue],
     };
   }, {});
+
+  const categories = mergeCategories(featuresByCategory);
 
   const accessory = new this.hap.Accessory(device.name.substring(0, 64), device.id);
   Object.keys(categories).forEach((category) => {

--- a/server/services/homekit/lib/buildService.js
+++ b/server/services/homekit/lib/buildService.js
@@ -11,10 +11,12 @@ const {
 const { normalize } = require('../../../utils/device');
 const { fahrenheitToCelsius } = require('../../../utils/units');
 const {
+  mappings,
   coverStateMapping,
   gasDetectedThresholds,
   aqiToAirQuality,
   clampToCharacteristic,
+  toMicrogramPerCubicMeter,
 } = require('./deviceMappings');
 
 const sleep = promisify(setTimeout);
@@ -200,6 +202,30 @@ function buildService(device, features, categoryMapping, subtype) {
             clampToCharacteristic(
               this.gladys.stateManager.get('deviceFeature', feature.selector).last_value,
               lightLevelCharacteristic.props,
+            ),
+          );
+        });
+        break;
+      }
+      case `${DEVICE_FEATURE_CATEGORIES.PM25_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.DECIMAL}`:
+      case `${DEVICE_FEATURE_CATEGORIES.PM25_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.INTEGER}`:
+      case `${DEVICE_FEATURE_CATEGORIES.PM10_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.DECIMAL}`:
+      case `${DEVICE_FEATURE_CATEGORIES.PM10_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.INTEGER}`: {
+        // Densities share the AirQualitySensor service with the index, so the characteristic comes
+        // from the feature category and not from the category hosting the service.
+        const densityCharacteristic = service.getCharacteristic(
+          Characteristic[mappings[feature.category].capabilities[feature.type].characteristics[0]],
+        );
+
+        densityCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+          callback(
+            undefined,
+            clampToCharacteristic(
+              toMicrogramPerCubicMeter(
+                this.gladys.stateManager.get('deviceFeature', feature.selector).last_value,
+                feature.unit,
+              ),
+              densityCharacteristic.props,
             ),
           );
         });

--- a/server/services/homekit/lib/deviceMappings.js
+++ b/server/services/homekit/lib/deviceMappings.js
@@ -1,4 +1,9 @@
-const { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES, COVER_STATE } = require('../../../utils/constants');
+const {
+  DEVICE_FEATURE_CATEGORIES,
+  DEVICE_FEATURE_TYPES,
+  DEVICE_FEATURE_UNITS,
+  COVER_STATE,
+} = require('../../../utils/constants');
 
 const mappings = {
   [DEVICE_FEATURE_CATEGORIES.LIGHT]: {
@@ -91,6 +96,28 @@ const mappings = {
       },
     },
   },
+  [DEVICE_FEATURE_CATEGORIES.PM25_SENSOR]: {
+    service: 'AirQualitySensor',
+    capabilities: {
+      [DEVICE_FEATURE_TYPES.SENSOR.DECIMAL]: {
+        characteristics: ['PM2_5Density'],
+      },
+      [DEVICE_FEATURE_TYPES.SENSOR.INTEGER]: {
+        characteristics: ['PM2_5Density'],
+      },
+    },
+  },
+  [DEVICE_FEATURE_CATEGORIES.PM10_SENSOR]: {
+    service: 'AirQualitySensor',
+    capabilities: {
+      [DEVICE_FEATURE_TYPES.SENSOR.DECIMAL]: {
+        characteristics: ['PM10Density'],
+      },
+      [DEVICE_FEATURE_TYPES.SENSOR.INTEGER]: {
+        characteristics: ['PM10Density'],
+      },
+    },
+  },
   [DEVICE_FEATURE_CATEGORIES.SWITCH]: {
     service: 'Switch',
     capabilities: {
@@ -173,6 +200,30 @@ const gasDetectedThresholds = {
   [DEVICE_FEATURE_CATEGORIES.CO2_SENSOR]: 1000,
 };
 
+// HomeKit expects particulate densities in µg/m³, while Gladys lets an integration report them in
+// milligrams, micrograms or nanograms. Without this conversion a sensor reporting mg/m³ would be
+// shown a thousand times too low.
+const microgramPerCubicMeterFactors = {
+  [DEVICE_FEATURE_UNITS.MILLIGRAM_PER_CUBIC_METER]: 1000,
+  [DEVICE_FEATURE_UNITS.MICROGRAM_PER_CUBIC_METER]: 1,
+  [DEVICE_FEATURE_UNITS.NANOGRAM_PER_CUBIC_METER]: 0.001,
+};
+
+/**
+ * @description Convert a particulate concentration to the µg/m³ HomeKit expects.
+ * @param {number} value - Concentration reported by Gladys.
+ * @param {string} unit - Gladys unit the concentration is expressed in.
+ * @returns {number} The concentration in µg/m³.
+ * @example
+ * toMicrogramPerCubicMeter(0.05, DEVICE_FEATURE_UNITS.MILLIGRAM_PER_CUBIC_METER);
+ */
+function toMicrogramPerCubicMeter(value, unit) {
+  // An integration that declares no unit is assumed to already report µg/m³, which is what the
+  // Zigbee and Matter clusters use.
+  const factor = microgramPerCubicMeterFactors[unit] === undefined ? 1 : microgramPerCubicMeterFactors[unit];
+  return value * factor;
+}
+
 /**
  * @description Convert a Gladys air quality index to the HomeKit AirQuality characteristic value.
  * @param {number} airQualityIndex - Air quality index reported by Gladys.
@@ -205,10 +256,26 @@ function clampToCharacteristic(value, props = {}) {
   return Math.min(maxValue, Math.max(minValue, value));
 }
 
+// HomeKit exposes air quality as a single AirQualitySensor service carrying the index and the
+// particulate densities, while Gladys splits them across categories. The first host category present
+// on a device owns the service and absorbs the features of the other categories listed here.
+const mergedServiceCategories = [
+  {
+    hosts: [
+      DEVICE_FEATURE_CATEGORIES.AIRQUALITY_SENSOR,
+      DEVICE_FEATURE_CATEGORIES.PM25_SENSOR,
+      DEVICE_FEATURE_CATEGORIES.PM10_SENSOR,
+    ],
+    merged: [],
+  },
+];
+
 module.exports = {
   mappings,
   coverStateMapping,
   gasDetectedThresholds,
   aqiToAirQuality,
   clampToCharacteristic,
+  toMicrogramPerCubicMeter,
+  mergedServiceCategories,
 };

--- a/server/services/homekit/lib/sendState.js
+++ b/server/services/homekit/lib/sendState.js
@@ -8,6 +8,7 @@ const {
   gasDetectedThresholds,
   aqiToAirQuality,
   clampToCharacteristic,
+  toMicrogramPerCubicMeter,
 } = require('./deviceMappings');
 
 /**
@@ -103,6 +104,20 @@ function sendState(hkAccessory, feature, event) {
       service.updateCharacteristic(
         Characteristic[characteristicName],
         clampToCharacteristic(event.last_value, characteristic.props),
+      );
+      break;
+    }
+    case `${DEVICE_FEATURE_CATEGORIES.PM25_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.DECIMAL}`:
+    case `${DEVICE_FEATURE_CATEGORIES.PM25_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.INTEGER}`:
+    case `${DEVICE_FEATURE_CATEGORIES.PM10_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.DECIMAL}`:
+    case `${DEVICE_FEATURE_CATEGORIES.PM10_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.INTEGER}`: {
+      const service = hkAccessory.getService(Service[mappings[feature.category].service]);
+      const characteristicName = mappings[feature.category].capabilities[feature.type].characteristics[0];
+      const characteristic = service.getCharacteristic(Characteristic[characteristicName]);
+
+      service.updateCharacteristic(
+        Characteristic[characteristicName],
+        clampToCharacteristic(toMicrogramPerCubicMeter(event.last_value, feature.unit), characteristic.props),
       );
       break;
     }

--- a/server/test/services/homekit/lib/buildAccessory.test.js
+++ b/server/test/services/homekit/lib/buildAccessory.test.js
@@ -50,4 +50,53 @@ describe('Build accessory', () => {
     ]);
     expect(addService.callCount).to.equal(2);
   });
+
+  it('should build a single air quality service from the index and the densities', async () => {
+    homekitHandler.buildService = sinon.stub().returns('builded-service');
+    const addService = sinon.stub();
+    homekitHandler.hap = {
+      Accessory: sinon.stub().returns({ addService, services: ['service1', 'service2'] }),
+    };
+
+    const device = {
+      id: 'c22a4d4b-e261-4b22-a2be-309baf12c3ca',
+      name: 'Capteur qualité air',
+      features: [
+        { name: 'Indice', category: 'airquality-sensor', type: 'aqi' },
+        { name: 'PM2.5', category: 'pm25-sensor', type: 'decimal' },
+        { name: 'PM10', category: 'pm10-sensor', type: 'decimal' },
+      ],
+    };
+
+    await homekitHandler.buildAccessory(device);
+
+    // one AirQualitySensor service, not three
+    expect(homekitHandler.buildService.callCount).to.equal(1);
+    expect(homekitHandler.buildService.args[0][1]).to.have.deep.members(device.features);
+    // no subtype, so the Home app shows a single tile
+    expect(homekitHandler.buildService.args[0][3]).to.equal(undefined);
+    expect(addService.callCount).to.equal(1);
+  });
+
+  it('should host the air quality service on the density when there is no index', async () => {
+    homekitHandler.buildService = sinon.stub().returns('builded-service');
+    const addService = sinon.stub();
+    homekitHandler.hap = {
+      Accessory: sinon.stub().returns({ addService, services: ['service1', 'service2'] }),
+    };
+
+    const device = {
+      id: 'c22a4d4b-e261-4b22-a2be-309baf12c3ca',
+      name: 'Capteur particules',
+      features: [
+        { name: 'PM2.5', category: 'pm25-sensor', type: 'decimal' },
+        { name: 'PM10', category: 'pm10-sensor', type: 'decimal' },
+      ],
+    };
+
+    await homekitHandler.buildAccessory(device);
+
+    expect(homekitHandler.buildService.callCount).to.equal(1);
+    expect(homekitHandler.buildService.args[0][1]).to.have.deep.members(device.features);
+  });
 });

--- a/server/test/services/homekit/lib/buildService.test.js
+++ b/server/test/services/homekit/lib/buildService.test.js
@@ -895,6 +895,89 @@ describe('Build service', () => {
     expect(cb.args[3][1]).to.equal(0);
   });
 
+  it('should build particulate density characteristics on the air quality service', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pm25-microgram').returns({ last_value: 42 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pm25-milligram').returns({ last_value: 0.05 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pm10-nanogram').returns({ last_value: 8000 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pm10-sans-unite').returns({ last_value: 5000 });
+    const on = stub();
+    const getCharacteristic = stub().returns({
+      on,
+      props: {
+        minValue: 0,
+        maxValue: 1000,
+      },
+    });
+    const AirQualitySensor = stub().returns({
+      getCharacteristic,
+    });
+
+    homekitHandler.hap = {
+      Characteristic: {
+        PM2_5Density: 'PM25DENSITY',
+        PM10Density: 'PM10DENSITY',
+      },
+      CharacteristicEventTypes: stub(),
+      Service: {
+        AirQualitySensor,
+      },
+    };
+    const device = {
+      name: 'Capteur particules',
+    };
+    // integrations report densities in milligrams, micrograms or nanograms per cubic meter
+    const features = [
+      {
+        name: 'PM2.5 µg',
+        selector: 'pm25-microgram',
+        category: DEVICE_FEATURE_CATEGORIES.PM25_SENSOR,
+        type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+        unit: DEVICE_FEATURE_UNITS.MICROGRAM_PER_CUBIC_METER,
+      },
+      {
+        name: 'PM2.5 mg',
+        selector: 'pm25-milligram',
+        category: DEVICE_FEATURE_CATEGORIES.PM25_SENSOR,
+        type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+        unit: DEVICE_FEATURE_UNITS.MILLIGRAM_PER_CUBIC_METER,
+      },
+      {
+        name: 'PM10 ng',
+        selector: 'pm10-nanogram',
+        category: DEVICE_FEATURE_CATEGORIES.PM10_SENSOR,
+        type: DEVICE_FEATURE_TYPES.SENSOR.INTEGER,
+        unit: DEVICE_FEATURE_UNITS.NANOGRAM_PER_CUBIC_METER,
+      },
+      {
+        name: 'PM10 sans unité',
+        selector: 'pm10-sans-unite',
+        category: DEVICE_FEATURE_CATEGORIES.PM10_SENSOR,
+        type: DEVICE_FEATURE_TYPES.SENSOR.INTEGER,
+      },
+    ];
+
+    const cb = stub();
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.AIRQUALITY_SENSOR]);
+    await on.args[0][1](cb);
+    await on.args[1][1](cb);
+    await on.args[2][1](cb);
+    await on.args[3][1](cb);
+
+    expect(on.callCount).to.equal(4);
+    expect(getCharacteristic.args[0][0]).to.equal('PM25DENSITY');
+    expect(getCharacteristic.args[2][0]).to.equal('PM10DENSITY');
+    // already in µg/m³
+    expect(cb.args[0][1]).to.equal(42);
+    // 0.05 mg/m³ is 50 µg/m³
+    expect(cb.args[1][1]).to.equal(50);
+    // 8000 ng/m³ is 8 µg/m³
+    expect(cb.args[2][1]).to.equal(8);
+    // no unit declared, the value is taken as µg/m³ and only clamped
+    expect(cb.args[3][1]).to.equal(1000);
+  });
+
   it('should build shutter/curtain service', async () => {
     homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'shutter-state').returns({
       id: '31c6a4a7-9710-4951-bf34-04eeae5b9ff7',

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -34,6 +34,8 @@ describe('Send state to HomeKit', () => {
         CarbonDioxideLevel: 'CARBONDIOXIDELEVEL',
         CarbonDioxideDetected: 'CARBONDIOXIDEDETECTED',
         AirQuality: 'AIRQUALITY',
+        PM2_5Density: 'PM25DENSITY',
+        PM10Density: 'PM10DENSITY',
       },
       Service: {
         ContactSensor: 'CONTACTSENSOR',
@@ -544,6 +546,53 @@ describe('Send state to HomeKit', () => {
     await homekitHandler.sendState(accessory, feature, event);
 
     expect(updateCharacteristic.args[0]).eql(['AIRQUALITY', 4]);
+  });
+
+  it('should notify particulate densities', async () => {
+    const updateCharacteristic = stub().returns();
+    const getCharacteristic = stub().returns({
+      props: {
+        minValue: 0,
+        maxValue: 1000,
+      },
+    });
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns({ updateCharacteristic, getCharacteristic }),
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'PM2.5 sensor',
+      category: DEVICE_FEATURE_CATEGORIES.PM25_SENSOR,
+      type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+      unit: DEVICE_FEATURE_UNITS.MICROGRAM_PER_CUBIC_METER,
+    };
+    const event = { type: EVENTS.DEVICE.NEW_STATE, last_value: 42 };
+
+    await homekitHandler.sendState(accessory, feature, event);
+    // 0.05 mg/m³ is 50 µg/m³
+    await homekitHandler.sendState(
+      accessory,
+      { ...feature, unit: DEVICE_FEATURE_UNITS.MILLIGRAM_PER_CUBIC_METER },
+      { ...event, last_value: 0.05 },
+    );
+    // 8000 ng/m³ is 8 µg/m³, on the PM10 category this time
+    await homekitHandler.sendState(
+      accessory,
+      {
+        ...feature,
+        category: DEVICE_FEATURE_CATEGORIES.PM10_SENSOR,
+        type: DEVICE_FEATURE_TYPES.SENSOR.INTEGER,
+        unit: DEVICE_FEATURE_UNITS.NANOGRAM_PER_CUBIC_METER,
+      },
+      { ...event, last_value: 8000 },
+    );
+
+    expect(updateCharacteristic.args[0]).eql(['PM25DENSITY', 42]);
+    expect(updateCharacteristic.args[1]).eql(['PM25DENSITY', 50]);
+    expect(updateCharacteristic.args[2]).eql(['PM10DENSITY', 8]);
   });
 
   it('should do nothing wrong device category & type', async () => {


### PR DESCRIPTION
Follow-up to #2781, which added the `AirQualitySensor` service with the air
quality index. HomeKit carries the particulate densities on that same service,
and both Matter and Zigbee2mqtt report them, but they were left out.

They belong in #2781 and would have been there had I audited the bridge against
the full list of HAP services before opening it rather than after. Since that PR
is merged, they come as a follow-up instead.

| Gladys category | HomeKit characteristic |
| --- | --- |
| `pm25-sensor` | `PM2_5Density` |
| `pm10-sensor` | `PM10Density` |

### One service, not three

Gladys splits the index and the densities across three categories, while HomeKit
carries them on one service. Built naively that gives three tiles in the Home app
for a single sensor. They are folded into one service, and the first category
present on the device hosts it — a device reporting only PM2.5 still gets its
service.

### Unit conversion

HomeKit expects µg/m³. Gladys lets an integration report milligrams, micrograms
or nanograms per cubic meter, so values are converted: without it a sensor
reporting mg/m³ shows up a thousand times too low, silently. A feature that
declares no unit is taken as µg/m³, which is what the Zigbee and Matter clusters
use.

### VOC deliberately left out

Gladys stores VOC in ppb and HomeKit wants µg/m³. That conversion needs the molar
mass of the compound, which a generic "VOC" feature does not carry, so no
factor could be picked honestly.

### Testing

Unit tests cover both categories, both feature types, the three units, the
no-unit fallback, the clamping and the service merge, on the pull and the push
path. 100% patch coverage.

Not yet paired with an actual iPhone — feedback from anyone who can test on real
hardware is very welcome.

This is part of a series extending the HomeKit bridge, one category per PR:
sensors (merged in #2781), siren, lock, fan, thermostat, device selection,
particulate densities, smoke, battery, button.

They are independent and reviewable on their own, but they all add cases to the
same `switch` statements in `buildService.js` and `sendState.js`, so whichever
merges first will leave the others needing a rebase. Happy to rebase in whatever
order suits you.


This PR introduces a `mergeCategories` helper in `buildAccessory.js`, because
HomeKit models as one service what Gladys splits across several categories. The
thermostat, particulate density and battery PRs each need it and each carry
their own copy, so whichever merges first, the others will drop theirs on
rebase. Tell me if you would rather have it extracted into its own PR first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PM2.5 and PM10 particulate readings to HomeKit air-quality services.
  * Supports microgram, milligram, nanogram, and unitless readings with automatic conversion and safe value limits.
  * Combines air-quality index and particulate readings into a single service when applicable.

* **Bug Fixes**
  * Improved grouping of air-quality features for consistent HomeKit presentation.

* **Tests**
  * Added coverage for particulate mappings, conversions, limits, and service grouping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->