### PR TITLE
Show labeled value lists in the scene editor instead of raw numbers

### DIFF
--- a/front/src/components/device/SelectDeviceFeatureValue.jsx
+++ b/front/src/components/device/SelectDeviceFeatureValue.jsx
@@ -1,0 +1,39 @@
+import { Text } from 'preact-i18n';
+import Select from 'react-select';
+
+import { isValueInOptions } from '../../utils/deviceFeatureValueOptions';
+
+/**
+ * @description Select one of the values a device feature holding constants can take.
+ * The options carry their translated label, so the scene editor shows "Vacuum" where it used to
+ * show the raw "5", like the device widget on the dashboard does.
+ * @param {Object} props - The component props.
+ * @param {Array} props.options - The list of { label, value } options.
+ * @param {any} props.value - The currently selected value, if any.
+ * @param {Function} props.updateValue - Called with the new value, or undefined when cleared.
+ * @returns {Object} The select.
+ * @example
+ * <SelectDeviceFeatureValue options={options} value={2} updateValue={setValue} />
+ */
+const SelectDeviceFeatureValue = ({ options, value, updateValue }) => {
+  // Controlled, and null when the value is not in the list: a value the feature does not declare
+  // must show as nothing selected rather than as a valid-looking choice.
+  const selectedOption = isValueInOptions(options, value)
+    ? options.find(option => `${option.value}` === `${value}`)
+    : null;
+
+  const handleChange = selectedValueOption => updateValue(selectedValueOption ? selectedValueOption.value : undefined);
+
+  return (
+    <Select
+      value={selectedOption}
+      onChange={handleChange}
+      options={options}
+      placeholder={<Text id="global.selectPlaceholder" />}
+      className="react-select-container"
+      classNamePrefix="react-select"
+    />
+  );
+};
+
+export default SelectDeviceFeatureValue;

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -3105,6 +3105,8 @@
         "valueLabel": "Wert",
         "valueTypeSimple": "Einfach",
         "simpleExplanationText": "Gebe hier den neuen Wert ein, den du deinem Gerät zuweisen möchten.",
+        "useCustomValue": "Eigenen Wert eingeben",
+        "useValueList": "Aus der Werteliste auswählen",
         "valueTypeComputed": "Berechnet",
         "computedExplanationText": "Anstelle eines festen Werts kannst du hier eine Berechnung auf Basis einer Szenenvariable eingeben. Um eine Variable in den Text einzufügen, gib \"{{\" ein. Um einen Variablenwert festzulegen, musst du zuerst das Feld \"Gerätewert abrufen\" verwenden."
       },
@@ -3396,6 +3398,8 @@
         "lessOrEqual": "kleiner oder gleich",
         "different": "unterschiedlich",
         "valuePlaceholder": "Wert",
+        "useCustomValue": "Eigenen Wert eingeben",
+        "useValueList": "Aus der Werteliste auswählen",
         "on": "Ein",
         "off": "Aus",
         "deviceSeen": "Wenn das Gerät erkannt wird",
@@ -4919,6 +4923,22 @@
           "4": "Kehrt zur Ladestation zurück",
           "5": "Lädt",
           "6": "Angedockt"
+        },
+        "run-mode": {
+          "unknown": "{{value}} (unbekannt)",
+          "0": "Leerlauf",
+          "1": "Reinigen",
+          "2": "Kartieren"
+        },
+        "clean-mode": {
+          "unknown": "{{value}} (unbekannt)",
+          "0": "Auto",
+          "1": "Schnell",
+          "2": "Leise",
+          "3": "Geräuscharm",
+          "4": "Tiefenreinigung",
+          "5": "Saugen",
+          "6": "Wischen"
         }
       },
       "water-heater": {

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -3105,6 +3105,8 @@
         "valueLabel": "Value",
         "valueTypeSimple": "Simple",
         "simpleExplanationText": "Enter the new value you wish to assign to your device here.",
+        "useCustomValue": "Enter a custom value",
+        "useValueList": "Choose from the list of values",
         "valueTypeComputed": "Computed",
         "computedExplanationText": "Instead of a fixed value, you can enter here a calculation based on a scene variable. To inject a variable in the text, press '{{'. To set a variable value, you need to use the 'Get device value' box before this one."
       },
