### PR TITLE
Fix flaky CI: stop the gateway restore tests from poisoning the shared test database

### DIFF
--- a/server/test/helpers/db.test.js
+++ b/server/test/helpers/db.test.js
@@ -3,6 +3,7 @@ const { promisify } = require('util');
 const Promise = require('bluebird');
 const { join } = require('path');
 const db = require('../../models');
+const logger = require('../../utils/logger');
 
 const SEEDERS_PATH = join(__filename, '../../../seeders');
 
@@ -41,7 +42,7 @@ let cleanMarkers = null;
 
 // Observability for dbReset.test.js: lets the tests assert that the skip
 // branches really skip (an unnecessary reset would produce the same data).
-const resetDbStats = { sqliteResets: 0, duckDeletes: 0 };
+const resetDbStats = { sqliteResets: 0, duckDeletes: 0, snapshotRebuilds: 0 };
 
 // Most tests never write to the database, so even the fast snapshot copy is
 // wasted work for them. Before copying, we read two cheap freshness markers
@@ -65,6 +66,9 @@ const initSnapshotReset = async () => {
   sqliteAll = promisify(connection.all.bind(connection));
 
   const snapshotPath = `${db.sequelize.options.storage.replace(/\.db$/, '')}-snapshot.db`;
+  // On a rebuild the previous snapshot is still attached: detach it first so
+  // the file can be replaced (no-op errors ignored on the first build).
+  await sqliteExec('DETACH DATABASE seed_snapshot').catch(() => {});
   if (existsSync(snapshotPath)) {
     unlinkSync(snapshotPath);
   }
@@ -84,41 +88,53 @@ const initSnapshotReset = async () => {
   ].join(';\n');
 };
 
