### PR TITLE
Speed up server tests: skip DB reset for clean tests, cache server node_modules in CI

### DIFF
--- a/.github/workflows/docker-pr-build.yml
+++ b/.github/workflows/docker-pr-build.yml
@@ -55,6 +55,7 @@ jobs:
       - name: ⬇️ Checkout Gladys code
         uses: actions/checkout@v3
       - name: 💽 Setup nodejs
+        id: setup-node
         uses: actions/setup-node@v3
         with:
           node-version-file: 'server/package.json'
@@ -64,10 +65,21 @@ jobs:
         run: |
           sudo apt update
           sudo apt-get install -y libudev-dev sqlite3 openssl python-is-python3
+      # Same server node_modules cache as the "Server test" job (shared key).
+      - name: 💾 Restore NPM dependencies cache
+        id: deps-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            server/node_modules
+            server/services/*/node_modules
+          key: server-deps-v1-${{ runner.os }}-node${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('server/**/package-lock.json') }}
       - name: 📦 Install Global NPM Packages
+        if: steps.deps-cache.outputs.cache-hit != 'true'
         run: |
           sudo npm install typescript node-gyp -g
       - name: 📦 Install NPM server packages
+        if: steps.deps-cache.outputs.cache-hit != 'true'
         working-directory: ./server
         run: |
           npm ci
@@ -91,6 +103,7 @@ jobs:
         with:
           fetch-depth: 2
       - name: 💽 Setup nodejs
+        id: setup-node
         uses: actions/setup-node@v3
         with:
           node-version-file: 'server/package.json'
@@ -100,10 +113,26 @@ jobs:
         run: |
           sudo apt update
           sudo apt-get install -y libudev-dev sqlite3 openssl python-is-python3
+      # Installing the server dependencies takes ~40s on every run: cache the
+      # installed node_modules keyed on the lockfiles and skip the install on a
+      # cache hit (same pattern as the Cypress job). server/services/*/node_modules
+      # matters because the server postinstall installs every service's own
+      # dependencies. The node version is part of the key because the trees
+      # contain native addons built for the running node.
+      - name: 💾 Restore NPM dependencies cache
+        id: deps-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            server/node_modules
+            server/services/*/node_modules
+          key: server-deps-v1-${{ runner.os }}-node${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('server/**/package-lock.json') }}
       - name: 📦 Install Global NPM Packages
+        if: steps.deps-cache.outputs.cache-hit != 'true'
         run: |
           sudo npm install typescript node-gyp -g
       - name: 📦 Install NPM server packages
+        if: steps.deps-cache.outputs.cache-hit != 'true'
         working-directory: ./server
         run: |
           npm ci

