### PR TITLE
feat(homekit): expose thermostats and air conditioners

### DIFF
--- a/server/services/homekit/lib/buildAccessory.js
+++ b/server/services/homekit/lib/buildAccessory.js
@@ -11,7 +11,7 @@ const { mappings, mergedServiceCategories } = require('./deviceMappings');
 function mergeCategories(categories) {
   const mergedCategories = { ...categories };
 
-  mergedServiceCategories.forEach(({ hosts }) => {
+  mergedServiceCategories.forEach(({ hosts, merged }) => {
     const hostCategory = hosts.find((category) => mergedCategories[category]);
     if (!hostCategory) {
       return;
@@ -22,6 +22,21 @@ function mergeCategories(categories) {
       .forEach((category) => {
         mergedCategories[hostCategory] = [...mergedCategories[hostCategory], ...mergedCategories[category]];
         delete mergedCategories[category];
+      });
+
+    // A Thermostat has a single CurrentTemperature, so only the first feature of a merged category
+    // joins it. Any extra one keeps its own service, as it did before.
+    merged
+      .filter((category) => mergedCategories[category])
+      .forEach((category) => {
+        const [firstFeature, ...otherFeatures] = mergedCategories[category];
+        mergedCategories[hostCategory] = [...mergedCategories[hostCategory], firstFeature];
+
+        if (otherFeatures.length === 0) {
+          delete mergedCategories[category];
+        } else {
+          mergedCategories[category] = otherFeatures;
+        }
       });
   });
 

--- a/server/services/homekit/lib/buildService.js
+++ b/server/services/homekit/lib/buildService.js
@@ -18,6 +18,7 @@ const {
   clampToCharacteristic,
   toMicrogramPerCubicMeter,
 } = require('./deviceMappings');
+const { buildThermostatService } = require('./buildThermostatService');
 
 const sleep = promisify(setTimeout);
 
@@ -38,6 +39,12 @@ function buildService(device, features, categoryMapping, subtype) {
     (subtype ? features[0].name : device.name).substring(0, 64),
     subtype,
   );
+
+  // A thermostat is driven by features of several Gladys categories at once, so its characteristics
+  // cannot be wired one feature at a time like the others.
+  if (categoryMapping.service === 'Thermostat') {
+    return buildThermostatService.call(this, service, device, features);
+  }
 
   features.forEach((feature) => {
     switch (`${feature.category}:${feature.type}`) {

--- a/server/services/homekit/lib/buildThermostatService.js
+++ b/server/services/homekit/lib/buildThermostatService.js
@@ -66,6 +66,26 @@ function clampToCharacteristic(value, props = {}) {
 }
 
 /**
+ * @description List the Gladys air conditioning modes a device declares.
+ * @param {object} modeFeature - Gladys mode feature of the device.
+ * @returns {Array} AC_MODE values the device supports.
+ * @example
+ * listSupportedAcModes({ supported_options: [{ value: 1 }, { value: 3 }] });
+ */
+function listSupportedAcModes(modeFeature) {
+  // supported_options lists the modes the device actually declares, and they are not contiguous:
+  // a Matter cooling-only air conditioner reports cool, dry and fan — 1, 3 and 4 — so walking
+  // min..max would offer HomeKit a heat mode the device cannot honour, and SET would write it.
+  // min/max are only a fallback for integrations that declare no options.
+  if (modeFeature.supported_options) {
+    return modeFeature.supported_options.map(({ value }) => value);
+  }
+  return Object.keys(acModeToHeatingCoolingState)
+    .map(Number)
+    .filter((acMode) => acMode >= modeFeature.min && acMode <= modeFeature.max);
+}
+
+/**
  * @description List the HomeKit heating/cooling states the device can actually be switched to, so
  * the Home app does not offer modes the device cannot honour.
  * @param {object} thermostatFeatures - Features driving the thermostat state.
@@ -82,17 +102,7 @@ function buildValidTargetStates(thermostatFeatures) {
   }
 
   if (modeFeature) {
-    // supported_options lists the modes the device actually declares, and they are not contiguous:
-    // a Matter cooling-only air conditioner reports cool, dry and fan — 1, 3 and 4 — so walking
-    // min..max would offer HomeKit a heat mode the device cannot honour, and SET would write it.
-    // min/max are only a fallback for integrations that declare no options.
-    const supportedAcModes = modeFeature.supported_options
-      ? modeFeature.supported_options.map(({ value }) => value)
-      : Object.keys(acModeToHeatingCoolingState)
-          .map(Number)
-          .filter((acMode) => acMode >= modeFeature.min && acMode <= modeFeature.max);
-
-    supportedAcModes.forEach((acMode) => {
+    listSupportedAcModes(modeFeature).forEach((acMode) => {
       const state = acModeToHeatingCoolingState[acMode];
       if (state !== undefined && !validStates.includes(state)) {
         validStates.push(state);
@@ -215,6 +225,20 @@ function buildThermostatService(service, device, features) {
       return targetState;
     }
 
+    // A device driven as a range sits idle between its two setpoints. Comparing against the heating
+    // one alone would report a room at 21 °C, between a 20 °C heating and a 25 °C cooling setpoint,
+    // as cooling — the Home app would show it working when it is doing nothing.
+    if (currentTemperatureFeature && heatingSetpointFeature && coolingSetpointFeature) {
+      const currentTemperature = readCelsius(currentTemperatureFeature);
+      if (currentTemperature < readCelsius(heatingSetpointFeature)) {
+        return HOMEKIT_HEATING_COOLING_STATE.HEAT;
+      }
+      if (currentTemperature > readCelsius(coolingSetpointFeature)) {
+        return HOMEKIT_HEATING_COOLING_STATE.COOL;
+      }
+      return HOMEKIT_HEATING_COOLING_STATE.OFF;
+    }
+
     const setpointFeature = heatingSetpointFeature || coolingSetpointFeature;
     if (currentTemperatureFeature && setpointFeature) {
       return readCelsius(setpointFeature) > readCelsius(currentTemperatureFeature)
@@ -288,7 +312,12 @@ function buildThermostatService(service, device, features) {
       emitValue(powerFeature, 1);
     }
     if (modeFeature && heatingCoolingStateToAcMode[value] !== undefined) {
-      emitValue(modeFeature, heatingCoolingStateToAcMode[value]);
+      // Dry and fan are reported to HomeKit as Auto, so Auto has to stay selectable even on a
+      // device that has no auto mode — but writing AC_MODE.AUTO there would push a mode it never
+      // declared. The device is left in whatever mode it was running in; powering it on is enough.
+      if (listSupportedAcModes(modeFeature).includes(heatingCoolingStateToAcMode[value])) {
+        emitValue(modeFeature, heatingCoolingStateToAcMode[value]);
+      }
     }
     callback();
   });

--- a/server/services/homekit/lib/buildThermostatService.js
+++ b/server/services/homekit/lib/buildThermostatService.js
@@ -1,0 +1,350 @@
+const {
+  DEVICE_FEATURE_CATEGORIES,
+  DEVICE_FEATURE_TYPES,
+  ACTIONS,
+  ACTIONS_STATUS,
+  EVENTS,
+  DEVICE_FEATURE_UNITS,
+} = require('../../../utils/constants');
+const { celsiusToFahrenheit, fahrenheitToCelsius } = require('../../../utils/units');
+const {
+  HOMEKIT_HEATING_COOLING_STATE,
+  acModeToHeatingCoolingState,
+  heatingCoolingStateToAcMode,
+} = require('./deviceMappings');
+
+const KELVIN_OFFSET = 273.15;
+
+/**
+ * @description Convert a Gladys temperature to Celsius, the only unit HomeKit accepts.
+ * @param {number} value - Temperature in the feature unit.
+ * @param {string} unit - Gladys unit of the feature.
+ * @returns {number} Temperature in Celsius.
+ * @example
+ * toCelsius(68, DEVICE_FEATURE_UNITS.FAHRENHEIT);
+ */
+function toCelsius(value, unit) {
+  if (unit === DEVICE_FEATURE_UNITS.KELVIN) {
+    return value - KELVIN_OFFSET;
+  }
+  if (unit === DEVICE_FEATURE_UNITS.FAHRENHEIT) {
+    return fahrenheitToCelsius(value);
+  }
+  return value;
+}
+
+/**
+ * @description Convert a Celsius temperature coming from HomeKit back to the feature unit.
+ * @param {number} celsius - Temperature in Celsius.
+ * @param {string} unit - Gladys unit of the feature.
+ * @returns {number} Temperature in the feature unit.
+ * @example
+ * fromCelsius(20, DEVICE_FEATURE_UNITS.FAHRENHEIT);
+ */
+function fromCelsius(celsius, unit) {
+  if (unit === DEVICE_FEATURE_UNITS.KELVIN) {
+    return celsius + KELVIN_OFFSET;
+  }
+  if (unit === DEVICE_FEATURE_UNITS.FAHRENHEIT) {
+    return celsiusToFahrenheit(celsius);
+  }
+  return celsius;
+}
+
+/**
+ * @description Keep a temperature inside the bounds of a HomeKit characteristic.
+ * @param {number} value - Temperature in Celsius.
+ * @param {object} props - Props of the HomeKit characteristic receiving the value.
+ * @returns {number} Temperature clamped between the characteristic bounds.
+ * @example
+ * clampToCharacteristic(45, { minValue: 10, maxValue: 38 });
+ */
+function clampToCharacteristic(value, props = {}) {
+  const minValue = props.minValue === undefined ? -Infinity : props.minValue;
+  const maxValue = props.maxValue === undefined ? Infinity : props.maxValue;
+  return Math.min(maxValue, Math.max(minValue, value));
+}
+
+/**
+ * @description List the HomeKit heating/cooling states the device can actually be switched to, so
+ * the Home app does not offer modes the device cannot honour.
+ * @param {object} thermostatFeatures - Features driving the thermostat state.
+ * @returns {Array} HomeKit TargetHeatingCoolingState values the device supports.
+ * @example
+ * buildValidTargetStates({ powerFeature, modeFeature, heatingSetpointFeature, coolingSetpointFeature });
+ */
+function buildValidTargetStates(thermostatFeatures) {
+  const { powerFeature, modeFeature, heatingSetpointFeature, coolingSetpointFeature } = thermostatFeatures;
+  const validStates = [];
+
+  if (powerFeature) {
+    validStates.push(HOMEKIT_HEATING_COOLING_STATE.OFF);
+  }
+
+  if (modeFeature) {
+    // supported_options lists the modes the device actually declares, and they are not contiguous:
+    // a Matter cooling-only air conditioner reports cool, dry and fan — 1, 3 and 4 — so walking
+    // min..max would offer HomeKit a heat mode the device cannot honour, and SET would write it.
+    // min/max are only a fallback for integrations that declare no options.
+    const supportedAcModes = modeFeature.supported_options
+      ? modeFeature.supported_options.map(({ value }) => value)
+      : Object.keys(acModeToHeatingCoolingState)
+          .map(Number)
+          .filter((acMode) => acMode >= modeFeature.min && acMode <= modeFeature.max);
+
+    supportedAcModes.forEach((acMode) => {
+      const state = acModeToHeatingCoolingState[acMode];
+      if (state !== undefined && !validStates.includes(state)) {
+        validStates.push(state);
+      }
+    });
+  } else if (heatingSetpointFeature && !coolingSetpointFeature) {
+    validStates.push(HOMEKIT_HEATING_COOLING_STATE.HEAT);
+  } else if (coolingSetpointFeature && !heatingSetpointFeature) {
+    validStates.push(HOMEKIT_HEATING_COOLING_STATE.COOL);
+  } else {
+    validStates.push(HOMEKIT_HEATING_COOLING_STATE.AUTO);
+  }
+
+  return validStates.sort((a, b) => a - b);
+}
+
+/**
+ * @description Bind one of the two threshold temperatures to its Gladys setpoint feature.
+ * @param {object} service - HomeKit Thermostat service to fill.
+ * @param {object} characteristicType - Heating or cooling threshold characteristic.
+ * @param {object} feature - Gladys setpoint feature backing the threshold.
+ * @param {object} helpers - Read and emit helpers bound to the current device.
+ * @returns {undefined}
+ * @example
+ * bindThresholdCharacteristic.call(this, service, Characteristic.HeatingThresholdTemperature, feature, helpers);
+ */
+function bindThresholdCharacteristic(service, characteristicType, feature, helpers) {
+  const { CharacteristicEventTypes } = this.hap;
+  const characteristic = service.getCharacteristic(characteristicType);
+
+  characteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+    callback(undefined, clampToCharacteristic(helpers.readCelsius(feature), characteristic.props));
+  });
+  characteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
+    helpers.emitValue(feature, fromCelsius(value, feature.unit));
+    callback();
+  });
+}
+
+/**
+ * @description Wire the HomeKit Thermostat characteristics of a device.
+ * Unlike the other categories, a thermostat is built from features of several Gladys categories at
+ * once (the setpoints, the mode, the on/off command and the temperature sensor of the same device),
+ * so the whole service is wired here instead of feature by feature.
+ * @param {object} service - HomeKit Thermostat service to fill.
+ * @param {object} device - Gladys device exposed as this thermostat.
+ * @param {object} features - Device features merged into the thermostat service.
+ * @returns {object} The HomeKit service, with its characteristics bound.
+ * @example
+ * buildThermostatService.call(this, service, device, features);
+ */
+function buildThermostatService(service, device, features) {
+  const { Characteristic, CharacteristicEventTypes } = this.hap;
+
+  const findFeature = (category, type) => features.find((f) => f.category === category && f.type === type);
+
+  const currentTemperatureFeature = findFeature(
+    DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
+    DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+  );
+  const heatingSetpointFeature = findFeature(
+    DEVICE_FEATURE_CATEGORIES.THERMOSTAT,
+    DEVICE_FEATURE_TYPES.THERMOSTAT.TARGET_TEMPERATURE,
+  );
+  const coolingSetpointFeature = findFeature(
+    DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+    DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE,
+  );
+  const modeFeature = findFeature(
+    DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+    DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
+  );
+  const powerFeature = findFeature(
+    DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+    DEVICE_FEATURE_TYPES.AIR_CONDITIONING.BINARY,
+  );
+
+  const readValue = (feature) => this.gladys.stateManager.get('deviceFeature', feature.selector).last_value;
+  const readCelsius = (feature) => toCelsius(readValue(feature), feature.unit);
+  const emitValue = (feature, value) => {
+    const action = {
+      type: ACTIONS.DEVICE.SET_VALUE,
+      status: ACTIONS_STATUS.PENDING,
+      value,
+      device: device.selector,
+      device_feature: feature.selector,
+    };
+    this.gladys.event.emit(EVENTS.ACTION.TRIGGERED, action);
+  };
+
+  // Gladys has no "off" AC mode, the binary feature carries it. A device without that feature is
+  // always considered on.
+  const isOn = () => (powerFeature ? Boolean(readValue(powerFeature)) : true);
+
+  const readTargetHeatingCoolingState = () => {
+    if (!isOn()) {
+      return HOMEKIT_HEATING_COOLING_STATE.OFF;
+    }
+    if (modeFeature) {
+      const state = acModeToHeatingCoolingState[readValue(modeFeature)];
+      return state === undefined ? HOMEKIT_HEATING_COOLING_STATE.AUTO : state;
+    }
+    if (heatingSetpointFeature && !coolingSetpointFeature) {
+      return HOMEKIT_HEATING_COOLING_STATE.HEAT;
+    }
+    if (coolingSetpointFeature && !heatingSetpointFeature) {
+      return HOMEKIT_HEATING_COOLING_STATE.COOL;
+    }
+    return HOMEKIT_HEATING_COOLING_STATE.AUTO;
+  };
+
+  // In AUTO (and in the DRY/FAN modes reported as AUTO), HomeKit still wants to know whether the
+  // device is currently heating or cooling: it is deduced from the setpoint and the room temperature.
+  const readCurrentHeatingCoolingState = () => {
+    const targetState = readTargetHeatingCoolingState();
+    if (targetState === HOMEKIT_HEATING_COOLING_STATE.OFF) {
+      return HOMEKIT_HEATING_COOLING_STATE.OFF;
+    }
+    if (targetState !== HOMEKIT_HEATING_COOLING_STATE.AUTO) {
+      return targetState;
+    }
+
+    const setpointFeature = heatingSetpointFeature || coolingSetpointFeature;
+    if (currentTemperatureFeature && setpointFeature) {
+      return readCelsius(setpointFeature) > readCelsius(currentTemperatureFeature)
+        ? HOMEKIT_HEATING_COOLING_STATE.HEAT
+        : HOMEKIT_HEATING_COOLING_STATE.COOL;
+    }
+    return coolingSetpointFeature && !heatingSetpointFeature
+      ? HOMEKIT_HEATING_COOLING_STATE.COOL
+      : HOMEKIT_HEATING_COOLING_STATE.HEAT;
+  };
+
+  // The setpoint TargetTemperature reads and writes. With both setpoints, the active one follows the
+  // mode the device is running in.
+  const activeSetpointFeature = () => {
+    if (!heatingSetpointFeature) {
+      return coolingSetpointFeature;
+    }
+    if (!coolingSetpointFeature) {
+      return heatingSetpointFeature;
+    }
+    return readTargetHeatingCoolingState() === HOMEKIT_HEATING_COOLING_STATE.COOL
+      ? coolingSetpointFeature
+      : heatingSetpointFeature;
+  };
+
+  // HomeKit only ever exchanges Celsius, this characteristic is the unit shown in the Home app.
+  service
+    .getCharacteristic(Characteristic.TemperatureDisplayUnits)
+    .on(CharacteristicEventTypes.GET, async (callback) => {
+      callback(undefined, Characteristic.TemperatureDisplayUnits.CELSIUS);
+    });
+
+  // CurrentTemperature is required. Without a temperature sensor on the device, the setpoint is the
+  // closest thing to the room temperature we can report.
+  const temperatureSourceFeature = currentTemperatureFeature || heatingSetpointFeature || coolingSetpointFeature;
+  if (temperatureSourceFeature) {
+    const currentTemperatureCharacteristic = service.getCharacteristic(Characteristic.CurrentTemperature);
+    currentTemperatureCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+      callback(
+        undefined,
+        clampToCharacteristic(readCelsius(temperatureSourceFeature), currentTemperatureCharacteristic.props),
+      );
+    });
+  }
+
+  const targetStateCharacteristic = service.getCharacteristic(Characteristic.TargetHeatingCoolingState);
+  const validTargetStates = buildValidTargetStates({
+    powerFeature,
+    modeFeature,
+    heatingSetpointFeature,
+    coolingSetpointFeature,
+  });
+  // An integration declaring only modes HomeKit has no equivalent for would leave the list empty,
+  // and HAP rejects a characteristic with no valid value at all.
+  if (validTargetStates.length > 0) {
+    targetStateCharacteristic.setProps({ validValues: validTargetStates });
+  }
+  targetStateCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+    callback(undefined, readTargetHeatingCoolingState());
+  });
+  targetStateCharacteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
+    if (value === HOMEKIT_HEATING_COOLING_STATE.OFF) {
+      if (powerFeature) {
+        emitValue(powerFeature, 0);
+      }
+      callback();
+      return;
+    }
+
+    if (powerFeature) {
+      emitValue(powerFeature, 1);
+    }
+    if (modeFeature && heatingCoolingStateToAcMode[value] !== undefined) {
+      emitValue(modeFeature, heatingCoolingStateToAcMode[value]);
+    }
+    callback();
+  });
+
+  service.getCharacteristic(Characteristic.CurrentHeatingCoolingState).on(CharacteristicEventTypes.GET, (callback) => {
+    callback(undefined, readCurrentHeatingCoolingState());
+  });
+
+  // TargetTemperature is required by HomeKit, but a device exposing only a mode or an on/off
+  // command has no setpoint to back it. Binding handlers there would throw on the first poll, so
+  // the characteristic is left with its HAP default instead.
+  if (heatingSetpointFeature || coolingSetpointFeature) {
+    const targetTemperatureCharacteristic = service.getCharacteristic(Characteristic.TargetTemperature);
+    targetTemperatureCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+      callback(
+        undefined,
+        clampToCharacteristic(readCelsius(activeSetpointFeature()), targetTemperatureCharacteristic.props),
+      );
+    });
+    targetTemperatureCharacteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
+      const setpointFeature = activeSetpointFeature();
+      emitValue(setpointFeature, fromCelsius(value, setpointFeature.unit));
+      callback();
+    });
+  }
+
+  // A device exposing both setpoints can be driven as a range in the Home app.
+  if (heatingSetpointFeature && coolingSetpointFeature) {
+    bindThresholdCharacteristic.call(
+      this,
+      service,
+      Characteristic.HeatingThresholdTemperature,
+      heatingSetpointFeature,
+      {
+        readCelsius,
+        emitValue,
+      },
+    );
+    bindThresholdCharacteristic.call(
+      this,
+      service,
+      Characteristic.CoolingThresholdTemperature,
+      coolingSetpointFeature,
+      {
+        readCelsius,
+        emitValue,
+      },
+    );
+  }
+
+  return service;
+}
+
+module.exports = {
+  buildThermostatService,
+  buildValidTargetStates,
+  toCelsius,
+  fromCelsius,
+};

