### PR TITLE
fix(test): remove race condition in device.new-state trigger tests

### DIFF
--- a/server/test/helpers/waitUntil.js
+++ b/server/test/helpers/waitUntil.js
@@ -1,0 +1,36 @@
+const DEFAULT_TIMEOUT = 2000;
+const DEFAULT_INTERVAL = 2;
+
+/**
+ * @description Poll a condition until it becomes true, and reject if it's still
+ * false after the timeout. Useful to avoid relying on an arbitrary fixed delay
+ * when waiting for an asynchronous side effect, which is flaky on slow machines.
+ * @param {Function} condition - Function returning true when the expected state is reached.
+ * @param {object} [options] - Options.
+ * @param {number} [options.timeout] - Maximum time to wait, in ms.
+ * @param {number} [options.interval] - Delay between two checks, in ms.
+ * @param {string} [options.message] - Description of what is awaited, displayed when the timeout is reached.
+ * @returns {Promise} Resolve when the condition is true.
+ * @example
+ * await waitUntil(() => device.setValue.called, { message: 'the scene to be executed' });
+ */
+function waitUntil(condition, options = {}) {
+  const { timeout = DEFAULT_TIMEOUT, interval = DEFAULT_INTERVAL, message = 'condition to be true' } = options;
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeout;
+    const check = () => {
+      if (condition()) {
+        resolve();
+      } else if (Date.now() >= deadline) {
+        reject(new Error(`Timed out after ${timeout}ms while waiting for ${message}`));
+      } else {
+        setTimeout(check, interval);
+      }
+    };
+    check();
+  });
+}
+
+module.exports = {
+  waitUntil,
+};

--- a/server/test/lib/scene/triggers/scene.trigger.deviceNewState.test.js
+++ b/server/test/lib/scene/triggers/scene.trigger.deviceNewState.test.js
@@ -8,6 +8,7 @@ const { assert, fake } = sinon;
 const { EVENTS, ACTIONS } = require('../../../../utils/constants');
 const SceneManager = require('../../../../lib/scene');
 const StateManager = require('../../../../lib/state');
+const { waitUntil } = require('../../../helpers/waitUntil');
 
 const event = new EventEmitter();
 
@@ -358,18 +359,13 @@ describe('scene.triggers.deviceNewState', () => {
       previous_value: 11,
       last_value: 14,
     });
