### PR TITLE
feat(dashboard): redesign the weather widget

### DIFF
--- a/front/src/actions/dashboard/boxes/weather.js
+++ b/front/src/actions/dashboard/boxes/weather.js
@@ -78,7 +78,11 @@ const isAlertOngoing = alert => {
  * identical 'heat' entries. Expired bulletins are dropped first — the same
  * providers keep serving them after their end date — then the rest are merged
  * on their type (or on their event label when the provider sends no type),
- * keeping the worst severity, the widest time range and the first description.
+ * keeping the worst severity and the widest time range.
+ * Descriptions are accumulated instead of collapsed: two bulletins of a same
+ * phenomenon may carry different safety instructions, and keeping only the
+ * first would silently drop the others. `description` stays the first one, for
+ * the badge tooltip; `descriptions` holds every distinct text, for the widget.
  */
 const normalizeAlerts = alerts => {
   const byPhenomenon = new Map();
@@ -86,7 +90,7 @@ const normalizeAlerts = alerts => {
     const key = alert.type || alert.event;
     const previous = byPhenomenon.get(key);
     if (!previous) {
-      byPhenomenon.set(key, { ...alert });
+      byPhenomenon.set(key, { ...alert, descriptions: alert.description ? [alert.description] : [] });
       return;
     }
     // the merged alert carries the worst severity, so its badge keeps the
@@ -103,6 +107,9 @@ const normalizeAlerts = alerts => {
     }
     if (!previous.description && alert.description) {
       previous.description = alert.description;
+    }
+    if (alert.description && !previous.descriptions.includes(alert.description)) {
+      previous.descriptions.push(alert.description);
     }
   });
   return Array.from(byPhenomenon.values());
@@ -200,8 +207,12 @@ function createActions(store) {
             // option — the pivot caps `hours` at 24 entries (a single day),
             // so only the first day could ever be filled. The row is shown
             // only when the provider fills wind_speed on every day itself.
+            // gusts are peaks, not an average: the value is flagged so the
+            // widget can mark it with a `~` instead of passing a peak off as
+            // the day's wind speed
             if (typeof day.wind_speed !== 'number' && typeof day.wind_gust === 'number') {
               day.wind_speed = day.wind_gust;
+              day.wind_speed_from_gust = true;
             }
             day.datetime_beautiful = dayjs(day.datetime)
               .locale(state.user.language)

--- a/front/src/actions/dashboard/boxes/weather.js
+++ b/front/src/actions/dashboard/boxes/weather.js
@@ -47,6 +47,67 @@ const degreesToCardinal = degrees => {
   return WIND_CARDINALS[Math.round((((Number(degrees) % 360) + 360) % 360) / 45) % 8];
 };
 
+// CAP severities from the least to the most serious, to keep the worst one
+// when several bulletins of the same phenomenon are merged
+const ALERT_SEVERITY_ORDER = ['minor', 'moderate', 'severe', 'extreme'];
+
+const severityRank = severity => {
+  const rank = ALERT_SEVERITY_ORDER.indexOf(severity);
+  return rank === -1 ? 0 : rank;
+};
+
+/**
+ * Whether an alert is still running.
+ * `end` is optional in the generic weather format: an alert without one has no
+ * known expiry and is kept — dropping it would hide the Météo France alerts,
+ * which carry no end date on most bulletins. An unparsable date is kept too:
+ * hiding a real alert over a malformed field is the worse failure.
+ */
+const isAlertOngoing = alert => {
+  if (!alert.end) {
+    return true;
+  }
+  const end = dayjs(alert.end);
+  return !end.isValid() || end.isAfter(dayjs());
+};
+
+/**
+ * Collapse the alerts of a same phenomenon into a single one.
+ * Providers relaying raw CAP bulletins (OpenWeather does) emit one alert per
+ * phenomenon AND per validity window, so a two-day heat wave arrives as two
+ * identical 'heat' entries. Expired bulletins are dropped first — the same
+ * providers keep serving them after their end date — then the rest are merged
+ * on their type (or on their event label when the provider sends no type),
+ * keeping the worst severity, the widest time range and the first description.
+ */
+const normalizeAlerts = alerts => {
+  const byPhenomenon = new Map();
+  alerts.filter(isAlertOngoing).forEach(alert => {
+    const key = alert.type || alert.event;
+    const previous = byPhenomenon.get(key);
+    if (!previous) {
+      byPhenomenon.set(key, { ...alert });
+      return;
+    }
+    // the merged alert carries the worst severity, so its badge keeps the
+    // color of the most serious bulletin of the phenomenon
+    if (severityRank(alert.severity) > severityRank(previous.severity)) {
+      previous.severity = alert.severity;
+      previous.event = alert.event;
+    }
+    if (alert.start && (!previous.start || alert.start < previous.start)) {
+      previous.start = alert.start;
+    }
+    if (alert.end && (!previous.end || alert.end > previous.end)) {
+      previous.end = alert.end;
+    }
+    if (!previous.description && alert.description) {
+      previous.description = alert.description;
+    }
+  });
+  return Array.from(byPhenomenon.values());
+};
+
 function createActions(store) {
   const boxActions = createBoxActions(store);
 
@@ -121,6 +182,9 @@ function createActions(store) {
               }
             })
           );
