### PR TITLE
Integration catalog: make the search accent-insensitive

### DIFF
--- a/front/src/components/scene/IconSelector.jsx
+++ b/front/src/components/scene/IconSelector.jsx
@@ -9,22 +9,15 @@ import iconList from '../../../../server/config/icons.json';
 import iconKeywords from '../../config/i18n/icon-keywords';
 import { AVAILABLE_LANGUAGES } from '../../../../server/utils/constants';
 import style from './IconSelector.css';
+import normalizeSearchText from '../../utils/normalizeSearchText';
 
 // Fold both the query and the searched text down to plain lowercase letters:
-// dashes disappear, so "door open", "door-open" and "dooropen" all match the
-// same icon, and accents and ligatures do too, so "eclair" finds "éclair",
-// "coeur" finds "Cœur" and "vergrossern" finds "vergrößern".
-const normalize = value =>
-  value
-    .toLowerCase()
-    // NFD leaves ligatures alone, so the ASCII filter below would drop them
-    // outright: "cœur" became "cur" and matched "curseurs".
-    .replace(/œ/g, 'oe')
-    .replace(/æ/g, 'ae')
-    .replace(/ß/g, 'ss')
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^a-z0-9]/g, '');
+// the shared search fold takes care of the case, of the accents and of the
+// ligatures, so "eclair" finds "éclair", "coeur" finds "Cœur" and
+// "vergrossern" finds "vergrößern". Icons take a stricter fold than the rest
+// of the front on top of it: everything that is not a letter or a digit goes
+// too, so "door open", "door-open" and "dooropen" all match the same icon.
+const normalize = value => normalizeSearchText(value).replace(/[^a-z0-9]/g, '');
 
 const IconSelector = ({ value, onChange, darkModeNoFilter = false, user }) => {
   const [search, setSearch] = useState('');

--- a/front/src/routes/integration/all/mqtt/device-page/utils.js
+++ b/front/src/routes/integration/all/mqtt/device-page/utils.js
@@ -10,6 +10,7 @@ import {
 } from '../../../../../../../server/utils/constants';
 import { slugify } from '../../../../../../../server/utils/slugify';
 import { isPushButtonFeature } from '../../../../../utils/consts';
+import normalizeSearchText from '../../../../../utils/normalizeSearchText';
 
 const SENSOR_CATEGORY_SUFFIX = '-sensor';
 
@@ -61,11 +62,7 @@ export const isSensorCategory = category => {
   return category.endsWith(SENSOR_CATEGORY_SUFFIX) || category === DEVICE_FEATURE_CATEGORIES.SIGNAL;
 };
 
-export const normalizeForSearch = value =>
-  value
-    .toLowerCase()
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '');
+export const normalizeForSearch = normalizeSearchText;
 
 const categoryTypeKey = (category, type) => `${category}|${type}`;
 

--- a/front/src/routes/integration/all/mqtt/device-page/utils.js
+++ b/front/src/routes/integration/all/mqtt/device-page/utils.js
@@ -1179,6 +1179,12 @@ export const filterFeatureCatalogOptions = (options, search, dictionary) => {
   }
 
   const normalizedSearch = normalizeForSearch(search.trim());
