### PR TITLE
fix(external-integration): ignore unsolicited SRV/TXT records in mDNS discovery scan

### DIFF
--- a/server/lib/external-integration/networkDiscovery/networkDiscovery.scanMdns.js
+++ b/server/lib/external-integration/networkDiscovery/networkDiscovery.scanMdns.js
@@ -37,13 +37,17 @@ async function scanMdns({ service, timeoutMs, mdnsOptions }) {
   mdns.on('response', (response) => {
     const records = [...(response.answers || []), ...(response.additionals || [])];
     records.forEach((record) => {
+      // the socket sees every mDNS packet on the network, not only the
+      // answers to our PTR query: SRV/TXT records of foreign services
+      // (unsolicited announcements) must never create an instance, or the
+      // scan would return arbitrary hosts/ports of the whole network
       if (record.type === 'PTR' && record.name === serviceName) {
         getInstance(record.data);
-      } else if (record.type === 'SRV') {
+      } else if (record.type === 'SRV' && record.name.endsWith(`.${serviceName}`)) {
         const instance = getInstance(record.name);
         instance.host = record.data.target;
         instance.port = record.data.port;
-      } else if (record.type === 'TXT') {
+      } else if (record.type === 'TXT' && record.name.endsWith(`.${serviceName}`)) {
         const entries = Array.isArray(record.data) ? record.data : [record.data];
         getInstance(record.name).txt = entries.map((entry) => entry.toString('utf8'));
       } else if (record.type === 'A' || record.type === 'AAAA') {

--- a/server/test/lib/external-integration/externalIntegration.networkDiscovery.test.js
+++ b/server/test/lib/external-integration/externalIntegration.networkDiscovery.test.js
@@ -458,6 +458,47 @@ describe('externalIntegration.scanMdns', () => {
     ]);
   });
 
+  it('should ignore SRV/TXT records of services that were not queried', async () => {
+    const { externalIntegration } = buildSupervisor();
+    const mdnsPort = await getFreeUdpPort();
+    const responder = multicastDns({ port: mdnsPort, ip: '127.0.0.1', multicast: false });
+    const mdnsOptions = { port: mdnsPort, ip: '127.0.0.1', multicast: false, bind: false };
+    responder.on('query', (query, remoteInfo) => {
+      // during the scan window the socket also sees unsolicited
+      // announcements of foreign services (SSH here): their SRV/TXT must
+      // not leak into the results as instances with arbitrary host/port
+      responder.respond(
+        {
+          answers: [
+            { name: '_hue._tcp.local', type: 'PTR', data: 'Hue Bridge._hue._tcp.local' },
+            { name: '_ssh._tcp.local', type: 'PTR', data: 'NAS._ssh._tcp.local' },
+            { name: 'NAS._ssh._tcp.local', type: 'SRV', data: { target: 'nas.local', port: 22 } },
+            { name: 'NAS._ssh._tcp.local', type: 'TXT', data: [Buffer.from('key=value')] },
+          ],
+          additionals: [
+            { name: 'Hue Bridge._hue._tcp.local', type: 'SRV', data: { target: 'hue.local', port: 443 } },
+            { name: 'hue.local', type: 'A', data: '192.168.1.40' },
+            { name: 'nas.local', type: 'A', data: '192.168.1.94' },
+          ],
+        },
+        remoteInfo,
+      );
+    });
+    const results = await externalIntegration.scanMdns({ service: '_hue._tcp', timeoutMs: 700, mdnsOptions });
+    await new Promise((resolve) => {
+      responder.destroy(resolve);
+    });
+    expect(results).to.deep.equal([
+      {
+        name: 'Hue Bridge._hue._tcp.local',
+        host: 'hue.local',
+        addresses: ['192.168.1.40'],
+        port: 443,
+        txt: [],
+      },
+    ]);
+  });
+
   it('should return nothing when the mDNS socket cannot be opened', async () => {
     const { externalIntegration } = buildSupervisor();
     // udp6 without ip/interface makes multicast-dns throw at creation


### PR DESCRIPTION
### Description

The mediated mDNS network discovery (`scanNetwork('mdns', ...)` for external integrations) leaked foreign services into scan results. The scan socket receives **every** packet on 224.0.0.251:5353 — not only answers to the PTR query it sent — and the `on('response')` handler filtered by service type only on PTR records. SRV and TXT records were aggregated unconditionally, and since aggregation creates the instance when it doesn't exist yet, every spontaneous announcement of a foreign service (`_ssh._tcp`, `_googlecast._tcp`, `_matter._tcp`, …) seen during the scan window became a phantom entry carrying a real host and port (22, 21, 445, 8009, …).

Impact: any integration declaring an mDNS `network_discovery` received this noise, and integrations that probe returned entries (the normal usage) ended up contacting arbitrary hosts on arbitrary ports — reported in the field as IDS/firewall "port scan" alerts, with e.g. IPP payloads POSTed to SSH/SMB ports.

Fix: only aggregate SRV/TXT records whose name belongs to the queried DNS-SD service (`record.name.endsWith('.' + serviceName)`). The suffix check keeps the fix robust to record ordering across packets (an SRV may arrive in a packet before its PTR), unlike restricting instance creation to the PTR branch. The `A`/`AAAA` accumulation in `addressesByHost` is unchanged: addresses are only joined to retained instances at the end, so foreign address records can no longer surface once phantom instances are gone.

Added a regression test: a response mixing a legitimate `_hue._tcp` instance with parasitic `_ssh._tcp` PTR/SRV/TXT/A records, asserting only the Hue instance is returned. Without the fix, the test fails with a `NAS._ssh._tcp.local` ghost entry exposing `nas.local:22`.

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9vuwK67SbkpMs18ze5Xwg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9vuwK67SbkpMs18ze5Xwg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mDNS network discovery to ignore unrelated service announcements.
  * Ensured discovered devices include only records associated with the requested service, improving scan accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->