+// Build a pristine seeded state with the real seeders (in a single
+// transaction to avoid one journal sync per statement), then snapshot it so
+// every later reset is a fast native copy. Called on the first reset, and
+// again as a rescue whenever the fast copy no longer matches the live schema.
+const rebuildSeededSnapshot = async () => {
+  await db.sequelize.query('BEGIN');
+  try {
+    const queryInterface = db.sequelize.getQueryInterface();
+    await Promise.each(reversedSeed, async (seed) => {
+      await seed.down(queryInterface);
+    });
+    await Promise.each(seeds, async (seed) => {
+      await seed.up(queryInterface);
+    });
+    await db.sequelize.query('COMMIT');
+  } catch (e) {
+    await db.sequelize.query('ROLLBACK');
+    throw e;
+  }
+  await initSnapshotReset();
+  cleanMarkers = await readFreshnessMarkers();
+};
+
 const resetDb = async () => {
   if (!sqliteResetScript) {
-    // First reset: build a pristine seeded state with the real seeders (in a
-    // single transaction to avoid one journal sync per statement), then
-    // snapshot it so every later reset is a fast native copy.
-    await db.sequelize.query('BEGIN');
-    try {
-      const queryInterface = db.sequelize.getQueryInterface();
-      await Promise.each(reversedSeed, async (seed) => {
-        await seed.down(queryInterface);
-      });
-      await Promise.each(seeds, async (seed) => {
-        await seed.up(queryInterface);
-      });
-      await db.sequelize.query('COMMIT');
-    } catch (e) {
-      await db.sequelize.query('ROLLBACK');
-      throw e;
-    }
-    await initSnapshotReset();
-    cleanMarkers = await readFreshnessMarkers();
+    await rebuildSeededSnapshot();
   } else {
     const markers = await readFreshnessMarkers();
     if (markers !== cleanMarkers) {
       resetDbStats.sqliteResets += 1;
       try {
         await sqliteExec(sqliteResetScript);
+        // The reset itself moved the markers: re-read them so the next call
+        // compares against the freshly restored state.
+        cleanMarkers = await readFreshnessMarkers();
       } catch (e) {
         // A failed exec can leave an open transaction and foreign keys disabled.
-        await sqliteExec('ROLLBACK; PRAGMA foreign_keys = ON').catch(() => {});
-        throw e;
+        await sqliteExec('ROLLBACK').catch(() => {});
+        await sqliteExec('PRAGMA foreign_keys = ON').catch(() => {});
+        // The fast copy assumes the live schema still matches the snapshot's.
+        // A test that alters the schema (e.g. restoring a real backup over the
+        // database file) would otherwise fail every later test of this worker:
+        // rebuild the seeded state and a fresh snapshot instead of giving up.
+        logger.warn(`resetDb: snapshot reset failed (${e.message}), rebuilding the seed snapshot`);
+        resetDbStats.snapshotRebuilds += 1;
+        await rebuildSeededSnapshot();
       }
-      // The reset itself moved the markers: re-read them so the next call
-      // compares against the freshly restored state.
-      cleanMarkers = await readFreshnessMarkers();
     }
   }
   // Clean DuckDB database (a separate database, not covered by the snapshot).

--- a/server/test/helpers/dbReset.test.js
+++ b/server/test/helpers/dbReset.test.js
@@ -55,6 +55,30 @@ describe('resetDb freshness detection', () => {
     expect(restored.name).to.equal(house.name);
   });
 
+  it('should rebuild the snapshot when the live schema drifted', async () => {
+    // Simulate what restoring a real backup over the database file does: the
+    // live schema no longer matches the snapshot's, so the positional
+    // INSERT ... SELECT * of the fast reset cannot work anymore. resetDb must
+    // rebuild the seeded snapshot instead of failing every later test.
+    // (DDL moves neither freshness marker, so also dirty a row to make sure
+    // the reset path actually runs.)
+    const [house] = await db.House.findAll();
+    await db.sequelize.query('ALTER TABLE t_house ADD COLUMN test_drift_column INTEGER');
+    await db.sequelize.query(`UPDATE t_house SET name = 'dirty' WHERE id = '${house.id}'`);
+    const stats = { ...resetDbStats };
+    await resetDb();
+    expect(resetDbStats.snapshotRebuilds).to.equal(stats.snapshotRebuilds + 1);
+    expect((await db.House.findByPk(house.id)).name).to.equal(house.name);
+    // Heal in the other direction too: dropping the column makes the live
+    // table narrower than the (just rebuilt) snapshot. The second rebuild
+    // brings the snapshot back to the pristine schema for the tests after us.
+    await db.sequelize.query('ALTER TABLE t_house DROP COLUMN test_drift_column');
+    await db.sequelize.query(`UPDATE t_house SET name = 'dirty' WHERE id = '${house.id}'`);
+    await resetDb();
+    expect(resetDbStats.snapshotRebuilds).to.equal(stats.snapshotRebuilds + 2);
+    expect((await db.House.findByPk(house.id)).name).to.equal(house.name);
+  });
+
   it('should clear DuckDB states when rows are present', async () => {
     await db.duckDbWriteConnectionAllAsync(
       `INSERT INTO t_device_feature_state VALUES ('ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4', 12, '2024-01-01 00:00:00')`,

--- a/server/test/lib/gateway/gateway.restoreBackup.test.js
+++ b/server/test/lib/gateway/gateway.restoreBackup.test.js
@@ -35,7 +35,10 @@ describe('gateway.restoreBackup', () => {
     event.on = fake.returns(null);
     event.emit = fake.returns(null);
 
-    const config = getConfig();
+    // Restore into a throwaway file, NOT the worker's live test database (see
+    // gateway.restoreBackupEvent.test.js). Spread getConfig()'s result: it
+    // returns a shared object, mutating it would leak to the whole process.
+    const config = { ...getConfig(), storage: `/tmp/gladys-database-restore-test-${process.pid}.db` };
 
     const scheduler = {
       scheduleJob: (rule, callback) => {
@@ -50,7 +53,6 @@ describe('gateway.restoreBackup', () => {
     sequelize.close = fake.resolves(null);
 
     gateway = new Gateway(variable, event, {}, sequelize, config, {}, {}, {}, job, scheduler);
-    gateway.config.storage = `/tmp/gladys-database-restore-test-${process.pid}.db`;
   });
 
   afterEach(() => {

--- a/server/test/lib/gateway/gateway.restoreBackupEvent.test.js
+++ b/server/test/lib/gateway/gateway.restoreBackupEvent.test.js
@@ -4,8 +4,6 @@ const proxyquire = require('proxyquire').noCallThru();
 const path = require('path');
 
 const GladysGatewayClientMock = require('./GladysGatewayClientMock.test');
-const db = require('../../../models');
-const { cleanDb } = require('../../helpers/db.test');
 const getConfig = require('../../../utils/getConfig');
 
 const { fake, assert } = sinon;
@@ -41,7 +39,13 @@ describe('gateway.restoreBackupEvent', () => {
 
     system.shutdown = fake.resolves(true);
 
-    const config = getConfig();
+    // Restore into a throwaway file, NOT the worker's live test database: the
+    // backup fixtures carry the schema of old real instances (e.g. a t_session
+    // client_id column left over from removed OAuth migrations), and restoring
+    // them over the live database would poison every test running after this
+    // file. Spread getConfig()'s result: it returns a shared object, mutating
+    // it would leak the storage override to the whole process.
+    const config = { ...getConfig(), storage: `/tmp/gladys-database-restore-test-${process.pid}.db` };
 
     const scheduler = {
       scheduleJob: (rule, callback) => {
@@ -58,8 +62,6 @@ describe('gateway.restoreBackupEvent', () => {
 
   afterEach(async () => {
     sinon.reset();
-    await db.umzug.up();
-    await cleanDb();
   });
 
   it('should download and restore new backup (sqlite + parquet), then shutdown', async () => {


### PR DESCRIPTION
### Description

Fixes the intermittent CI failures seen since the test-speedup series (e.g. [this run](https://github.com/GladysAssistant/Gladys/actions/runs/31439302612/job/93620396570?pr=2808)), where hundreds of tests failed in `beforeEach` with:

```
Error: SQLITE_ERROR: table t_session has 15 columns but 14 values were supplied
```

**Root cause.** `gateway.restoreBackupEvent.test.js` restores real backup fixtures over the worker's live SQLite database. The old fixture carries schema drift: a `t_session.client_id` column created by OAuth migrations that were later removed from the repo, so no migration drops it and the `db.umzug.up()` in the test's `afterEach` cannot repair it. After that test, the live `t_session` has 15 columns while a freshly migrated schema has 14. The fast snapshot reset introduced in #2818 rebuilds tables with a positional `INSERT INTO ... SELECT *`, which then fails for every test running after this file **on the same worker**. Whether any tests run after it depends on how `mocha --parallel` distributes files across workers — hence the flakiness, and why re-running the job usually goes green.

**Fix.**
- `gateway.restoreBackupEvent.test.js` now restores into a throwaway `/tmp` file instead of the worker's live database — exactly what `gateway.restoreBackup.test.js` was already doing. Both files now **copy** the object returned by `getConfig()` instead of mutating it in place (it is a shared object, so the previous `gateway.config.storage = ...` override leaked to every other consumer of the config). The `db.umzug.up()` + `cleanDb()` repair in `afterEach` becomes unnecessary and is removed.
- Defense in depth: `resetDb` is now self-healing. If the snapshot copy fails because the live schema no longer matches the snapshot's, it logs a warning, rebuilds the seeded state with the real seeders and takes a fresh snapshot, instead of failing the remainder of the worker. A regression test covers both drift directions (column added, column dropped).

Reproduced deterministically before the fix (5/5 locally by running any test file after the gateway restore file in the same mocha process); after the fix the same scenario passes and the full suite shows zero `t_session` errors.

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xj8nWW9CWrNUvw5C6wd5yp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xj8nWW9CWrNUvw5C6wd5yp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test database resets to recover from snapshot-copy failures without interrupting test execution.
  - Database snapshots now rebuild correctly after schema changes and restore original data and structure.
  - Gateway backup restoration tests now use isolated temporary storage, preventing changes to shared test data.

- **Tests**
  - Added regression coverage for database schema drift and snapshot rebuilding.
  - Improved reset statistics and freshness tracking for more reliable test validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->