### PR TITLE
fix: clarify Zigbee2mqtt scene action topic requires the zigbee2mqtt/ prefix (#2826)

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -3240,7 +3240,8 @@
       },
       "zigbee2mqttMessage": {
         "topic": "Topic",
-        "topicPlaceholder": "gladys/mein-topic",
+        "topicPlaceholder": "zigbee2mqtt/mein-geraet/set",
+        "topicExplanation": "Das Topic wird unverändert veröffentlicht: Du musst das vollständige MQTT-Topic angeben, einschließlich des Präfixes \"zigbee2mqtt/\" (zum Beispiel \"zigbee2mqtt/mein-geraet/set\").",
         "messageLabel": "Message",
         "variablesExplanation": "Um eine Variable im Text einzufügen, gib \"{{\" ein. Um einen Variablenwert festzulegen, musst du vor diesem Feld das das Feld \"Gerätewert abrufen\" verwenden.",
         "messagePlaceholder": "Meine Message"

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -3240,7 +3240,8 @@
       },
       "zigbee2mqttMessage": {
         "topic": "Topic",
-        "topicPlaceholder": "gladys/my-topic",
+        "topicPlaceholder": "zigbee2mqtt/my-device/set",
+        "topicExplanation": "The topic is published as-is: you must write the full MQTT topic, including the 'zigbee2mqtt/' prefix (for example 'zigbee2mqtt/my-device/set').",
         "messageLabel": "Message",
         "variablesExplanation": "To inject a variable in the text, press '{{ '. To set a variable value, you need to use the 'Get device value' box before this one.",
         "messagePlaceholder": "My message"

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -3240,7 +3240,8 @@
       },
       "zigbee2mqttMessage": {
         "topic": "Topic",
-        "topicPlaceholder": "gladys/my-topic",
+        "topicPlaceholder": "zigbee2mqtt/mon-appareil/set",
+        "topicExplanation": "Le topic est publié tel quel : vous devez écrire le topic MQTT complet, préfixe 'zigbee2mqtt/' inclus (par exemple 'zigbee2mqtt/mon-appareil/set').",
         "messageLabel": "Message",
         "variablesExplanation": "Pour injecter une variable, tapez '{{ '. Attention, vous devez avoir défini une variable auparavant dans une action 'Récupérer le dernier état' placé avant ce bloc message.",
         "messagePlaceholder": "Mon message"

--- a/front/src/routes/scene/edit-scene/actions/SendZigbee2MqttMessage.jsx
+++ b/front/src/routes/scene/edit-scene/actions/SendZigbee2MqttMessage.jsx
@@ -29,6 +29,9 @@ class SendZigbee2MqttMessage extends Component {
                 <Text id="global.requiredField" />
               </span>
             </label>
+            <div style={helpTextStyle}>
+              <Text id="editScene.actionsCard.zigbee2mqttMessage.topicExplanation" />
+            </div>
             <Localizer>
               <input
                 type="text"


### PR DESCRIPTION
> **This pull request was produced by an automated routine and has NOT been reviewed by a human.** Please review it carefully before merging.

Fixes #2826

### Description

**What changed and why**

The `Send a Zigbee2mqtt message` scene action (`ACTIONS.ZIGBEE2MQTT.SEND` in `server/lib/scene/scene.actions.js`) publishes `action.topic` verbatim — `server/services/zigbee2mqtt/lib/publish.js` does no prefixing, unlike the device path in `setValue.js`, which builds `` `zigbee2mqtt/${topic}/set` `` itself. But the topic field showed the generic MQTT placeholder `gladys/my-topic`, identical to the one used by the plain MQTT action. A user following that placeholder writes e.g. `relais_03/set`, the message is published on a topic nobody subscribes to, and nothing happens.

This is a front-end-only, behaviour-preserving clarification (existing scenes keep working exactly as before):

- `front/src/config/i18n/{en,fr,de}.json` — `editScene.actionsCard.zigbee2mqttMessage.topicPlaceholder` now shows a realistic full topic (`zigbee2mqtt/my-device/set` and its localized equivalents) instead of `gladys/my-topic`.
- Added a new `zigbee2mqttMessage.topicExplanation` key in all three locales, stating that the topic is published as-is and the full topic including the `zigbee2mqtt/` prefix is required.
- `front/src/routes/scene/edit-scene/actions/SendZigbee2MqttMessage.jsx` — renders that help text under the topic label, using the same `helpTextStyle` pattern already used for the message field in this component.

Scope note: the issue also mentions an adjacent question — `topic` is marked required in the UI but is only `Joi.string()` in `server/models/scene.js`, so a scene can be saved with no topic. That field is shared by several action types and the issue explicitly leaves the decision open, so it is **not** addressed here and issue #2826 can be reopened or a follow-up filed for it.

**What was verified locally** (in `front/`, deps installed with `CYPRESS_INSTALL_BINARY=0 npm ci`)

- `npm run prettier-check` — pass ("All matched files use Prettier code style!")
- `npm run eslint` — pass, 0 errors (189 pre-existing warnings repo-wide; the 2 in the touched file are the pre-existing `react/forbid-dom-props` inline-style warnings, one of which is the line added here, matching the existing convention in the same file)
- `npm run compare-translations` — pass, all three locale files reported complete
- `npm run build` — pass (Vite production build, built in 27.70s)
- No server files changed, so no server tests apply. Cypress was **not** run: the Cypress binary failed to download in this sandbox (checksum/size mismatch on the 10.11.0 download). No existing spec under `front/cypress/e2e/` references the scene action topic placeholder, so no E2E impact is expected — CI will confirm.

**What a human must check before merge**

- The wording of the three help strings, in particular the **German** one, which was written without a native reviewer.
- Whether the chosen placeholder (`zigbee2mqtt/my-device/set`) is the example you want, or whether a friendly-name based one would be clearer for Zigbee2mqtt users.
- That the help text renders acceptably in the scene editor action card (it adds a third line of text to a fairly compact box).
- Whether the real fix you want is instead to make the action prefix `zigbee2mqtt/` itself — that would be a breaking change for existing scenes, so this PR deliberately only follows the documentation fix suggested in the issue.

## Forum

<!-- Reported context: https://community.gladysassistant.com/t/alternatives-pour-les-scenes-interrompues-par-les-mises-a-jour/10505 -->

### Checklist

- [x] Tests pass: no server code changed, so `npm run coverage` does not apply; Cypress could not be run locally (binary download failed in the sandbox) — CI will run it
- [x] Linter and prettier pass on both front and server (front changed only: `npm run eslint`, `npm run prettier-check`, `npm run compare-translations`, `npm run build`)
- [x] No undocumented breaking change — text-only change, runtime behaviour is unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01MikdwoQX9BGzyhnjN1SrM6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Zigbee2MQTT scene-action instructions in English, German, and French.
  * Updated topic examples to include the complete `zigbee2mqtt/` prefix.
* **User Interface**
  * Added help text explaining that the full Zigbee2MQTT topic is published unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->