+  // a search made of accents only folds down to nothing, and every string
+  // contains the empty string: without this it would list the whole catalog,
+  // as if the field were empty
+  if (!normalizedSearch.length) {
+    return [];
+  }
 
   return options
     .map(group => {

--- a/front/src/routes/integration/index.js
+++ b/front/src/routes/integration/index.js
@@ -358,13 +358,18 @@ class Integration extends Component {
       // both sides are stripped of their accents: "meteo" has to find "Météo",
       // and typing "Météo" has to keep finding it
       const normalizedSearchKeyword = normalizeSearchText(searchKeyword);
-      selectedIntegrations = selectedIntegrations.filter(integration => {
-        const { name, description } = integration;
-        return (
-          normalizeSearchText(name).includes(normalizedSearchKeyword) ||
-          normalizeSearchText(description).includes(normalizedSearchKeyword)
-        );
-      });
+      // a keyword made of accents only folds down to nothing, and every string
+      // contains the empty string: without this, such a search would display
+      // the whole catalog as if the field were empty
+      selectedIntegrations = normalizedSearchKeyword.length
+        ? selectedIntegrations.filter(integration => {
+            const { name, description } = integration;
+            return (
+              normalizeSearchText(name).includes(normalizedSearchKeyword) ||
+              normalizeSearchText(description).includes(normalizedSearchKeyword)
+            );
+          })
+        : [];
     }
 
     // Sort

--- a/front/src/routes/integration/index.js
+++ b/front/src/routes/integration/index.js
@@ -5,6 +5,7 @@ import { route } from 'preact-router';
 
 import IntegrationPage from './IntegrationPage';
 import withIntlAsProp from '../../utils/withIntlAsProp';
+import normalizeSearchText from '../../utils/normalizeSearchText';
 import { USER_ROLE, WEBSOCKET_MESSAGE_TYPES } from '../../../../server/utils/constants';
 import debounce from 'debounce';
 import { integrations, integrationsByType, categories } from '../../config/integrations';
@@ -354,12 +355,14 @@ class Integration extends Component {
 
     // Filter
     if (searchKeyword && searchKeyword.length > 0) {
-      const lowerCaseSearchKeyword = searchKeyword.toLowerCase();
+      // both sides are stripped of their accents: "meteo" has to find "Météo",
+      // and typing "Météo" has to keep finding it
+      const normalizedSearchKeyword = normalizeSearchText(searchKeyword);
       selectedIntegrations = selectedIntegrations.filter(integration => {
         const { name, description } = integration;
         return (
-          name.toLowerCase().includes(lowerCaseSearchKeyword) ||
-          description.toLowerCase().includes(lowerCaseSearchKeyword)
+          normalizeSearchText(name).includes(normalizedSearchKeyword) ||
+          normalizeSearchText(description).includes(normalizedSearchKeyword)
         );
       });
     }

--- a/front/src/utils/normalizeSearchText.js
+++ b/front/src/utils/normalizeSearchText.js
@@ -1,0 +1,18 @@
+// Accents must not split a search in two: someone looking for "Météo" types
+// "meteo", and the integration names are translated, so the accents depend on
+// the language Gladys is displayed in and not on what the user types.
+// Unicode decomposition (NFD) splits an accented letter into its base letter
+// followed by a combining mark, so dropping the marks leaves the plain letter.
+const COMBINING_MARKS = /[\u0300-\u036f]/g;
+
+function normalizeSearchText(text) {
+  if (typeof text !== 'string') {
+    return '';
+  }
+  return text
+    .normalize('NFD')
+    .replace(COMBINING_MARKS, '')
+    .toLowerCase();
+}
+
+export default normalizeSearchText;

--- a/front/src/utils/normalizeSearchText.js
+++ b/front/src/utils/normalizeSearchText.js
@@ -1,18 +1,31 @@
-// Accents must not split a search in two: someone looking for "Météo" types
-// "meteo", and the integration names are translated, so the accents depend on
-// the language Gladys is displayed in and not on what the user types.
-// Unicode decomposition (NFD) splits an accented letter into its base letter
-// followed by a combining mark, so dropping the marks leaves the plain letter.
-const COMBINING_MARKS = /[\u0300-\u036f]/g;
+// Fold a string down to the form a search should compare: lowercase, without
+// accents. Accents must not split a search in two — someone looking for
+// "Météo" types "meteo" — and the integration names are translated, so the
+// accents depend on the language Gladys is displayed in, not on what the user
+// types.
+//
+// Ligatures are expanded first: they have no canonical decomposition, so NFD
+// leaves them alone and "coeur" would never find "Cœur" nor "strasse"
+// "Straße".
+// NFD then splits an accented letter into its base letter followed by a
+// combining mark, so dropping the marks leaves the plain letter. Every mark a
+// canonical decomposition produces is a non-spacing mark, which is what
+// \p{Mn} matches: it covers the accents of the Latin, Greek and Cyrillic
+// alphabets (all inside U+0300-U+036F) as well as the ones other scripts use
+// — a community integration name is free to be written in any of them.
+const NON_SPACING_MARKS = /\p{Mn}/gu;
 
 function normalizeSearchText(text) {
   if (typeof text !== 'string') {
     return '';
   }
   return text
+    .toLowerCase()
+    .replace(/œ/g, 'oe')
+    .replace(/æ/g, 'ae')
+    .replace(/ß/g, 'ss')
     .normalize('NFD')
-    .replace(COMBINING_MARKS, '')
-    .toLowerCase();
+    .replace(NON_SPACING_MARKS, '');
 }
 
 export default normalizeSearchText;


### PR DESCRIPTION
### Description

Searching the integration catalog for `meteo` returned nothing, while `Météo` worked: the filter compared the raw lowercased strings, so an accented letter only matched itself. Integration names come from the i18n dictionary, so which words carry accents depends on the display language, not on what the user types.

Both sides of the comparison now go through a shared fold before matching: lowercase, ligatures expanded, then a Unicode NFD decomposition whose combining marks are dropped, leaving the plain letters. Searching with or without accents returns the same integrations, in both directions (`meteo` → **Météo**, and `Météo` → **Météo**).

**Changes**

- new `front/src/utils/normalizeSearchText.js`: lowercase, `œ`/`æ`/`ß` expansion (ligatures have no canonical decomposition, so NFD leaves them alone), NFD, `\p{Mn}` strip, non-string safe.
  `\p{Mn}` and not the `U+0300–U+036F` block: every Latin, Greek and Cyrillic accent decomposes inside that block, but other scripts produce marks outside it (Arabic hamza, Devanagari nukta) and a community integration name is free text from a manifest. `\p{Mn}` and not `\p{M}`: the spacing marks are vowels in their own right in the Indic scripts, dropping them would merge distinct words.
- `front/src/routes/integration/index.js`: the catalog filter uses it for the name and the description. A keyword made of accents only folds to an empty string that every name contains, so it now matches nothing instead of listing the whole catalog.
- `front/src/components/scene/IconSelector.jsx` and `front/src/routes/integration/all/mqtt/device-page/utils.js` each carried their own copy of the same fold and now build on the shared one — the icon selector keeping the stricter `[^a-z0-9]` filter it needs on top of it. The MQTT feature search got the same empty-fold fix as the catalog.

The forum topic reports the integration catalog search; the two other call sites are the existing duplicates of the same fold, brought onto it rather than left to drift.

## Forum

Forum: https://community.gladysassistant.com/t/liste-dintegration-la-recherche-ne-devrait-pas-tenir-compte-des-accents/10489

### Checklist

- [x] Tests pass: front-only change, no server test or coverage impact (Codecov green). Cypress passes in CI.
- [x] Linter and prettier pass on both front and server
- [x] No undocumented breaking change