--- a/server/services/homekit/lib/deviceMappings.js
+++ b/server/services/homekit/lib/deviceMappings.js
@@ -3,6 +3,7 @@ const {
   DEVICE_FEATURE_TYPES,
   DEVICE_FEATURE_UNITS,
   COVER_STATE,
+  AC_MODE,
 } = require('../../../utils/constants');
 
 const mappings = {
@@ -150,6 +151,28 @@ const mappings = {
       },
     },
   },
+  [DEVICE_FEATURE_CATEGORIES.THERMOSTAT]: {
+    service: 'Thermostat',
+    capabilities: {
+      [DEVICE_FEATURE_TYPES.THERMOSTAT.TARGET_TEMPERATURE]: {
+        characteristics: ['TargetTemperature'],
+      },
+    },
+  },
+  [DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]: {
+    service: 'Thermostat',
+    capabilities: {
+      [DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE]: {
+        characteristics: ['TargetTemperature'],
+      },
+      [DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE]: {
+        characteristics: ['TargetHeatingCoolingState', 'CurrentHeatingCoolingState'],
+      },
+      [DEVICE_FEATURE_TYPES.AIR_CONDITIONING.BINARY]: {
+        characteristics: ['TargetHeatingCoolingState', 'CurrentHeatingCoolingState'],
+      },
+    },
+  },
   [DEVICE_FEATURE_CATEGORIES.SHUTTER]: {
     service: 'WindowCovering',
     capabilities: {
@@ -276,7 +299,37 @@ const mergedServiceCategories = [
     ],
     merged: [],
   },
+  // A heating or cooling device is one Thermostat service, while Gladys splits it across the
+  // setpoints, the mode, the on/off command and the temperature sensor reading the room.
+  {
+    hosts: [DEVICE_FEATURE_CATEGORIES.THERMOSTAT, DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING],
+    merged: [DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR],
+  },
 ];
