### PR TITLE
ci: accept the autofix fire URL from a secret as well as a variable

### DIFF
--- a/.github/CLAUDE_AUTOFIX.md
+++ b/.github/CLAUDE_AUTOFIX.md
@@ -99,9 +99,12 @@ environment. What remains is web-UI-only:
    **API** trigger.
 2. Copy the trigger URL
    (`https://api.anthropic.com/v1/claude_code/routines/trig_.../fire`) into
-   the repository **variable** `CLAUDE_AUTOFIX_FIRE_URL`.
+   the repository **variable** `CLAUDE_AUTOFIX_FIRE_URL` (Settings →
+   Secrets and variables → Actions → **Variables** tab; a secret of the
+   same name works too, the workflow accepts either).
 3. Click **Generate token** and store the `sk-ant-oat01-...` value (shown
-   once) as the repository **secret** `CLAUDE_AUTOFIX_ROUTINE_TOKEN`.
+   once) as the repository **secret** `CLAUDE_AUTOFIX_ROUTINE_TOKEN`
+   (**Secrets** tab).
 
 No Anthropic API key and no PAT are needed: sessions bill the claude.ai
 subscription, and their GitHub access comes from the account's GitHub

--- a/.github/workflows/claude-scheduled-autofix.yml
+++ b/.github/workflows/claude-scheduled-autofix.yml
@@ -358,7 +358,11 @@ jobs:
     steps:
       - name: 🚀 Fire a Claude Code cloud session
         env:
-          FIRE_URL: ${{ vars.CLAUDE_AUTOFIX_FIRE_URL }}
+          # The URL is not sensitive (the token is), so it belongs in a
+          # repository variable — but a secret of the same name works too,
+          # since mixing up the two tabs of Settings > Secrets and
+          # variables is an easy mistake.
+          FIRE_URL: ${{ vars.CLAUDE_AUTOFIX_FIRE_URL || secrets.CLAUDE_AUTOFIX_FIRE_URL }}
           FIRE_TOKEN: ${{ secrets.CLAUDE_AUTOFIX_ROUTINE_TOKEN }}
           PR_NUMBER: ${{ matrix.pr.number }}
           PR_BRANCH: ${{ matrix.pr.branch }}
@@ -368,8 +372,11 @@ jobs:
         run: |
           set -uo pipefail
 
-          if [ -z "${FIRE_URL:-}" ] || [ -z "${FIRE_TOKEN:-}" ]; then
-            echo "::error::Missing CLAUDE_AUTOFIX_FIRE_URL (repository variable) or CLAUDE_AUTOFIX_ROUTINE_TOKEN (secret). See .github/CLAUDE_AUTOFIX.md for the one-time routine setup."
+          MISSING=''
+          [ -n "${FIRE_URL:-}" ] || MISSING="CLAUDE_AUTOFIX_FIRE_URL (repository variable, or secret)"
+          [ -n "${FIRE_TOKEN:-}" ] || MISSING="${MISSING:+$MISSING and }CLAUDE_AUTOFIX_ROUTINE_TOKEN (repository secret)"
+          if [ -n "$MISSING" ]; then
+            echo "::error::Missing: $MISSING. Both live under Settings > Secrets and variables > Actions. See .github/CLAUDE_AUTOFIX.md for the one-time routine setup."
             exit 1
           fi
 


### PR DESCRIPTION
### Description

Follow-up to #2838. The `fire` job read `CLAUDE_AUTOFIX_FIRE_URL` exclusively from the `vars` context, so storing it in the **Secrets** tab (an easy mix-up in *Settings → Secrets and variables → Actions*) left `FIRE_URL` empty and failed the guard with a message blaming both values at once — which is exactly what happened on the first real run.

- `FIRE_URL` now falls back to a secret of the same name: `vars.CLAUDE_AUTOFIX_FIRE_URL || secrets.CLAUDE_AUTOFIX_FIRE_URL`.
- The guard reports exactly which value is missing and where each one lives, instead of a combined message.
- `.github/CLAUDE_AUTOFIX.md` setup steps now point at the right tabs (Variables vs Secrets).

## Forum

### Checklist

- [x] Tests pass: CI-only change, no server/front code touched
- [x] Linter and prettier pass on both front and server (no front/server files changed)
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxWshsBa124xbKSEQH5m5h)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to clarify supported locations for the autofix trigger URL and routine token.

* **Bug Fixes**
  * Improved configuration handling by accepting the trigger URL from either a repository variable or secret.
  * Enhanced validation messages to identify missing settings and supported configuration locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->