@@ -3396,6 +3398,8 @@
         "lessOrEqual": "less or equal",
         "different": "different",
         "valuePlaceholder": "Value",
+        "useCustomValue": "Enter a custom value",
+        "useValueList": "Choose from the list of values",
         "on": "On",
         "off": "Off",
         "deviceSeen": "If the device is detected",
@@ -4919,6 +4923,22 @@
           "4": "Returning to Dock",
           "5": "Charging",
           "6": "Docked"
+        },
+        "run-mode": {
+          "unknown": "{{value}} (unknown)",
+          "0": "Idle",
+          "1": "Clean",
+          "2": "Map"
+        },
+        "clean-mode": {
+          "unknown": "{{value}} (unknown)",
+          "0": "Auto",
+          "1": "Quick",
+          "2": "Quiet",
+          "3": "Low Noise",
+          "4": "Deep Clean",
+          "5": "Vacuum",
+          "6": "Mop"
         }
       },
       "water-heater": {

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -3105,6 +3105,8 @@
         "valueLabel": "Valeur",
         "valueTypeSimple": "Simple",
         "simpleExplanationText": "Entrez ici la nouvelle valeur que vous souhaitez assigner à votre appareil.",
+        "useCustomValue": "Saisir une valeur personnalisée",
+        "useValueList": "Choisir dans la liste des valeurs",
         "valueTypeComputed": "Calculée",
         "computedExplanationText": "À la place d'une valeur fixe, vous pouvez entrer ici un calcul basé sur une variable de scène. Pour injecter une variable, tapez '{{'. Attention, vous devez avoir défini une variable auparavant dans une action 'Récupérer le dernier état' placé avant ce bloc."
       },
@@ -3396,6 +3398,8 @@
         "lessOrEqual": "inférieur ou égal",
         "different": "différent",
         "valuePlaceholder": "Valeur",
+        "useCustomValue": "Saisir une valeur personnalisée",
+        "useValueList": "Choisir dans la liste des valeurs",
         "on": "On",
         "off": "Off",
         "deviceSeen": "Si l'appareil est détecté",
@@ -4919,6 +4923,22 @@
           "4": "Retour à la base",
           "5": "En charge",
           "6": "Sur la base"
+        },
+        "run-mode": {
+          "unknown": "{{value}} (inconnu)",
+          "0": "Repos",
+          "1": "Nettoyer",
+          "2": "Cartographier"
+        },
+        "clean-mode": {
+          "unknown": "{{value}} (inconnu)",
+          "0": "Auto",
+          "1": "Rapide",
+          "2": "Silencieux",
+          "3": "Faible bruit",
+          "4": "Nettoyage profond",
+          "5": "Aspiration",
+          "6": "Serpillère"
         }
       },
       "water-heater": {

--- a/front/src/routes/scene/edit-scene/actions/DeviceSetValue.jsx
+++ b/front/src/routes/scene/edit-scene/actions/DeviceSetValue.jsx
@@ -107,7 +107,7 @@ class DeviceSetValue extends Component {
       return false;
     }
     const { value } = this.props.action;
-    return value === undefined || value === '' || isValueInOptions(valueOptions, value);
+    return value === undefined || value === null || value === '' || isValueInOptions(valueOptions, value);
   };
 
   handleNewEvalValue = text => {
@@ -286,17 +286,21 @@ class DeviceSetValue extends Component {
           )}
         </div>
 