+
+// Values of the HomeKit TargetHeatingCoolingState characteristic. CurrentHeatingCoolingState uses
+// the same values without AUTO.
+const HOMEKIT_HEATING_COOLING_STATE = {
+  OFF: 0,
+  HEAT: 1,
+  COOL: 2,
+  AUTO: 3,
+};
+
+// AC_MODE.DRYING and AC_MODE.FAN have no HomeKit equivalent, they are reported as AUTO.
+const acModeToHeatingCoolingState = {
+  [AC_MODE.AUTO]: HOMEKIT_HEATING_COOLING_STATE.AUTO,
+  [AC_MODE.COOLING]: HOMEKIT_HEATING_COOLING_STATE.COOL,
+  [AC_MODE.HEATING]: HOMEKIT_HEATING_COOLING_STATE.HEAT,
+  [AC_MODE.DRYING]: HOMEKIT_HEATING_COOLING_STATE.AUTO,
+  [AC_MODE.FAN]: HOMEKIT_HEATING_COOLING_STATE.AUTO,
+};
+
+const heatingCoolingStateToAcMode = {
+  [HOMEKIT_HEATING_COOLING_STATE.HEAT]: AC_MODE.HEATING,
+  [HOMEKIT_HEATING_COOLING_STATE.COOL]: AC_MODE.COOLING,
+  [HOMEKIT_HEATING_COOLING_STATE.AUTO]: AC_MODE.AUTO,
+};
 
 module.exports = {
   mappings,
@@ -286,4 +339,7 @@ module.exports = {
   clampToCharacteristic,
   toMicrogramPerCubicMeter,
   mergedServiceCategories,
+  HOMEKIT_HEATING_COOLING_STATE,
+  acModeToHeatingCoolingState,
+  heatingCoolingStateToAcMode,
 };

--- a/server/services/homekit/lib/sendState.js
+++ b/server/services/homekit/lib/sendState.js
@@ -10,6 +10,31 @@ const {
   clampToCharacteristic,
   toMicrogramPerCubicMeter,
 } = require('./deviceMappings');
+const { toCelsius } = require('./buildThermostatService');
+
+/**
+ * @description Recompute a thermostat characteristic through the GET handler built by buildService
+ * and push the result to HomeKit. A thermostat characteristic depends on several Gladys features at
+ * once (power, mode, setpoints, room temperature), so it cannot be derived from the single feature
+ * that changed.
+ * @param {object} hap - HAP library.
+ * @param {object} service - HomeKit service holding the characteristic.
+ * @param {object} characteristicType - HomeKit characteristic to refresh.
+ * @returns {undefined}
+ * @example
+ * refreshCharacteristic(hap, service, hap.Characteristic.CurrentHeatingCoolingState);
+ */
+function refreshCharacteristic(hap, service, characteristicType) {
+  if (!service.testCharacteristic(characteristicType)) {
+    return;
+  }
+
+  service.getCharacteristic(characteristicType).emit(hap.CharacteristicEventTypes.GET, (error, value) => {
+    if (!error) {
+      service.updateCharacteristic(characteristicType, value);
+    }
+  });
+}
 
 /**
  * @description Forward new state value to HomeKit.
@@ -91,9 +116,46 @@ function sendState(hkAccessory, feature, event) {
       } else if (feature.unit === DEVICE_FEATURE_UNITS.FAHRENHEIT) {
         currentTemp = fahrenheitToCelsius(currentTemp);
       }
-      hkAccessory
-        .getService(Service.TemperatureSensor)
-        .updateCharacteristic(Characteristic.CurrentTemperature, currentTemp);
+      // On a heating or cooling device the temperature sensor is merged into the Thermostat service.
+      const service = hkAccessory.getService(Service.TemperatureSensor) || hkAccessory.getService(Service.Thermostat);
+      // Clamped like the GET path: HAP throws on a value outside the characteristic bounds, and a
+      // sensor reporting an out-of-range reading must not take the bridge down.
+      service.updateCharacteristic(
+        Characteristic.CurrentTemperature,
+        clampToCharacteristic(currentTemp, service.getCharacteristic(Characteristic.CurrentTemperature).props),
+      );
+      // In AUTO, whether the device is heating or cooling depends on the room temperature.
+      refreshCharacteristic(this.hap, service, Characteristic.CurrentHeatingCoolingState);
+      break;
+    }
+    case `${DEVICE_FEATURE_CATEGORIES.THERMOSTAT}:${DEVICE_FEATURE_TYPES.THERMOSTAT.TARGET_TEMPERATURE}`:
+    case `${DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING}:${DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE}`: {
+      const service = hkAccessory.getService(Service.Thermostat);
+      const thresholdCharacteristic =
+        feature.category === DEVICE_FEATURE_CATEGORIES.THERMOSTAT
+          ? Characteristic.HeatingThresholdTemperature
+          : Characteristic.CoolingThresholdTemperature;
+
+      if (service.testCharacteristic(thresholdCharacteristic)) {
+        service.updateCharacteristic(
+          thresholdCharacteristic,
+          clampToCharacteristic(
+            toCelsius(event.last_value, feature.unit),
+            service.getCharacteristic(thresholdCharacteristic).props,
+          ),
+        );
+      }
+      // Which setpoint TargetTemperature follows depends on the mode, so it is recomputed.
+      refreshCharacteristic(this.hap, service, Characteristic.TargetTemperature);
+      refreshCharacteristic(this.hap, service, Characteristic.CurrentHeatingCoolingState);
+      break;
+    }
+    case `${DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING}:${DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE}`:
+    case `${DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING}:${DEVICE_FEATURE_TYPES.AIR_CONDITIONING.BINARY}`: {
+      const service = hkAccessory.getService(Service.Thermostat);
+      refreshCharacteristic(this.hap, service, Characteristic.TargetHeatingCoolingState);
+      refreshCharacteristic(this.hap, service, Characteristic.CurrentHeatingCoolingState);
+      refreshCharacteristic(this.hap, service, Characteristic.TargetTemperature);
       break;
     }
     case `${DEVICE_FEATURE_CATEGORIES.LIGHT_SENSOR}:${DEVICE_FEATURE_TYPES.SENSOR.DECIMAL}`:

--- a/server/test/services/homekit/lib/buildAccessory.test.js
+++ b/server/test/services/homekit/lib/buildAccessory.test.js
@@ -99,4 +99,109 @@ describe('Build accessory', () => {
     expect(homekitHandler.buildService.callCount).to.equal(1);
     expect(homekitHandler.buildService.args[0][1]).to.have.deep.members(device.features);
   });
+  it('should merge thermostat, air conditioning and temperature features into one service', async () => {
+    homekitHandler.buildService = sinon.stub().returns('builded-service');
+    const addService = sinon.stub();
+    homekitHandler.hap = {
+      Accessory: sinon.stub().returns({ addService, services: ['service1', 'service2'] }),
+    };
+
+    const device = {
+      id: 'c22a4d4b-e261-4b22-a2be-309baf12c3ca',
+      name: 'Thermostat',
+      features: [
+        {
+          name: 'Température',
+          category: 'temperature-sensor',
+          type: 'decimal',
+        },
+        {
+          name: 'Chauffage',
+          category: 'thermostat',
+          type: 'target-temperature',
+        },
+        {
+          name: 'Refroidissement',
+          category: 'air-conditioning',
+          type: 'target-temperature',
+        },
+        {
+          name: 'Mode',
+          category: 'air-conditioning',
+          type: 'mode',
+        },
+      ],
+    };
+
+    await homekitHandler.buildAccessory(device);
+
+    expect(homekitHandler.buildService.callCount).to.equal(1);
+    expect(homekitHandler.buildService.args[0][1]).to.have.deep.members(device.features);
+    expect(addService.callCount).to.equal(1);
+  });
+
+  it('should keep extra temperature sensors out of the thermostat service', async () => {
+    homekitHandler.buildService = sinon.stub().returns('builded-service');
+    const addService = sinon.stub();
+    homekitHandler.hap = {
+      Accessory: sinon.stub().returns({ addService, services: ['service1', 'service2'] }),
+    };
+
+    const device = {
+      id: 'c22a4d4b-e261-4b22-a2be-309baf12c3ca',
+      name: 'Thermostat',
+      features: [
+        {
+          name: 'Température intérieure',
+          category: 'temperature-sensor',
+          type: 'decimal',
+        },
+        {
+          name: 'Température extérieure',
+          category: 'temperature-sensor',
+          type: 'decimal',
+        },
+        {
+          name: 'Chauffage',
+          category: 'thermostat',
+          type: 'target-temperature',
+        },
+      ],
+    };
+
+    await homekitHandler.buildAccessory(device);
+
+    expect(homekitHandler.buildService.callCount).to.equal(2);
+    // the second sensor keeps its own TemperatureSensor service
+    expect(homekitHandler.buildService.args[0][1]).to.have.deep.members([device.features[1]]);
+    expect(homekitHandler.buildService.args[0][2].service).to.equal('TemperatureSensor');
+    expect(homekitHandler.buildService.args[1][1]).to.have.deep.members([device.features[2], device.features[0]]);
+    expect(homekitHandler.buildService.args[1][2].service).to.equal('Thermostat');
+    expect(addService.callCount).to.equal(2);
+  });
+
+  it('should leave a temperature sensor alone when the device has no thermostat', async () => {
+    homekitHandler.buildService = sinon.stub().returns('builded-service');
+    const addService = sinon.stub();
+    homekitHandler.hap = {
+      Accessory: sinon.stub().returns({ addService, services: ['service1', 'service2'] }),
+    };
+
+    const device = {
+      id: 'c22a4d4b-e261-4b22-a2be-309baf12c3ca',
+      name: 'Capteur',
+      features: [
+        {
+          name: 'Température',
+          category: 'temperature-sensor',
+          type: 'decimal',
+        },
+      ],
+    };
+
+    await homekitHandler.buildAccessory(device);
+
+    expect(homekitHandler.buildService.callCount).to.equal(1);
+    expect(homekitHandler.buildService.args[0][2].service).to.equal('TemperatureSensor');
+  });
 });

--- a/server/test/services/homekit/lib/buildService.test.js
+++ b/server/test/services/homekit/lib/buildService.test.js
@@ -1171,6 +1171,93 @@ describe('Build service', () => {
     expect(characteristics.TargetHeatingCoolingState.setProps.callCount).to.equal(0);
   });
 
+  it('should compare against the single setpoint it has when running in auto', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-mode').returns({ last_value: AC_MODE.AUTO });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-heat').returns({ last_value: 21 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-temp').returns({ last_value: 18.5 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildThermostatHapStub();
+    homekitHandler.hap = hap;
+
+    const features = [
+      {
+        name: 'Mode',
+        selector: 'clim-mode',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
+        min: AC_MODE.AUTO,
+        max: AC_MODE.HEATING,
+      },
+      {
+        name: 'Consigne',
+        selector: 'clim-heat',
+        category: DEVICE_FEATURE_CATEGORIES.THERMOSTAT,
+        type: DEVICE_FEATURE_TYPES.THERMOSTAT.TARGET_TEMPERATURE,
+        unit: DEVICE_FEATURE_UNITS.CELSIUS,
+      },
+      {
+        name: 'Température',
+        selector: 'clim-temp',
+        category: DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
+        type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+        unit: DEVICE_FEATURE_UNITS.CELSIUS,
+      },
+    ];
+
+    await homekitHandler.buildService({ name: 'Clim' }, features, mappings[DEVICE_FEATURE_CATEGORIES.THERMOSTAT]);
+
+    // with a single setpoint there is no idle band: below it the device heats, above it it cools
+    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(1);
+
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-temp').returns({ last_value: 23 });
+    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(2);
+  });
+
+  it('should not write an auto mode the air conditioner never declared', async () => {
+    homekitHandler.gladys.stateManager.get = stub().returns({ last_value: AC_MODE.COOLING });
+    homekitHandler.gladys.event.emit = stub();
+    const { hap, characteristics } = buildThermostatHapStub();
+    homekitHandler.hap = hap;
+
+    // a Matter cooling-only air conditioner: cool, dry and fan, no auto
+    const features = [
+      {
+        name: 'Marche',
+        selector: 'clim-power',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.BINARY,
+      },
+      {
+        name: 'Mode',
+        selector: 'clim-mode',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
+        supported_options: [{ value: AC_MODE.COOLING }, { value: AC_MODE.DRYING }, { value: AC_MODE.FAN }],
+      },
+    ];
+
+    await homekitHandler.buildService({ name: 'Clim' }, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
+
+    // dry and fan are reported to HomeKit as auto, so auto stays selectable
+    expect(characteristics.TargetHeatingCoolingState.setProps.args[0][0]).to.eql({ validValues: [0, 2, 3] });
+
+    const cb = stub();
+    await characteristics.TargetHeatingCoolingState.handlers.set(3, cb);
+
+    // the device is powered on, but its mode is left alone rather than written to an auto it never
+    // declared and could not honour
+    expect(homekitHandler.gladys.event.emit.callCount).to.equal(1);
+    expect(homekitHandler.gladys.event.emit.args[0][1].device_feature).to.equal('clim-power');
+
+    // a mode it does declare is written
+    await characteristics.TargetHeatingCoolingState.handlers.set(2, cb);
+
+    expect(homekitHandler.gladys.event.emit.args[2][1].device_feature).to.equal('clim-mode');
+    expect(homekitHandler.gladys.event.emit.args[2][1].value).to.equal(AC_MODE.COOLING);
+  });
+
   it('should build thermostat service from a setpoint and a temperature sensor', async () => {
     homekitHandler.gladys.stateManager.get = stub();
     homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'chauffage-setpoint').returns({ last_value: 21 });
@@ -1356,8 +1443,9 @@ describe('Build service', () => {
     // the mode is auto, so TargetTemperature follows the heating setpoint
     expect(await readCharacteristic(characteristics.TargetTemperature)).to.equal(20);
     expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(3);
-    // in AUTO, the room is above the heating setpoint so the device is cooling
-    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(2);
+    // in AUTO, 22 °C sits between the 20 °C heating and 25 °C cooling setpoints: the device has
+    // nothing to do, and reporting it as cooling would show the Home app working on an idle unit
+    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(0);
     // no device with an off command, so HomeKit is not offered the off state
     expect(characteristics.TargetHeatingCoolingState.setProps.args[0][0]).to.eql({ validValues: [1, 2, 3] });
 
@@ -1463,6 +1551,14 @@ describe('Build service', () => {
     await characteristics.TargetTemperature.handlers.set(23, cb);
     expect(homekitHandler.gladys.event.emit.args[0][1].device_feature).to.equal(features[1].selector);
     expect(homekitHandler.gladys.event.emit.args[0][1].value).to.equal(23);
+
+    // between the two setpoints the device is idle, not cooling
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pac-temp').returns({ last_value: 24 });
+    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(0);
+
+    // above the cooling setpoint it is cooling
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pac-temp').returns({ last_value: 28 });
+    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(2);
   });
 
   it('should build thermostat service for a cooling only device', async () => {

--- a/server/test/services/homekit/lib/buildService.test.js
+++ b/server/test/services/homekit/lib/buildService.test.js
@@ -8,7 +8,87 @@ const {
   ACTIONS,
   ACTIONS_STATUS,
   DEVICE_FEATURE_UNITS,
+  AC_MODE,
 } = require('../../../../utils/constants');
+
+// The Thermostat service binds many characteristics, so they are stubbed by name instead of by call
+// order. Each stub records its GET/SET handlers so tests can trigger them directly.
+const THERMOSTAT_CHARACTERISTIC_PROPS = {
+  CurrentTemperature: { minValue: -270, maxValue: 100 },
+  TargetTemperature: { minValue: 10, maxValue: 38 },
+  HeatingThresholdTemperature: { minValue: 0, maxValue: 25 },
+  CoolingThresholdTemperature: { minValue: 10, maxValue: 35 },
+};
+
+/**
+ * @description Build a HomeKit stub exposing a Thermostat service.
+ * @returns {object} An object holding the fake hap library and the stubbed characteristics.
+ * @example
+ * const { hap, characteristics } = buildThermostatHapStub();
+ */
+function buildThermostatHapStub() {
+  const names = [
+    'CurrentTemperature',
+    'TargetTemperature',
+    'CurrentHeatingCoolingState',
+    'TargetHeatingCoolingState',
+    'HeatingThresholdTemperature',
+    'CoolingThresholdTemperature',
+  ];
+
+  const Characteristic = { TemperatureDisplayUnits: { name: 'TemperatureDisplayUnits', CELSIUS: 0 } };
+  const characteristics = {
+    TemperatureDisplayUnits: { handlers: {}, props: {}, setProps: stub() },
+  };
+
+  names.forEach((name) => {
+    Characteristic[name] = { name };
+    characteristics[name] = {
+      handlers: {},
+      props: THERMOSTAT_CHARACTERISTIC_PROPS[name] || {},
+      setProps: stub(),
+    };
+  });
+
+  Object.values(characteristics).forEach((characteristic) => {
+    characteristic.on = (event, handler) => {
+      characteristic.handlers[event] = handler;
+      return characteristic;
+    };
+  });
+
+  const updateCharacteristic = stub();
+  const Thermostat = stub().returns({
+    getCharacteristic: (type) => characteristics[type.name],
+    updateCharacteristic,
+  });
+
+  return {
+    characteristics,
+    updateCharacteristic,
+    hap: {
+      Characteristic,
+      CharacteristicEventTypes: { GET: 'get', SET: 'set' },
+      Perms: { PAIRED_READ: 'PAIRED_READ', PAIRED_WRITE: 'PAIRED_WRITE' },
+      Service: { Thermostat },
+    },
+  };
+}
+
+/**
+ * @description Call the GET handler of a stubbed characteristic and return the value it reports.
+ * @param {object} characteristic - Stubbed characteristic holding the handlers.
+ * @returns {Promise} The value passed to the HomeKit callback.
+ * @example
+ * const value = await readCharacteristic(characteristics.TargetTemperature);
+ */
+async function readCharacteristic(characteristic) {
+  let read;
+  await characteristic.handlers.get((error, value) => {
+    read = value;
+  });
+  return read;
+}
 
 describe('Build service', () => {
   const homekitHandler = {
@@ -1041,6 +1121,452 @@ describe('Build service', () => {
     expect(cb.args[2][1]).to.equal(8);
     // no unit declared, the value is taken as µg/m³ and only clamped
     expect(cb.args[3][1]).to.equal(1000);
+  });
+
+  it('should not bind TargetTemperature on a device with no setpoint', async () => {
+    homekitHandler.gladys.stateManager.get = stub().returns({ last_value: 1 });
+    homekitHandler.gladys.event.emit = stub();
+    const { hap, characteristics } = buildThermostatHapStub();
+    homekitHandler.hap = hap;
+
+    // an air conditioner exposing only an on/off command has nothing to back TargetTemperature,
+    // and binding a handler there would throw on the first HomeKit poll
+    const features = [
+      {
+        name: 'Marche',
+        selector: 'clim-power',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.BINARY,
+      },
+    ];
+
+    await homekitHandler.buildService({ name: 'Clim' }, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
+
+    expect(characteristics.TargetTemperature.handlers.get).to.equal(undefined);
+    expect(characteristics.TargetTemperature.handlers.set).to.equal(undefined);
+    // the states it can honour are still offered
+    expect(characteristics.TargetHeatingCoolingState.handlers.get).to.be.a('function');
+  });
+
+  it('should leave the target state unconstrained when no mode maps to HomeKit', async () => {
+    homekitHandler.gladys.stateManager.get = stub().returns({ last_value: 0 });
+    homekitHandler.gladys.event.emit = stub();
+    const { hap, characteristics } = buildThermostatHapStub();
+    homekitHandler.hap = hap;
+
+    // an integration declaring only modes HomeKit has no equivalent for would produce an empty
+    // validValues list, which HAP rejects: setProps must be skipped rather than called with []
+    const features = [
+      {
+        name: 'Mode',
+        selector: 'clim-mode-inconnu',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
+        supported_options: [{ value: 99 }],
+      },
+    ];
+
+    await homekitHandler.buildService({ name: 'Clim' }, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
+
+    expect(characteristics.TargetHeatingCoolingState.setProps.callCount).to.equal(0);
+  });
+
+  it('should build thermostat service from a setpoint and a temperature sensor', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'chauffage-setpoint').returns({ last_value: 21 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'chauffage-temp').returns({ last_value: 18.5 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildThermostatHapStub();
+    homekitHandler.hap = hap;
+
+    const device = { name: 'Chauffage', selector: 'chauffage' };
+    const features = [
+      {
+        name: 'Consigne',
+        selector: 'chauffage-setpoint',
+        category: DEVICE_FEATURE_CATEGORIES.THERMOSTAT,
+        type: DEVICE_FEATURE_TYPES.THERMOSTAT.TARGET_TEMPERATURE,
+        unit: DEVICE_FEATURE_UNITS.CELSIUS,
+        min: 5,
+        max: 30,
+      },
+      {
+        name: 'Température',
+        selector: 'chauffage-temp',
+        category: DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
+        type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+        unit: DEVICE_FEATURE_UNITS.CELSIUS,
+      },
+    ];
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.THERMOSTAT]);
+
+    expect(await readCharacteristic(characteristics.CurrentTemperature)).to.equal(18.5);
+    expect(await readCharacteristic(characteristics.TargetTemperature)).to.equal(21);
+    expect(await readCharacteristic(characteristics.TemperatureDisplayUnits)).to.equal(0);
+    // heating only device: HomeKit is told it cannot be switched off or set to cool
+    expect(characteristics.TargetHeatingCoolingState.setProps.args[0][0]).to.eql({ validValues: [1] });
+    expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(1);
+    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(1);
+    // no second setpoint, so no range in the Home app
+    expect(characteristics.HeatingThresholdTemperature.handlers.get).to.equal(undefined);
+
+    const cb = stub();
+    await characteristics.TargetTemperature.handlers.set(22.5, cb);
+    expect(homekitHandler.gladys.event.emit.args[0][1]).to.eql({
+      type: ACTIONS.DEVICE.SET_VALUE,
+      status: ACTIONS_STATUS.PENDING,
+      value: 22.5,
+      device: device.selector,
+      device_feature: features[0].selector,
+    });
+  });
+
+  it('should build thermostat service for an air conditioner', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-power').returns({ last_value: 1 });
+    homekitHandler.gladys.stateManager.get
+      .withArgs('deviceFeature', 'clim-mode')
+      .returns({ last_value: AC_MODE.COOLING });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-setpoint').returns({ last_value: 24 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildThermostatHapStub();
+    homekitHandler.hap = hap;
+
+    const device = { name: 'Clim', selector: 'clim' };
+    const features = [
+      {
+        name: 'Marche',
+        selector: 'clim-power',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.BINARY,
+        min: 0,
+        max: 1,
+      },
+      {
+        name: 'Mode',
+        selector: 'clim-mode',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
+        min: AC_MODE.AUTO,
+        max: AC_MODE.FAN,
+      },
+      {
+        name: 'Consigne',
+        selector: 'clim-setpoint',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE,
+        unit: DEVICE_FEATURE_UNITS.CELSIUS,
+        min: 16,
+        max: 31,
+      },
+    ];
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
+
+    expect(characteristics.TargetHeatingCoolingState.setProps.args[0][0]).to.eql({ validValues: [0, 1, 2, 3] });
+    expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(2);
+    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(2);
+    // no temperature sensor on the device, the setpoint is the closest reading available
+    expect(await readCharacteristic(characteristics.CurrentTemperature)).to.equal(24);
+
+    const cb = stub();
+    await characteristics.TargetHeatingCoolingState.handlers.set(1, cb);
+    expect(homekitHandler.gladys.event.emit.args[0][1]).to.eql({
+      type: ACTIONS.DEVICE.SET_VALUE,
+      status: ACTIONS_STATUS.PENDING,
+      value: 1,
+      device: device.selector,
+      device_feature: features[0].selector,
+    });
+    expect(homekitHandler.gladys.event.emit.args[1][1]).to.eql({
+      type: ACTIONS.DEVICE.SET_VALUE,
+      status: ACTIONS_STATUS.PENDING,
+      value: AC_MODE.HEATING,
+      device: device.selector,
+      device_feature: features[1].selector,
+    });
+
+    // switching off only writes the binary feature, Gladys has no "off" AC mode
+    homekitHandler.gladys.event.emit = stub();
+    await characteristics.TargetHeatingCoolingState.handlers.set(0, cb);
+    expect(homekitHandler.gladys.event.emit.callCount).to.equal(1);
+    expect(homekitHandler.gladys.event.emit.args[0][1].value).to.equal(0);
+    expect(homekitHandler.gladys.event.emit.args[0][1].device_feature).to.equal(features[0].selector);
+
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-power').returns({ last_value: 0 });
+    expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(0);
+    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(0);
+  });
+
+  it('should build thermostat service with both setpoints in Fahrenheit', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'matter-heat').returns({ last_value: 68 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'matter-cool').returns({ last_value: 77 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'matter-temp').returns({ last_value: 71.6 });
+    homekitHandler.gladys.stateManager.get
+      .withArgs('deviceFeature', 'matter-mode')
+      .returns({ last_value: AC_MODE.AUTO });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildThermostatHapStub();
+    homekitHandler.hap = hap;
+
+    const device = { name: 'Matter', selector: 'matter' };
+    const features = [
+      {
+        name: 'Température',
+        selector: 'matter-temp',
+        category: DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
+        type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+        unit: DEVICE_FEATURE_UNITS.FAHRENHEIT,
+      },
+      {
+        name: 'Chauffage',
+        selector: 'matter-heat',
+        category: DEVICE_FEATURE_CATEGORIES.THERMOSTAT,
+        type: DEVICE_FEATURE_TYPES.THERMOSTAT.TARGET_TEMPERATURE,
+        unit: DEVICE_FEATURE_UNITS.FAHRENHEIT,
+      },
+      {
+        name: 'Refroidissement',
+        selector: 'matter-cool',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE,
+        unit: DEVICE_FEATURE_UNITS.FAHRENHEIT,
+      },
+      {
+        name: 'Mode',
+        selector: 'matter-mode',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
+        min: AC_MODE.AUTO,
+        max: AC_MODE.HEATING,
+      },
+    ];
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.THERMOSTAT]);
+
+    // 71.6 °F is 22 °C
+    expect(await readCharacteristic(characteristics.CurrentTemperature)).to.be.closeTo(22, 0.001);
+    expect(await readCharacteristic(characteristics.HeatingThresholdTemperature)).to.equal(20);
+    expect(await readCharacteristic(characteristics.CoolingThresholdTemperature)).to.equal(25);
+    // the mode is auto, so TargetTemperature follows the heating setpoint
+    expect(await readCharacteristic(characteristics.TargetTemperature)).to.equal(20);
+    expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(3);
+    // in AUTO, the room is above the heating setpoint so the device is cooling
+    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(2);
+    // no device with an off command, so HomeKit is not offered the off state
+    expect(characteristics.TargetHeatingCoolingState.setProps.args[0][0]).to.eql({ validValues: [1, 2, 3] });
+
+    const cb = stub();
+    await characteristics.CoolingThresholdTemperature.handlers.set(26, cb);
+    // written back in the unit of the feature
+    expect(homekitHandler.gladys.event.emit.args[0][1]).to.eql({
+      type: ACTIONS.DEVICE.SET_VALUE,
+      status: ACTIONS_STATUS.PENDING,
+      value: 78.8,
+      device: device.selector,
+      device_feature: features[2].selector,
+    });
+
+    // switched to cooling, TargetTemperature follows the cooling setpoint instead
+    homekitHandler.gladys.stateManager.get
+      .withArgs('deviceFeature', 'matter-mode')
+      .returns({ last_value: AC_MODE.COOLING });
+    expect(await readCharacteristic(characteristics.TargetTemperature)).to.equal(25);
+  });
+
+  it('should report cooling in auto when only a cooling setpoint is known', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-mode').returns({ last_value: AC_MODE.AUTO });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-cool').returns({ last_value: 24 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildThermostatHapStub();
+    homekitHandler.hap = hap;
+
+    const device = { name: 'Clim', selector: 'clim' };
+    const features = [
+      {
+        name: 'Mode',
+        selector: 'clim-mode',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
+        min: AC_MODE.AUTO,
+        max: AC_MODE.COOLING,
+      },
+      {
+        name: 'Consigne froid',
+        selector: 'clim-cool',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE,
+        unit: DEVICE_FEATURE_UNITS.CELSIUS,
+      },
+    ];
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
+
+    expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(3);
+    // no room temperature to compare against, but the device can only cool
+    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(2);
+  });
+
+  it('should build thermostat service with both setpoints and no mode feature', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pac-heat').returns({ last_value: 22 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pac-cool').returns({ last_value: 26 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pac-temp').returns({ last_value: 19 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildThermostatHapStub();
+    homekitHandler.hap = hap;
+
+    const device = { name: 'PAC', selector: 'pac' };
+    const features = [
+      {
+        name: 'Température',
+        selector: 'pac-temp',
+        category: DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
+        type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+        unit: DEVICE_FEATURE_UNITS.CELSIUS,
+      },
+      {
+        name: 'Consigne chaud',
+        selector: 'pac-heat',
+        category: DEVICE_FEATURE_CATEGORIES.THERMOSTAT,
+        type: DEVICE_FEATURE_TYPES.THERMOSTAT.TARGET_TEMPERATURE,
+        unit: DEVICE_FEATURE_UNITS.CELSIUS,
+      },
+      {
+        name: 'Consigne froid',
+        selector: 'pac-cool',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE,
+        unit: DEVICE_FEATURE_UNITS.CELSIUS,
+      },
+    ];
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.THERMOSTAT]);
+
+    // both setpoints and no mode: the device covers the whole range, so auto
+    expect(characteristics.TargetHeatingCoolingState.setProps.args[0][0]).to.eql({ validValues: [3] });
+    expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(3);
+    // the room is below the heating setpoint, so the device is heating
+    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(1);
+    // not cooling, so TargetTemperature follows the heating setpoint
+    expect(await readCharacteristic(characteristics.TargetTemperature)).to.equal(22);
+
+    const cb = stub();
+    await characteristics.TargetTemperature.handlers.set(23, cb);
+    expect(homekitHandler.gladys.event.emit.args[0][1].device_feature).to.equal(features[1].selector);
+    expect(homekitHandler.gladys.event.emit.args[0][1].value).to.equal(23);
+  });
+
+  it('should build thermostat service for a cooling only device', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-cool').returns({ last_value: 24 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildThermostatHapStub();
+    homekitHandler.hap = hap;
+
+    const device = { name: 'Clim', selector: 'clim' };
+    const features = [
+      {
+        name: 'Consigne froid',
+        selector: 'clim-cool',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE,
+        unit: DEVICE_FEATURE_UNITS.CELSIUS,
+      },
+    ];
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
+
+    // no mode and no heating setpoint: the device can only cool
+    expect(characteristics.TargetHeatingCoolingState.setProps.args[0][0]).to.eql({ validValues: [2] });
+    expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(2);
+    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(2);
+    // the cooling setpoint is the only setpoint, so it drives TargetTemperature
+    expect(await readCharacteristic(characteristics.TargetTemperature)).to.equal(24);
+    // and it stands in for the missing room temperature
+    expect(await readCharacteristic(characteristics.CurrentTemperature)).to.equal(24);
+
+    const cb = stub();
+    await characteristics.TargetTemperature.handlers.set(25, cb);
+    expect(homekitHandler.gladys.event.emit.args[0][1].value).to.equal(25);
+    expect(homekitHandler.gladys.event.emit.args[0][1].device_feature).to.equal(features[0].selector);
+  });
+
+  it('should build thermostat service without any temperature feature', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-power').returns({ last_value: 1 });
+    // a mode value the AC_MODE mapping does not know about
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-mode').returns({ last_value: 99 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildThermostatHapStub();
+    homekitHandler.hap = hap;
+
+    const device = { name: 'Clim', selector: 'clim' };
+    const features = [
+      {
+        name: 'Marche',
+        selector: 'clim-power',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.BINARY,
+      },
+      {
+        name: 'Mode',
+        selector: 'clim-mode',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
+        min: AC_MODE.AUTO,
+        max: AC_MODE.FAN,
+      },
+    ];
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
+
+    // nothing carries a temperature, CurrentTemperature is left unbound
+    expect(characteristics.CurrentTemperature.handlers.get).to.equal(undefined);
+    // an unknown AC mode falls back to auto
+    expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(3);
+    // in auto without any temperature to compare, heating is the assumed state
+    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(1);
+  });
+
+  it('should build thermostat service without an on/off command', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'chauffage-setpoint').returns({ last_value: 21 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildThermostatHapStub();
+    homekitHandler.hap = hap;
+
+    const device = { name: 'Chauffage', selector: 'chauffage' };
+    const features = [
+      {
+        name: 'Consigne',
+        selector: 'chauffage-setpoint',
+        category: DEVICE_FEATURE_CATEGORIES.THERMOSTAT,
+        type: DEVICE_FEATURE_TYPES.THERMOSTAT.TARGET_TEMPERATURE,
+        unit: DEVICE_FEATURE_UNITS.CELSIUS,
+      },
+    ];
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.THERMOSTAT]);
+
+    const cb = stub();
+    // HomeKit can still send those, they are simply not actionable without an on/off feature
+    await characteristics.TargetHeatingCoolingState.handlers.set(0, cb);
+    await characteristics.TargetHeatingCoolingState.handlers.set(1, cb);
+
+    expect(homekitHandler.gladys.event.emit.callCount).to.equal(0);
+    expect(cb.callCount).to.equal(2);
   });
 
   it('should build shutter/curtain service', async () => {

--- a/server/test/services/homekit/lib/buildThermostatService.test.js
+++ b/server/test/services/homekit/lib/buildThermostatService.test.js
@@ -1,0 +1,118 @@
+const { expect } = require('chai');
+const {
+  buildValidTargetStates,
+  toCelsius,
+  fromCelsius,
+} = require('../../../../services/homekit/lib/buildThermostatService');
+const { clampToCharacteristic } = require('../../../../services/homekit/lib/deviceMappings');
+const { DEVICE_FEATURE_UNITS, AC_MODE } = require('../../../../utils/constants');
+
+const HEATING_SETPOINT = { selector: 'heating' };
+const COOLING_SETPOINT = { selector: 'cooling' };
+const POWER = { selector: 'power' };
+
+describe('Thermostat unit conversion', () => {
+  it('should convert to Celsius from every unit Gladys can carry', () => {
+    expect(toCelsius(20, DEVICE_FEATURE_UNITS.CELSIUS)).to.equal(20);
+    expect(toCelsius(293.15, DEVICE_FEATURE_UNITS.KELVIN)).to.be.closeTo(20, 0.001);
+    expect(toCelsius(68, DEVICE_FEATURE_UNITS.FAHRENHEIT)).to.equal(20);
+    // an undeclared unit is already Celsius, HomeKit exchanges nothing else
+    expect(toCelsius(20, undefined)).to.equal(20);
+  });
+
+  it('should convert back from Celsius to the feature unit', () => {
+    expect(fromCelsius(20, DEVICE_FEATURE_UNITS.CELSIUS)).to.equal(20);
+    expect(fromCelsius(20, DEVICE_FEATURE_UNITS.KELVIN)).to.be.closeTo(293.15, 0.001);
+    expect(fromCelsius(20, DEVICE_FEATURE_UNITS.FAHRENHEIT)).to.equal(68);
+    expect(fromCelsius(20, undefined)).to.equal(20);
+  });
+});
+
+describe('Thermostat characteristic clamping', () => {
+  it('should clamp a temperature between the characteristic bounds', () => {
+    expect(clampToCharacteristic(45, { minValue: 10, maxValue: 38 })).to.equal(38);
+    expect(clampToCharacteristic(5, { minValue: 10, maxValue: 38 })).to.equal(10);
+    expect(clampToCharacteristic(21, { minValue: 10, maxValue: 38 })).to.equal(21);
+  });
+
+  it('should leave the value alone when the characteristic declares no bound', () => {
+    expect(clampToCharacteristic(45, {})).to.equal(45);
+    expect(clampToCharacteristic(45, { minValue: 10 })).to.equal(45);
+    expect(clampToCharacteristic(5, { maxValue: 38 })).to.equal(5);
+    expect(clampToCharacteristic(45)).to.equal(45);
+  });
+});
+
+describe('Thermostat valid target states', () => {
+  it('should only offer heat on a heating only thermostat', () => {
+    expect(buildValidTargetStates({ heatingSetpointFeature: HEATING_SETPOINT })).to.eql([1]);
+  });
+
+  it('should only offer cool on a cooling only device', () => {
+    expect(buildValidTargetStates({ coolingSetpointFeature: COOLING_SETPOINT })).to.eql([2]);
+  });
+
+  it('should offer auto when both setpoints exist without a mode feature', () => {
+    expect(
+      buildValidTargetStates({
+        heatingSetpointFeature: HEATING_SETPOINT,
+        coolingSetpointFeature: COOLING_SETPOINT,
+      }),
+    ).to.eql([3]);
+  });
+
+  it('should follow supported_options rather than the min/max range', () => {
+    // Matter reports a cooling-only air conditioner as cool, dry and fan — 1, 3 and 4 — so the
+    // 1..4 range would wrongly include heat, which is 2
+    const coolingOnly = {
+      min: 1,
+      max: 4,
+      supported_options: [{ value: 1 }, { value: 3 }, { value: 4 }],
+    };
+    // cool, plus auto for dry and fan, and no heat
+    expect(buildValidTargetStates({ modeFeature: coolingOnly })).to.eql([2, 3]);
+
+    // and the other way round: auto and heat must not bring cool along
+    const autoAndHeating = {
+      min: 0,
+      max: 2,
+      supported_options: [{ value: 0 }, { value: 2 }],
+    };
+    expect(buildValidTargetStates({ modeFeature: autoAndHeating })).to.eql([1, 3]);
+  });
+
+  it('should return no state at all when the device declares only unknown modes', () => {
+    // an integration whose modes have no HomeKit equivalent must not produce an empty validValues
+    // list silently accepted as valid: the caller checks the length before calling setProps
+    expect(buildValidTargetStates({ modeFeature: { supported_options: [{ value: 99 }] } })).to.eql([]);
+  });
+
+  it('should fall back on the min/max range when no options are declared', () => {
+    expect(buildValidTargetStates({ modeFeature: { min: 0, max: 4 } })).to.eql([1, 2, 3]);
+    expect(buildValidTargetStates({ modeFeature: { min: 2, max: 2 } })).to.eql([1]);
+  });
+
+  it('should offer off only when the device has an on/off command', () => {
+    expect(
+      buildValidTargetStates({
+        powerFeature: POWER,
+        heatingSetpointFeature: HEATING_SETPOINT,
+      }),
+    ).to.eql([0, 1]);
+  });
+
+  it('should derive the states from the AC modes the device declares', () => {
+    // a heat pump declaring auto, cooling and heating
+    expect(
+      buildValidTargetStates({
+        modeFeature: { min: AC_MODE.AUTO, max: AC_MODE.HEATING },
+      }),
+    ).to.eql([1, 2, 3]);
+    // a cooling only air conditioner: auto and cooling, dry and fan both fold into auto
+    expect(
+      buildValidTargetStates({
+        modeFeature: { min: AC_MODE.AUTO, max: AC_MODE.COOLING },
+      }),
+    ).to.eql([2, 3]);
+  });
+});

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -28,6 +28,11 @@ describe('Send state to HomeKit', () => {
         CurrentPosition: 'CURRENTPOSITION',
         PositionState: 'POSITIONSTATE',
         TargetPosition: 'TARGETPOSITION',
+        CoolingThresholdTemperature: 'COOLINGTHRESHOLDTEMPERATURE',
+        HeatingThresholdTemperature: 'HEATINGTHRESHOLDTEMPERATURE',
+        TargetHeatingCoolingState: 'TARGETHEATINGCOOLINGSTATE',
+        CurrentHeatingCoolingState: 'CURRENTHEATINGCOOLINGSTATE',
+        TargetTemperature: 'TARGETTEMPERATURE',
         CurrentAmbientLightLevel: 'CURRENTAMBIENTLIGHTLEVEL',
         CarbonMonoxideDetected: 'CARBONMONOXIDEDETECTED',
         CarbonMonoxideLevel: 'CARBONMONOXIDELEVEL',
@@ -37,10 +42,13 @@ describe('Send state to HomeKit', () => {
         PM2_5Density: 'PM25DENSITY',
         PM10Density: 'PM10DENSITY',
       },
+      CharacteristicEventTypes: { GET: 'get', SET: 'set' },
       Service: {
         ContactSensor: 'CONTACTSENSOR',
         MotionSensor: 'MOTIONSENSOR',
         WindowCovering: 'WINDOWCOVERING',
+        Thermostat: 'THERMOSTAT',
+        TemperatureSensor: 'TEMPERATURESENSOR',
         LightSensor: 'LIGHTSENSOR',
         CarbonMonoxideSensor: 'CARBONMONOXIDESENSOR',
         CarbonDioxideSensor: 'CARBONDIOXIDESENSOR',
@@ -54,7 +62,11 @@ describe('Send state to HomeKit', () => {
     const updateCharacteristic = stub().returns();
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
-      getService: stub().returns({ updateCharacteristic }),
+      getService: stub().returns({
+        updateCharacteristic,
+        testCharacteristic: stub().returns(false),
+        getCharacteristic: stub().returns({ props: { minValue: -270, maxValue: 100 } }),
+      }),
     };
 
     const event = {
@@ -79,7 +91,11 @@ describe('Send state to HomeKit', () => {
     const updateCharacteristic = stub().returns();
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
-      getService: stub().returns({ updateCharacteristic }),
+      getService: stub().returns({
+        updateCharacteristic,
+        testCharacteristic: stub().returns(false),
+        getCharacteristic: stub().returns({ props: { minValue: -270, maxValue: 100 } }),
+      }),
     };
 
     const event = {
@@ -104,7 +120,11 @@ describe('Send state to HomeKit', () => {
     const updateCharacteristic = stub().returns();
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
-      getService: stub().returns({ updateCharacteristic }),
+      getService: stub().returns({
+        updateCharacteristic,
+        testCharacteristic: stub().returns(false),
+        getCharacteristic: stub().returns({ props: { minValue: -270, maxValue: 100 } }),
+      }),
     };
 
     const event = {
@@ -129,7 +149,11 @@ describe('Send state to HomeKit', () => {
     const updateCharacteristic = stub().returns();
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
-      getService: stub().returns({ updateCharacteristic }),
+      getService: stub().returns({
+        updateCharacteristic,
+        testCharacteristic: stub().returns(false),
+        getCharacteristic: stub().returns({ props: { minValue: -270, maxValue: 100 } }),
+      }),
     };
 
     const event = {
@@ -193,7 +217,11 @@ describe('Send state to HomeKit', () => {
 
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
-      getService: stub().returns({ updateCharacteristic }),
+      getService: stub().returns({
+        updateCharacteristic,
+        testCharacteristic: stub().returns(false),
+        getCharacteristic: stub().returns({ props: { minValue: -270, maxValue: 100 } }),
+      }),
     };
 
     const event = {
@@ -294,7 +322,11 @@ describe('Send state to HomeKit', () => {
     const updateCharacteristic = stub().returns();
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
-      getService: stub().returns({ updateCharacteristic }),
+      getService: stub().returns({
+        updateCharacteristic,
+        testCharacteristic: stub().returns(false),
+        getCharacteristic: stub().returns({ props: { minValue: -270, maxValue: 100 } }),
+      }),
     };
 
     const event = {
@@ -320,7 +352,11 @@ describe('Send state to HomeKit', () => {
     const updateCharacteristic = stub().returns();
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
-      getService: stub().returns({ updateCharacteristic }),
+      getService: stub().returns({
+        updateCharacteristic,
+        testCharacteristic: stub().returns(false),
+        getCharacteristic: stub().returns({ props: { minValue: -270, maxValue: 100 } }),
+      }),
     };
 
     const event = {
@@ -346,7 +382,11 @@ describe('Send state to HomeKit', () => {
     const updateCharacteristic = stub().returns();
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
-      getService: stub().returns({ updateCharacteristic }),
+      getService: stub().returns({
+        updateCharacteristic,
+        testCharacteristic: stub().returns(false),
+        getCharacteristic: stub().returns({ props: { minValue: -270, maxValue: 100 } }),
+      }),
     };
 
     const event = {
@@ -451,7 +491,11 @@ describe('Send state to HomeKit', () => {
     const updateCharacteristic = stub().returns();
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
-      getService: stub().returns({ updateCharacteristic }),
+      getService: stub().returns({
+        updateCharacteristic,
+        testCharacteristic: stub().returns(false),
+        getCharacteristic: stub().returns({ props: { minValue: -270, maxValue: 100 } }),
+      }),
     };
 
     const event = {
@@ -552,7 +596,11 @@ describe('Send state to HomeKit', () => {
     const updateCharacteristic = stub().returns();
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
-      getService: stub().returns({ updateCharacteristic }),
+      getService: stub().returns({
+        updateCharacteristic,
+        testCharacteristic: stub().returns(false),
+        getCharacteristic: stub().returns({ props: { minValue: -270, maxValue: 100 } }),
+      }),
     };
 
     const event = {
@@ -620,11 +668,250 @@ describe('Send state to HomeKit', () => {
     expect(updateCharacteristic.args[2]).eql(['PM10DENSITY', 8]);
   });
 
+  it('should notify current temperature on a merged thermostat', async () => {
+    const updateCharacteristic = stub().returns();
+    const currentStateCharacteristic = { emit: stub().callsArgWith(1, undefined, 2) };
+    const thermostatService = {
+      updateCharacteristic,
+      testCharacteristic: stub().returns(true),
+      getCharacteristic: stub().returns(currentStateCharacteristic),
+    };
+    // the device has no standalone TemperatureSensor service, it was merged into the thermostat
+    const getService = stub();
+    getService.withArgs('TEMPERATURESENSOR').returns(undefined);
+    getService.withArgs('THERMOSTAT').returns(thermostatService);
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService,
+    };
+
+    const event = {
+      type: EVENTS.DEVICE.NEW_STATE,
+      last_value: 19.5,
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Room temperature',
+      category: DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
+      type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+      unit: DEVICE_FEATURE_UNITS.CELSIUS,
+    };
+
+    await homekitHandler.sendState(accessory, feature, event);
+
+    expect(updateCharacteristic.args[0]).eql(['CURRENTTEMPERATURE', 19.5]);
+    // heating or cooling in AUTO depends on the room temperature, so it is recomputed
+    expect(updateCharacteristic.args[1]).eql(['CURRENTHEATINGCOOLINGSTATE', 2]);
+  });
+
+  it('should notify a thermostat setpoint', async () => {
+    const updateCharacteristic = stub().returns();
+    const characteristic = { emit: stub().callsArgWith(1, undefined, 21) };
+    const thermostatService = {
+      updateCharacteristic,
+      testCharacteristic: stub().returns(true),
+      getCharacteristic: stub().returns(characteristic),
+    };
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns(thermostatService),
+    };
+
+    const event = {
+      type: EVENTS.DEVICE.NEW_STATE,
+      last_value: 69.8,
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Setpoint',
+      category: DEVICE_FEATURE_CATEGORIES.THERMOSTAT,
+      type: DEVICE_FEATURE_TYPES.THERMOSTAT.TARGET_TEMPERATURE,
+      unit: DEVICE_FEATURE_UNITS.FAHRENHEIT,
+    };
+
+    await homekitHandler.sendState(accessory, feature, event);
+
+    // 69.8 °F is 21 °C
+    expect(updateCharacteristic.args[0][0]).eql('HEATINGTHRESHOLDTEMPERATURE');
+    expect(updateCharacteristic.args[0][1]).to.be.closeTo(21, 0.001);
+    expect(updateCharacteristic.args[1]).eql(['TARGETTEMPERATURE', 21]);
+  });
+
+  it('should notify an air conditioning setpoint on a thermostat without thresholds', async () => {
+    const updateCharacteristic = stub().returns();
+    const characteristic = { emit: stub().callsArgWith(1, undefined, 24) };
+    const thermostatService = {
+      updateCharacteristic,
+      // a device with a single setpoint has no threshold characteristic
+      testCharacteristic: stub().returns(false),
+      getCharacteristic: stub().returns(characteristic),
+    };
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns(thermostatService),
+    };
+
+    const event = {
+      type: EVENTS.DEVICE.NEW_STATE,
+      last_value: 24,
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Cooling setpoint',
+      category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+      type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE,
+      unit: DEVICE_FEATURE_UNITS.CELSIUS,
+    };
+
+    await homekitHandler.sendState(accessory, feature, event);
+
+    // a service exposing none of those characteristics is left untouched
+    expect(updateCharacteristic.callCount).eql(0);
+  });
+
+  it('should notify an air conditioning mode change', async () => {
+    const updateCharacteristic = stub().returns();
+    const characteristic = { emit: stub().callsArgWith(1, undefined, 2) };
+    const thermostatService = {
+      updateCharacteristic,
+      testCharacteristic: stub().returns(true),
+      getCharacteristic: stub().returns(characteristic),
+    };
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns(thermostatService),
+    };
+
+    const event = {
+      type: EVENTS.DEVICE.NEW_STATE,
+      last_value: 1,
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Mode',
+      category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+      type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
+    };
+
+    await homekitHandler.sendState(accessory, feature, event);
+
+    expect(updateCharacteristic.args[0]).eql(['TARGETHEATINGCOOLINGSTATE', 2]);
+    expect(updateCharacteristic.args[1]).eql(['CURRENTHEATINGCOOLINGSTATE', 2]);
+    expect(updateCharacteristic.args[2]).eql(['TARGETTEMPERATURE', 2]);
+  });
+
+  it('should not push a thermostat characteristic whose read failed', async () => {
+    const updateCharacteristic = stub().returns();
+    const characteristic = { emit: stub().callsArgWith(1, new Error('read failed')) };
+    const thermostatService = {
+      updateCharacteristic,
+      testCharacteristic: stub().returns(true),
+      getCharacteristic: stub().returns(characteristic),
+    };
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns(thermostatService),
+    };
+
+    const event = {
+      type: EVENTS.DEVICE.NEW_STATE,
+      last_value: 1,
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Mode',
+      category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+      type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
+    };
+
+    await homekitHandler.sendState(accessory, feature, event);
+
+    expect(updateCharacteristic.callCount).eql(0);
+  });
+
+  it('should notify an air conditioning power change', async () => {
+    const updateCharacteristic = stub().returns();
+    const characteristic = { emit: stub().callsArgWith(1, undefined, 0) };
+    const thermostatService = {
+      updateCharacteristic,
+      testCharacteristic: stub().returns(true),
+      getCharacteristic: stub().returns(characteristic),
+    };
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns(thermostatService),
+    };
+
+    const event = {
+      type: EVENTS.DEVICE.NEW_STATE,
+      last_value: 0,
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Power',
+      category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+      type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.BINARY,
+    };
+
+    await homekitHandler.sendState(accessory, feature, event);
+
+    expect(updateCharacteristic.args[0]).eql(['TARGETHEATINGCOOLINGSTATE', 0]);
+    expect(updateCharacteristic.args[1]).eql(['CURRENTHEATINGCOOLINGSTATE', 0]);
+    expect(updateCharacteristic.args[2]).eql(['TARGETTEMPERATURE', 0]);
+  });
+
+  it('should clamp temperatures pushed to a thermostat', async () => {
+    const updateCharacteristic = stub().returns();
+    const service = {
+      updateCharacteristic,
+      testCharacteristic: stub().returns(true),
+      getCharacteristic: stub().returns({
+        props: { minValue: -270, maxValue: 100 },
+        emit: (event, cb) => cb(undefined, 0),
+      }),
+    };
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns(service),
+    };
+
+    // a sensor glitching far outside the HomeKit bounds must be clamped, not thrown at HAP
+    await homekitHandler.sendState(
+      accessory,
+      {
+        id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+        device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+        name: 'Room temperature',
+        category: DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
+        type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+      },
+      { type: EVENTS.DEVICE.NEW_STATE, last_value: 5000 },
+    );
+
+    expect(updateCharacteristic.args[0]).eql(['CURRENTTEMPERATURE', 100]);
+  });
+
   it('should do nothing wrong device category & type', async () => {
     const updateCharacteristic = stub().returns();
     const accessory = {
       UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
-      getService: stub().returns({ updateCharacteristic }),
+      getService: stub().returns({
+        updateCharacteristic,
+        testCharacteristic: stub().returns(false),
+        getCharacteristic: stub().returns({ props: { minValue: -270, maxValue: 100 } }),
+      }),
     };
 
     const event = {


### PR DESCRIPTION
Heating and cooling devices are not exposed to HomeKit today. This maps them to the
`Thermostat` service, with mode, setpoint and current temperature.

### Why this one is not a simple mapping entry

HomeKit models a heating/cooling device as a **single** `Thermostat` service.
Gladys splits the same device across several categories: `thermostat` for the
heating setpoint, `air-conditioning` for the cooling setpoint and the mode, and
`temperature-sensor` for the room reading.

Mapping one feature at a time — which is how every other category works — would
have produced two or three unrelated services for one device. So:

- `deviceMappings.js` gains a `mergedServiceCategories` table describing which
  categories fold into which host category.
- `buildAccessory` folds them before building.
- The service itself is built by a dedicated `buildThermostatService.js`, since its
  characteristics each depend on several features at once.

### Mapping decisions

**Modes.** `AC_MODE.DRYING` and `AC_MODE.FAN` have no HomeKit equivalent and are
reported as `AUTO`. `TargetHeatingCoolingState.validValues` is restricted to the
modes the device actually has, so the Home app never offers a mode Gladys cannot
honour.

**Setpoints.** In `HEAT` or `COOL`, `TargetTemperature` follows the matching
setpoint. In `AUTO`, HomeKit uses `HeatingThresholdTemperature` and
`CoolingThresholdTemperature`, which are wired to the two Gladys setpoints.

**Units.** Setpoints are converted to and from Celsius, honouring the feature unit
(Celsius, Fahrenheit, Kelvin), and clamped to the characteristic bounds so an
out-of-range value cannot make HAP throw.

**Push updates.** A thermostat characteristic cannot be derived from the single
feature that changed — whether the device is heating in `AUTO` depends on the room
temperature, and which setpoint `TargetTemperature` follows depends on the mode. So
`sendState` re-runs the GET handler and pushes the result, rather than duplicating
the derivation logic.

### Testing

Unit tests cover every mode, both setpoints, the three units, the merge, the
clamping and the push path. `npm run coverage` is green with 100% patch coverage.

The bridge has been smoke-tested against the real `hap-nodejs` library, but **not
yet paired with an actual iPhone**. This is the most derived of the HomeKit
mappings, so real-hardware confirmation before merging would be reasonable —
feedback very welcome.

This is part of a series extending the HomeKit bridge, one category per PR:
sensors (merged in #2781), siren, lock, fan, thermostat, device selection,
particulate densities, smoke, battery, button.

They are independent and reviewable on their own, but they all add cases to the
same `switch` statements in `buildService.js` and `sendState.js`, so whichever
merges first will leave the others needing a rebase. Happy to rebase in whatever
order suits you.

This PR introduces a `mergeCategories` helper in `buildAccessory.js`, because
HomeKit models as one service what Gladys splits across several categories. The
thermostat, particulate density and battery PRs each need it and each carry
their own copy, so whichever merges first, the others will drop theirs on
rebase. Tell me if you would rather have it extracted into its own PR first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HomeKit thermostat support for heating, cooling, setpoints, operating modes, power controls, and temperature units.
  * Added Celsius, Fahrenheit, and Kelvin conversion with safe temperature limits.
  * Combined related thermostat, air-conditioning, and temperature features into unified HomeKit services while preserving additional sensors separately.
  * HomeKit state updates now stay synchronized after temperature, mode, and power changes.

* **Tests**
  * Added comprehensive coverage for thermostat behavior, conversions, service grouping, fallback handling, and state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->