### PR TITLE
Fix the integration counter mixing scopes across catalog views

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -693,6 +693,7 @@
     "root": {
       "title": "Integrationen",
       "subtitle": "{{length}} von {{total}} Integrationen",
+      "subtitleTotal": "{{total}} Integrationen",
       "searchPlaceholder": "Integration suchen",
       "noIntegrations": "Keine Integrationen gefunden",
       "allIntegrationsUpToDate": "Alle Ihre Integrationen sind auf dem neuesten Stand.",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -693,6 +693,7 @@
     "root": {
       "title": "Integrations",
       "subtitle": "{{length}} of {{total}} integrations",
+      "subtitleTotal": "{{total}} integrations",
       "searchPlaceholder": "Search an integration",
       "noIntegrations": "No integration found",
       "allIntegrationsUpToDate": "All your integrations are up to date.",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -692,7 +692,8 @@
     },
     "root": {
       "title": "Intégrations",
-      "subtitle": "{{length}} de {{total}} intégrations",
+      "subtitle": "{{length}} sur {{total}} intégrations",
+      "subtitleTotal": "{{total}} intégrations",
       "searchPlaceholder": "Chercher une intégration",
       "noIntegrations": "Aucune intégration trouvée",
       "allIntegrationsUpToDate": "Toutes vos intégrations sont à jour.",

--- a/front/src/routes/integration/IntegrationPageHeader.jsx
+++ b/front/src/routes/integration/IntegrationPageHeader.jsx
@@ -25,10 +25,13 @@ const IntegrationPageHeader = ({
   totalSize,
   showInstallFromGithub
 }) => {
-  const searching = searchKeyword.length > 0;
+  const hasSearch = searchKeyword.length > 0;
+  // a search matching every integration of the view leaves the list untouched,
+  // so it is not a case for "X of Y" either
+  const searchNarrowsView = hasSearch && integrationsLength < totalSize;
   // an empty view (the catalog still loading, no favorite yet) already displays
   // a message in the page body, "0 integrations" on top of it says nothing more
-  const showCount = searching || totalSize > 0;
+  const showCount = hasSearch || totalSize > 0;
   const searchPlaceholder = get(intl.dictionary, 'integration.root.searchPlaceholder', {
     default: ''
   });
@@ -42,7 +45,11 @@ const IntegrationPageHeader = ({
           </h1>
           {showCount && (
             <div class="page-subtitle">
-              <IntegrationCount searching={searching} integrationsLength={integrationsLength} totalSize={totalSize} />
+              <IntegrationCount
+                searching={searchNarrowsView}
+                integrationsLength={integrationsLength}
+                totalSize={totalSize}
+              />
             </div>
           )}
           <div class="page-options d-flex align-items-center">
@@ -97,7 +104,11 @@ const IntegrationPageHeader = ({
         )}
         {showCount && (
           <div class={style.mobileResultCount}>
-            <IntegrationCount searching={searching} integrationsLength={integrationsLength} totalSize={totalSize} />
+            <IntegrationCount
+              searching={searchNarrowsView}
+              integrationsLength={integrationsLength}
+              totalSize={totalSize}
+            />
           </div>
         )}
       </div>

--- a/front/src/routes/integration/IntegrationPageHeader.jsx
+++ b/front/src/routes/integration/IntegrationPageHeader.jsx
@@ -5,6 +5,16 @@ import InstallFromGithubCard from './all/external-integration/install-from-githu
 import withIntlAsProp from '../../utils/withIntlAsProp';
 import style from './style.css';
 
+// while no search narrows the list down, the displayed count and the total of
+// the current view are the same number: showing "75 of 75 integrations" is
+// noise, the total alone says everything
+const IntegrationCount = ({ searching, integrationsLength, totalSize }) =>
+  searching ? (
+    <Text id="integration.root.subtitle" fields={{ length: integrationsLength, total: totalSize }} />
+  ) : (
+    <Text id="integration.root.subtitleTotal" fields={{ total: totalSize }} />
+  );
+
 const IntegrationPageHeader = ({
   intl,
   orderDir,
@@ -15,7 +25,10 @@ const IntegrationPageHeader = ({
   totalSize,
   showInstallFromGithub
 }) => {
-  const showResultCount = searchKeyword.length > 0 || integrationsLength !== totalSize;
+  const searching = searchKeyword.length > 0;
+  // an empty view (the catalog still loading, no favorite yet) already displays
+  // a message in the page body, "0 integrations" on top of it says nothing more
+  const showCount = searching || totalSize > 0;
   const searchPlaceholder = get(intl.dictionary, 'integration.root.searchPlaceholder', {
     default: ''
   });
@@ -27,9 +40,11 @@ const IntegrationPageHeader = ({
           <h1 class="page-title">
             <Text id="integration.root.title" />
           </h1>
-          <div class="page-subtitle">
-            <Text id="integration.root.subtitle" fields={{ length: integrationsLength, total: totalSize }} />
-          </div>
+          {showCount && (
+            <div class="page-subtitle">
+              <IntegrationCount searching={searching} integrationsLength={integrationsLength} totalSize={totalSize} />
+            </div>
+          )}
           <div class="page-options d-flex align-items-center">
             {showInstallFromGithub && (
               <div class="mr-3">
@@ -80,9 +95,9 @@ const IntegrationPageHeader = ({
             <InstallFromGithubCard button block />
           </div>
         )}
-        {showResultCount && (
+        {showCount && (
           <div class={style.mobileResultCount}>
-            <Text id="integration.root.subtitle" fields={{ length: integrationsLength, total: totalSize }} />
+            <IntegrationCount searching={searching} integrationsLength={integrationsLength} totalSize={totalSize} />
           </div>
         )}
       </div>

--- a/front/src/routes/integration/index.js
+++ b/front/src/routes/integration/index.js
@@ -291,8 +291,6 @@ class Integration extends Component {
       category && !VIRTUAL_CATEGORIES.includes(category) ? integrationsByType[category] || [] : integrations;
     // Load all categories
     let integrationCategories = categories;
-    // Total size
-    let totalSize = integrations.length;
 
     // Filter integrations and categories according to user role
     if (user.role !== USER_ROLE.ADMIN) {
@@ -305,8 +303,6 @@ class Integration extends Component {
       integrationCategories = integrationCategories.filter(
         i => HIDDEN_CATEGORIES_FOR_NON_ADMIN_USERS.indexOf(i.type) === -1
       );
-
-      totalSize = integrations.filter(i => HIDDEN_CATEGORIES_FOR_NON_ADMIN_USERS.indexOf(i.type) === -1).length;
     }
 
     // Get favorites (use cached state if available, otherwise empty)
@@ -338,19 +334,23 @@ class Integration extends Component {
       isFavorite: favorites.includes(card.key)
     }));
     selectedIntegrations = selectedIntegrations.concat(externalCards);
-    totalSize += externalCards.length;
 
     // If we are in favorites view, only display favorites
     if (category === 'favorites') {
       selectedIntegrations = selectedIntegrations.filter(integration => integration.isFavorite);
-      totalSize = selectedIntegrations.length;
     }
 
     // If we are in updates view, only display the integrations to update
     if (category === 'updates') {
       selectedIntegrations = selectedIntegrations.filter(integration => integration.updateAvailable);
-      totalSize = selectedIntegrations.length;
     }
+
+    // the total is the size of the view the user is currently looking at, once
+    // every filter that defines this view has been applied (role, category,
+    // favorites, updates) but before the search: it is the reference the search
+    // result count is compared to. Computing it any earlier would mix scopes,
+    // e.g. counting the integrations of every type while displaying only one
+    const totalSize = selectedIntegrations.length;
 
     // Filter
     if (searchKeyword && searchKeyword.length > 0) {


### PR DESCRIPTION
### Description

The `X of Y integrations` subtitle of the integration catalog displayed a total that did not mean the same thing depending on the view, which is what the forum topic reports.

**On a category page, the total was a meaningless mix of two scopes.** It started from `integrations.length` — every native integration, all types confused — and then added the store cards, which had already been filtered down to the current category. With the catalog as it stands today: 36 native integrations (all types) + 32 external device cards = the `68` of the reported `57 of 68`, while the page displays 57 device cards out of a 75 integration catalog. The `68` is neither the global total nor the category total.

**On the other views, the total was computed from the displayed list itself**, so it was equal to the displayed count by construction: `75 of 75` on "All integrations", `10 of 10` on "Favorites".

Changes:

- `totalSize` is now computed once, after every filter that defines the current view (role, category, favorites, updates) and before the search filter. That makes it the reference the search result count is compared to, and removes the scope mixing.
- The counter is only rendered as `X of Y` while a search narrows the list down; otherwise it shows the total alone (`75 integrations`). `IntegrationPageHeader` already computed a `showResultCount` flag for that purpose but only applied it to the mobile header, so the desktop one kept displaying `75 of 75` where mobile hid it. Both headers now share the same logic.
- The counter is hidden when the view is empty and no search is active — the page body already displays a message in that case.
- French wording: `X de Y` was a calque of the English `X of Y`, replaced by `X sur Y`. A `subtitleTotal` key is added to the three locale files.

## Forum

Forum: https://community.gladysassistant.com/t/calcul-du-nombre-total-dintegrations/10499

### Checklist

- [x] Tests pass: no server code is touched by this change, and there is no existing front test suite for this page. `npm run build` passes on the front.
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`). `npm run compare-translations` passes too, the three locale files stay in sync.
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAdRKWV6NEykDk8eXEupFT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAdRKWV6NEykDk8eXEupFT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integration catalog headers now display the total number of integrations.
  * Search results show both the matching count and overall total.
  * Counts reflect selected categories, favorites, and updates filters before search is applied.
  * Added and updated English, German, and French translations for integration totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->