### PR TITLE
Add a "back to integrations" link on every integration page

### DIFF
--- a/front/src/components/integration/BackToIntegrationsLink.jsx
+++ b/front/src/components/integration/BackToIntegrationsLink.jsx
@@ -1,0 +1,19 @@
+import { Text } from 'preact-i18n';
+import { Link } from 'preact-router/match';
+import { getBackToCatalogUrl } from '../../routes/integration/catalog-url';
+
+// Every integration page is reached from the integration catalog, but nothing
+// on the page led back to it: on mobile especially, the browser back button
+// was the only way out. The link points at the catalog view the user came
+// from (category, search and sort order travel in the URL), and falls back to
+// the whole catalog when the page was opened directly.
+const BackToIntegrationsLink = () => (
+  <div class="mb-4">
+    <Link href={getBackToCatalogUrl()} class="btn btn-secondary btn-sm">
+      <i class="fe fe-arrow-left mr-1" />
+      <Text id="integration.backToIntegrations" />
+    </Link>
+  </div>
+);
+
+export default BackToIntegrationsLink;

--- a/front/src/components/integration/BackToIntegrationsLink.jsx
+++ b/front/src/components/integration/BackToIntegrationsLink.jsx
@@ -5,8 +5,10 @@ import { getBackToCatalogUrl } from '../../routes/integration/catalog-url';
 // Every integration page is reached from the integration catalog, but nothing
 // on the page led back to it: on mobile especially, the browser back button
 // was the only way out. The link points at the catalog view the user came
-// from (category, search and sort order travel in the URL), and falls back to
-// the whole catalog when the page was opened directly.
+// from, with its category, search and sort order. Only the install page
+// carries them in its own query string; the other integration routes cannot
+// (see catalog-url.js) and rely on the catalog view remembered there. Both
+// fall back to the whole catalog.
 const BackToIntegrationsLink = () => (
   <div class="mb-4">
     <Link href={getBackToCatalogUrl()} class="btn btn-secondary btn-sm">

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -905,7 +905,6 @@
         "updateTitle": "Die Integration hat dieses Gerät mit einer anderen Struktur erneut veröffentlicht: neue Definition anwenden"
       },
       "install": {
-        "backToCatalog": "Zurück zu den Integrationen",
         "notFound": "Diese Integration wurde nicht im Store gefunden.",
         "starsLabel": "Sterne",
         "lastPushLabel": "Letzte Aktualisierung:",
@@ -2988,6 +2987,7 @@
       "keyNameLabel": "Schlüssel:",
       "registeredLabel": "Registriert am:"
     },
+    "backToIntegrations": "Zurück zu den Integrationen",
     "deprecationWarning": "Diese native Integration wird bald zugunsten einer gleichwertigen externen Community-Integration <b>eingestellt</b>. Beide Versionen werden während der Übergangszeit im Katalog nebeneinander bestehen — du kannst diese vorerst weiter verwenden."
   },
   "editScene": {

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -905,7 +905,6 @@
         "updateTitle": "The integration re-published this device with a different structure: apply the new definition"
       },
       "install": {
-        "backToCatalog": "Back to integrations",
         "notFound": "This integration was not found in the store.",
         "starsLabel": "stars",
         "lastPushLabel": "Last update:",
@@ -2988,6 +2987,7 @@
       "keyNameLabel": "Key:",
       "registeredLabel": "Registered on:"
     },
+    "backToIntegrations": "Back to integrations",
     "deprecationWarning": "This built-in integration will soon be <b>deprecated</b> in favor of an equivalent community external integration. Both versions will co-exist in the catalog during the transition — you can keep using this one for now."
   },
   "editScene": {

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -905,7 +905,6 @@
         "updateTitle": "L'intégration a re-publié cet appareil avec une structure différente : appliquer la nouvelle définition"
       },
       "install": {
-        "backToCatalog": "Retour aux intégrations",
         "notFound": "Cette intégration n'a pas été trouvée dans le store.",
         "starsLabel": "étoiles",
         "lastPushLabel": "Dernière mise à jour :",
@@ -2988,6 +2987,7 @@
       "keyNameLabel": "Clé :",
       "registeredLabel": "Enregistré le :"
     },