+        }
+        if (weather.alerts) {
+          weather.alerts = normalizeAlerts(weather.alerts);
         }
         if (weather.days) {
           // keep future days only: never assume the provider leads with

--- a/front/src/actions/dashboard/boxes/weather.js
+++ b/front/src/actions/dashboard/boxes/weather.js
@@ -6,30 +6,45 @@ import get from 'get-value';
 
 const BOX_KEY = 'Weather';
 
-const WEATHER_ICONS = {
-  snow: 'fe-cloud-snow',
-  rain: 'fe-cloud-rain',
-  pouring: 'fe-cloud-rain',
-  drizzle: 'fe-cloud-drizzle',
-  thunderstorm: 'fe-cloud-lightning',
-  clear: 'fe-sun',
-  'partly-cloudy': 'fe-cloud',
-  cloud: 'fe-cloud',
-  fog: 'fe-cloud',
-  sleet: 'fe-cloud-drizzle',
-  hail: 'fe-cloud-snow',
-  wind: 'fe-wind',
-  night: 'fe-moon'
+// Emoji per generic condition of the pivot weather format, in a day and a
+// night variant. The night variant is picked from the optional is_day flag,
+// so a clear night renders as a moon while the condition stays 'clear'.
+const WEATHER_EMOJIS = {
+  clear: { day: '☀️', night: '🌙' },
+  'partly-cloudy': { day: '🌤️', night: '☁️' },
+  cloud: { day: '☁️', night: '☁️' },
+  fog: { day: '🌫️', night: '🌫️' },
+  drizzle: { day: '🌦️', night: '🌦️' },
+  rain: { day: '🌧️', night: '🌧️' },
+  pouring: { day: '🌧️', night: '🌧️' },
+  sleet: { day: '🌨️', night: '🌨️' },
+  hail: { day: '🌨️', night: '🌨️' },
+  snow: { day: '❄️', night: '❄️' },
+  thunderstorm: { day: '⛈️', night: '⛈️' },
+  wind: { day: '💨', night: '💨' },
+  // 'night' is deprecated as a condition but still rendered
+  night: { day: '🌙', night: '🌙' },
+  unknown: { day: '🌡️', night: '🌡️' }
 };
 
-// is_day is the optional day/night flag of the generic weather format:
-// a clear night renders as a moon while the condition stays 'clear'
-// ('night' as a condition is deprecated but still rendered)
-const translateWeatherToFeIcon = (weather, isDay) => {
-  if (weather === 'clear' && isDay === false) {
-    return 'fe-moon';
+/**
+ * Emoji of a generic weather condition.
+ * isDay is the optional day/night flag of the pivot format: only an explicit
+ * false switches to the night variant, an absent flag stays on the day one.
+ */
+const translateWeatherToEmoji = (weather, isDay) => {
+  const entry = WEATHER_EMOJIS[weather] || WEATHER_EMOJIS.unknown;
+  return isDay === false ? entry.night : entry.day;
+};
+
+// Wind direction in degrees to a localized cardinal key (N, NE, E, SE, S, SW, W, NW)
+const WIND_CARDINALS = ['n', 'ne', 'e', 'se', 's', 'sw', 'w', 'nw'];
+
+const degreesToCardinal = degrees => {
+  if (degrees === undefined || degrees === null || Number.isNaN(Number(degrees))) {
+    return null;
   }
-  return get(WEATHER_ICONS, weather, { default: 'fe-question' });
+  return WIND_CARDINALS[Math.round((((Number(degrees) % 360) + 360) % 360) / 45) % 8];
 };
 
 function createActions(store) {
@@ -45,8 +60,8 @@ function createActions(store) {
         const weather = await state.httpClient.get(`/api/v1/house/${box.house}/weather`, providerParams);
         weather.datetime_beautiful = dayjs(weather.datetime)
           .locale(state.user.language)
-          .format('D MMM');
-        weather.weatherIcon = translateWeatherToFeIcon(weather.weather, weather.is_day);
+          .format('dddd D MMMM');
+        weather.weatherEmoji = translateWeatherToEmoji(weather.weather, weather.is_day);
         // optional fields of the generic weather format: only present when
         // the provider supplies them
         if (weather.sunrise) {
@@ -55,10 +70,37 @@ function createActions(store) {
         if (weather.sunset) {
           weather.sunset_beautiful = dayjs(weather.sunset).format('HH:mm');
         }
+        weather.wind_cardinal = degreesToCardinal(weather.wind_direction);
 
         if (weather.hours) {
-          weather.hours.map(hour => {
-            hour.weatherIcon = translateWeatherToFeIcon(hour.weather, hour.is_day);
+          // rain of the current conditions: read before the hourly list is
+          // trimmed to its 8 columns, and from the slot that covers now
+          // rather than hours[0] — the trim drops the running hour, so
+          // hours[0] is already the *next* slot
+          const currentSlot =
+            weather.hours.filter(hour => !dayjs(hour.datetime).isAfter(dayjs())).pop() || weather.hours[0];
+          if (currentSlot) {
+            if (typeof currentSlot.precipitation === 'number') {
+              weather.current_precipitation = currentSlot.precipitation;
+            }
+            if (typeof currentSlot.precipitation_probability === 'number') {
+              weather.current_precipitation_probability = currentSlot.precipitation_probability;
+            }
+          }
+          // keep the coming hours only: a provider may lead with past
+          // entries of the current day
+          const now = dayjs().subtract(30, 'minute');
+          weather.hours = weather.hours.filter(hour => dayjs(hour.datetime).isAfter(now));
+          // cover the next 24 hours in 8 columns: hourly entries keep one
+          // out of three, entries already spaced by 3 hours are kept as-is
+          if (weather.hours.length > 1) {
+            const stepMinutes = dayjs(weather.hours[1].datetime).diff(dayjs(weather.hours[0].datetime), 'minute');
+            const columnSkip = stepMinutes >= 180 ? 1 : 3;
+            weather.hours = weather.hours.filter((hour, index) => index % columnSkip === 0);
+          }
+          weather.hours = weather.hours.slice(0, 8);
+          weather.hours.forEach(hour => {
+            hour.weatherEmoji = translateWeatherToEmoji(hour.weather, hour.is_day);
             hour.datetime_beautiful = dayjs(hour.datetime).format('HH');
           });
         }
@@ -84,11 +126,21 @@ function createActions(store) {
           // keep future days only: never assume the provider leads with
           // today (that was an OpenWeather-specific shape)
           weather.days = weather.days.filter(day => dayjs(day.datetime).isAfter(dayjs(), 'day'));
-          weather.days.map(day => {
+          weather.days = weather.days.slice(0, 5);
+          weather.days.forEach(day => {
             // the per-day condition is optional in the generic weather
-            // format (openweather does not provide it): no icon without it
-            day.weatherIcon = day.weather ? translateWeatherToFeIcon(day.weather) : null;
-            day.datetime_beautiful = dayjs(day.datetime).format('dddd');
+            // format (openweather does not provide it): no emoji without it
+            day.weatherEmoji = day.weather ? translateWeatherToEmoji(day.weather) : null;
+            // daily wind: aggregating it from the hourly entries is not an
+            // option — the pivot caps `hours` at 24 entries (a single day),
+            // so only the first day could ever be filled. The row is shown
+            // only when the provider fills wind_speed on every day itself.
+            if (typeof day.wind_speed !== 'number' && typeof day.wind_gust === 'number') {
+              day.wind_speed = day.wind_gust;
+            }
+            day.datetime_beautiful = dayjs(day.datetime)
+              .locale(state.user.language)
+              .format('ddd D');
           });
         }
 

--- a/front/src/actions/dashboard/boxes/weather.js
+++ b/front/src/actions/dashboard/boxes/weather.js
@@ -152,11 +152,12 @@ function createActions(store) {
           // entries of the current day
           const now = dayjs().subtract(30, 'minute');
           weather.hours = weather.hours.filter(hour => dayjs(hour.datetime).isAfter(now));
-          // cover the next 24 hours in 8 columns: hourly entries keep one
-          // out of three, entries already spaced by 3 hours are kept as-is
+          // cover the next 24 hours in 8 columns, so one entry every 3 hours:
+          // the skip is derived from the provider's own step, entries already
+          // spaced by 3 hours or more are kept as-is
           if (weather.hours.length > 1) {
             const stepMinutes = dayjs(weather.hours[1].datetime).diff(dayjs(weather.hours[0].datetime), 'minute');
-            const columnSkip = stepMinutes >= 180 ? 1 : 3;
+            const columnSkip = stepMinutes > 0 ? Math.max(1, Math.round(180 / stepMinutes)) : 1;
             weather.hours = weather.hours.filter((hour, index) => index % columnSkip === 0);
           }
           weather.hours = weather.hours.slice(0, 8);

--- a/front/src/components/boxs/weather/EditWeatherBox.jsx
+++ b/front/src/components/boxs/weather/EditWeatherBox.jsx
@@ -5,6 +5,11 @@ import BaseEditBox from '../baseEditBox';
 import actions from '../../../actions/dashboard/boxActions';
 import { GetWeatherModes, DEFAULT_ON_WEATHER_MODES } from '../../../utils/consts';
 
+// modes on by default stay checked until explicitly unchecked, so widgets
+// saved before they existed keep their current look
+const isModeChecked = (modes, mode) =>
+  DEFAULT_ON_WEATHER_MODES.includes(mode) ? modes[mode] !== false : Boolean(modes[mode]);
+
 const EditWeatherBox = ({ children, ...props }) => (
   <BaseEditBox {...props} titleKey="dashboard.boxTitle.weather">
     <div class="form-group">
@@ -53,17 +58,13 @@ const EditWeatherBox = ({ children, ...props }) => (
         {Object.keys(GetWeatherModes).map(key => {
           const mode = GetWeatherModes[key];
           const label = `dashboard.boxes.weather.displayModes.${mode}`;
-          const modes = props.box.modes || {};
-          // modes on by default stay checked until explicitly unchecked,
-          // so widgets saved before they existed keep their current look
-          const checked = DEFAULT_ON_WEATHER_MODES.includes(mode) ? modes[mode] !== false : Boolean(modes[mode]);
           return (
             <div className="form-check">
               <input
                 type="checkbox"
                 className="form-check-input"
                 name={mode}
-                checked={checked}
+                checked={isModeChecked(props.box.modes || {}, mode)}
                 onChange={props.updateBoxModes}
               />
               <label className="form-check-label">
@@ -73,6 +74,11 @@ const EditWeatherBox = ({ children, ...props }) => (
           );
         })}
       </div>
+      {props.noModeSelected && (
+        <div className="alert alert-warning mt-3 mb-0">
+          <Text id="dashboard.boxes.weather.noModeSelected" />
+        </div>
+      )}
     </div>
   </BaseEditBox>
 );
@@ -137,11 +143,14 @@ class EditWeatherBoxComponent extends Component {
   }
 
   render(props, { houses, providers }) {
+    const modes = props.box.modes || {};
+    const noModeSelected = !Object.keys(GetWeatherModes).some(key => isModeChecked(modes, GetWeatherModes[key]));
     return (
       <EditWeatherBox
         {...props}
         houses={houses}
         providers={providers}
+        noModeSelected={noModeSelected}
         updateBoxHouse={this.updateBoxHouse}
         updateBoxModes={this.updateBoxModes}
         updateBoxProvider={this.updateBoxProvider}

--- a/front/src/components/boxs/weather/EditWeatherBox.jsx
+++ b/front/src/components/boxs/weather/EditWeatherBox.jsx
@@ -3,7 +3,7 @@ import { connect } from 'unistore/preact';
 import { Text } from 'preact-i18n';
 import BaseEditBox from '../baseEditBox';
 import actions from '../../../actions/dashboard/boxActions';
-import { GetWeatherModes } from '../../../utils/consts';
+import { GetWeatherModes, DEFAULT_ON_WEATHER_MODES } from '../../../utils/consts';
 
 const EditWeatherBox = ({ children, ...props }) => (
   <BaseEditBox {...props} titleKey="dashboard.boxTitle.weather">
@@ -53,13 +53,17 @@ const EditWeatherBox = ({ children, ...props }) => (
         {Object.keys(GetWeatherModes).map(key => {
           const mode = GetWeatherModes[key];
           const label = `dashboard.boxes.weather.displayModes.${mode}`;
+          const modes = props.box.modes || {};
+          // modes on by default stay checked until explicitly unchecked,
+          // so widgets saved before they existed keep their current look
+          const checked = DEFAULT_ON_WEATHER_MODES.includes(mode) ? modes[mode] !== false : Boolean(modes[mode]);
           return (
             <div className="form-check">
               <input
                 type="checkbox"
                 className="form-check-input"
                 name={mode}
-                checked={props.box.modes !== undefined && props.box.modes[mode]}
+                checked={checked}
                 onChange={props.updateBoxModes}
               />
               <label className="form-check-label">
@@ -81,7 +85,9 @@ class EditWeatherBoxComponent extends Component {
   };
 
   updateBoxModes = e => {
-    const modes = this.props.box.modes || {};
+    // clone the modes object: mutating it in place would prevent
+    // componentDidUpdate from detecting the change in the widget
+    const modes = { ...(this.props.box.modes || {}) };
     modes[e.target.name] = e.target.checked;
     this.props.updateBoxConfig(this.props.x, this.props.y, {
       modes

--- a/front/src/components/boxs/weather/WeatherBox.jsx
+++ b/front/src/components/boxs/weather/WeatherBox.jsx
@@ -262,7 +262,9 @@ class WeatherBoxComponent extends Component {
                   {weather.weatherEmoji}
                 </div>
                 <div style="font-size: 16px; font-weight: 500; margin-left: 12px">
-                  <Text id={`dashboard.boxes.weather.conditions.${weather.weather}`} />
+                  {/* same fallback as the emoji mapping: a provider omitting
+                  the condition still gets a label instead of a blank line */}
+                  <Text id={`dashboard.boxes.weather.conditions.${weather.weather || 'unknown'}`} />
                 </div>
               </div>
               <div style="font-size: 36px; font-weight: 600; line-height: 1; white-space: nowrap; margin-left: 8px">
@@ -379,7 +381,16 @@ class WeatherBoxComponent extends Component {
                   <div
                     key={`description-${alertKey}`}
                     class="text-muted"
+                    role="button"
+                    tabIndex="0"
+                    aria-expanded={Boolean(expanded)}
                     onClick={() => this.toggleAlertDescription(alertKey)}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        this.toggleAlertDescription(alertKey);
+                      }
+                    }}
                     style={`font-size: 12px; margin-top: 4px; white-space: pre-line; cursor: pointer; ${
                       expanded
                         ? ''

--- a/front/src/components/boxs/weather/WeatherBox.jsx
+++ b/front/src/components/boxs/weather/WeatherBox.jsx
@@ -206,6 +206,20 @@ class WeatherBoxComponent extends Component {
     const isModeOn = mode => (DEFAULT_ON_WEATHER_MODES.includes(mode) ? modes[mode] !== false : Boolean(modes[mode]));
     const showDateLocation = isModeOn(GetWeatherModes.DateLocation);
     const showCurrentWeather = isModeOn(GetWeatherModes.CurrentWeather);
+    const shownAlerts = isModeOn(GetWeatherModes.Alerts) ? alerts : [];
+    // several phenomena of a same area often share one bulletin (Météo France
+    // sends the whole department bulletin as every alert description), so the
+    // text is only printed once
+    const seenDescriptions = new Set();
+    const alertDescriptions = shownAlerts
+      .filter(alert => alert.description && !seenDescriptions.has(alert.description))
+      .map(alert => {
+        seenDescriptions.add(alert.description);
+        return {
+          alertKey: `${alert.severity}-${alert.event}-${alert.start || ''}`,
+          description: alert.description
+        };
+      });
     const showChips =
       isModeOn(GetWeatherModes.AdvancedWeather) &&
       (humidity !== null ||
@@ -222,7 +236,7 @@ class WeatherBoxComponent extends Component {
 
     // section separators are only useful when there is content above them
     const hasContentAboveHourly =
-      showDateLocation || showCurrentWeather || showChips || alerts.length > 0 || shownImages.length > 0;
+      showDateLocation || showCurrentWeather || showChips || shownAlerts.length > 0 || shownImages.length > 0;
     const hasContentAboveDaily = hasContentAboveHourly || showHourly;
 
     return (
@@ -337,9 +351,9 @@ class WeatherBoxComponent extends Component {
           )}
 
           {/* Weather alerts */}
-          {alerts.length > 0 && (
+          {shownAlerts.length > 0 && (
             <div style="margin-bottom: 10px">
-              {alerts.map(alert => {
+              {shownAlerts.map(alert => {
                 const style = ALERT_SEVERITY_STYLE[alert.severity] || { background: '#ccc', color: '#333' };
                 return (
                   <span
@@ -359,26 +373,23 @@ class WeatherBoxComponent extends Component {
                   </span>
                 );
               })}
-              {alerts
-                .filter(alert => alert.description)
-                .map(alert => {
-                  const alertKey = `${alert.severity}-${alert.event}-${alert.start || ''}`;
-                  const expanded = expandedAlerts[alertKey];
-                  return (
-                    <div
-                      key={`description-${alertKey}`}
-                      class="text-muted"
-                      onClick={() => this.toggleAlertDescription(alertKey)}
-                      style={`font-size: 12px; margin-top: 4px; white-space: pre-line; cursor: pointer; ${
-                        expanded
-                          ? ''
-                          : 'display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden'
-                      }`}
-                    >
-                      {alert.description}
-                    </div>
-                  );
-                })}
+              {alertDescriptions.map(({ alertKey, description }) => {
+                const expanded = expandedAlerts[alertKey];
+                return (
+                  <div
+                    key={`description-${alertKey}`}
+                    class="text-muted"
+                    onClick={() => this.toggleAlertDescription(alertKey)}
+                    style={`font-size: 12px; margin-top: 4px; white-space: pre-line; cursor: pointer; ${
+                      expanded
+                        ? ''
+                        : 'display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden'
+                    }`}
+                  >
+                    {description}
+                  </div>
+                );
+              })}
             </div>
           )}
 

--- a/front/src/components/boxs/weather/WeatherBox.jsx
+++ b/front/src/components/boxs/weather/WeatherBox.jsx
@@ -2,8 +2,7 @@ import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
-import cx from 'classnames';
-import dayjs from 'dayjs';
+import get from 'get-value';
 
 import { WEATHER_UNITS } from '../../../../../server/utils/constants';
 
@@ -12,342 +11,84 @@ import {
   RequestStatus,
   GetWeatherModes,
   GetWeatherStatus,
+  DEFAULT_ON_WEATHER_MODES,
   DASHBOARD_BOX_STATUS_KEY,
   DASHBOARD_BOX_DATA_KEY
 } from '../../../utils/consts';
-import get from 'get-value';
 
-const padding = {
-  paddingLeft: '40px',
-  paddingRight: '40px',
-  paddingTop: '10px',
-  paddingBottom: '10px'
-};
-
+const BOX_KEY = 'Weather';
+const BOX_DATA_KEY = `${DASHBOARD_BOX_DATA_KEY}${BOX_KEY}`;
+const BOX_STATUS_KEY = `${DASHBOARD_BOX_STATUS_KEY}${BOX_KEY}`;
 const BOX_REFRESH_INTERVAL_MS = 30 * 60 * 1000;
 
 // CAP-style severities of the generic weather format, mapped to the
-// Météo France vigilance color language (minor = blue, moderate = yellow,
+// vigilance color language (minor = blue, moderate = yellow,
 // severe = orange, extreme = red)
-const ALERT_SEVERITY_COLORS = {
-  minor: '#45aaf2',
-  moderate: '#f1c40f',
-  severe: '#fd9644',
-  extreme: '#e74c3c'
+const ALERT_SEVERITY_STYLE = {
+  minor: { background: '#45aaf2', color: '#fff' },
+  moderate: { background: '#f7c600', color: '#212529' },
+  severe: { background: '#f68f00', color: '#fff' },
+  extreme: { background: '#d63939', color: '#fff' }
 };
 
-// pictogram per generic alert phenomenon type; untyped alerts keep the
+// Emoji per generic alert phenomenon type; untyped alerts keep the
 // generic warning triangle
-const ALERT_TYPE_ICONS = {
-  wind: 'fe-wind',
-  rain: 'fe-cloud-rain',
-  flood: 'fe-droplet',
-  thunderstorm: 'fe-cloud-lightning',
-  snow: 'fe-cloud-snow',
-  heat: 'fe-sun',
-  cold: 'fe-thermometer',
-  avalanche: 'fe-alert-triangle',
-  coastal: 'fe-anchor',
-  fog: 'fe-cloud'
+const ALERT_TYPE_EMOJIS = {
+  wind: '💨',
+  rain: '🌧️',
+  flood: '🌊',
+  thunderstorm: '⛈️',
+  snow: '❄️',
+  heat: '🥵',
+  cold: '🥶',
+  avalanche: '🏔️',
+  coastal: '🌊',
+  fog: '🌫️'
 };
 
-const WeatherBox = ({ children, ...props }) => (
+const MOON_EMOJIS = ['🌑', '🌒', '🌓', '🌔', '🌕', '🌖', '🌗', '🌘'];
+
+// Official UV index scale colors (green, yellow, orange, red, violet)
+function getUvColor(uv) {
+  if (uv >= 11) {
+    return '#8557e0';
+  }
+  if (uv >= 8) {
+    return '#d63939';
+  }
+  if (uv >= 6) {
+    return '#f68f00';
+  }
+  if (uv >= 3) {
+    return '#d4a900';
+  }
+  return '#2fb344';
+}
+
+// Moon phase index (0 = new moon, 4 = full moon) from the synodic month,
+// using the new moon of January 6th 2000 18:14 UTC as reference
+function getMoonPhaseIndex() {
+  const synodicMonth = 29.53058867;
+  const knownNewMoon = Date.UTC(2000, 0, 6, 18, 14) / 86400000;
+  const daysSince = Date.now() / 86400000 - knownNewMoon;
+  const age = ((daysSince % synodicMonth) + synodicMonth) % synodicMonth;
+  return Math.round(age / (synodicMonth / 8)) % 8;
+}
+
+const ErrorCard = ({ messageId, children }) => (
   <div class="card">
-    {props.boxStatus === GetWeatherStatus.HouseHasNoCoordinates && (
-      <div>
-        <h4 class="card-header">
-          <Text id="dashboard.boxTitle.weather" />
-        </h4>
-        <div class="card-body">
-          <p class="alert alert-danger">
-            <i class="fe fe-bell" />
-            <span class="pl-2">
-              <Text id="dashboard.boxes.weather.houseHasNoCoordinates" />
-            </span>
-          </p>
-        </div>
-      </div>
-    )}
-    {props.boxStatus === GetWeatherStatus.ServiceNotConfigured && (
-      <div>
-        <h4 class="card-header">
-          <Text id="dashboard.boxTitle.weather" />
-        </h4>
-        <div class="card-body">
-          <p class="alert alert-danger">
-            <i class="fe fe-bell" />
-            <span class="pl-2">
-              <Text id="dashboard.boxes.weather.serviceNotConfigured" />
-            </span>
-          </p>
-        </div>
-      </div>
-    )}
-    {props.boxStatus === RequestStatus.Error && (
-      <div>
-        <h4 class="card-header">
-          <Text id="dashboard.boxTitle.weather" />
-        </h4>
-        <div class="card-body">
-          <p class="alert alert-danger">
-            <i class="fe fe-bell" />
-            <span class="pl-2">
-              <Text id="dashboard.boxes.weather.unknownError" />
-            </span>
-          </p>
-        </div>
-      </div>
-    )}
-    {props.boxStatus === RequestStatus.Getting && !props.weather && (
-      <div>
-        <div class="card-body">
-          <div class="dimmer active">
-            <div class="loader" />
-            <div class="dimmer-content" style={padding} />
-          </div>
-        </div>
-      </div>
-    )}
-    {props.boxStatus === GetWeatherStatus.RequestToThirdPartyFailed && (
-      <div>
-        <h4 class="card-header">
-          <Text id="dashboard.boxTitle.weather" />
-        </h4>
-        <div class="card-body">
-          <p class="alert alert-danger">
-            <i class="fe fe-bell" />
-            <span class="pl-2">
-              <Text id="dashboard.boxes.weather.requestToThirdPartyFailed" />{' '}
-              <Link href="/dashboard/integration/weather">
-                <Text id="dashboard.boxes.weather.clickHere" />
-              </Link>
-            </span>
-          </p>
-        </div>
-      </div>
-    )}
-    {props.weather && (
-      <div style={padding} class="card-block px-30 py-10">
-        <div
-          style={{
-            fontSize: '14px',
-            color: '#76838f'
-          }}
-        >
-          {`${props.datetimeBeautiful} - ${props.houseName}`}
-        </div>
-        {props.alerts && props.alerts.length > 0 && (
-          <div
-            style={{
-              marginTop: '0.25em',
-              marginBottom: '0.25em'
-            }}
-          >
-            {props.alerts.map(alert => (
-              <span
-                key={`${alert.severity}-${alert.event}-${alert.start || ''}`}
-                class="badge"
-                style={{
-                  backgroundColor: ALERT_SEVERITY_COLORS[alert.severity],
-                  color: 'white',
-                  marginRight: '0.25em'
-                }}
-                title={alert.description || alert.event}
-              >
-                <i class={cx('fe', 'mr-1', ALERT_TYPE_ICONS[alert.type] || 'fe-alert-triangle')} />
-                {/* typed alerts get a translated label, the provider's
-                free-text event stays the fallback */}
-                {alert.type ? (
-                  <Text id={`dashboard.boxes.weather.alertTypes.${alert.type}`}>{alert.event}</Text>
-                ) : (
-                  alert.event
-                )}
-              </span>
-            ))}
-            {props.alerts
-              .filter(alert => alert.description)
-              .map(alert => {
-                const alertKey = `${alert.severity}-${alert.event}-${alert.start || ''}`;
-                const expanded = props.expandedAlerts[alertKey];
-                return (
-                  <div
-                    key={`description-${alertKey}`}
-                    onClick={() => props.toggleAlertDescription(alertKey)}
-                    style={`font-size: 12px; color: #76838f; margin-top: 0.25em; white-space: pre-line; cursor: pointer; ${
-                      expanded
-                        ? ''
-                        : 'display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden'
-                    }`}
-                  >
-                    {alert.description}
-                  </div>
-                );
-              })}
-          </div>
-        )}
-        {props.display_mode[GetWeatherModes.ProviderImages] &&
-          props.images &&
-          props.images
-            .filter(image => image.src)
-            .map(image => {
-              const imageLabel =
-                image.label && (image.label[props.user.language] || image.label.en || Object.values(image.label)[0]);
-              return (
-                <div key={image.key} style={{ marginTop: '0.5em', marginBottom: '0.5em' }}>
-                  {imageLabel && (
-                    <div
-                      style={{
-                        fontSize: '12px',
-                        color: '#76838f',
-                        marginBottom: '0.25em'
-                      }}
-                    >
-                      {imageLabel}
-                    </div>
-                  )}
-                  <img src={image.src} alt={imageLabel || image.key} style={{ width: '100%', borderRadius: '4px' }} />
-                </div>
-              );
-            })}
-        <div class="row">
-          <div class="col-9">
-            <div
-              style={{
-                fontSize: '40px',
-                lineHeight: '1.2'
-              }}
-              class="font-size-40 blue-grey-700"
-            >
-              <Text id="global.degreeValue" fields={{ value: props.temperature }} />
-              <span
-                style={{
-                  fontSize: '30px'
-                }}
-              >
-                {props.units === WEATHER_UNITS.METRIC ? <Text id="global.celsius" /> : <Text id="global.fahrenheit" />}
-              </span>
-            </div>
-          </div>
-          <div
-            class="col-3 text-right"
-            style={{
-              paddingRight: '10px',
-              paddingLeft: '10px',
-              marginTop: '-0.75rem'
-            }}
-          >
-            <i
-              className={cx('fe', props.weatherIcon)}
-              style={{
-                fontSize: '50px'
-              }}
-            />
-          </div>
-        </div>
-        {props.display_mode[GetWeatherModes.AdvancedWeather] &&
-          (props.humidity !== undefined || props.wind !== undefined) && (
-            <div className="col-9 p-0">
-              {props.humidity !== undefined && (
-                <span>
-                  <i
-                    class="fe fe-droplet"
-                    style={{
-                      paddingRight: '5px'
-                    }}
-                  />
-                  {props.humidity}
-                  <span
-                    style={{
-                      fontSize: '12px',
-                      color: 'grey'
-                    }}
-                  >
-                    <Text id="global.percent" />
-                  </span>
-                </span>
-              )}
-              {props.wind !== undefined && (
-                <span className="float-right">
-                  <i
-                    class="fe fe-wind"
-                    style={{
-                      paddingRight: '5px'
-                    }}
-                  />
-                  {props.wind}
-                  <span
-                    style={{
-                      fontSize: '12px',
-                      color: 'grey'
-                    }}
-                  >
-                    {props.units === WEATHER_UNITS.METRIC ? (
-                      <Text id="global.metersPerSec" />
-                    ) : (
-                      <Text id="global.milesPerHour" />
-                    )}
-                  </span>
-                </span>
-              )}
-            </div>
-          )}
-        {props.display_mode[GetWeatherModes.AdvancedWeather] &&
-          (props.sunrise || props.sunset || props.uvIndex !== undefined) && (
-            <div className="col-12 p-0" style={{ marginTop: '0.25em' }}>
-              {props.sunrise && (
-                <span>
-                  <i
-                    class="fe fe-sunrise"
-                    style={{
-                      paddingRight: '5px'
-                    }}
-                  />
-                  {props.sunrise}
-                </span>
-              )}
-              {props.sunset && (
-                <span
-                  style={{
-                    marginLeft: '1em'
-                  }}
-                >
-                  <i
-                    class="fe fe-sunset"
-                    style={{
-                      paddingRight: '5px'
-                    }}
-                  />
-                  {props.sunset}
-                </span>
-              )}
-              {props.uvIndex !== undefined && (
-                <span className="float-right">
-                  <Text id="dashboard.boxes.weather.uv" /> {props.uvIndex}
-                </span>
-              )}
-            </div>
-          )}
-        {props.display_mode[GetWeatherModes.HourlyForecast] && (
-          <div>
-            <div
-              class="row"
-              style={{
-                marginTop: '0.5em'
-              }}
-            >
-              {props.hours_display}
-            </div>
-          </div>
-        )}
-        {props.display_mode[GetWeatherModes.DailyForecast] && (
-          <div>
-            <div class="row">
-              <div className="container">{props.days_display}</div>
-            </div>
-          </div>
-        )}
-      </div>
-    )}
+    <h4 class="card-header">
+      <Text id="dashboard.boxTitle.weather" />
+    </h4>
+    <div class="card-body">
+      <p class="alert alert-danger mb-0">
+        <i class="fe fe-bell" />
+        <span class="pl-2">
+          <Text id={messageId} />
+          {children}
+        </span>
+      </p>
+    </div>
   </div>
 );
 
@@ -363,29 +104,20 @@ class WeatherBoxComponent extends Component {
       expandedAlerts: { ...expandedAlerts, [alertKey]: !expandedAlerts[alertKey] }
     });
   };
+
   componentDidMount() {
     this.refreshData();
-    // refresh weather every interval
-    this.interval = setInterval(() => this.refreshData(), BOX_REFRESH_INTERVAL_MS);
+    this.interval = setInterval(this.refreshData, BOX_REFRESH_INTERVAL_MS);
   }
 
   componentDidUpdate(previousProps) {
     const houseChanged = get(previousProps, 'box.house') !== get(this.props, 'box.house');
-    const advancedWeatherChanged =
-      get(previousProps, 'box.modes.advancedWeather') !== get(this.props, 'box.modes.advancedWeather');
-    const dailyForecastChanged =
-      get(previousProps, 'box.modes.dailyForecast') !== get(this.props, 'box.modes.dailyForecast');
-    const hourlyForecastChanged =
-      get(previousProps, 'box.modes.hourlyForecast') !== get(this.props, 'box.modes.hourlyForecast');
+    const providerChanged = get(previousProps, 'box.provider') !== get(this.props, 'box.provider');
+    // only the modes changing what the widget fetches trigger a refresh;
+    // the purely cosmetic ones re-render from the data already in the store
     const providerImagesChanged =
       get(previousProps, 'box.modes.providerImages') !== get(this.props, 'box.modes.providerImages');
-    if (
-      houseChanged ||
-      advancedWeatherChanged ||
-      dailyForecastChanged ||
-      hourlyForecastChanged ||
-      providerImagesChanged
-    ) {
+    if (houseChanged || providerChanged || providerImagesChanged) {
       this.refreshData();
     }
   }
@@ -394,108 +126,367 @@ class WeatherBoxComponent extends Component {
     clearInterval(this.interval);
   }
 
-  render(props, {}) {
-    const boxData = get(props, `${DASHBOARD_BOX_DATA_KEY}Weather.${props.x}_${props.y}`);
-    const boxStatus = get(props, `${DASHBOARD_BOX_STATUS_KEY}Weather.${props.x}_${props.y}`);
-    const weatherObject = get(boxData, 'weather');
-    const displayMode = this.props.box.modes || {};
-    const datetimeBeautiful = get(weatherObject, 'datetime_beautiful');
-    const temperature = Math.round(get(weatherObject, 'temperature'));
-    const units = get(weatherObject, 'units');
+  render(props) {
+    const boxStatus = get(props, `${BOX_STATUS_KEY}.${props.x}_${props.y}`);
+    const weather = get(props, `${BOX_DATA_KEY}.${props.x}_${props.y}.weather`);
+    const modes = props.box.modes || {};
+    const userLanguage = get(props, 'user.language') || 'en';
 
-    const houseName = get(weatherObject, 'house.name');
-
-    const weather = get(weatherObject, 'weather');
-    const weatherIcon = get(weatherObject, 'weatherIcon');
-    // optional fields of the generic weather format
-    const alerts = get(weatherObject, 'alerts');
-    const images = get(weatherObject, 'images');
-    const sunrise = get(weatherObject, 'sunrise_beautiful');
-    const sunset = get(weatherObject, 'sunset_beautiful');
-    const uvIndex = get(weatherObject, 'uv_index');
-
-    let humidity, wind, hoursDisplay, daysDisplay;
-    if (displayMode[GetWeatherModes.AdvancedWeather]) {
-      humidity = get(weatherObject, 'humidity');
-      wind = get(weatherObject, 'wind_speed');
-      if (units === 'si') {
-        wind = wind * 3.6;
-        wind = wind.toFixed(2);
-      }
+    if (boxStatus === GetWeatherStatus.HouseHasNoCoordinates) {
+      return <ErrorCard messageId="dashboard.boxes.weather.houseHasNoCoordinates" />;
     }
-
-    if (displayMode[GetWeatherModes.HourlyForecast]) {
-      const hours = get(weatherObject, 'hours');
-      if (typeof hours !== 'undefined') {
-        hoursDisplay = hours.map(hour => {
-          return (
-            <div style={Object.assign({ width: '10%', margin: '0.25em 1.25%' })}>
-              <p style={{ margin: 'auto', textAlign: 'center', fontSize: '10px', color: 'grey' }}>
-                {`${hour.datetime_beautiful}h`}
-              </p>
-              <p style={{ margin: 'auto', textAlign: 'center' }}>
-                <i className={cx('fe', hour.weatherIcon)} style={{ fontSize: '20px' }} />
-              </p>
-              <p style={{ margin: 'auto', textAlign: 'center', fontSize: '12px' }}>
-                <Text id="global.degreeValue" fields={{ value: hour.temperature }} />
-              </p>
+    if (boxStatus === GetWeatherStatus.ServiceNotConfigured) {
+      return <ErrorCard messageId="dashboard.boxes.weather.serviceNotConfigured" />;
+    }
+    if (boxStatus === GetWeatherStatus.RequestToThirdPartyFailed) {
+      return (
+        <ErrorCard messageId="dashboard.boxes.weather.requestToThirdPartyFailed">
+          {' '}
+          <Link href="/dashboard/integration/weather">
+            <Text id="dashboard.boxes.weather.clickHere" />
+          </Link>
+        </ErrorCard>
+      );
+    }
+    // when a refresh fails but a previous response is still in the store,
+    // keep displaying it rather than replacing the widget with an error
+    if (boxStatus === RequestStatus.Error && !weather) {
+      return <ErrorCard messageId="dashboard.boxes.weather.unknownError" />;
+    }
+    if (!weather) {
+      return (
+        <div class="card">
+          <div class="card-body">
+            <div class="dimmer active">
+              <div class="loader" />
+              <div class="dimmer-content" style="min-height: 60px" />
             </div>
-          );
-        });
-      }
+          </div>
+        </div>
+      );
     }
 
-    if (displayMode[GetWeatherModes.DailyForecast]) {
-      const days = get(weatherObject, 'days');
-      if (typeof days !== 'undefined') {
-        daysDisplay = days.map(day => {
-          return (
-            <div className="row" style={{ marginTop: '0.5em' }}>
-              <div className="col-5" style={{ textTransform: 'capitalize' }}>
-                {dayjs(day.datetime)
-                  .locale(props.user.language)
-                  .format('dddd')}
-              </div>
-              <div className="col-3">
-                {day.weatherIcon && <i className={cx('fe', day.weatherIcon)} style={{ fontSize: '20px' }} />}
-              </div>
-              <div className="col-4" style={{ textAlign: 'right' }}>
-                <Text
-                  id="dashboard.boxes.weather.minMaxDegreeValue"
-                  fields={{ min: day.temperature_min, max: day.temperature_max }}
-                />
-              </div>
-            </div>
-          );
-        });
-      }
-    }
+    // the pivot format carries its own unit system: the provider already
+    // converted the values, the widget only picks the matching labels
+    const isMetric = weather.units === WEATHER_UNITS.METRIC;
+    const tempUnit = isMetric ? '°C' : '°F';
+    const windUnit = isMetric ? 'km/h' : 'mph';
+    // metric wind speed comes in m/s, imperial already in mph
+    const formatWind = speed => `${Math.round(isMetric ? speed * 3.6 : speed)} ${windUnit}`;
+    const formatRain = amount =>
+      isMetric ? `${Math.round(amount * 10) / 10} mm` : `${Math.round(amount * 100) / 100} in`;
+
+    const temperature = Math.round(weather.temperature);
+    const humidity = typeof weather.humidity === 'number' ? Math.round(weather.humidity) : null;
+    const pressure = typeof weather.pressure === 'number' ? Math.round(weather.pressure) : null;
+    const windSpeed = typeof weather.wind_speed === 'number' ? weather.wind_speed : null;
+    const uvIndex = typeof weather.uv_index === 'number' ? weather.uv_index : null;
+    // rain of the current slot: the pivot carries no precipitation at the
+    // root, so it is lifted from the running hourly entry by the actions
+    const rainAmount = typeof weather.current_precipitation === 'number' ? weather.current_precipitation : null;
+    const rainProbability =
+      typeof weather.current_precipitation_probability === 'number'
+        ? Math.round(weather.current_precipitation_probability)
+        : null;
+    const alerts = weather.alerts || [];
+    const images = weather.images || [];
+    const hours = weather.hours || [];
+    const days = weather.days || [];
+    const moonPhase = getMoonPhaseIndex();
+    const expandedAlerts = this.state.expandedAlerts || {};
+
+    // a rain row is only drawn when at least one entry carries an amount:
+    // most providers give none, and an empty line before the wind is noise
+    const hasHourlyRain = hours.some(hour => typeof hour.precipitation === 'number');
+    const hasHourlyWind = hours.some(hour => typeof hour.wind_speed === 'number');
+    const hasDailyRain = days.some(day => typeof day.precipitation === 'number');
+    const hasDailyWind = days.some(day => typeof day.wind_speed === 'number');
+
+    // default to visible for widgets saved before these options existed
+    const isModeOn = mode => (DEFAULT_ON_WEATHER_MODES.includes(mode) ? modes[mode] !== false : Boolean(modes[mode]));
+    const showDateLocation = isModeOn(GetWeatherModes.DateLocation);
+    const showCurrentWeather = isModeOn(GetWeatherModes.CurrentWeather);
+    const showChips =
+      isModeOn(GetWeatherModes.AdvancedWeather) &&
+      (humidity !== null ||
+        pressure !== null ||
+        windSpeed !== null ||
+        uvIndex !== null ||
+        rainAmount !== null ||
+        rainProbability !== null ||
+        weather.sunrise_beautiful ||
+        weather.sunset_beautiful);
+    const showHourly = isModeOn(GetWeatherModes.HourlyForecast) && hours.length > 0;
+    const showDaily = isModeOn(GetWeatherModes.DailyForecast) && days.length > 0;
+    const shownImages = isModeOn(GetWeatherModes.ProviderImages) ? images.filter(image => image.src) : [];
+
+    // section separators are only useful when there is content above them
+    const hasContentAboveHourly =
+      showDateLocation || showCurrentWeather || showChips || alerts.length > 0 || shownImages.length > 0;
+    const hasContentAboveDaily = hasContentAboveHourly || showHourly;
 
     return (
-      <WeatherBox
-        {...props}
-        weather={weather}
-        weatherIcon={weatherIcon}
-        temperature={temperature}
-        units={units}
-        boxStatus={boxStatus}
-        datetimeBeautiful={datetimeBeautiful}
-        houseName={houseName}
-        hours_display={hoursDisplay}
-        days_display={daysDisplay}
-        humidity={humidity}
-        wind={wind}
-        alerts={alerts}
-        images={images}
-        expandedAlerts={this.state.expandedAlerts || {}}
-        toggleAlertDescription={this.toggleAlertDescription}
-        sunrise={sunrise}
-        sunset={sunset}
-        uvIndex={uvIndex}
-        display_mode={displayMode}
-      />
+      <div class="card">
+        <div class="card-body" style="padding-top: 12px; padding-bottom: 12px">
+          {showDateLocation && (
+            <div
+              class="text-muted"
+              style="font-size: 14px; margin-bottom: 8px; display: flex; justify-content: space-between; align-items: baseline"
+            >
+              <span style="text-transform: capitalize; min-width: 0">{weather.datetime_beautiful}</span>
+              {get(weather, 'house.name') && (
+                <span style="margin-left: 8px; white-space: nowrap">{weather.house.name}</span>
+              )}
+            </div>
+          )}
+
+          {/* Current conditions */}
+          {showCurrentWeather && (
+            <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px">
+              <div style="display: flex; align-items: center; min-width: 0">
+                <div class="weather-real-colors" style="font-size: 52px; line-height: 1">
+                  {weather.weatherEmoji}
+                </div>
+                <div style="font-size: 16px; font-weight: 500; margin-left: 12px">
+                  <Text id={`dashboard.boxes.weather.conditions.${weather.weather}`} />
+                </div>
+              </div>
+              <div style="font-size: 36px; font-weight: 600; line-height: 1; white-space: nowrap; margin-left: 8px">
+                {temperature}
+                <span class="text-muted" style="font-size: 20px; font-weight: 400">
+                  {tempUnit}
+                </span>
+              </div>
+            </div>
+          )}
+
+          {/* Weather details */}
+          {showChips && (
+            <div style="background: rgba(70, 127, 207, 0.08); border-radius: 6px; padding: 8px 12px; margin-bottom: 12px; font-size: 13px; line-height: 1.9">
+              <div style="display: flex; justify-content: space-between">
+                <div>
+                  {humidity !== null && (
+                    <div>
+                      <i class="fe fe-droplet mr-2" style="color: #467fcf" />
+                      {humidity}
+                      <Text id="global.percent" />
+                    </div>
+                  )}
+                  {pressure !== null && (
+                    <div>
+                      <i class="fe fe-activity mr-2" style="color: #467fcf" />
+                      {pressure} hPa
+                    </div>
+                  )}
+                  {weather.sunrise_beautiful && (
+                    <div>
+                      <i class="fe fe-sunrise mr-2 weather-real-colors" style="color: #f59f00" />
+                      {weather.sunrise_beautiful}
+                    </div>
+                  )}
+                </div>
+                <div style="text-align: right">
+                  {windSpeed !== null && (
+                    <div>
+                      {formatWind(windSpeed)}
+                      {weather.wind_cardinal && (
+                        <span>
+                          {' '}
+                          <Text id={`dashboard.boxes.weather.windCardinals.${weather.wind_cardinal}`} />
+                        </span>
+                      )}
+                      <i class="fe fe-wind ml-2" style="color: #467fcf" />
+                    </div>
+                  )}
+                  {(rainAmount !== null || rainProbability !== null) && (
+                    <div>
+                      {rainAmount !== null && <span>{formatRain(rainAmount)}</span>}
+                      {rainAmount !== null && rainProbability !== null && <span class="text-muted mx-1">|</span>}
+                      {rainProbability !== null && (
+                        <span>
+                          {rainProbability}
+                          <Text id="global.percent" />
+                        </span>
+                      )}
+                      <i class="fe fe-umbrella ml-2" style="color: #467fcf" />
+                    </div>
+                  )}
+                  {weather.sunset_beautiful && (
+                    <div>
+                      {weather.sunset_beautiful}
+                      <i class="fe fe-sunset ml-2 weather-real-colors" style="color: #f59f00" />
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div style="display: flex; justify-content: space-between">
+                <div>
+                  <span class="mr-2 weather-real-colors">{MOON_EMOJIS[moonPhase]}</span>
+                  <Text id={`dashboard.boxes.weather.moonPhases.${moonPhase}`} />
+                </div>
+                {uvIndex !== null && (
+                  <div>
+                    <Text id="dashboard.boxes.weather.uv" />{' '}
+                    <span class="weather-real-colors" style={`font-weight: 600; color: ${getUvColor(uvIndex)}`}>
+                      {uvIndex}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Weather alerts */}
+          {alerts.length > 0 && (
+            <div style="margin-bottom: 10px">
+              {alerts.map(alert => {
+                const style = ALERT_SEVERITY_STYLE[alert.severity] || { background: '#ccc', color: '#333' };
+                return (
+                  <span
+                    key={`${alert.severity}-${alert.event}-${alert.start || ''}`}
+                    class="weather-real-colors"
+                    style={`background:${style.background};color:${style.color};border-radius:12px;padding:3px 10px;font-size:12px;font-weight:600;display:inline-block;margin-right:5px;margin-bottom:4px`}
+                    title={alert.description || alert.event}
+                  >
+                    {(alert.type && ALERT_TYPE_EMOJIS[alert.type]) || '⚠️'}{' '}
+                    {/* typed alerts get a translated label, the provider's
+                    free-text event stays the fallback */}
+                    {alert.type ? (
+                      <Text id={`dashboard.boxes.weather.alertTypes.${alert.type}`}>{alert.event}</Text>
+                    ) : (
+                      alert.event
+                    )}
+                  </span>
+                );
+              })}
+              {alerts
+                .filter(alert => alert.description)
+                .map(alert => {
+                  const alertKey = `${alert.severity}-${alert.event}-${alert.start || ''}`;
+                  const expanded = expandedAlerts[alertKey];
+                  return (
+                    <div
+                      key={`description-${alertKey}`}
+                      class="text-muted"
+                      onClick={() => this.toggleAlertDescription(alertKey)}
+                      style={`font-size: 12px; margin-top: 4px; white-space: pre-line; cursor: pointer; ${
+                        expanded
+                          ? ''
+                          : 'display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden'
+                      }`}
+                    >
+                      {alert.description}
+                    </div>
+                  );
+                })}
+            </div>
+          )}
+
+          {/* Provider images (vigilance map, rain radar…) */}
+          {shownImages.map(image => {
+            const imageLabel =
+              image.label && (image.label[userLanguage] || image.label.en || Object.values(image.label)[0]);
+            return (
+              <div key={image.key} style="margin-bottom: 10px">
+                {imageLabel && (
+                  <div class="text-muted" style="font-size: 12px; margin-bottom: 4px">
+                    {imageLabel}
+                  </div>
+                )}
+                <img
+                  src={image.src}
+                  alt={imageLabel || image.key}
+                  class="weather-provider-image"
+                  style="width: 100%; border-radius: 6px"
+                />
+              </div>
+            );
+          })}
+
+          {/* Hourly forecast */}
+          {showHourly && (
+            <div
+              class={hasContentAboveHourly ? 'border-top' : ''}
+              style="display: flex; justify-content: space-between; align-items: flex-end; padding-top: 10px; margin-bottom: 10px"
+            >
+              {hours.map((hour, index) => (
+                <div key={hour.datetime} style="text-align: center; flex: 1">
+                  {/* the first column is the current time slot: emphasize it */}
+                  <div
+                    class={index === 0 ? '' : 'text-muted'}
+                    style={`font-size: ${index === 0 ? '12px' : '10px'}; font-weight: ${
+                      index === 0 ? '600' : '400'
+                    }; margin-bottom: 3px`}
+                  >
+                    {hour.datetime_beautiful}h
+                  </div>
+                  <div
+                    class="weather-real-colors"
+                    style={`font-size: ${index === 0 ? '30px' : '20px'}; line-height: 1.5; margin-bottom: 3px`}
+                  >
+                    {hour.weatherEmoji}
+                  </div>
+                  <div style={`font-size: ${index === 0 ? '15px' : '12px'}; font-weight: 600; margin-bottom: 4px`}>
+                    {Math.round(hour.temperature)}°
+                  </div>
+                  {hasHourlyRain && (
+                    <div class="text-muted" style="font-size: 10px; white-space: nowrap; margin-bottom: 3px">
+                      {typeof hour.precipitation === 'number' ? formatRain(hour.precipitation) : ' '}
+                    </div>
+                  )}
+                  {hasHourlyWind && (
+                    <div class="text-muted" style="font-size: 10px; white-space: nowrap">
+                      {typeof hour.wind_speed === 'number' ? formatWind(hour.wind_speed) : ' '}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Daily forecast */}
+          {showDaily && (
+            <div
+              class={hasContentAboveDaily ? 'border-top' : ''}
+              style="display: flex; justify-content: space-between; padding-top: 10px"
+            >
+              {days.map(day => (
+                <div key={day.datetime} style="text-align: center; flex: 1">
+                  <div
+                    class="text-muted"
+                    style="font-size: 14px; text-transform: capitalize; white-space: nowrap; margin-bottom: 3px"
+                  >
+                    {day.datetime_beautiful}
+                  </div>
+                  {day.weatherEmoji && (
+                    <div class="weather-real-colors" style="font-size: 32px; line-height: 1.5; margin-bottom: 3px">
+                      {day.weatherEmoji}
+                    </div>
+                  )}
+                  <div style="font-size: 16px; font-weight: 600; margin-bottom: 4px">
+                    {Math.round(day.temperature_max)}°
+                  </div>
+                  <div class="text-muted" style="font-size: 14px; margin-bottom: 4px">
+                    {Math.round(day.temperature_min)}°
+                  </div>
+                  {hasDailyRain && (
+                    <div class="text-muted" style="font-size: 11px; white-space: nowrap; margin-bottom: 3px">
+                      {typeof day.precipitation === 'number' ? formatRain(day.precipitation) : ' '}
+                    </div>
+                  )}
+                  {hasDailyWind && (
+                    <div class="text-muted" style="font-size: 11px; white-space: nowrap">
+                      {typeof day.wind_speed === 'number' ? formatWind(day.wind_speed) : ' '}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
     );
   }
 }
 
-export default connect('DashboardBoxDataWeather,DashboardBoxStatusWeather,user', actions)(WeatherBoxComponent);
+export default connect(`${BOX_DATA_KEY},${BOX_STATUS_KEY},user`, actions)(WeatherBoxComponent);

--- a/front/src/components/boxs/weather/WeatherBox.jsx
+++ b/front/src/components/boxs/weather/WeatherBox.jsx
@@ -1,6 +1,6 @@
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
-import { Text } from 'preact-i18n';
+import { Text, Localizer } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import get from 'get-value';
 
@@ -166,15 +166,21 @@ class WeatherBoxComponent extends Component {
       );
     }
 
-    // the pivot format carries its own unit system: the provider already
-    // converted the values, the widget only picks the matching labels
+    // the pivot format carries its own unit system: temperatures and wind are
+    // already in the requested system, the widget only picks the matching
+    // labels — precipitation is the exception, always in mm (see formatRain)
     const isMetric = weather.units === WEATHER_UNITS.METRIC;
     const tempUnit = isMetric ? '°C' : '°F';
     const windUnit = isMetric ? 'km/h' : 'mph';
     // metric wind speed comes in m/s, imperial already in mph
-    const formatWind = speed => `${Math.round(isMetric ? speed * 3.6 : speed)} ${windUnit}`;
+    // `fromGust` marks a value the provider only gave as a gust: prefixed with
+    // `~` so a peak is not read as the average wind speed
+    const formatWind = (speed, fromGust) =>
+      `${fromGust ? '~' : ''}${Math.round(isMetric ? speed * 3.6 : speed)} ${windUnit}`;
+    // precipitation is always in mm in the pivot, whatever `units` says: the
+    // server stamps the unit system but never converts the amounts
     const formatRain = amount =>
-      isMetric ? `${Math.round(amount * 10) / 10} mm` : `${Math.round(amount * 100) / 100} in`;
+      isMetric ? `${Math.round(amount * 10) / 10} mm` : `${Math.round((amount / 25.4) * 100) / 100} in`;
 
     const temperature = Math.round(weather.temperature);
     const humidity = typeof weather.humidity === 'number' ? Math.round(weather.humidity) : null;
@@ -207,19 +213,25 @@ class WeatherBoxComponent extends Component {
     const showDateLocation = isModeOn(GetWeatherModes.DateLocation);
     const showCurrentWeather = isModeOn(GetWeatherModes.CurrentWeather);
     const shownAlerts = isModeOn(GetWeatherModes.Alerts) ? alerts : [];
-    // several phenomena of a same area often share one bulletin (Météo France
-    // sends the whole department bulletin as every alert description), so the
-    // text is only printed once
+    // a merged alert carries every distinct bulletin text of its phenomenon,
+    // and several phenomena of a same area often share one bulletin (Météo
+    // France sends the whole department bulletin as every alert description),
+    // so each text is printed once across the whole widget
     const seenDescriptions = new Set();
-    const alertDescriptions = shownAlerts
-      .filter(alert => alert.description && !seenDescriptions.has(alert.description))
-      .map(alert => {
-        seenDescriptions.add(alert.description);
-        return {
-          alertKey: `${alert.severity}-${alert.event}-${alert.start || ''}`,
-          description: alert.description
-        };
+    const alertDescriptions = [];
+    shownAlerts.forEach(alert => {
+      const descriptions = alert.descriptions || (alert.description ? [alert.description] : []);
+      descriptions.forEach((description, index) => {
+        if (seenDescriptions.has(description)) {
+          return;
+        }
+        seenDescriptions.add(description);
+        alertDescriptions.push({
+          alertKey: `${alert.severity}-${alert.event}-${alert.start || ''}-${index}`,
+          description
+        });
       });
+    });
     const showChips =
       isModeOn(GetWeatherModes.AdvancedWeather) &&
       (humidity !== null ||
@@ -497,9 +509,21 @@ class WeatherBoxComponent extends Component {
                     </div>
                   )}
                   {hasDailyWind && (
-                    <div class="text-muted" style="font-size: 11px; white-space: nowrap">
-                      {typeof day.wind_speed === 'number' ? formatWind(day.wind_speed) : ' '}
-                    </div>
+                    // the `~` of a gust-only value is not self-explanatory:
+                    // the tooltip spells it out without widening the column
+                    <Localizer>
+                      <div
+                        class="text-muted"
+                        style="font-size: 11px; white-space: nowrap"
+                        title={
+                          day.wind_speed_from_gust ? <Text id="dashboard.boxes.weather.windGustTitle" /> : undefined
+                        }
+                      >
+                        {typeof day.wind_speed === 'number'
+                          ? formatWind(day.wind_speed, day.wind_speed_from_gust)
+                          : ' '}
+                      </div>
+                    </Localizer>
                   )}
                 </div>
               ))}

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -340,11 +340,13 @@
         "displayModes": {
           "dateLocation": "Datum und Ort",
           "currentWeather": "Aktuelles Wetter",
+          "alerts": "Wetterwarnungen",
           "advancedWeather": "Wetterdetails (Luftfeuchtigkeit, Wind, UV, Mond…)",
           "hourlyForecast": "Vorhersage für die nächsten 24 Stunden",
           "dailyForecast": "Vorhersage für die nächsten 5 Tage",
           "providerImages": "Anbieter-Bilder (Warnkarte, Regenradar…)"
         },
+        "noModeSelected": "Wähle mindestens einen Anzeigemodus aus, sonst bleibt das Widget leer.",
         "minMaxDegreeValue": "{{min}}°/{{max}}°",
         "uv": "UV",
         "alertTypes": {

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -349,6 +349,7 @@
         "noModeSelected": "Wähle mindestens einen Anzeigemodus aus, sonst bleibt das Widget leer.",
         "minMaxDegreeValue": "{{min}}°/{{max}}°",
         "uv": "UV",
+        "windGustTitle": "Windböen (der Anbieter liefert für diesen Tag keine mittlere Windgeschwindigkeit)",
         "alertTypes": {
           "wind": "Starker Wind",
           "rain": "Starkregen",

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -338,7 +338,9 @@
         "providerInternalOpenWeather": "Internes OpenWeather (veraltet)",
         "editModeLabel": "Wähle den Anzeigemodus aus:",
         "displayModes": {
-          "advancedWeather": "Luftfeuchtigkeit und Windgeschwindigkeit",
+          "dateLocation": "Datum und Ort",
+          "currentWeather": "Aktuelles Wetter",
+          "advancedWeather": "Wetterdetails (Luftfeuchtigkeit, Wind, UV, Mond…)",
           "hourlyForecast": "Vorhersage für die nächsten 24 Stunden",
           "dailyForecast": "Vorhersage für die nächsten 5 Tage",
           "providerImages": "Anbieter-Bilder (Warnkarte, Regenradar…)"
@@ -356,6 +358,42 @@
           "avalanche": "Lawinen",
           "coastal": "Sturmflut",
           "fog": "Nebel"
+        },
+        "conditions": {
+          "clear": "Klarer Himmel",
+          "partly-cloudy": "Leicht bewölkt",
+          "cloud": "Bewölkt",
+          "fog": "Nebel",
+          "drizzle": "Nieselregen",
+          "rain": "Regen",
+          "pouring": "Starkregen",
+          "sleet": "Schneeregen",
+          "hail": "Hagel",
+          "snow": "Schnee",
+          "thunderstorm": "Gewitter",
+          "wind": "Windig",
+          "night": "Nacht",
+          "unknown": "Nicht verfügbar"
+        },
+        "moonPhases": {
+          "0": "Neumond",
+          "1": "Zunehmende Sichel",
+          "2": "Erstes Viertel",
+          "3": "Zunehmender Mond",
+          "4": "Vollmond",
+          "5": "Abnehmender Mond",
+          "6": "Letztes Viertel",
+          "7": "Abnehmende Sichel"
+        },
+        "windCardinals": {
+          "n": "N",
+          "ne": "NO",
+          "e": "O",
+          "se": "SO",
+          "s": "S",
+          "sw": "SW",
+          "w": "W",
+          "nw": "NW"
         }
       },
       "devicesInRoom": {

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -340,11 +340,13 @@
         "displayModes": {
           "dateLocation": "Date and location",
           "currentWeather": "Current weather",
+          "alerts": "Weather alerts",
           "advancedWeather": "Weather details (humidity, wind, UV, moon…)",
           "hourlyForecast": "Forecast for the next 24 hours",
           "dailyForecast": "Forecast for the next 5 days",
           "providerImages": "Provider images (vigilance map, rain radar…)"
         },
+        "noModeSelected": "Select at least one display mode, otherwise the widget will stay empty.",
         "minMaxDegreeValue": "{{min}}°/{{max}}°",
         "uv": "UV",
         "alertTypes": {

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -349,6 +349,7 @@
         "noModeSelected": "Select at least one display mode, otherwise the widget will stay empty.",
         "minMaxDegreeValue": "{{min}}°/{{max}}°",
         "uv": "UV",
+        "windGustTitle": "Wind gusts (the provider gives no average wind speed for this day)",
         "alertTypes": {
           "wind": "Strong wind",
           "rain": "Heavy rain",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -338,7 +338,9 @@
         "providerInternalOpenWeather": "Internal OpenWeather (deprecated)",
         "editModeLabel": "Select display mode:",
         "displayModes": {
-          "advancedWeather": "Humidity and wind speed",
+          "dateLocation": "Date and location",
+          "currentWeather": "Current weather",
+          "advancedWeather": "Weather details (humidity, wind, UV, moon…)",
           "hourlyForecast": "Forecast for the next 24 hours",
           "dailyForecast": "Forecast for the next 5 days",
           "providerImages": "Provider images (vigilance map, rain radar…)"
@@ -356,6 +358,42 @@
           "avalanche": "Avalanches",
           "coastal": "Coastal event",
           "fog": "Fog"
+        },
+        "conditions": {
+          "clear": "Clear sky",
+          "partly-cloudy": "Partly cloudy",
+          "cloud": "Cloudy",
+          "fog": "Fog",
+          "drizzle": "Drizzle",
+          "rain": "Rain",
+          "pouring": "Heavy rain",
+          "sleet": "Sleet",
+          "hail": "Hail",
+          "snow": "Snow",
+          "thunderstorm": "Thunderstorm",
+          "wind": "Windy",
+          "night": "Night",
+          "unknown": "Unavailable"
+        },
+        "moonPhases": {
+          "0": "New moon",
+          "1": "Waxing crescent",
+          "2": "First quarter",
+          "3": "Waxing gibbous",
+          "4": "Full moon",
+          "5": "Waning gibbous",
+          "6": "Last quarter",
+          "7": "Waning crescent"
+        },
+        "windCardinals": {
+          "n": "N",
+          "ne": "NE",
+          "e": "E",
+          "se": "SE",
+          "s": "S",
+          "sw": "SW",
+          "w": "W",
+          "nw": "NW"
         }
       },
       "devicesInRoom": {

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -349,6 +349,7 @@
         "noModeSelected": "Sélectionnez au moins un mode d'affichage, sinon le widget restera vide.",
         "minMaxDegreeValue": "{{min}}°/{{max}}°",
         "uv": "UV",
+        "windGustTitle": "Rafales de vent (le fournisseur ne donne pas de vent moyen pour ce jour)",
         "alertTypes": {
           "wind": "Vent violent",
           "rain": "Pluie-inondation",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -338,7 +338,9 @@
         "providerInternalOpenWeather": "OpenWeather interne (déprécié)",
         "editModeLabel": "Mode d'affichage :",
         "displayModes": {
-          "advancedWeather": "Humidité et vitesse du vent",
+          "dateLocation": "Date et lieu",
+          "currentWeather": "Météo actuelle",
+          "advancedWeather": "Détails météo (humidité, vent, UV, lune…)",
           "hourlyForecast": "Prévisions pour les 24 prochaines heures",
           "dailyForecast": "Prévisions pour les 5 prochains jours",
           "providerImages": "Images du fournisseur (carte de vigilance, radar de pluie…)"
@@ -356,6 +358,42 @@
           "avalanche": "Avalanches",
           "coastal": "Vagues-submersion",
           "fog": "Brouillard"
+        },
+        "conditions": {
+          "clear": "Ciel dégagé",
+          "partly-cloudy": "Peu nuageux",
+          "cloud": "Nuageux",
+          "fog": "Brouillard",
+          "drizzle": "Bruine",
+          "rain": "Pluie",
+          "pouring": "Fortes pluies",
+          "sleet": "Pluie et neige mêlées",
+          "hail": "Grêle",
+          "snow": "Neige",
+          "thunderstorm": "Orages",
+          "wind": "Vent",
+          "night": "Nuit",
+          "unknown": "Indisponible"
+        },
+        "moonPhases": {
+          "0": "Nouvelle lune",
+          "1": "Premier croissant",
+          "2": "Premier quartier",
+          "3": "Gibbeuse croissante",
+          "4": "Pleine lune",
+          "5": "Gibbeuse décroissante",
+          "6": "Dernier quartier",
+          "7": "Dernier croissant"
+        },
+        "windCardinals": {
+          "n": "N",
+          "ne": "NE",
+          "e": "E",
+          "se": "SE",
+          "s": "S",
+          "sw": "SO",
+          "w": "O",
+          "nw": "NO"
         }
       },
       "devicesInRoom": {

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -340,11 +340,13 @@
         "displayModes": {
           "dateLocation": "Date et lieu",
           "currentWeather": "Météo actuelle",
+          "alerts": "Alertes météo",
           "advancedWeather": "Détails météo (humidité, vent, UV, lune…)",
           "hourlyForecast": "Prévisions pour les 24 prochaines heures",
           "dailyForecast": "Prévisions pour les 5 prochains jours",
           "providerImages": "Images du fournisseur (carte de vigilance, radar de pluie…)"
         },
+        "noModeSelected": "Sélectionnez au moins un mode d'affichage, sinon le widget restera vide.",
         "minMaxDegreeValue": "{{min}}°/{{max}}°",
         "uv": "UV",
         "alertTypes": {

--- a/front/src/style/dark-mode.css
+++ b/front/src/style/dark-mode.css
@@ -199,3 +199,18 @@ body.dark-mode {
 .dark-mode .mode-toggle:hover {
   background-color: rgba(0, 0, 0, 0.1); /* Keep the same in dark mode due to global inversion */
 }
+
+/* Weather provider images (vigilance map, rain radar…): pre-darkening keeps the
+   double inversion within gamut, so the image keeps its real hues (yellow/orange/red)
+   instead of washed-out ones */
+.dark-mode img.weather-provider-image {
+  filter: brightness(0.6) invert(100%) hue-rotate(180deg) !important;
+}
+
+/* Weather widget emojis, badges and colored icons: same pre-darkening trick as
+   the provider images. Plain dark-mode-no-invert only cancels the global
+   inversion, which leaves these washed out — the brightness step keeps the
+   real colors (yellow/orange suns, alert badges, UV index) */
+.dark-mode .weather-real-colors {
+  filter: brightness(0.7) invert(100%) hue-rotate(180deg) !important;
+}

--- a/front/src/utils/consts.js
+++ b/front/src/utils/consts.js
@@ -95,6 +95,7 @@ export const GetWeatherStatus = {
 export const GetWeatherModes = {
   DateLocation: 'dateLocation',
   CurrentWeather: 'currentWeather',
+  Alerts: 'alerts',
   AdvancedWeather: 'advancedWeather',
   HourlyForecast: 'hourlyForecast',
   DailyForecast: 'dailyForecast',
@@ -102,8 +103,12 @@ export const GetWeatherModes = {
 };
 
 // Modes enabled by default for widgets saved before they existed: the
-// two blocks the widget has always displayed unconditionally
-export const DEFAULT_ON_WEATHER_MODES = [GetWeatherModes.DateLocation, GetWeatherModes.CurrentWeather];
+// blocks the widget has always displayed unconditionally
+export const DEFAULT_ON_WEATHER_MODES = [
+  GetWeatherModes.DateLocation,
+  GetWeatherModes.CurrentWeather,
+  GetWeatherModes.Alerts
+];
 
 export const DASHBOARD_BOX_STATUS_KEY = 'DashboardBoxStatus';
 export const DASHBOARD_BOX_DATA_KEY = 'DashboardBoxData';

--- a/front/src/utils/consts.js
+++ b/front/src/utils/consts.js
@@ -93,11 +93,17 @@ export const GetWeatherStatus = {
 };
 
 export const GetWeatherModes = {
+  DateLocation: 'dateLocation',
+  CurrentWeather: 'currentWeather',
   AdvancedWeather: 'advancedWeather',
   HourlyForecast: 'hourlyForecast',
   DailyForecast: 'dailyForecast',
   ProviderImages: 'providerImages'
 };
+
+// Modes enabled by default for widgets saved before they existed: the
+// two blocks the widget has always displayed unconditionally
+export const DEFAULT_ON_WEATHER_MODES = [GetWeatherModes.DateLocation, GetWeatherModes.CurrentWeather];
 
 export const DASHBOARD_BOX_STATUS_KEY = 'DashboardBoxStatus';
 export const DASHBOARD_BOX_DATA_KEY = 'DashboardBoxData';


### PR DESCRIPTION
### Description

Reworks the weather widget rendering, reusing the design built in my
`feature/meteo-france_integration` branch but feeding it from the **generic pivot
weather format** instead of the raw Météo France payload. The widget therefore keeps
working with every provider — the internal openweather service and the external
`ext-*` weather integrations alike — and the provider selector introduced on master
is preserved as-is.

No server change: the pivot format already carries every field the new rendering
needs (`uv_index`, `precipitation`, `precipitation_probability`, `wind_direction`,
`sunrise`/`sunset`, `is_day`, `alerts[]`, `images[]`, per-hour and per-day
conditions).

**Rendering**

- Weather emojis per generic pivot condition, with a night variant driven by the
  optional `is_day` flag, replacing the monochrome feather icons
- Details panel: humidity, pressure, wind with cardinal direction, rain amount and
  probability, sunrise/sunset, moon phase, and a UV index colored along the official
  scale
- Hourly strip covering the next 24 hours in 8 columns, the running slot emphasized
- 5-day forecast with per-day condition, min/max, rain and wind
- Rain and wind rows are only drawn when the provider supplies the values, so a
  poorer provider degrades gracefully instead of showing empty lines

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

<img width="353" height="1236" alt="image" src="https://github.com/user-attachments/assets/d6323931-ba10-4453-b0a1-bcb5562ece12" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Redesigned the weather widget with current conditions, hourly and daily forecasts, precipitation, wind, UV, moon phases, alerts, and configurable sections.
  - Added emoji-based weather visuals, localized dates, and cardinal wind directions.
  - Weather settings now provide sensible defaults and warn when no display modes are selected.
- **Bug Fixes**
  - Improved refresh behavior and preserved existing data during temporary errors.
  - Limited forecasts to relevant upcoming periods and improved wind-speed fallbacks.
- **Localization**
  - Added weather translations in English, German, and French.
- **Style**
  - Improved weather widget colors and imagery in dark mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->