### PR TITLE
fix: make scene condition formulas fail closed and pin the formula operator surface (#2823)

### DIFF
--- a/server/lib/scene/scene.actions.js
+++ b/server/lib/scene/scene.actions.js
@@ -9,9 +9,12 @@ const {
   largerDependencies,
   largerEqDependencies,
   modDependencies,
+  multiplyDependencies,
   roundDependencies,
   smallerDependencies,
   smallerEqDependencies,
+  subtractDependencies,
+  unaryMinusDependencies,
   randomDependencies,
 } = require('mathjs');
 const set = require('set-value');
@@ -31,6 +34,10 @@ const executeActionsFactory = require('./scene.executeActions');
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
+// Every operator the formula engine supports must be listed explicitly here.
+// mathjs only exposes in the "math" namespace what is passed to create(), so an operator
+// that is only pulled in transitively by another factory (multiply through divide, for example)
+// is not guaranteed to stay available across mathjs releases.
 const { evaluate } = create({
   addDependencies,
   divideDependencies,
@@ -39,7 +46,10 @@ const { evaluate } = create({
   smallerDependencies,
   largerEqDependencies,
   modDependencies,
+  multiplyDependencies,
   smallerEqDependencies,
+  subtractDependencies,
+  unaryMinusDependencies,
   roundDependencies,
   randomDependencies,
 });
@@ -322,11 +332,19 @@ const actionsFunc = {
     action.conditions.forEach((condition) => {
       let { value } = condition;
       if (condition.evaluate_value !== undefined) {
-        value = evaluate(
-          Handlebars.compile(condition.evaluate_value, {
-            noEscape: true,
-          })(scope).replace(/\s/g, ''),
-        );
+        // If the formula cannot be evaluated, the condition cannot be trusted:
+        // we abort the scene instead of silently letting the rest of the scene run.
+        try {
+          value = evaluate(
+            Handlebars.compile(condition.evaluate_value, {
+              noEscape: true,
+            })(scope).replace(/\s/g, ''),
+          );
+        } catch (e) {
+          logger.warn(`Continue only if: Error evaluating value: ${condition.evaluate_value}`);
+          logger.warn(e);
+          throw new AbortScene('CONDITION_VALUE_NOT_A_NUMBER');
+        }
       }
 
       // For numeric comparison operators (>, >=, <, <=), value must be a number

--- a/server/test/lib/scene/actions/scene.action.continueOnlyIf.test.js
+++ b/server/test/lib/scene/actions/scene.action.continueOnlyIf.test.js
@@ -1,6 +1,6 @@
 const sinon = require('sinon').createSandbox();
 
-const { fake } = sinon;
+const { assert, fake } = sinon;
 const EventEmitter = require('events');
 const chaiAssert = require('chai').assert;
 
@@ -92,6 +92,53 @@ describe('scene.continue-only-if', () => {
       scope,
     );
     return chaiAssert.isRejected(promise, AbortScene, 'CONDITION_VALUE_NOT_A_NUMBER');
+  });
+  it('should abort scene and not run following actions, condition formula cannot be evaluated', async () => {
+    stateManager.setState('deviceFeature', 'my-device-feature', {
+      category: 'light',
+      type: 'binary',
+      last_value: 15,
+    });
+    const device = {
+      setValue: fake.resolves(null),
+    };
+    const scope = {};
+    const promise = executeActions(
+      { stateManager, event, device },
+      [
+        [
+          {
+            type: ACTIONS.DEVICE.GET_VALUE,
+            device_feature: 'my-device-feature',
+          },
+        ],
+        [
+          {
+            type: ACTIONS.CONDITION.ONLY_CONTINUE_IF,
+            conditions: [
+              {
+                variable: '0.0.last_value',
+                operator: '=',
+                // "sqrt" is not part of the restricted formula engine namespace,
+                // so evaluating this condition throws.
+                evaluate_value: 'sqrt(400)',
+              },
+            ],
+          },
+        ],
+        [
+          {
+            type: ACTIONS.DEVICE.SET_VALUE,
+            device_feature: 'my-device-feature',
+            value: 99,
+          },
+        ],
+      ],
+      scope,
+    );
+    await chaiAssert.isRejected(promise, AbortScene, 'CONDITION_VALUE_NOT_A_NUMBER');
+    // The guard must fail closed: the action after it must not have been executed.
+    assert.notCalled(device.setValue);
   });
   it('should finish scene, condition is verified', async () => {
     stateManager.setState('deviceFeature', 'my-device-feature', {

--- a/server/test/lib/scene/actions/scene.action.formula.test.js
+++ b/server/test/lib/scene/actions/scene.action.formula.test.js
@@ -1,0 +1,126 @@
+const sinon = require('sinon').createSandbox();
+
+const { fake } = sinon;
+const EventEmitter = require('events');
+const { expect } = require('chai');
+
+const { ACTIONS } = require('../../../../utils/constants');
+const executeActionsFactory = require('../../../../lib/scene/scene.executeActions');
+
+const StateManager = require('../../../../lib/state');
+const actionsFunc = require('../../../../lib/scene/scene.actions');
+
+// The scene formula engine is a restricted mathjs instance built in scene.actions.js.
+// Only the operators explicitly passed to create() are guaranteed to stay in the "math"
+// namespace across mathjs releases, so every supported operator needs a test here:
+// a mathjs upgrade that drops one must fail CI instead of failing silently in production.
+describe('scene.formula', () => {
+  let event;
+  let stateManager;
+  const { executeActions } = executeActionsFactory(actionsFunc);
+
+  beforeEach(() => {
+    event = new EventEmitter();
+    stateManager = new StateManager(event);
+  });
+
+  afterEach(() => {
+    sinon.reset();
+  });
+
+  /**
+   * @description Evaluate a formula through the device.set-value action and
+   * return the value that was sent to the device.
+   * @param {string} formula - The formula to evaluate.
+   * @returns {Promise<number>} The value passed to device.setValue.
+   * @example const value = await evaluateFormula('180 - 5');
+   */
+  async function evaluateFormula(formula) {
+    stateManager.setState('deviceFeature', 'my-device-feature', {
+      category: 'light',
+      type: 'brightness',
+      last_value: 15,
+    });
+    const device = {
+      setValue: fake.resolves(null),
+    };
+    await executeActions(
+      { stateManager, event, device },
+      [
+        [
+          {
+            type: ACTIONS.DEVICE.SET_VALUE,
+            device_feature: 'my-device-feature',
+            evaluate_value: formula,
+          },
+        ],
+      ],
+      {},
+    );
+    expect(device.setValue.callCount).to.equal(1);
+    return device.setValue.firstCall.args[2];
+  }
+
+  it('should support addition', async () => {
+    expect(await evaluateFormula('180 + 5')).to.equal(185);
+  });
+
+  it('should support subtraction', async () => {
+    expect(await evaluateFormula('180 - 5')).to.equal(175);
+  });
+
+  it('should support multiplication', async () => {
+    expect(await evaluateFormula('3 * 3600')).to.equal(10800);
+  });
+
+  it('should support division', async () => {
+    expect(await evaluateFormula('10 / 2')).to.equal(5);
+  });
+
+  it('should support modulo', async () => {
+    expect(await evaluateFormula('10 % 3')).to.equal(1);
+  });
+
+  it('should support unary minus', async () => {
+    expect(await evaluateFormula('-5')).to.equal(-5);
+  });
+
+  it('should support round', async () => {
+    expect(await evaluateFormula('round(1.4)')).to.equal(1);
+  });
+
+  it('should support parenthesis and operator precedence', async () => {
+    expect(await evaluateFormula('(10 - 4) * 2')).to.equal(12);
+  });
+
+  it('should subtract from a scene variable', async () => {
+    stateManager.setState('deviceFeature', 'my-device-feature', {
+      category: 'light',
+      type: 'brightness',
+      last_value: 15,
+    });
+    const device = {
+      setValue: fake.resolves(null),
+    };
+    await executeActions(
+      { stateManager, event, device },
+      [
+        [
+          {
+            type: ACTIONS.DEVICE.GET_VALUE,
+            device_feature: 'my-device-feature',
+          },
+        ],
+        [
+          {
+            type: ACTIONS.DEVICE.SET_VALUE,
+            device_feature: 'my-device-feature',
+            evaluate_value: '{{0.0.last_value}} - 5',
+          },
+        ],
+      ],
+      {},
+    );
+    expect(device.setValue.firstCall.args[2]).to.equal(10);
+  });
+});


### PR DESCRIPTION
Fixes #2823

> **This PR was produced by an automated routine and has not been reviewed by a human.** Please review carefully before merging — in particular the "What a human must check" section, which flags a factual correction to the issue as filed.

## (a) What changed and why

**First, an important correction to the issue.** The headline claim — that `subtract` is missing from the restricted mathjs namespace and that *any* formula containing a binary `-` throws — **does not reproduce** on the pinned `mathjs@11.8.0` (exact version in `server/package-lock.json`). Verified two ways:

- The issue's own reproduction snippet, run verbatim: `evaluate('180-5')` returns `175`.
- Through the real code path: a `device.set-value` action with `evaluate_value: '{{0.0.last_value}} - 5'` and `last_value: 15` calls `device.setValue(..., 10)` on unmodified `master`.

`create()` populates the namespace with the whole transitive factory graph, so `subtract`, `multiply`, `unaryMinus`, `pow`, `ceil` and `floor` are all already present via `divide` → `inv`. So there is no user-visible subtraction bug to fix, and the community-forum countdown pattern (`{{0.0.last_value}} - 5`) works.

**But the issue's point 3 is a real bug, and it is reproducible.** `condition.only-continue-if` evaluated its formula outside any `try/catch`. When `evaluate()` throws for *any* reason — a malformed formula, or a function genuinely outside the namespace such as `sqrt`, `min` or `max` — the error is not an `AbortScene`, so [`scene.executeActions.js`](https://github.com/GladysAssistant/Gladys/blob/master/server/lib/scene/scene.executeActions.js#L32-L44) swallows it with a `logger.warn` and **the scene keeps running with the guard bypassed**. Reproduced on unmodified `master`: a scene whose guard is `0.0.last_value = sqrt(400)` (false — `last_value` is 15) still executed the action after the guard.

Two changes:

1. **`condition.only-continue-if` now fails closed.** The `evaluate()` call is wrapped the same way `time.delay` already wraps its own, throwing `AbortScene('CONDITION_VALUE_NOT_A_NUMBER')` — an existing code, so no new user-facing string or translation is introduced.
2. **The operator surface is pinned.** `subtractDependencies`, `multiplyDependencies` and `unaryMinusDependencies` are now passed explicitly to `create()`. This is a **behavioural no-op today** — it only removes the reliance on transitive factory resolution, so a future mathjs upgrade that reshapes `divide`/`inv` cannot silently drop these operators. New tests exercise every supported operator through the real action path, so such a regression would fail CI instead of reaching production.

Deliberately **not** changed: no new operators were added to the namespace. `pow`/`ceil`/`floor` are currently reachable only transitively and `min`/`max`/`sqrt`/`abs` are absent entirely — deciding what the formula engine is meant to support is a product decision, left to a maintainer (see below).

## (b) What I verified locally

- Bug reproduction and fix, through the real `executeActions` path, before and after the change.
- Scene test suite: `mocha --recursive "./test/lib/scene/**/*.test.js"` → **240 passing, 0 failing** (includes 9 new formula tests and 1 new fail-closed test).
- `npm run prettier-check` → `All matched files use Prettier code style!`
- `npm run eslint` → **0 errors**, 26 warnings, all pre-existing and none in the changed files.

Not run: the full `npm run coverage` suite (~4100 tests) and the front/Cypress jobs — this change is server-only and touches no front code, translations or routes.

## (c) What a human must check before merge

1. **The premise of the issue is wrong** — subtraction is not broken. If a user reported subtraction failing in the field, the real cause is elsewhere (different mathjs version in their install, or a formula whose Handlebars output is malformed) and this PR does not address it. Worth confirming before closing the issue as fixed.
2. **Is `CONDITION_VALUE_NOT_A_NUMBER` the right abort code** for an unevaluable formula? It is reused because it already exists and is not surfaced in the front's i18n files; a dedicated code may read better in logs.
3. **Behaviour change with real user impact:** scenes that today silently continue past a broken condition formula will now abort. That is the intended fix, but any existing scene relying on the old fail-open behaviour will change behaviour after upgrade — this may deserve a CHANGELOG entry.
4. **Should `device.set-value` also fail closed?** It has the same unguarded `evaluate()` (`scene.actions.js#L60-L66`); on throw the feature is never updated and the scene continues. Left alone to keep this PR minimal, but it is the same class of defect.
5. **Operator surface decision** (issue point 1's open question): confirm that the formula engine should stay limited to `+ - * / % round() random()` and comparisons, or open a follow-up to add `min`/`max`/`abs`/`pow` deliberately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E87aG1Tu2mGZaZKHirxrMq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scene formula evaluation for multiplication, subtraction, unary negation, rounding, parentheses, and operator precedence.
  * Invalid condition formulas now stop scene execution safely with a clear error instead of exposing a raw evaluation failure.
  * Prevented subsequent device actions from running when a condition formula cannot be evaluated.

* **Tests**
  * Added coverage for arithmetic formulas and invalid condition handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->