+    "backToIntegrations": "Retour aux intégrations",
     "deprecationWarning": "Cette intégration native sera bientôt <b>dépréciée</b> au profit d'une intégration externe équivalente maintenue par la communauté. Les deux versions vont co-exister dans le catalogue pendant la transition — vous pouvez continuer à utiliser celle-ci pour le moment."
   },
   "editScene": {

--- a/front/src/routes/integration/all/airplay/AirplayPage.jsx
+++ b/front/src/routes/integration/all/airplay/AirplayPage.jsx
@@ -1,6 +1,7 @@
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const AirplayPage = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const AirplayPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.airplay.title" />
               </h3>

--- a/front/src/routes/integration/all/alexa-gateway/welcome.jsx
+++ b/front/src/routes/integration/all/alexa-gateway/welcome.jsx
@@ -2,6 +2,7 @@ import { Text, MarkupText } from 'preact-i18n';
 import { connect } from 'unistore/preact';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
 import GladysPlusUpsell from '../../../../components/gateway/GladysPlusUpsell';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const AlexaWelcomePage = ({ user }) => (
   <div class="page">
@@ -10,6 +11,7 @@ const AlexaWelcomePage = ({ user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.alexa.title" />
               </h3>

--- a/front/src/routes/integration/all/bluetooth/BluetoothPage.js
+++ b/front/src/routes/integration/all/bluetooth/BluetoothPage.js
@@ -1,6 +1,7 @@
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const BluetoothPage = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const BluetoothPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.bluetooth.title" />
               </h3>

--- a/front/src/routes/integration/all/broadlink/BroadlinkPage.js
+++ b/front/src/routes/integration/all/broadlink/BroadlinkPage.js
@@ -1,6 +1,7 @@
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const BroadlinkPage = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const BroadlinkPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.broadlink.title" />
               </h3>

--- a/front/src/routes/integration/all/caldav/CalDAV.js
+++ b/front/src/routes/integration/all/caldav/CalDAV.js
@@ -1,6 +1,7 @@
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const CalDAV = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const CalDAV = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.caldav.title" />
               </h3>

--- a/front/src/routes/integration/all/callmebot/CallMeBot.jsx
+++ b/front/src/routes/integration/all/callmebot/CallMeBot.jsx
@@ -1,6 +1,7 @@
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const CallMeBotPage = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const CallMeBotPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.callmebot.title" />
               </h3>

--- a/front/src/routes/integration/all/enedis-gateway/EnedisPage.jsx
+++ b/front/src/routes/integration/all/enedis-gateway/EnedisPage.jsx
@@ -1,6 +1,7 @@
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const EnedisPage = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const EnedisPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.enedis.title" />
               </h3>

--- a/front/src/routes/integration/all/energy-monitoring/EnergyMonitoring.jsx
+++ b/front/src/routes/integration/all/energy-monitoring/EnergyMonitoring.jsx
@@ -6,6 +6,7 @@ import cx from 'classnames';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
 import ImportPricesPage from './ImportPrices';
 import withIntlAsProp from '../../../../utils/withIntlAsProp';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 import {
   DEVICE_FEATURE_CATEGORIES,
   DEVICE_FEATURE_TYPES,
@@ -1557,6 +1558,7 @@ class EnergyMonitoringPage extends Component {
             <div class="container">
               <div class="row">
                 <div class="col-lg-3">
+                  <BackToIntegrationsLink />
                   <h3 class="page-title mb-5">
                     <Text id="integration.energyMonitoring.title" />
                   </h3>

--- a/front/src/routes/integration/all/ewelink/EweLinkPage.jsx
+++ b/front/src/routes/integration/all/ewelink/EweLinkPage.jsx
@@ -1,6 +1,7 @@
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const EweLinkPage = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const EweLinkPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.eWeLink.title" />
               </h3>

--- a/front/src/routes/integration/all/external-integration/ExternalIntegrationPage.jsx
+++ b/front/src/routes/integration/all/external-integration/ExternalIntegrationPage.jsx
@@ -4,6 +4,7 @@ import { connect } from 'unistore/preact';
 import get from 'get-value';
 
 import { USER_ROLE } from '../../../../../../server/utils/constants';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 // last known display name per integration: each tab reloads the integration
 // on mount, and showing the raw selector while it loads made the title
@@ -38,6 +39,7 @@ const ExternalIntegrationPage = ({ selector, integration, user, children }) => {
           <div class="container">
             <div class="row">
               <div class="col-lg-3">
+                <BackToIntegrationsLink />
                 <h3 class="page-title mb-5">{getDisplayName(selector, integration)}</h3>
                 <div>
                   <div class="list-group list-group-transparent mb-0">

--- a/front/src/routes/integration/all/external-integration/install-page/index.js
+++ b/front/src/routes/integration/all/external-integration/install-page/index.js
@@ -7,7 +7,7 @@ import cx from 'classnames';
 import get from 'get-value';
 
 import { getLocalizedText, getGithubRepoUrl, getRequestedHardwareClasses } from '../utils';
-import { getBackToCatalogUrl } from '../../../catalog-url';
+import BackToIntegrationsLink from '../../../../../components/integration/BackToIntegrationsLink';
 import SubContainersSummary from '../components/SubContainersSummary';
 import HardwareSwitches from '../components/HardwareSwitches';
 import NetworkDiscoverySummary from '../components/NetworkDiscoverySummary';
@@ -148,12 +148,7 @@ class ExternalIntegrationInstallPage extends Component {
             <div class="container">
               <div class="row justify-content-center">
                 <div class="col-lg-8">
-                  <div class="mb-4">
-                    <Link href={getBackToCatalogUrl()} class="btn btn-secondary btn-sm">
-                      <i class="fe fe-arrow-left mr-1" />
-                      <Text id="integration.externalIntegration.install.backToCatalog" />
-                    </Link>
-                  </div>
+                  <BackToIntegrationsLink />
                   <div
                     class={cx('dimmer', {
                       active: loadStatus === RequestStatus.Getting

--- a/front/src/routes/integration/all/free-mobile/FreeMobile.jsx
+++ b/front/src/routes/integration/all/free-mobile/FreeMobile.jsx
@@ -2,6 +2,7 @@ import { Text, MarkupText, Localizer } from 'preact-i18n';
 import cx from 'classnames';
 import { RequestStatus } from '../../../../utils/consts';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const FreeMobilePage = ({ children, ...props }) => (
   <div class="page">
@@ -10,6 +11,7 @@ const FreeMobilePage = ({ children, ...props }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.free-mobile.title" />
               </h3>

--- a/front/src/routes/integration/all/google-cast/GoogleCastPage.jsx
+++ b/front/src/routes/integration/all/google-cast/GoogleCastPage.jsx
@@ -1,6 +1,7 @@
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const GoogleCastPage = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const GoogleCastPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.google-cast.title" />
               </h3>

--- a/front/src/routes/integration/all/google-home-gateway/welcome.jsx
+++ b/front/src/routes/integration/all/google-home-gateway/welcome.jsx
@@ -2,6 +2,7 @@ import { Text, MarkupText } from 'preact-i18n';
 import { connect } from 'unistore/preact';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
 import GladysPlusUpsell from '../../../../components/gateway/GladysPlusUpsell';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const GoogleWelcomePage = ({ user }) => (
   <div class="page">
@@ -10,6 +11,7 @@ const GoogleWelcomePage = ({ user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.googleHome.title" />
               </h3>

--- a/front/src/routes/integration/all/homekit/HomeKit.jsx
+++ b/front/src/routes/integration/all/homekit/HomeKit.jsx
@@ -6,6 +6,7 @@ import cx from 'classnames';
 import style from './style.css';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
 import { EXPOSURE_MODES } from './actions';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const mdnsAdvertisers = {
   AVAHI: 'avahi',
@@ -48,6 +49,7 @@ const HomKitPage = ({ children, ...props }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.homekit.title" />
               </h3>

--- a/front/src/routes/integration/all/lan-manager/LANManagerPage.js
+++ b/front/src/routes/integration/all/lan-manager/LANManagerPage.js
@@ -1,6 +1,7 @@
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const LANManagerPage = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const LANManagerPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.lanManager.title" />
               </h3>

--- a/front/src/routes/integration/all/matter/MatterPage.jsx
+++ b/front/src/routes/integration/all/matter/MatterPage.jsx
@@ -1,6 +1,7 @@
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const MatterPage = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const MatterPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.matter.title" />
               </h3>

--- a/front/src/routes/integration/all/matterbridge/MatterbridgePage.js
+++ b/front/src/routes/integration/all/matterbridge/MatterbridgePage.js
@@ -1,6 +1,7 @@
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const MatterbridgePage = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const MatterbridgePage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.matterbridge.title" />
               </h3>

--- a/front/src/routes/integration/all/mcp/mcp.jsx
+++ b/front/src/routes/integration/all/mcp/mcp.jsx
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
 import config from '../../../../config';
 import MCPApiKey from './MCPApiKeys';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const MCPWelcomePage = ({ user, ...props }) => (
   <div class="page">
@@ -12,6 +13,7 @@ const MCPWelcomePage = ({ user, ...props }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.mcp.title" />
               </h3>

--- a/front/src/routes/integration/all/melcloud/MELCloudPage.jsx
+++ b/front/src/routes/integration/all/melcloud/MELCloudPage.jsx
@@ -2,6 +2,7 @@ import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
 import DeprecationWarning from '../../../../components/integration/DeprecationWarning';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const MELCloudPage = ({ children, user }) => (
   <div class="page">
@@ -10,6 +11,7 @@ const MELCloudPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.melcloud.title" />
               </h3>

--- a/front/src/routes/integration/all/mqtt/MqttPage.js
+++ b/front/src/routes/integration/all/mqtt/MqttPage.js
@@ -1,6 +1,7 @@
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const MqttPage = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const MqttPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.mqtt.title" />
               </h3>

--- a/front/src/routes/integration/all/netatmo/NetatmoPage.jsx
+++ b/front/src/routes/integration/all/netatmo/NetatmoPage.jsx
@@ -2,6 +2,7 @@ import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
 import DeprecationWarning from '../../../../components/integration/DeprecationWarning';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const NetatmoPage = props => (
   <div class="page">
@@ -10,6 +11,7 @@ const NetatmoPage = props => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.netatmo.title" />
               </h3>

--- a/front/src/routes/integration/all/nextcloud-talk/NextcloudTalk.jsx
+++ b/front/src/routes/integration/all/nextcloud-talk/NextcloudTalk.jsx
@@ -2,6 +2,7 @@ import { Text, MarkupText, Localizer } from 'preact-i18n';
 import cx from 'classnames';
 import { RequestStatus } from '../../../../utils/consts';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const NextcloudTalkPage = ({ children, ...props }) => (
   <div class="page">
@@ -10,6 +11,7 @@ const NextcloudTalkPage = ({ children, ...props }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.nextcloudTalk.title" />
               </h3>

--- a/front/src/routes/integration/all/node-red/NodeRedPage.js
+++ b/front/src/routes/integration/all/node-red/NodeRedPage.js
@@ -1,6 +1,7 @@
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const NodeRedPage = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const NodeRedPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.nodeRed.title" />
               </h3>

--- a/front/src/routes/integration/all/nuki/NukiPage.js
+++ b/front/src/routes/integration/all/nuki/NukiPage.js
@@ -1,6 +1,7 @@
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const NukiPage = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const NukiPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.nuki.title" />
               </h3>

--- a/front/src/routes/integration/all/openai/Layout.jsx
+++ b/front/src/routes/integration/all/openai/Layout.jsx
@@ -1,5 +1,6 @@
 import { Text } from 'preact-i18n';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const Layout = ({ children, user }) => (
   <div class="page">
@@ -8,6 +9,7 @@ const Layout = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.openai.title" />
               </h3>

--- a/front/src/routes/integration/all/openweather/OpenWeather.jsx
+++ b/front/src/routes/integration/all/openweather/OpenWeather.jsx
@@ -1,6 +1,7 @@
 import { Text, MarkupText, Localizer } from 'preact-i18n';
 import cx from 'classnames';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const OpenWeatherPage = ({ children, ...props }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const OpenWeatherPage = ({ children, ...props }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.openWeather.title" />
               </h3>

--- a/front/src/routes/integration/all/owntracks/welcome.jsx
+++ b/front/src/routes/integration/all/owntracks/welcome.jsx
@@ -1,6 +1,7 @@
 import { Text, MarkupText } from 'preact-i18n';
 import { connect } from 'unistore/preact';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const OwntracksWelcomePage = ({ user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const OwntracksWelcomePage = ({ user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.owntracks.title" />
               </h3>

--- a/front/src/routes/integration/all/philips-hue/PhilipsHuePage.jsx
+++ b/front/src/routes/integration/all/philips-hue/PhilipsHuePage.jsx
@@ -2,6 +2,7 @@ import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
 import DeprecationWarning from '../../../../components/integration/DeprecationWarning';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const PhilipsHuePage = ({ children, user }) => (
   <div class="page">
@@ -10,6 +11,7 @@ const PhilipsHuePage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.philipsHue.title" />
               </h3>

--- a/front/src/routes/integration/all/rtsp-camera/RtspCamera.jsx
+++ b/front/src/routes/integration/all/rtsp-camera/RtspCamera.jsx
@@ -7,6 +7,7 @@ import { RequestStatus } from '../../../../utils/consts';
 import style from './style.css';
 import CardFilter from '../../../../components/layout/CardFilter';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const RtspCameraPage = ({ children, ...props }) => (
   <div class="page">
@@ -15,6 +16,7 @@ const RtspCameraPage = ({ children, ...props }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.rtspCamera.title" />
               </h3>

--- a/front/src/routes/integration/all/sonos/SonosPage.jsx
+++ b/front/src/routes/integration/all/sonos/SonosPage.jsx
@@ -1,6 +1,7 @@
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const SonosPage = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const SonosPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.sonos.title" />
               </h3>

--- a/front/src/routes/integration/all/tasmota/TasmotaPage.js
+++ b/front/src/routes/integration/all/tasmota/TasmotaPage.js
@@ -1,6 +1,7 @@
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const TasmotaPage = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const TasmotaPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.tasmota.title" />
               </h3>

--- a/front/src/routes/integration/all/telegram/Telegram.jsx
+++ b/front/src/routes/integration/all/telegram/Telegram.jsx
@@ -4,6 +4,7 @@ import { USER_ROLE } from '../../../../../../server/utils/constants';
 import cx from 'classnames';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
 import DeprecationWarning from '../../../../components/integration/DeprecationWarning';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const TelegramPage = ({ children, ...props }) => (
   <div class="page">
@@ -12,6 +13,7 @@ const TelegramPage = ({ children, ...props }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.telegram.title" />
               </h3>

--- a/front/src/routes/integration/all/tp-link/TpLinkPage.jsx
+++ b/front/src/routes/integration/all/tp-link/TpLinkPage.jsx
@@ -2,6 +2,7 @@ import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
 import DeprecationWarning from '../../../../components/integration/DeprecationWarning';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const TpLinkPage = ({ children, user }) => (
   <div class="page">
@@ -10,6 +11,7 @@ const TpLinkPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.tpLink.title" />
               </h3>

--- a/front/src/routes/integration/all/tuya/TuyaPage.jsx
+++ b/front/src/routes/integration/all/tuya/TuyaPage.jsx
@@ -2,6 +2,7 @@ import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
 import DeprecationWarning from '../../../../components/integration/DeprecationWarning';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const TuyaPage = ({ children, user }) => (
   <div class="page">
@@ -10,6 +11,7 @@ const TuyaPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.tuya.title" />
               </h3>

--- a/front/src/routes/integration/all/xiaomi/XiaomiLayout.jsx
+++ b/front/src/routes/integration/all/xiaomi/XiaomiLayout.jsx
@@ -1,6 +1,7 @@
 import { Text, MarkupText } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const XiaomiLayout = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const XiaomiLayout = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.xiaomi.title" />
               </h3>

--- a/front/src/routes/integration/all/zigbee2mqtt/Zigbee2mqttPage.js
+++ b/front/src/routes/integration/all/zigbee2mqtt/Zigbee2mqttPage.js
@@ -1,6 +1,7 @@
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const Zigbee2mqttPage = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const Zigbee2mqttPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.zigbee2mqtt.title" />
               </h3>

--- a/front/src/routes/integration/all/zwavejs-ui/ZwaveJSUIPage.jsx
+++ b/front/src/routes/integration/all/zwavejs-ui/ZwaveJSUIPage.jsx
@@ -1,6 +1,7 @@
 import { Text } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
+import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
 
 const ZwaveJSUIPage = ({ children, user }) => (
   <div class="page">
@@ -9,6 +10,7 @@ const ZwaveJSUIPage = ({ children, user }) => (
         <div class="container">
           <div class="row">
             <div class="col-lg-3">
+              <BackToIntegrationsLink />
               <h3 class="page-title mb-5">
                 <Text id="integration.zwavejs-ui.title" />
               </h3>

--- a/front/src/routes/integration/catalog-url.js
+++ b/front/src/routes/integration/catalog-url.js
@@ -71,12 +71,20 @@ export const rememberCatalogUrl = url => {
   lastCatalogUrl = url;
 };
 
+// a remembered URL carries its filters in the query string, so only its path
+// is compared to the known catalog views. It is written from getCatalogUrl()
+// alone today: checking it keeps the guarantee held by the "from" parameter,
+// that this helper never sends the user outside of the catalog
+const isCatalogUrl = url => typeof url === 'string' && CATALOG_PATHS.has(url.split('?')[0]);
+
 export const getBackToCatalogUrl = (queryString = window.location.search) => {
   const from = new URLSearchParams(queryString).get('from');
-  // the parameter comes from the URL: fall back to the last catalog seen
-  // rather than trusting an arbitrary path
+  // the parameter comes from the URL: fall back to the last catalog seen, then
+  // to the whole catalog, rather than trusting an arbitrary path
   if (!CATALOG_PATHS.has(from)) {
-    return lastCatalogUrl || CATALOG_BASE_URL;
+    return isCatalogUrl(lastCatalogUrl)
+      ? lastCatalogUrl
+      : withQuery(CATALOG_BASE_URL, buildFilterParams(getCatalogFilters(queryString)));
   }
   return withQuery(from, buildFilterParams(getCatalogFilters(queryString)));
 };

--- a/front/src/routes/integration/catalog-url.js
+++ b/front/src/routes/integration/catalog-url.js
@@ -58,10 +58,25 @@ export const getUrlFromCatalog = (path, { category, searchKeyword, orderDir }) =
   return withQuery(path, urlParams);
 };
 
+// last catalog view the user visited. The native integration pages cannot
+// carry the filters in their own URL the way the install page does: their
+// query string is handed to the page component as props by preact-router,
+// where a "search" parameter would shadow the search action of the pages that
+// have one. Remembering the catalog here keeps their back link accurate
+// without touching their URL — a page reload simply forgets it and the link
+// falls back to the whole catalog.
+let lastCatalogUrl = null;
+
+export const rememberCatalogUrl = url => {
+  lastCatalogUrl = url;
+};
+
 export const getBackToCatalogUrl = (queryString = window.location.search) => {
   const from = new URLSearchParams(queryString).get('from');
-  // the parameter comes from the URL: fall back to the whole catalog rather
-  // than trusting an arbitrary path
-  const path = CATALOG_PATHS.has(from) ? from : CATALOG_BASE_URL;
-  return withQuery(path, buildFilterParams(getCatalogFilters(queryString)));
+  // the parameter comes from the URL: fall back to the last catalog seen
+  // rather than trusting an arbitrary path
+  if (!CATALOG_PATHS.has(from)) {
+    return lastCatalogUrl || CATALOG_BASE_URL;
+  }
+  return withQuery(from, buildFilterParams(getCatalogFilters(queryString)));
 };

--- a/front/src/routes/integration/index.js
+++ b/front/src/routes/integration/index.js
@@ -9,7 +9,7 @@ import { USER_ROLE, WEBSOCKET_MESSAGE_TYPES } from '../../../../server/utils/con
 import debounce from 'debounce';
 import { integrations, integrationsByType, categories } from '../../config/integrations';
 import { getLocalizedText } from './all/external-integration/utils';
-import { getCatalogFilters, getCatalogUrl, getUrlFromCatalog } from './catalog-url';
+import { getCatalogFilters, getCatalogUrl, getUrlFromCatalog, rememberCatalogUrl } from './catalog-url';
 import createActionsExternalIntegrationUpdates from '../../actions/externalIntegrationUpdates';
 import { RequestStatus } from '../../utils/consts';
 
@@ -374,6 +374,10 @@ class Integration extends Component {
     // the counter is computed from the installed integrations, not from the
     // cards being displayed: it must stay the same in every category
     const integrationsToUpdate = this.countIntegrationsToUpdate();
+
+    // the integration pages send the user back here: this runs on mount and on
+    // every filter change, so the remembered view is always the current one
+    rememberCatalogUrl(getCatalogUrl({ category, searchKeyword, orderDir }));
 
     this.setState({
       integrations: selectedIntegrations,

--- a/front/src/routes/integration/index.js
+++ b/front/src/routes/integration/index.js
@@ -40,8 +40,13 @@ class Integration extends Component {
   // a render, the new value is not readable in the state right away
   updateURL(filters = this.state) {
     const { searchKeyword, orderDir } = filters;
+    const url = getCatalogUrl({ category: this.props.category, searchKeyword, orderDir });
+    // the list is only reloaded 300ms later (the search is debounced): without
+    // this, opening an integration in between would send its back link to the
+    // previous view, while the browser back button already goes to this one
+    rememberCatalogUrl(url);
     // replace and not push: filtering should not fill the browser history
-    route(getCatalogUrl({ category: this.props.category, searchKeyword, orderDir }), true);
+    route(url, true);
   }
 
   componentWillMount() {


### PR DESCRIPTION
### Description

Integration pages are reached from the integration catalog, but nothing on them led back to it: the browser back button was the only way out, which is awkward on mobile where it is not always visible. The external integration *install* page already had a "Back to integrations" button — this brings the same thing to every other integration page.

A shared `BackToIntegrationsLink` component is now rendered at the top of the left column of every integration layout — the 36 native ones (Zigbee2mqtt, Philips Hue, MQTT, Tasmota, Matter, Energy monitoring…) plus the installed external integration layout. It reuses the exact markup the install page already had (`btn btn-secondary btn-sm` + `fe fe-arrow-left`), and the install page now renders the shared component too instead of its own copy.

**Where the link points.** It goes back to the catalog view the user came from, so the category, search keyword and sort order are restored:

- The install page carries `?from=…&search=…&order_dir=…` in its own URL and keeps doing so — unchanged behaviour.
- The other integration pages cannot use that mechanism: preact-router hands the query string to the page component as props, and a `search` parameter there would shadow the `search` action that several device pages receive from `unistore` (`props.search` would become a string instead of a function, breaking their search field). Instead, the catalog records the view it is displaying, and `getBackToCatalogUrl()` falls back to that when the URL carries no valid `from`. A full page reload simply forgets it and the link falls back to the whole catalog — still a working back button.

**i18n:** the `integration.externalIntegration.install.backToCatalog` key is replaced by a shared `integration.backToIntegrations` key, with the same wording in `en` / `fr` / `de`.

<details>
<summary>Files changed</summary>

- new `front/src/components/integration/BackToIntegrationsLink.jsx`
- `front/src/routes/integration/catalog-url.js` — remember the last catalog view, use it as the fallback target
- `front/src/routes/integration/index.js` — record the displayed catalog view
- `front/src/routes/integration/all/*/…Page.{js,jsx}` — 37 layouts render the link
- `front/src/config/i18n/{en,fr,de}.json` — shared translation key

</details>

## Forum

Forum: https://community.gladysassistant.com/t/ajouter-un-bouton-retour-sur-les-integrations-internes/10493

### Checklist

- [x] Tests pass: no server code changed, so `npm run coverage` is not affected. Cypress could not be run in this environment (the Cypress binary download fails behind the proxy); the front build, eslint and `compare-translations` all pass, and the existing integration specs (`Zigbee2MqttSetupLocalContainers`, `Zigbee2MqttSetupRemoteGladys`, `ExternalIntegrationOAuth`) do not assert on the integration page header.
- [x] Linter and prettier pass on the front (`npm run eslint`: 0 errors, `npm run prettier-check`, `npm run compare-translations`, `npm run build`)
- [x] No undocumented breaking change

I was not able to click through the running app here (the server dependencies do not install in this environment), so a quick visual check of the button placement in the left column would be welcome.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsidvF1P3T3T18uAik6MaL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a consistent “Back to integrations” link across integration pages.
  * Preserved catalog filters, search terms, and sorting when returning to the integration catalog.
  * Improved fallback navigation when the original catalog location is unavailable.
  * Added localized navigation text in English, French, and German.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->