-    return new Promise((resolve, reject) => {
-      sceneManager.queue.start(async () => {
-        try {
-          await Promise.delay(5);
-          assert.calledOnce(device.setValue);
-          expect(sceneManager.checkTriggersDurationTimer.size).to.equal(0);
-          resolve();
-        } catch (e) {
-          reject(e);
-        }
-      });
-    });
+    // The scene is not executed synchronously: the trigger first schedules a timer,
+    // and the scene is only queued when this timer fires. So we wait for the scene
+    // to be executed, then for the queue to be empty, instead of waiting a fixed delay.
+    await waitUntil(() => device.setValue.called, { message: 'the scene to be executed' });
+    await waitUntil(() => sceneManager.queue.length === 0, { message: 'the scene queue to be empty' });
+    assert.calledOnce(device.setValue);
+    expect(sceneManager.checkTriggersDurationTimer.size).to.equal(0);
   });
   it('should start timer to check now and re-send new value still validating the condition', async () => {
     await sceneManager.addScene({
@@ -406,18 +402,11 @@ describe('scene.triggers.deviceNewState', () => {
       previous_value: 14,
       last_value: 14,
     });
-    return new Promise((resolve, reject) => {
-      sceneManager.queue.start(async () => {
-        try {
-          await Promise.delay(10);
-          assert.calledOnce(device.setValue);
-          expect(sceneManager.checkTriggersDurationTimer.size).to.equal(0);
-          resolve();
-        } catch (e) {
-          reject(e);
-        }
-      });
-    });
+    // Same as above: the scene is only queued when the trigger timer fires.
+    await waitUntil(() => device.setValue.called, { message: 'the scene to be executed' });
+    await waitUntil(() => sceneManager.queue.length === 0, { message: 'the scene queue to be empty' });
+    assert.calledOnce(device.setValue);
+    expect(sceneManager.checkTriggersDurationTimer.size).to.equal(0);
   });
   it('should start timer to check now and condition should not be valid on second call', async () => {
     await sceneManager.addScene({
@@ -454,18 +443,11 @@ describe('scene.triggers.deviceNewState', () => {
       previous_value: 14,
       last_value: 5,
     });
-    return new Promise((resolve, reject) => {
-      sceneManager.queue.start(async () => {
-        try {
-          await Promise.delay(5);
-          assert.notCalled(device.setValue);
-          expect(sceneManager.checkTriggersDurationTimer.size).to.equal(0);
-          resolve();
-        } catch (e) {
-          reject(e);
-        }
-      });
-    });
+    // The timer is cancelled synchronously by the second event, we wait longer than
+    // the trigger duration (10ms) to be sure it doesn't fire anyway.
+    await Promise.delay(100);
+    assert.notCalled(device.setValue);
+    expect(sceneManager.checkTriggersDurationTimer.size).to.equal(0);
   });
   it('should execute scene with string value equality (text device feature like Shelly Button)', async () => {
     await sceneManager.addScene({


### PR DESCRIPTION
### Description

Fixes the flaky test seen on `master`:

```
  1) scene.triggers.deviceNewState
       should start timer to check now and condition should still be valid on second call:
     AssertError: expected fake to be called once but was called 0 times
      at .../test/lib/scene/triggers/scene.trigger.deviceNewState.test.js:365:18
```

**Root cause**

The three `for_duration` tests were written like this:

```js
sceneManager.checkTrigger({ ... });
return new Promise((resolve, reject) => {
  sceneManager.queue.start(async () => {
    await Promise.delay(5);
    assert.calledOnce(device.setValue);
    ...
  });
});
```

The intent was that `queue.start(cb)` waits for the scene queue to drain. But for a trigger with a `for_duration`, `checkTrigger()` does **not** queue anything — it only schedules a timer and returns `false`. So when `queue.start(cb)` is called the queue is empty, and [`queue`](https://github.com/jessetane/queue/blob/master/index.js) calls `done()` (and therefore the callback) **synchronously**.

The assertion was then guarded only by the hardcoded `Promise.delay(5)`, while the actual chain that has to complete in those 5ms is:

`setTimeout(for_duration)` → `TRIGGERS.CHECK` event → `checkTrigger` → `execute` → `queue.push` → `executeActions` → `device.setValue`

Every hop is a bluebird `await` (scheduled with `setImmediate`), so on a loaded CI runner the whole chain regularly takes longer than 5ms and the assertion fires too early. Same thing for the `Promise.delay(10)` in `should start timer to check now and re-send new value still validating the condition`.

**Fix**

Wait for the observable outcome instead of a fixed delay: first for the scene to actually be executed, then for the scene queue to be drained (so `calledOnce` remains meaningful and would still catch a double execution).

```js
await waitUntil(() => device.setValue.called, { message: 'the scene to be executed' });
await waitUntil(() => sceneManager.queue.length === 0, { message: 'the scene queue to be empty' });
assert.calledOnce(device.setValue);
```

This uses a new small `test/helpers/waitUntil.js` helper (polls a condition, rejects with an explicit message after 2s), reusable for other tests with the same pattern.

For the negative test (`condition should not be valid on second call`), there is nothing to wait *for*, so it keeps a delay — but bumped to 100ms, comfortably longer than the trigger's 10ms `for_duration`, so it genuinely proves the cancelled timer never fires.

No production code was changed — the source behaviour was correct, only the tests were racy.

**Verification**

Temporarily slowing `executeActions` down by 60ms reproduces the CI failure exactly on `master`, and passes with this branch:

| | before | after |
|---|---|---|
| normal run | 14 passing | 14 passing |
| with +60ms in `executeActions` | 12 passing, **2 failing** (`expected fake to be called once but was called 0 times`) | 14 passing |

Also ran the file 15 times in a row with 10 busy-loop processes saturating the CPU: 15/15 passing.

## Forum

N/A

### Checklist

- [x] Tests pass — `scene.trigger.deviceNewState.test.js`: 14 passing (also checked the rest of `test/lib/scene/**` is unchanged vs. `master` in this sandbox)
- [x] Linter and prettier pass on the changed files (`npx eslint`, `npx prettier --check`)
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnWjtF9SPa6LCgASRguaLX

---
_Generated by [Claude Code](https://claude.ai/code/session_01VnWjtF9SPa6LCgASRguaLX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved scene trigger test reliability by waiting for execution and queue completion.
  * Preserved cancellation coverage by verifying that canceled triggers do not execute.
  * Added configurable polling and timeout handling for asynchronous test conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->