-        <input
-          type="range"
-          value={this.props.action.value}
-          onChange={this.handleNewValue}
-          class={cx('form-control custom-range', {
-            'light-temperature': this.state.deviceFeature.type === DEVICE_FEATURE_TYPES.LIGHT.TEMPERATURE
-          })}
-          step="1"
-          min={this.state.deviceFeature.min}
-          max={this.state.deviceFeature.max}
-        />
+        {/* A feature holding constants has no continuous range to slide through: min/max are only
+            the bounds of its values, so the slider would be misleading next to a custom value */}
+        {!valueOptions && (
+          <input
+            type="range"
+            value={this.props.action.value}
+            onChange={this.handleNewValue}
+            class={cx('form-control custom-range', {
+              'light-temperature': this.state.deviceFeature.type === DEVICE_FEATURE_TYPES.LIGHT.TEMPERATURE
+            })}
+            step="1"
+            min={this.state.deviceFeature.min}
+            max={this.state.deviceFeature.max}
+          />
+        )}
         {valueOptions && (
           <small class="form-text">
             <a href="#" onClick={this.displayValueOptions}>

--- a/front/src/routes/scene/edit-scene/actions/DeviceSetValue.jsx
+++ b/front/src/routes/scene/edit-scene/actions/DeviceSetValue.jsx
@@ -5,6 +5,8 @@ import cx from 'classnames';
 import ColorPicker from '../../../../components/device/ColorPicker';
 
 import SelectDeviceFeature from '../../../../components/device/SelectDeviceFeature';
+import SelectDeviceFeatureValue from '../../../../components/device/SelectDeviceFeatureValue';
+import getDeviceFeatureValueOptions, { isValueInOptions } from '../../../../utils/deviceFeatureValueOptions';
 import withIntlAsProp from '../../../../utils/withIntlAsProp';
 
 import { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } from '../../../../../../server/utils/constants';
@@ -23,7 +25,8 @@ class DeviceSetValue extends Component {
     super(props);
     this.props = props;
     this.state = {
-      computed: props.action.evaluate_value !== undefined
+      computed: props.action.evaluate_value !== undefined,
+      customValue: false
     };
   }
 
@@ -35,7 +38,7 @@ class DeviceSetValue extends Component {
     // and took the whole scene editor down. Same shape as the trigger side's handler.
     if (!deviceFeature) {
       this.props.updateActionProperty(this.props.path, 'device_feature', null);
-      this.setState({ deviceFeature: null, device: null });
+      this.setState({ deviceFeature: null, device: null, customValue: false });
       return;
     }
 
@@ -55,6 +58,8 @@ class DeviceSetValue extends Component {
         this.props.updateActionProperty(this.props.path, 'value', undefined);
         this.props.updateActionProperty(this.props.path, 'evaluate_value', undefined);
       }
+      // The new feature comes with its own list of values, so we go back to that list
+      this.setState({ customValue: false });
     }
     this.setState({ deviceFeature, device });
   };
@@ -75,6 +80,34 @@ class DeviceSetValue extends Component {
     const newValue = previousValue === 1 ? 0 : 1;
     this.props.updateActionProperty(this.props.path, 'value', newValue);
     this.props.updateActionProperty(this.props.path, 'evaluate_value', undefined);
+  };
+
+  displayCustomValue = e => {
+    e.preventDefault();
+    this.setState({ customValue: true });
+  };
+
+  displayValueOptions = e => {
+    e.preventDefault();
+    this.setState({ customValue: false });
+    // A value that cannot be pre-selected in the list is dropped, otherwise the select would
+    // display nothing while the action still carries the old value
+    if (!isValueInOptions(this.getValueOptions(), this.props.action.value)) {
+      this.props.updateActionProperty(this.props.path, 'value', undefined);
+      this.props.updateActionProperty(this.props.path, 'evaluate_value', undefined);
+    }
+  };
+
+  getValueOptions = () => getDeviceFeatureValueOptions(this.props.intl.dictionary, this.state.deviceFeature);
+
+  // We display the list of values only if the feature holds constants, and if the current value can
+  // be represented in that list (it's not a value saved before this list existed)
+  shouldDisplayValueOptions = valueOptions => {
+    if (!valueOptions || this.state.customValue) {
+      return false;
+    }
+    const { value } = this.props.action;
+    return value === undefined || value === '' || isValueInOptions(valueOptions, value);
   };
 
   handleNewEvalValue = text => {
@@ -206,6 +239,29 @@ class DeviceSetValue extends Component {
       );
     }
 
+    // Features holding a known list of constants (vacuum cleaner run mode, lock state, siren
+    // mode...) get the same labeled list as the device widget, instead of a raw number to guess
+    const valueOptions = this.getValueOptions();
+    if (this.shouldDisplayValueOptions(valueOptions)) {
+      return (
+        <div>
+          <div className={style.explanationText}>
+            <Text id="editScene.actionsCard.deviceSetValue.simpleExplanationText" />
+          </div>
+          <SelectDeviceFeatureValue
+            options={valueOptions}
+            value={this.props.action.value}
+            updateValue={this.handleNewPureValue}
+          />
+          <small class="form-text">
+            <a href="#" onClick={this.displayCustomValue}>
+              <Text id="editScene.actionsCard.deviceSetValue.useCustomValue" />
+            </a>
+          </small>
+        </div>
+      );
+    }
+
     return (
       <div>
         <div className={style.explanationText}>
@@ -241,6 +297,13 @@ class DeviceSetValue extends Component {
           min={this.state.deviceFeature.min}
           max={this.state.deviceFeature.max}
         />
+        {valueOptions && (
+          <small class="form-text">
+            <a href="#" onClick={this.displayValueOptions}>
+              <Text id="editScene.actionsCard.deviceSetValue.useValueList" />
+            </a>
+          </small>
+        )}
       </div>
     );
   };

--- a/front/src/routes/scene/edit-scene/actions/only-continue-if/Condition.jsx
+++ b/front/src/routes/scene/edit-scene/actions/only-continue-if/Condition.jsx
@@ -3,6 +3,7 @@ import { Text, Localizer } from 'preact-i18n';
 import Select from 'react-select';
 import update from 'immutability-helper';
 
+import SelectDeviceFeatureValue from '../../../../../components/device/SelectDeviceFeatureValue';
 import TextWithVariablesInjected from '../../../../../components/scene/TextWithVariablesInjected';
 import getDeviceFeatureValueOptions, { isValueInOptions } from '../../../../../utils/deviceFeatureValueOptions';
 import withIntlAsProp from '../../../../../utils/withIntlAsProp';
@@ -10,8 +11,6 @@ import withIntlAsProp from '../../../../../utils/withIntlAsProp';
 import style from './Condition.css';
 
 const getDeviceFeature = option => (option && option.data ? option.data.deviceFeature : null);
-
-const isSameValue = (optionValue, conditionValue) => `${optionValue}` === `${conditionValue}`;
 
 class Condition extends Component {
   // The current value can be displayed in the list only if it's a raw value present in that list
@@ -42,10 +41,10 @@ class Condition extends Component {
     this.props.handleConditionChange(this.props.index, newCondition);
   };
 
-  handleValueOptionChange = selectedOption => {
+  handleValueOptionChange = value => {
     const newCondition = update(this.props.condition, {
       value: {
-        $set: selectedOption ? selectedOption.value : undefined
+        $set: value
       },
       evaluate_value: {
         $set: undefined
@@ -171,9 +170,6 @@ class Condition extends Component {
     const selectedOption = this.getSelectedOption();
     const valueOptions = this.getValueOptions(selectedOption);
     const showValueOptions = this.shouldDisplayValueOptions(valueOptions, customValue);
-    const selectedValueOption = showValueOptions
-      ? valueOptions.find(option => isSameValue(option.value, props.condition.value)) || null
-      : null;
     return (
       <div>
         <div class="row">
@@ -237,12 +233,10 @@ class Condition extends Component {
                 </span>
               </label>
               {showValueOptions && (
-                <Select
-                  value={selectedValueOption}
-                  onChange={this.handleValueOptionChange}
+                <SelectDeviceFeatureValue
                   options={valueOptions}
-                  className="react-select-container"
-                  classNamePrefix="react-select"
+                  value={props.condition.value}
+                  updateValue={this.handleValueOptionChange}
                 />
               )}
               {!showValueOptions && (

--- a/front/src/routes/scene/edit-scene/actions/only-continue-if/Condition.jsx
+++ b/front/src/routes/scene/edit-scene/actions/only-continue-if/Condition.jsx
@@ -4,7 +4,7 @@ import Select from 'react-select';
 import update from 'immutability-helper';
 
 import TextWithVariablesInjected from '../../../../../components/scene/TextWithVariablesInjected';
-import getDeviceFeatureValueOptions from '../../../../../utils/deviceFeatureValueOptions';
+import getDeviceFeatureValueOptions, { isValueInOptions } from '../../../../../utils/deviceFeatureValueOptions';
 import withIntlAsProp from '../../../../../utils/withIntlAsProp';
 
 import style from './Condition.css';
@@ -17,12 +17,7 @@ class Condition extends Component {
   // The current value can be displayed in the list only if it's a raw value present in that list
   isValueInValueOptions = valueOptions => {
     const { value, evaluate_value: evaluateValue } = this.props.condition;
-    return Boolean(
-      valueOptions &&
-        evaluateValue === undefined &&
-        value !== undefined &&
-        valueOptions.some(option => isSameValue(option.value, value))
-    );
+    return evaluateValue === undefined && isValueInOptions(valueOptions, value);
   };
 
   handleChange = selectedOption => {

--- a/front/src/routes/scene/edit-scene/actions/only-continue-if/Condition.jsx
+++ b/front/src/routes/scene/edit-scene/actions/only-continue-if/Condition.jsx
@@ -243,7 +243,7 @@ class Condition extends Component {
                 <Localizer>
                   <TextWithVariablesInjected
                     text={
-                      props.condition.value !== undefined
+                      props.condition.value !== undefined && props.condition.value !== null
                         ? props.condition.value.toString()
                         : props.condition.evaluate_value
                     }

--- a/front/src/routes/scene/edit-scene/triggers/device-states/DefaultDeviceState.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/device-states/DefaultDeviceState.jsx
@@ -3,7 +3,18 @@ import { Text, Localizer } from 'preact-i18n';
 
 import { DEVICE_FEATURE_CATEGORIES } from '../../../../../../../server/utils/constants';
 
+import SelectDeviceFeatureValue from '../../../../../components/device/SelectDeviceFeatureValue';
+import getDeviceFeatureValueOptions, { isValueInOptions } from '../../../../../utils/deviceFeatureValueOptions';
+import withIntlAsProp from '../../../../../utils/withIntlAsProp';
+
 class DefaultDeviceState extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      customValueSelector: null
+    };
+  }
+
   handleOperatorChange = e => {
     this.props.updateTriggerProperty(this.props.index, 'operator', e.target.value);
   };
@@ -28,8 +39,45 @@ class DefaultDeviceState extends Component {
     }
   };
 
+  handleValueOptionChange = value => {
+    this.props.updateTriggerProperty(this.props.index, 'value', value);
+  };
+
+  displayCustomValue = e => {
+    e.preventDefault();
+    // Tied to the feature it was asked for: this component is not remounted when another feature is
+    // selected, and the new one should start on its own list of values
+    this.setState({ customValueSelector: this.props.selectedDeviceFeature.selector });
+  };
+
+  displayValueOptions = e => {
+    e.preventDefault();
+    this.setState({ customValueSelector: null });
+    // A value that cannot be pre-selected in the list is dropped, otherwise the select would
+    // display nothing while the trigger still carries the old value
+    if (!isValueInOptions(this.getValueOptions(), this.props.trigger.value)) {
+      this.props.updateTriggerProperty(this.props.index, 'value', null);
+    }
+  };
+
+  getValueOptions = () => getDeviceFeatureValueOptions(this.props.intl.dictionary, this.props.selectedDeviceFeature);
+
+  // We display the list of values only if the feature holds constants, and if the current value can
+  // be represented in that list (it's not a value saved before this list existed)
+  shouldDisplayValueOptions = valueOptions => {
+    if (!valueOptions || this.state.customValueSelector === this.props.selectedDeviceFeature.selector) {
+      return false;
+    }
+    const { value } = this.props.trigger;
+    return value === undefined || value === null || value === '' || isValueInOptions(valueOptions, value);
+  };
+
   render({ selectedDeviceFeature, trigger }) {
     const isTextFeature = selectedDeviceFeature && selectedDeviceFeature.category === DEVICE_FEATURE_CATEGORIES.TEXT;
+    // Features holding a known list of constants (vacuum cleaner state, lock state, siren mode...)
+    // get the same labeled list as the device widget, instead of a raw number to guess
+    const valueOptions = this.getValueOptions();
+    const showValueOptions = this.shouldDisplayValueOptions(valueOptions);
 
     return (
       <Fragment>
@@ -70,24 +118,46 @@ class DefaultDeviceState extends Component {
         </div>
         <div class="col-12 col-md-4">
           <div class="form-group">
-            <div class="input-group">
-              <Localizer>
-                <input
-                  type="text"
-                  class="form-control"
-                  placeholder={<Text id="editScene.triggersCard.newState.valuePlaceholder" />}
-                  value={trigger.value}
-                  onChange={this.handleValueChange}
-                />
-              </Localizer>
-              {selectedDeviceFeature.unit && (
-                <span class="input-group-append" id="basic-addon2">
-                  <span class="input-group-text">
-                    <Text id={`deviceFeatureUnitShort.${selectedDeviceFeature.unit}`} />
+            {showValueOptions && (
+              <SelectDeviceFeatureValue
+                options={valueOptions}
+                value={trigger.value}
+                updateValue={this.handleValueOptionChange}
+              />
+            )}
+            {!showValueOptions && (
+              <div class="input-group">
+                <Localizer>
+                  <input
+                    type="text"
+                    class="form-control"
+                    placeholder={<Text id="editScene.triggersCard.newState.valuePlaceholder" />}
+                    value={trigger.value}
+                    onChange={this.handleValueChange}
+                  />
+                </Localizer>
+                {selectedDeviceFeature.unit && (
+                  <span class="input-group-append" id="basic-addon2">
+                    <span class="input-group-text">
+                      <Text id={`deviceFeatureUnitShort.${selectedDeviceFeature.unit}`} />
+                    </span>
                   </span>
-                </span>
-              )}
-            </div>
+                )}
+              </div>
+            )}
+            {valueOptions && (
+              <small class="form-text">
+                <a href="#" onClick={showValueOptions ? this.displayCustomValue : this.displayValueOptions}>
+                  <Text
+                    id={
+                      showValueOptions
+                        ? 'editScene.triggersCard.newState.useCustomValue'
+                        : 'editScene.triggersCard.newState.useValueList'
+                    }
+                  />
+                </a>
+              </small>
+            )}
           </div>
         </div>
       </Fragment>
@@ -95,4 +165,4 @@ class DefaultDeviceState extends Component {
   }
 }
 
-export default DefaultDeviceState;
+export default withIntlAsProp(DefaultDeviceState);

--- a/front/src/utils/deviceFeatureValueOptions.js
+++ b/front/src/utils/deviceFeatureValueOptions.js
@@ -25,6 +25,20 @@ const MATTER_INDEX_SENSOR_CATEGORIES = [
 const getValueLabel = (dictionary, path, value) => get(dictionary, `${path}.${value}`, { default: `${value}` });
 
 /**
+ * @description Tell if a value can be pre-selected in a list of options.
+ * @param {Array} options - The list of { label, value } options, or null.
+ * @param {any} value - The value to look for.
+ * @returns {boolean} True if the value is one of the options.
+ * @example
+ * const found = isValueInOptions([{ label: 'Idle', value: 0 }], '0');
+ */
+function isValueInOptions(options, value) {
+  // Values saved in scenes are not always typed like the options: a value entered by hand in the
+  // free input is a string, while the options built from the translations are numbers.
+  return Boolean(options && value !== undefined && options.some(option => `${option.value}` === `${value}`));
+}
+
+/**
  * @description Get the list of values a device feature can take, with their translated label.
  * @param {Object} dictionary - The i18n dictionary.
  * @param {Object} deviceFeature - The device feature.
@@ -85,4 +99,5 @@ function getDeviceFeatureValueOptions(dictionary, deviceFeature) {
   return options.length > 0 ? options : null;
 }
 
+export { isValueInOptions };
 export default getDeviceFeatureValueOptions;

--- a/front/src/utils/deviceFeatureValueOptions.js
+++ b/front/src/utils/deviceFeatureValueOptions.js
@@ -86,25 +86,23 @@ function getDeviceFeatureValueOptions(dictionary, deviceFeature) {
     ];
   }
 
-  // For all other features, the translations are the source of truth: a feature holding
-  // constants (button click, shutter state, pilot wire mode...) has one label per value.
+  // For all other features, two things can tell us a feature holds constants: the translations,
+  // which give one label per value (button click, shutter state, pilot wire mode...), and the
+  // supported_options the integration declared for this very appliance. Either one is enough.
   const valueLabels = get(dictionary, `deviceFeatureValue.category.${category}.${type}`);
-  if (!valueLabels) {
+  const supportedOptions = deviceFeature.supported_options;
+  if (!valueLabels && !(Array.isArray(supportedOptions) && supportedOptions.length > 0)) {
     return null;
   }
 
-  const catalog = Object.keys(valueLabels)
+  const catalog = Object.keys(valueLabels || {})
     .filter(key => NUMERIC_VALUE.test(key))
     .map(key => ({ value: Number(key) }))
     .sort((optionA, optionB) => optionA.value - optionB.value);
 
-  if (catalog.length === 0) {
-    return null;
-  }
-
   // When the integration declares which values this appliance actually supports, they drive the
   // list and its order, so a scene cannot be built on a mode the device does not have. A supported
-  // value outside the catalog keeps the label the device gave it.
+  // value the category knows nothing about keeps the label the device gave it.
   const options = resolveFeatureOptions(deviceFeature, catalog).map(option => ({
     value: option.value,
     label: getValueLabel(dictionary, `deviceFeatureValue.category.${category}.${type}`, option.value, option.label)

--- a/front/src/utils/deviceFeatureValueOptions.js
+++ b/front/src/utils/deviceFeatureValueOptions.js
@@ -6,6 +6,7 @@ import {
   LEVEL_MATTER_STATE,
   getFanFeatureOptions
 } from '../../../server/utils/constants';
+import { resolveFeatureOptions } from './supportedOptions';
 
 const NUMERIC_VALUE = /^-?\d+$/;
 
@@ -22,7 +23,8 @@ const MATTER_INDEX_SENSOR_CATEGORIES = [
   DEVICE_FEATURE_CATEGORIES.NO2_MATTER_INDEX_SENSOR
 ];
 
-const getValueLabel = (dictionary, path, value) => get(dictionary, `${path}.${value}`, { default: `${value}` });
+const getValueLabel = (dictionary, path, value, fallback) =>
+  get(dictionary, `${path}.${value}`, { default: fallback || `${value}` });
 
 /**
  * @description Tell if a value can be pre-selected in a list of options.
@@ -91,10 +93,22 @@ function getDeviceFeatureValueOptions(dictionary, deviceFeature) {
     return null;
   }
 
-  const options = Object.keys(valueLabels)
+  const catalog = Object.keys(valueLabels)
     .filter(key => NUMERIC_VALUE.test(key))
-    .map(key => ({ value: Number(key), label: valueLabels[key] }))
+    .map(key => ({ value: Number(key) }))
     .sort((optionA, optionB) => optionA.value - optionB.value);
+
+  if (catalog.length === 0) {
+    return null;
+  }
+
+  // When the integration declares which values this appliance actually supports, they drive the
+  // list and its order, so a scene cannot be built on a mode the device does not have. A supported
+  // value outside the catalog keeps the label the device gave it.
+  const options = resolveFeatureOptions(deviceFeature, catalog).map(option => ({
+    value: option.value,
+    label: getValueLabel(dictionary, `deviceFeatureValue.category.${category}.${type}`, option.value, option.label)
+  }));
 
   return options.length > 0 ? options : null;
 }


### PR DESCRIPTION
### Description

When a scene controls or tests a device feature that holds a known list of constants, the editor used to display raw numbers. Setting a Roborock's operating mode meant typing `2` and dragging a slider, and a condition on it compared against `0` — while the device widget on the dashboard has been offering a labeled dropdown ("Idle", "Vacuum"…) all along. There was no way to tell which number was which.

The scene editor now reuses the same labels wherever a feature holds a known list of values:

- **"Control a device" action** — a labeled select replaces the free text input and the range slider.
- **Device state trigger** — the same select replaces the free value input.
- **"Only continue if" condition** — already had this mechanism (`getDeviceFeatureValueOptions`); it now covers the vacuum cleaner too.

Each place keeps a small link to switch back to a free value, so scene variables and values saved before this list existed stay editable. A value that is not in the list keeps the free input selected by default, so no existing scene changes behavior or loses its value.

Vacuum cleaner run modes and clean modes were the missing piece: their labels only existed under `deviceFeatureAction`, keyed by name for the widget. They now also exist under `deviceFeatureValue`, keyed by value, in the three languages — the same shape the water heater already uses. As a side effect the device history displays them as text too.

Because the mechanism is driven by the translations rather than by a per-category branch, every other feature holding constants benefits at the same time: lock state, air conditioning mode / fan speed / swing, thermostat mode, siren volume, water valve status…

#### `supported_options`

The list also goes through `resolveFeatureOptions`, like the dashboard widgets and the water heater scene controls already did. When an integration has declared which values an appliance actually supports, those drive the list and its order (`sort_order`), so a scene cannot be built on a mode the device does not have; the translations still provide the label, and a supported value outside the category catalog keeps the label the device gave it. Features with no `supported_options` keep the full catalog, unchanged.

## Forum

Forum: https://community.gladysassistant.com/t/gladys-controler-ou-condition-sur-un-appareil-scene/10492

### Checklist

- [x] Tests pass: no server change in this PR, so `npm run coverage` is not impacted. Cypress could not be run in this environment (the Cypress binary download fails behind the proxy); the front changes were verified by mounting the edited components in jsdom against the real `fr.json` — a vacuum feature renders the labeled list, a numeric feature keeps its slider / free input untouched, a value outside the list keeps the free input, and a feature declaring `supported_options` offers only those values, in the declared order, with the catalog labels plus the device label for a value the catalog does not know.
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`), plus `npm run compare-translations` and `npm run build`
- [x] No undocumented breaking change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable value lists for supported device features in scene actions, conditions, and device-state triggers.
  * Added support for switching between predefined options and custom values.
  * Added localized device feature labels and vacuum-cleaner operating modes in English, German, and French.
  * Added fallback labels for unknown device values.

* **Bug Fixes**
  * Invalid or unavailable values are now cleared when switching back to predefined options.
  * Range controls are hidden when a feature provides fixed value options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->