--- a/server/test/helpers/db.test.js
+++ b/server/test/helpers/db.test.js
@@ -36,11 +36,29 @@ const cleanDb = async () => {
 // state is a complete consistent snapshot, so integrity holds by construction.
 let sqliteResetScript = null;
 let sqliteExec = null;
+let sqliteAll = null;
+let cleanMarkers = null;
+
+// Most tests never write to the database, so even the fast snapshot copy is
+// wasted work for them. Before copying, we read two cheap freshness markers
+// and skip the reset when both are unchanged since the last one:
+// - total_changes() counts every row insert/update/delete made through this
+//   connection (Sequelize routes all queries through it), including changes
+//   later rolled back, so a dirty database can never look clean;
+// - PRAGMA data_version increments when the file is modified by any OTHER
+//   connection or process (e.g. gateway.restoreBackup shelling out to the
+//   sqlite3 CLI), covering writes the first marker cannot see.
+const readFreshnessMarkers = async () => {
+  // node-sqlite3 all() only runs the first statement of a script: two queries.
+  const totalChanges = await sqliteAll('SELECT total_changes() AS tc');
+  const dataVersion = await sqliteAll('PRAGMA data_version');
+  return JSON.stringify([totalChanges, dataVersion]);
+};
 
 const initSnapshotReset = async () => {
   const connection = await db.sequelize.connectionManager.getConnection({ type: 'write' });
   sqliteExec = promisify(connection.exec.bind(connection));
-  const sqliteAll = promisify(connection.all.bind(connection));
+  sqliteAll = promisify(connection.all.bind(connection));
 
   const snapshotPath = `${db.sequelize.options.storage.replace(/\.db$/, '')}-snapshot.db`;
   if (existsSync(snapshotPath)) {
@@ -82,17 +100,30 @@ const resetDb = async () => {
       throw e;
     }
     await initSnapshotReset();
+    cleanMarkers = await readFreshnessMarkers();
   } else {
-    try {
-      await sqliteExec(sqliteResetScript);
-    } catch (e) {
-      // A failed exec can leave an open transaction and foreign keys disabled.
-      await sqliteExec('ROLLBACK; PRAGMA foreign_keys = ON').catch(() => {});
-      throw e;
+    const markers = await readFreshnessMarkers();
+    if (markers !== cleanMarkers) {
+      try {
+        await sqliteExec(sqliteResetScript);
+      } catch (e) {
+        // A failed exec can leave an open transaction and foreign keys disabled.
+        await sqliteExec('ROLLBACK; PRAGMA foreign_keys = ON').catch(() => {});
+        throw e;
+      }
+      // The reset itself moved the markers: re-read them so the next call
+      // compares against the freshly restored state.
+      cleanMarkers = await readFreshnessMarkers();
     }
   }
-  // Clean DuckDB database (a separate database, not covered by the snapshot)
-  await db.duckDbWriteConnectionAllAsync('DELETE FROM t_device_feature_state');
+  // Clean DuckDB database (a separate database, not covered by the snapshot).
+  // Same idea as above: the table is empty for the vast majority of tests, and
+  // counting is much cheaper than deleting. Both queries go through the
+  // serialized write queue, so they cannot race a pending write.
+  const rows = await db.duckDbWriteConnectionAllAsync('SELECT count(*) AS c FROM t_device_feature_state');
+  if (rows.length === 0 || Number(rows[0].c) !== 0) {
+    await db.duckDbWriteConnectionAllAsync('DELETE FROM t_device_feature_state');
+  }
 };
 
 module.exports = {

--- a/server/test/helpers/db.test.js
+++ b/server/test/helpers/db.test.js
@@ -39,6 +39,10 @@ let sqliteExec = null;
 let sqliteAll = null;
 let cleanMarkers = null;
 
+// Observability for dbReset.test.js: lets the tests assert that the skip
+// branches really skip (an unnecessary reset would produce the same data).
+const resetDbStats = { sqliteResets: 0, duckDeletes: 0 };
+
 // Most tests never write to the database, so even the fast snapshot copy is
 // wasted work for them. Before copying, we read two cheap freshness markers
 // and skip the reset when both are unchanged since the last one:
@@ -104,6 +108,7 @@ const resetDb = async () => {
   } else {
     const markers = await readFreshnessMarkers();
     if (markers !== cleanMarkers) {
+      resetDbStats.sqliteResets += 1;
       try {
         await sqliteExec(sqliteResetScript);
       } catch (e) {
@@ -122,6 +127,7 @@ const resetDb = async () => {
   // serialized write queue, so they cannot race a pending write.
   const rows = await db.duckDbWriteConnectionAllAsync('SELECT count(*) AS c FROM t_device_feature_state');
   if (rows.length === 0 || Number(rows[0].c) !== 0) {
+    resetDbStats.duckDeletes += 1;
     await db.duckDbWriteConnectionAllAsync('DELETE FROM t_device_feature_state');
   }
 };
@@ -130,4 +136,5 @@ module.exports = {
   seedDb,
   cleanDb,
   resetDb,
+  resetDbStats,
 };

--- a/server/test/helpers/dbReset.test.js
+++ b/server/test/helpers/dbReset.test.js
@@ -1,0 +1,56 @@
+const { expect } = require('chai');
+const { promisify } = require('util');
+const sqlite3 = require('sqlite3');
+const db = require('../../models');
+const { resetDb } = require('./db.test');
+
+// Direct tests of the freshness detection in resetDb (see db.test.js): a clean
+// database must be left intact by the skip path, and every kind of write —
+// through Sequelize, through a foreign connection, or into DuckDB — must be
+// detected and rolled back to the seeded state.
+describe('resetDb freshness detection', () => {
+  it('should keep the seeded rows intact when nothing was written (skip path)', async () => {
+    const before = await db.House.count();
+    expect(before).to.be.above(0);
+    // The global beforeEach just reset the database, so this call must take
+    // the "markers unchanged" branch and leave the data as-is.
+    await resetDb();
+    expect(await db.House.count()).to.equal(before);
+  });
+
+  it('should restore rows modified through the Sequelize connection', async () => {
+    const [house] = await db.House.findAll();
+    await db.sequelize.query(`UPDATE t_house SET name = 'dirty' WHERE id = '${house.id}'`);
+    expect((await db.House.findByPk(house.id)).name).to.equal('dirty');
+    // total_changes() moved: the reset must detect it and restore the seed.
+    await resetDb();
+    const restored = await db.House.findByPk(house.id);
+    expect(restored.name).to.equal(house.name);
+  });
+
+  it('should restore rows modified by another connection (data_version marker)', async () => {
+    const [house] = await db.House.findAll();
+    // Write through a second, independent SQLite connection: invisible to
+    // total_changes() on the Sequelize connection, but PRAGMA data_version
+    // must catch it — this mirrors gateway.restoreBackup calling the sqlite3
+    // CLI on the database file.
+    const external = new sqlite3.Database(db.sequelize.options.storage);
+    await promisify(external.run.bind(external))(`UPDATE t_house SET name = 'dirty' WHERE id = '${house.id}'`);
+    await promisify(external.close.bind(external))();
+    expect((await db.House.findByPk(house.id)).name).to.equal('dirty');
+    await resetDb();
+    const restored = await db.House.findByPk(house.id);
+    expect(restored.name).to.equal(house.name);
+  });
+
+  it('should clear DuckDB states when rows are present', async () => {
+    await db.duckDbWriteConnectionAllAsync(
+      `INSERT INTO t_device_feature_state VALUES ('ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4', 12, '2024-01-01 00:00:00')`,
+    );
+    const inserted = await db.duckDbWriteConnectionAllAsync('SELECT count(*) AS c FROM t_device_feature_state');
+    expect(Number(inserted[0].c)).to.equal(1);
+    await resetDb();
+    const after = await db.duckDbWriteConnectionAllAsync('SELECT count(*) AS c FROM t_device_feature_state');
+    expect(Number(after[0].c)).to.equal(0);
+  });
+});

--- a/server/test/helpers/dbReset.test.js
+++ b/server/test/helpers/dbReset.test.js
@@ -42,8 +42,11 @@ describe('resetDb freshness detection', () => {
     // must catch it — this mirrors gateway.restoreBackup calling the sqlite3
     // CLI on the database file.
     const external = new sqlite3.Database(db.sequelize.options.storage);
-    await promisify(external.run.bind(external))(`UPDATE t_house SET name = 'dirty' WHERE id = '${house.id}'`);
-    await promisify(external.close.bind(external))();
+    try {
+      await promisify(external.run.bind(external))(`UPDATE t_house SET name = 'dirty' WHERE id = '${house.id}'`);
+    } finally {
+      await promisify(external.close.bind(external))();
+    }
     expect((await db.House.findByPk(house.id)).name).to.equal('dirty');
     const stats = { ...resetDbStats };
     await resetDb();

--- a/server/test/helpers/dbReset.test.js
+++ b/server/test/helpers/dbReset.test.js
@@ -2,19 +2,24 @@ const { expect } = require('chai');
 const { promisify } = require('util');
 const sqlite3 = require('sqlite3');
 const db = require('../../models');
-const { resetDb } = require('./db.test');
+const { resetDb, resetDbStats } = require('./db.test');
 
 // Direct tests of the freshness detection in resetDb (see db.test.js): a clean
 // database must be left intact by the skip path, and every kind of write —
 // through Sequelize, through a foreign connection, or into DuckDB — must be
-// detected and rolled back to the seeded state.
+// detected and rolled back to the seeded state. The resetDbStats counters
+// prove which branch ran: a skipped reset and an unnecessary one would
+// otherwise produce the same data.
 describe('resetDb freshness detection', () => {
-  it('should keep the seeded rows intact when nothing was written (skip path)', async () => {
+  it('should skip both resets and keep the seeded rows when nothing was written', async () => {
     const before = await db.House.count();
     expect(before).to.be.above(0);
+    const stats = { ...resetDbStats };
     // The global beforeEach just reset the database, so this call must take
     // the "markers unchanged" branch and leave the data as-is.
     await resetDb();
+    expect(resetDbStats.sqliteResets).to.equal(stats.sqliteResets);
+    expect(resetDbStats.duckDeletes).to.equal(stats.duckDeletes);
     expect(await db.House.count()).to.equal(before);
   });
 
@@ -22,8 +27,10 @@ describe('resetDb freshness detection', () => {
     const [house] = await db.House.findAll();
     await db.sequelize.query(`UPDATE t_house SET name = 'dirty' WHERE id = '${house.id}'`);
     expect((await db.House.findByPk(house.id)).name).to.equal('dirty');
+    const stats = { ...resetDbStats };
     // total_changes() moved: the reset must detect it and restore the seed.
     await resetDb();
+    expect(resetDbStats.sqliteResets).to.equal(stats.sqliteResets + 1);
     const restored = await db.House.findByPk(house.id);
     expect(restored.name).to.equal(house.name);
   });
@@ -38,7 +45,9 @@ describe('resetDb freshness detection', () => {
     await promisify(external.run.bind(external))(`UPDATE t_house SET name = 'dirty' WHERE id = '${house.id}'`);
     await promisify(external.close.bind(external))();
     expect((await db.House.findByPk(house.id)).name).to.equal('dirty');
+    const stats = { ...resetDbStats };
     await resetDb();
+    expect(resetDbStats.sqliteResets).to.equal(stats.sqliteResets + 1);
     const restored = await db.House.findByPk(house.id);
     expect(restored.name).to.equal(house.name);
   });
@@ -49,7 +58,9 @@ describe('resetDb freshness detection', () => {
     );
     const inserted = await db.duckDbWriteConnectionAllAsync('SELECT count(*) AS c FROM t_device_feature_state');
     expect(Number(inserted[0].c)).to.equal(1);
+    const stats = { ...resetDbStats };
     await resetDb();
+    expect(resetDbStats.duckDeletes).to.equal(stats.duckDeletes + 1);
     const after = await db.duckDbWriteConnectionAllAsync('SELECT count(*) AS c FROM t_device_feature_state');
     expect(Number(after[0].c)).to.equal(0);
   });


### PR DESCRIPTION
### Description

Two independent optimizations of the server test pipeline (first of a series of three PRs following a profiling session of the ~5 500-test server suite):

**1. Conditional database reset in the global `beforeEach`** (`server/test/helpers/db.test.js`)

Profiling showed the global reset costs ~22.5s per run (~13.5s SQLite snapshot copy + ~9s DuckDB `DELETE`), even though most tests never write to the database. The reset is now skipped when the database is provably untouched, using two cheap freshness markers read before each copy:

- `SELECT total_changes()` — counts every row written through the Sequelize connection (including changes later rolled back, so a dirty database can never look clean);
- `PRAGMA data_version` — increments when the file is modified by any *other* connection or process, which covers `gateway.restoreBackup` shelling out to the `sqlite3` CLI.

The DuckDB `DELETE` is likewise replaced by a `count(*)` check when the states table is already empty (both statements go through the serialized write queue, so they cannot race a pending write).

Measured locally: **84% of tests skip the SQLite reset, 98% skip the DuckDB delete**; the full suite goes from 138s to 127s with strictly identical results (same passes, same failures, run-to-run).

**2. `node_modules` cache for the "Server test" and "Server lint" jobs**

Same pattern and rationale as the cache added to the Cypress job in #2813: keyed on the server lockfiles and the node version, covering the per-service `node_modules` installed by the server postinstall. On a warm cache both jobs skip `npm ci` (~40s) and the global typescript/node-gyp install.

Expected effect on the "Server test" job: ~3m24 → ~2m30 (cold cache) / ~2m10 (warm cache). Two follow-up PRs (per-file sinon sandboxes, then mocha parallel mode) will address the remaining test-time bottleneck.

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (changed files are test helpers and CI config, excluded from coverage)
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xj8nWW9CWrNUvw5C6wd5yp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test database reset reliability and recovery after failed resets.
  * Detects changes from independent database connections and restores modified data.
  * Reduces unnecessary database cleanup when no changes have occurred.
  * Added coverage for database freshness detection and state restoration.

* **Chores**
  * Improved automated build and test efficiency through smarter dependency caching.
  * Added safeguards to ensure validation runs consistently across supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->