### PR TITLE
fix(ci): grant pull-requests write so Cursor review comment reactions work

### DIFF
--- a/.github/workflows/cursor-automation-webhook.yml
+++ b/.github/workflows/cursor-automation-webhook.yml
@@ -36,8 +36,13 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
-  # Needed to react to the triggering comment (PR comments are issue comments).
+  # Reacting to the triggering comment needs write access. A comment on a PR is
+  # an issue comment, so the reaction endpoint lives under /issues/comments/,
+  # but GitHub authorises it against the scope of the parent resource, which is
+  # a pull request: "issues: write" alone answers "Resource not accessible by
+  # integration" (HTTP 403). Both scopes are declared to match the endpoint and
+  # the resource it hangs from.
+  pull-requests: write
   issues: write
 
 jobs:


### PR DESCRIPTION
### Description

Follow-up to #2824. The `/cursor review` command works end to end, but both reactions on the triggering comment fail with `Resource not accessible by integration` (HTTP 403).

Observed on [run 31393898423](https://github.com/GladysAssistant/Gladys/actions/runs/31393898423), triggered by a `/cursor-review` comment on #2822:

```
Cursor review requested by Pierre-Gilles on PR #2822.
gh: Resource not accessible by integration (HTTP 403)
Warning: Could not react to comment 5241054024
...
Cursor webhook HTTP status: 200
Cursor automation triggered successfully.
gh: Resource not accessible by integration (HTTP 403)
Warning: Could not react to comment 5241054024
```

Everything else behaved correctly: the command matched, `MEMBER` passed the permission check, the PR metadata was fetched and the Cursor webhook returned 200. Only the 👀 and 🚀 reactions were denied — the failure is non-fatal by design, so the review still started.

**Cause.** The workflow declared `issues: write` because the reaction endpoint is `POST /repos/{owner}/{repo}/issues/comments/{id}/reactions`. But a comment on a pull request hangs from a pull request, and GitHub authorises the call against the scope of that parent resource, which was still `pull-requests: read`. The read scope was enough for `gh api repos/.../pulls/2822` in the next step, which is why only the reactions failed.

**Fix.** `pull-requests: write`. `issues: write` is kept so the declared scopes match both the endpoint and the resource it hangs from. This mirrors `pr-classify.yml`, which already writes labels with `pull-requests: write` — confirming the repository does grant write scopes when they are declared correctly, so this was not an org-level restriction.

No behaviour change beyond the reactions, and no test can cover it locally: workflow token scopes are only resolved by GitHub at run time, so this needs one `/cursor review` comment on a PR after merge to confirm.

## Forum

<!-- Not applicable: CI-only change. -->

### Checklist

- [x] Tests pass — no application code changed, workflow YAML validated by parsing it
- [x] Linter and prettier pass on both front and server — no front or server file changed
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvPoJMy2tk1zpqkJgyKWAA

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvPoJMy2tk1zpqkJgyKWAA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation permissions to support responding to pull request comments.
  * Documented the required access scopes for pull request comment reactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->