### PR TITLE
feat(homekit): expose the house alarm as a SecuritySystem

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -1694,6 +1694,7 @@
       "exposureModeAll": "Alle kompatiblen Geräte bereitstellen",
       "exposureModeSelection": "Nur die ausgewählten Geräte bereitstellen",
       "noCompatibleDevice": "Noch kein Gerät Ihres Gladys kann in HomeKit bereitgestellt werden.",
+      "alarmLabel": "Alarm",
       "saveExposureButton": "Bereitgestellte Geräte speichern",
       "saveExposureSuccess": "Bereitgestellte Geräte gespeichert. Die HomeKit-Bridge startet automatisch neu, Ihre Kopplung bleibt erhalten.",
       "saveExposureError": "Beim Speichern der bereitgestellten Geräte ist ein Fehler aufgetreten.",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -1589,6 +1589,7 @@
       "exposureModeAll": "Expose all compatible devices",
       "exposureModeSelection": "Only expose the selected devices",
       "noCompatibleDevice": "No device of your Gladys can be exposed to HomeKit yet.",
+      "alarmLabel": "Alarm",
       "saveExposureButton": "Save the exposed devices",
       "saveExposureSuccess": "Exposed devices saved successfully. The HomeKit bridge restarts automatically, your pairing is kept.",
       "saveExposureError": "An error occurred while saving the exposed devices.",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -1827,6 +1827,7 @@
       "exposureModeAll": "Exposer tous les appareils compatibles",
       "exposureModeSelection": "Exposer uniquement les appareils sélectionnés",
       "noCompatibleDevice": "Aucun appareil de votre Gladys ne peut encore être exposé à HomeKit.",
+      "alarmLabel": "Alarme",
       "saveExposureButton": "Enregistrer les appareils exposés",
       "saveExposureSuccess": "Appareils exposés enregistrés. Le pont HomeKit redémarre automatiquement, votre appairage est conservé.",
       "saveExposureError": "Une erreur est survenue lors de l'enregistrement des appareils exposés.",

--- a/front/src/routes/integration/all/homekit/HomeKit.jsx
+++ b/front/src/routes/integration/all/homekit/HomeKit.jsx
@@ -1,4 +1,5 @@
 import { Text, MarkupText } from 'preact-i18n';
+import get from 'get-value';
 import Select from 'react-select';
 import { RequestStatus } from '../../../../utils/consts';
 import { USER_ROLE } from '../../../../../../server/utils/constants';
@@ -7,6 +8,7 @@ import style from './style.css';
 import DeviceConfigurationLink from '../../../../components/documentation/DeviceConfigurationLink';
 import { EXPOSURE_MODES } from './actions';
 import BackToIntegrationsLink from '../../../../components/integration/BackToIntegrationsLink';
+import withIntlAsProp from '../../../../utils/withIntlAsProp';
 
 const mdnsAdvertisers = {
   AVAHI: 'avahi',
@@ -15,10 +17,16 @@ const mdnsAdvertisers = {
   RESOLVED: 'resolved'
 };
 
-const ExposedDevicesSelect = ({ homekitCompatibleDevices, homekitExposedDevices, updateExposedDevices }) => {
+// The house alarm is offered in the same list as the devices, under a prefixed selector. Its name
+// is the name of the house, which on its own reads like a device, so it is labelled here — the
+// server has no translations.
+const ALARM_SELECTOR_PREFIX = 'house-alarm:';
+
+const ExposedDevicesSelect = ({ homekitCompatibleDevices, homekitExposedDevices, updateExposedDevices, intl }) => {
+  const alarmLabel = get(intl.dictionary, 'integration.homekit.alarmLabel');
   const deviceOptions = (homekitCompatibleDevices || []).map(device => ({
     value: device.selector,
-    label: device.name
+    label: device.selector.startsWith(ALARM_SELECTOR_PREFIX) ? `${alarmLabel} — ${device.name}` : device.name
   }));
 
   if (deviceOptions.length === 0) {
@@ -41,6 +49,8 @@ const ExposedDevicesSelect = ({ homekitCompatibleDevices, homekitExposedDevices,
     />
   );
 };
+
+const ExposedDevicesSelectWithIntl = withIntlAsProp(ExposedDevicesSelect);
 
 const HomKitPage = ({ children, ...props }) => (
   <div class="page">
@@ -152,7 +162,7 @@ const HomKitPage = ({ children, ...props }) => (
                           </select>
                           {props.homekitExposureMode === EXPOSURE_MODES.SELECTION && (
                             <div class="mb-2">
-                              <ExposedDevicesSelect {...props} />
+                              <ExposedDevicesSelectWithIntl {...props} />
                             </div>
                           )}
                           <button class="btn btn-success" onClick={props.saveExposure}>

--- a/server/services/homekit/api/homekit.controller.js
+++ b/server/services/homekit/api/homekit.controller.js
@@ -32,7 +32,10 @@ module.exports = function HomeKitController(homekitHandler) {
    */
   async function getDevices(req, res) {
     const devices = await homekitHandler.getCompatibleDevices();
-    res.json(devices.map(({ name, selector }) => ({ name, selector })));
+    // House alarms are offered alongside the devices: they are not devices, but the exposure
+    // setting is a single allow list of selectors and they have to be selectable like the rest.
+    const alarms = await homekitHandler.getCompatibleAlarms();
+    res.json([...devices, ...alarms].map(({ name, selector }) => ({ name, selector })));
   }
 
   return {

--- a/server/services/homekit/lib/buildAlarmAccessory.js
+++ b/server/services/homekit/lib/buildAlarmAccessory.js
@@ -1,4 +1,5 @@
 const { ALARM_MODES } = require('../../../utils/constants');
+const { ConflictError } = require('../../../utils/coreErrors');
 const logger = require('../../../utils/logger');
 
 // Values of the HomeKit SecuritySystemCurrentState characteristic. The target one uses the same
@@ -56,20 +57,31 @@ function buildAlarmAccessory(house) {
   service
     .getCharacteristic(Characteristic.SecuritySystemCurrentState)
     .on(CharacteristicEventTypes.GET, async (callback) => {
-      callback(undefined, await readState());
+      try {
+        callback(undefined, await readState());
+      } catch (e) {
+        // Answering the failure rather than saying nothing: a callback that is never called leaves
+        // the HAP request hanging until it times out.
+        callback(e);
+      }
     });
 
   const targetStateCharacteristic = service.getCharacteristic(Characteristic.SecuritySystemTargetState);
   targetStateCharacteristic.setProps({ validValues: SUPPORTED_TARGET_STATES });
   targetStateCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
-    const state = await readState();
+    try {
+      const state = await readState();
 
-    // A house that went off is still armed as far as the target goes: HomeKit has no triggered
-    // target, and reporting disarmed there would show the alarm as switched off while it rings.
-    callback(
-      undefined,
-      state === HOMEKIT_SECURITY_SYSTEM_STATE.ALARM_TRIGGERED ? HOMEKIT_SECURITY_SYSTEM_STATE.AWAY_ARM : state,
-    );
+      // A house that went off is still armed as far as the target goes: HomeKit has no triggered
+      // target, and reporting disarmed there would show the alarm as switched off while it rings.
+      // Which armed mode it was in before is not recorded anywhere, so away is the assumption.
+      callback(
+        undefined,
+        state === HOMEKIT_SECURITY_SYSTEM_STATE.ALARM_TRIGGERED ? HOMEKIT_SECURITY_SYSTEM_STATE.AWAY_ARM : state,
+      );
+    } catch (e) {
+      callback(e);
+    }
   });
   targetStateCharacteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
     try {
@@ -83,10 +95,19 @@ function buildAlarmAccessory(house) {
       callback();
     } catch (e) {
       // Asking for the mode the house is already in throws a conflict, and the Home app does that
-      // whenever two people press the same button. The request is answered as done rather than as
-      // failed: the house is in the state that was asked for either way.
-      logger.debug(`HomeKit: could not set alarm mode of house ${house.selector}: ${e.message}`);
-      callback();
+      // whenever two people press the same button. That one is answered as done: the house is in
+      // the state that was asked for either way.
+      if (e instanceof ConflictError) {
+        logger.debug(`HomeKit: house ${house.selector} is already in the requested alarm mode`);
+        callback();
+
+        return;
+      }
+
+      // Anything else really failed, and must be reported as such. Answering a failed disarm with a
+      // success would leave the Home app showing the alarm off while the house stays armed.
+      logger.error(`HomeKit: could not set alarm mode of house ${house.selector}: ${e.message}`);
+      callback(e);
     }
   });
 

--- a/server/services/homekit/lib/buildAlarmAccessory.js
+++ b/server/services/homekit/lib/buildAlarmAccessory.js
@@ -1,0 +1,103 @@
+const { ALARM_MODES } = require('../../../utils/constants');
+const logger = require('../../../utils/logger');
+
+// Values of the HomeKit SecuritySystemCurrentState characteristic. The target one uses the same
+// values without ALARM_TRIGGERED: HomeKit lets an alarm report that it went off, not be asked to.
+const HOMEKIT_SECURITY_SYSTEM_STATE = {
+  STAY_ARM: 0,
+  AWAY_ARM: 1,
+  NIGHT_ARM: 2,
+  DISARMED: 3,
+  ALARM_TRIGGERED: 4,
+};
+
+// Gladys arms the whole house or only part of it, where HomeKit distinguishes being away from
+// staying home — which is the same idea seen from the other side: a partially armed house is one
+// its occupants are still living in.
+const alarmModeToSecuritySystemState = {
+  [ALARM_MODES.ARMED]: HOMEKIT_SECURITY_SYSTEM_STATE.AWAY_ARM,
+  [ALARM_MODES.PARTIALLY_ARMED]: HOMEKIT_SECURITY_SYSTEM_STATE.STAY_ARM,
+  [ALARM_MODES.DISARMED]: HOMEKIT_SECURITY_SYSTEM_STATE.DISARMED,
+  [ALARM_MODES.PANIC]: HOMEKIT_SECURITY_SYSTEM_STATE.ALARM_TRIGGERED,
+};
+
+// NIGHT_ARM is absent on purpose: Gladys has no night mode, and offering a state the house cannot
+// honour would let the Home app ask for something that silently does nothing.
+const SUPPORTED_TARGET_STATES = [
+  HOMEKIT_SECURITY_SYSTEM_STATE.STAY_ARM,
+  HOMEKIT_SECURITY_SYSTEM_STATE.AWAY_ARM,
+  HOMEKIT_SECURITY_SYSTEM_STATE.DISARMED,
+];
+
+/**
+ * @description Create the HomeKit accessory exposing the alarm of a Gladys house.
+ * @param {object} house - Gladys house to expose.
+ * @returns {object} HomeKit accessory to expose.
+ * @example
+ * buildAlarmAccessory({ id: '...', name: 'Maison', selector: 'maison' });
+ */
+function buildAlarmAccessory(house) {
+  const { Characteristic, CharacteristicEventTypes, Service } = this.hap;
+
+  // The alarm is not a device: it lives on the house, so this accessory is built from a house
+  // rather than from `buildAccessory`, and its UUID is the house id.
+  const accessory = new this.hap.Accessory(house.name.substring(0, 64), house.id);
+  const service = new Service.SecuritySystem(house.name.substring(0, 64));
+
+  const readState = async () => {
+    const { alarm_mode: alarmMode } = await this.gladys.house.getBySelector(house.selector);
+    const state = alarmModeToSecuritySystemState[alarmMode];
+
+    // A mode this bridge does not know about is reported as disarmed rather than as an alarm going
+    // off: announcing a break-in that is not happening is the worse of the two mistakes.
+    return state === undefined ? HOMEKIT_SECURITY_SYSTEM_STATE.DISARMED : state;
+  };
+
+  service
+    .getCharacteristic(Characteristic.SecuritySystemCurrentState)
+    .on(CharacteristicEventTypes.GET, async (callback) => {
+      callback(undefined, await readState());
+    });
+
+  const targetStateCharacteristic = service.getCharacteristic(Characteristic.SecuritySystemTargetState);
+  targetStateCharacteristic.setProps({ validValues: SUPPORTED_TARGET_STATES });
+  targetStateCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+    const state = await readState();
+
+    // A house that went off is still armed as far as the target goes: HomeKit has no triggered
+    // target, and reporting disarmed there would show the alarm as switched off while it rings.
+    callback(
+      undefined,
+      state === HOMEKIT_SECURITY_SYSTEM_STATE.ALARM_TRIGGERED ? HOMEKIT_SECURITY_SYSTEM_STATE.AWAY_ARM : state,
+    );
+  });
+  targetStateCharacteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
+    try {
+      if (value === HOMEKIT_SECURITY_SYSTEM_STATE.DISARMED) {
+        await this.gladys.house.disarm(house.selector);
+      } else if (value === HOMEKIT_SECURITY_SYSTEM_STATE.STAY_ARM) {
+        await this.gladys.house.partialArm(house.selector);
+      } else if (value === HOMEKIT_SECURITY_SYSTEM_STATE.AWAY_ARM) {
+        await this.gladys.house.arm(house.selector);
+      }
+      callback();
+    } catch (e) {
+      // Asking for the mode the house is already in throws a conflict, and the Home app does that
+      // whenever two people press the same button. The request is answered as done rather than as
+      // failed: the house is in the state that was asked for either way.
+      logger.debug(`HomeKit: could not set alarm mode of house ${house.selector}: ${e.message}`);
+      callback();
+    }
+  });
+
+  accessory.addService(service);
+
+  return accessory;
+}
+
+module.exports = {
+  buildAlarmAccessory,
+  alarmModeToSecuritySystemState,
+  HOMEKIT_SECURITY_SYSTEM_STATE,
+  SUPPORTED_TARGET_STATES,
+};

--- a/server/services/homekit/lib/buildAlarmAccessory.js
+++ b/server/services/homekit/lib/buildAlarmAccessory.js
@@ -66,19 +66,28 @@ function buildAlarmAccessory(house) {
       }
     });
 
+  // HomeKit has no triggered target, so a house that went off has to keep the target it was armed
+  // with — reporting disarmed there would show the alarm as switched off while it rings. Gladys
+  // does not record which mode preceded the panic, so it is remembered here. A bridge restart
+  // forgets it, and away is then the assumption: it is the stricter of the two.
+  let lastArmedTarget = HOMEKIT_SECURITY_SYSTEM_STATE.AWAY_ARM;
+
   const targetStateCharacteristic = service.getCharacteristic(Characteristic.SecuritySystemTargetState);
   targetStateCharacteristic.setProps({ validValues: SUPPORTED_TARGET_STATES });
   targetStateCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
     try {
       const state = await readState();
 
-      // A house that went off is still armed as far as the target goes: HomeKit has no triggered
-      // target, and reporting disarmed there would show the alarm as switched off while it rings.
-      // Which armed mode it was in before is not recorded anywhere, so away is the assumption.
-      callback(
-        undefined,
-        state === HOMEKIT_SECURITY_SYSTEM_STATE.ALARM_TRIGGERED ? HOMEKIT_SECURITY_SYSTEM_STATE.AWAY_ARM : state,
-      );
+      if (state === HOMEKIT_SECURITY_SYSTEM_STATE.ALARM_TRIGGERED) {
+        callback(undefined, lastArmedTarget);
+
+        return;
+      }
+
+      if (state !== HOMEKIT_SECURITY_SYSTEM_STATE.DISARMED) {
+        lastArmedTarget = state;
+      }
+      callback(undefined, state);
     } catch (e) {
       callback(e);
     }
@@ -91,6 +100,11 @@ function buildAlarmAccessory(house) {
         await this.gladys.house.partialArm(house.selector);
       } else if (value === HOMEKIT_SECURITY_SYSTEM_STATE.AWAY_ARM) {
         await this.gladys.house.arm(house.selector);
+      }
+
+      // What the house is armed with is what it goes back to showing once the siren stops.
+      if (value !== HOMEKIT_SECURITY_SYSTEM_STATE.DISARMED) {
+        lastArmedTarget = value;
       }
       callback();
     } catch (e) {

--- a/server/services/homekit/lib/createBridge.js
+++ b/server/services/homekit/lib/createBridge.js
@@ -39,10 +39,11 @@ async function createBridge() {
 
   // The alarm is not a device: it lives on the house, so one accessory per house is built here
   // rather than from the device list. Several houses give several alarms in the Home app, each
-  // named after its own.
-  const houses = await this.gladys.house.get();
+  // named after its own. They go through the same exposure setting as the devices, so someone who
+  // does not use the Gladys alarm can leave it out.
+  const exposedAlarms = await this.getExposedAlarms();
   this.alarmAccessories = new Map();
-  houses.forEach((house) => {
+  exposedAlarms.forEach(({ house }) => {
     const alarmAccessory = this.buildAlarmAccessory(house);
     this.alarmAccessories.set(house.selector, alarmAccessory);
     accessories.push(alarmAccessory);

--- a/server/services/homekit/lib/createBridge.js
+++ b/server/services/homekit/lib/createBridge.js
@@ -37,6 +37,17 @@ async function createBridge() {
     .map((device) => this.buildAccessory(device))
     .filter((accessory) => accessory !== null);
 
+  // The alarm is not a device: it lives on the house, so one accessory per house is built here
+  // rather than from the device list. Several houses give several alarms in the Home app, each
+  // named after its own.
+  const houses = await this.gladys.house.get();
+  this.alarmAccessories = new Map();
+  houses.forEach((house) => {
+    const alarmAccessory = this.buildAlarmAccessory(house);
+    this.alarmAccessories.set(house.selector, alarmAccessory);
+    accessories.push(alarmAccessory);
+  });
+
   if (this.bridge) {
     await this.stopBridge();
   }

--- a/server/services/homekit/lib/exposedDevices.js
+++ b/server/services/homekit/lib/exposedDevices.js
@@ -10,6 +10,11 @@ const EXPOSURE_MODES = {
 const EXPOSURE_MODE_VARIABLE = 'HOMEKIT_EXPOSURE_MODE';
 const EXPOSED_DEVICES_VARIABLE = 'HOMEKIT_EXPOSED_DEVICES';
 
+// The alarm of a house is not a device, but the exposure setting is an allow list of selectors and
+// someone who does not use the Gladys alarm must be able to leave it out like any other accessory.
+// It is offered under a prefixed selector, which cannot collide with a device one.
+const ALARM_SELECTOR_PREFIX = 'house-alarm:';
+
 /**
  * @description Tell if a device carries at least one feature HomeKit knows how to expose.
  * @param {object} device - Gladys device to test.
@@ -35,19 +40,29 @@ async function getCompatibleDevices() {
 }
 
 /**
- * @description Get the devices the bridge must expose: every compatible one by default, or only the
- * ones the user selected. The selection is an allow list, so a device added later stays out of
- * HomeKit until it is picked.
- * @returns {Promise<Array>} The devices to expose.
+ * @description List the house alarms the bridge is able to expose. Every house has an alarm mode,
+ * so every house is offered.
+ * @returns {Promise<Array>} The exposable alarms, each carrying the house it belongs to.
  * @example
- * const devices = await getExposedDevices();
+ * const alarms = await getCompatibleAlarms();
  */
-async function getExposedDevices() {
-  const compatibleDevices = await this.getCompatibleDevices();
+async function getCompatibleAlarms() {
+  const houses = await this.gladys.house.get();
 
+  return houses.map((house) => ({ name: house.name, selector: `${ALARM_SELECTOR_PREFIX}${house.selector}`, house }));
+}
+
+/**
+ * @description Read the allow list of selectors the user picked, or null when every compatible
+ * accessory is exposed.
+ * @returns {Promise<Array|null>} The selected selectors, or null when the mode is not a selection.
+ * @example
+ * const selection = await readSelection();
+ */
+async function readSelection() {
   const mode = await this.gladys.variable.getValue(EXPOSURE_MODE_VARIABLE, this.serviceId);
   if (mode !== EXPOSURE_MODES.SELECTION) {
-    return compatibleDevices;
+    return null;
   }
 
   const rawSelection = await this.gladys.variable.getValue(EXPOSED_DEVICES_VARIABLE, this.serviceId);
@@ -66,14 +81,46 @@ async function getExposedDevices() {
     return [];
   }
 
-  return compatibleDevices.filter((device) => selectedSelectors.includes(device.selector));
+  return selectedSelectors;
+}
+
+/**
+ * @description Get the devices the bridge must expose: every compatible one by default, or only the
+ * ones the user selected. The selection is an allow list, so a device added later stays out of
+ * HomeKit until it is picked.
+ * @returns {Promise<Array>} The devices to expose.
+ * @example
+ * const devices = await getExposedDevices();
+ */
+async function getExposedDevices() {
+  const compatibleDevices = await this.getCompatibleDevices();
+  const selection = await readSelection.call(this);
+
+  return selection === null ? compatibleDevices : compatibleDevices.filter((d) => selection.includes(d.selector));
+}
+
+/**
+ * @description Get the house alarms the bridge must expose, through the same allow list as the
+ * devices.
+ * @returns {Promise<Array>} The alarms to expose.
+ * @example
+ * const alarms = await getExposedAlarms();
+ */
+async function getExposedAlarms() {
+  const compatibleAlarms = await this.getCompatibleAlarms();
+  const selection = await readSelection.call(this);
+
+  return selection === null ? compatibleAlarms : compatibleAlarms.filter((a) => selection.includes(a.selector));
 }
 
 module.exports = {
   EXPOSURE_MODES,
   EXPOSURE_MODE_VARIABLE,
   EXPOSED_DEVICES_VARIABLE,
+  ALARM_SELECTOR_PREFIX,
   isCompatibleDevice,
   getCompatibleDevices,
+  getCompatibleAlarms,
   getExposedDevices,
+  getExposedAlarms,
 };

--- a/server/services/homekit/lib/index.js
+++ b/server/services/homekit/lib/index.js
@@ -2,11 +2,13 @@ const { createBridge } = require('./createBridge');
 const { stopBridge } = require('./stopBridge');
 const { resetBridge } = require('./resetBridge');
 const { buildAccessory } = require('./buildAccessory');
+const { buildAlarmAccessory } = require('./buildAlarmAccessory');
 const { buildService } = require('./buildService');
 const { newPinCode } = require('./newPinCode');
 const { newUsername } = require('./newUsername');
 const { notifyChange } = require('./notifyChange');
 const { sendState } = require('./sendState');
+const { sendAlarmState } = require('./sendAlarmState');
 const { getCompatibleDevices, getExposedDevices } = require('./exposedDevices');
 
 /**
@@ -23,6 +25,7 @@ const HomeKitHandler = function HomeKitHandler(gladys, serviceId, hap) {
   this.hap = hap;
   this.bridge = null;
   this.notifyTimeouts = {};
+  this.alarmAccessories = new Map();
   this.notifyCb = null;
 };
 
@@ -32,9 +35,11 @@ HomeKitHandler.prototype.createBridge = createBridge;
 HomeKitHandler.prototype.stopBridge = stopBridge;
 HomeKitHandler.prototype.resetBridge = resetBridge;
 HomeKitHandler.prototype.buildAccessory = buildAccessory;
+HomeKitHandler.prototype.buildAlarmAccessory = buildAlarmAccessory;
 HomeKitHandler.prototype.buildService = buildService;
 HomeKitHandler.prototype.notifyChange = notifyChange;
 HomeKitHandler.prototype.sendState = sendState;
+HomeKitHandler.prototype.sendAlarmState = sendAlarmState;
 HomeKitHandler.prototype.getCompatibleDevices = getCompatibleDevices;
 HomeKitHandler.prototype.getExposedDevices = getExposedDevices;
 

--- a/server/services/homekit/lib/index.js
+++ b/server/services/homekit/lib/index.js
@@ -9,7 +9,7 @@ const { newUsername } = require('./newUsername');
 const { notifyChange } = require('./notifyChange');
 const { sendState } = require('./sendState');
 const { sendAlarmState } = require('./sendAlarmState');
-const { getCompatibleDevices, getExposedDevices } = require('./exposedDevices');
+const { getCompatibleDevices, getCompatibleAlarms, getExposedDevices, getExposedAlarms } = require('./exposedDevices');
 
 /**
  * @description Add ability to connect to HomeKit.
@@ -41,6 +41,8 @@ HomeKitHandler.prototype.notifyChange = notifyChange;
 HomeKitHandler.prototype.sendState = sendState;
 HomeKitHandler.prototype.sendAlarmState = sendAlarmState;
 HomeKitHandler.prototype.getCompatibleDevices = getCompatibleDevices;
+HomeKitHandler.prototype.getCompatibleAlarms = getCompatibleAlarms;
 HomeKitHandler.prototype.getExposedDevices = getExposedDevices;
+HomeKitHandler.prototype.getExposedAlarms = getExposedAlarms;
 
 module.exports = HomeKitHandler;

--- a/server/services/homekit/lib/notifyChange.js
+++ b/server/services/homekit/lib/notifyChange.js
@@ -1,6 +1,11 @@
 const { EVENTS } = require('../../../utils/constants');
 const { mappings } = require('./deviceMappings');
 
+// The alarm of a house is not a device feature, so its changes arrive on the same trigger stream
+// under their own event types. ARMING is left out: it announces the delay before the house actually
+// arms, and the mode has not changed yet when it fires.
+const ALARM_EVENTS = new Set([EVENTS.ALARM.ARM, EVENTS.ALARM.DISARM, EVENTS.ALARM.PARTIAL_ARM, EVENTS.ALARM.PANIC]);
+
 /**
  * @description Add delay before send new state to Homekit.
  * @param {object} accessories - HomeKit accessories.
@@ -10,6 +15,13 @@ const { mappings } = require('./deviceMappings');
  * notifyChange(accessories, event)
  */
 function notifyChange(accessories, event) {
+  if (ALARM_EVENTS.has(event.type)) {
+    // No debounce: an alarm arming or going off is exactly what HomeKit must hear about at once.
+    this.sendAlarmState(event.house);
+
+    return;
+  }
+
   if (event.type !== EVENTS.DEVICE.NEW_STATE) {
     return;
   }

--- a/server/services/homekit/lib/notifyChange.js
+++ b/server/services/homekit/lib/notifyChange.js
@@ -1,4 +1,5 @@
 const { EVENTS } = require('../../../utils/constants');
+const logger = require('../../../utils/logger');
 const { mappings } = require('./deviceMappings');
 
 // The alarm of a house is not a device feature, so its changes arrive on the same trigger stream
@@ -17,7 +18,11 @@ const ALARM_EVENTS = new Set([EVENTS.ALARM.ARM, EVENTS.ALARM.DISARM, EVENTS.ALAR
 function notifyChange(accessories, event) {
   if (ALARM_EVENTS.has(event.type)) {
     // No debounce: an alarm arming or going off is exactly what HomeKit must hear about at once.
-    this.sendAlarmState(event.house);
+    // The promise is caught rather than dropped: this runs from an event listener, where a
+    // rejection would go unhandled.
+    this.sendAlarmState(event.house).catch((e) => {
+      logger.error(`HomeKit: could not forward the alarm state of house ${event.house}: ${e.message}`);
+    });
 
     return;
   }

--- a/server/services/homekit/lib/sendAlarmState.js
+++ b/server/services/homekit/lib/sendAlarmState.js
@@ -1,0 +1,38 @@
+const { alarmModeToSecuritySystemState, HOMEKIT_SECURITY_SYSTEM_STATE } = require('./buildAlarmAccessory');
+
+/**
+ * @description Forward the new alarm mode of a house to HomeKit.
+ * @param {string} houseSelector - Selector of the house whose alarm changed.
+ * @returns {Promise} Resolve once HomeKit has been updated.
+ * @example
+ * await sendAlarmState('main-house');
+ */
+async function sendAlarmState(houseSelector) {
+  const accessory = this.alarmAccessories.get(houseSelector);
+
+  // A house created since the bridge was built has no accessory until the next reload.
+  if (!accessory) {
+    return;
+  }
+
+  const { Characteristic, Service } = this.hap;
+  const { alarm_mode: alarmMode } = await this.gladys.house.getBySelector(houseSelector);
+  const state = alarmModeToSecuritySystemState[alarmMode];
+
+  if (state === undefined) {
+    return;
+  }
+
+  const service = accessory.getService(Service.SecuritySystem);
+
+  service.updateCharacteristic(Characteristic.SecuritySystemCurrentState, state);
+  // The target has no triggered value, so a ringing house keeps the armed target it was set to.
+  // Pushing disarmed there would show the alarm as switched off while it is going off.
+  if (state !== HOMEKIT_SECURITY_SYSTEM_STATE.ALARM_TRIGGERED) {
+    service.updateCharacteristic(Characteristic.SecuritySystemTargetState, state);
+  }
+}
+
+module.exports = {
+  sendAlarmState,
+};

--- a/server/services/homekit/lib/sendAlarmState.js
+++ b/server/services/homekit/lib/sendAlarmState.js
@@ -17,11 +17,12 @@ async function sendAlarmState(houseSelector) {
 
   const { Characteristic, Service } = this.hap;
   const { alarm_mode: alarmMode } = await this.gladys.house.getBySelector(houseSelector);
-  const state = alarmModeToSecuritySystemState[alarmMode];
-
-  if (state === undefined) {
-    return;
-  }
+  // Same fallback as the GET handler: a mode this bridge does not know about is reported as
+  // disarmed rather than left alone, which would keep HomeKit showing a stale armed state.
+  const state =
+    alarmModeToSecuritySystemState[alarmMode] === undefined
+      ? HOMEKIT_SECURITY_SYSTEM_STATE.DISARMED
+      : alarmModeToSecuritySystemState[alarmMode];
 
   const service = accessory.getService(Service.SecuritySystem);
 

--- a/server/services/homekit/lib/sendAlarmState.js
+++ b/server/services/homekit/lib/sendAlarmState.js
@@ -27,11 +27,17 @@ async function sendAlarmState(houseSelector) {
   const service = accessory.getService(Service.SecuritySystem);
 
   service.updateCharacteristic(Characteristic.SecuritySystemCurrentState, state);
-  // The target has no triggered value, so a ringing house keeps the armed target it was set to.
-  // Pushing disarmed there would show the alarm as switched off while it is going off.
-  if (state !== HOMEKIT_SECURITY_SYSTEM_STATE.ALARM_TRIGGERED) {
-    service.updateCharacteristic(Characteristic.SecuritySystemTargetState, state);
-  }
+
+  // The target is recomputed through its own handler rather than derived a second time here: which
+  // target a ringing house keeps is only known inside the accessory, and deciding it in both places
+  // is how the two came to disagree.
+  service
+    .getCharacteristic(Characteristic.SecuritySystemTargetState)
+    .emit(this.hap.CharacteristicEventTypes.GET, (error, value) => {
+      if (!error) {
+        service.updateCharacteristic(Characteristic.SecuritySystemTargetState, value);
+      }
+    });
 }
 
 module.exports = {

--- a/server/test/services/homekit/api/homekit.controller.test.js
+++ b/server/test/services/homekit/api/homekit.controller.test.js
@@ -18,6 +18,9 @@ const homekitHandler = {
       features: [],
     },
   ]),
+  getCompatibleAlarms: fake.resolves([
+    { name: 'Maison', selector: 'house-alarm:maison', house: { selector: 'maison' } },
+  ]),
 };
 
 describe('HomeKitController GET /api/v1/service/homekit/device', () => {
@@ -37,10 +40,13 @@ describe('HomeKitController GET /api/v1/service/homekit/device', () => {
     await controller['get /api/v1/service/homekit/device'].controller(req, res);
 
     assert.calledOnce(homekitHandler.getCompatibleDevices);
-    // only what the selection screen needs, not the whole device with its features
+    assert.calledOnce(homekitHandler.getCompatibleAlarms);
+    // only what the selection screen needs, not the whole device with its features — and the house
+    // alarm alongside them, so it can be left out like any other accessory
     assert.calledWith(res.json, [
       { name: 'Lampe salon', selector: 'lampe-salon' },
       { name: 'Détecteur de fumée', selector: 'detecteur-fumee' },
+      { name: 'Maison', selector: 'house-alarm:maison' },
     ]);
   });
 });

--- a/server/test/services/homekit/index.test.js
+++ b/server/test/services/homekit/index.test.js
@@ -27,6 +27,9 @@ describe('HomeKitService', () => {
       system: {
         isDocker: stub().resolves(true),
       },
+      house: {
+        get: stub().resolves([]),
+      },
       event: {
         on: stub().returns(),
         removeListener: stub().returns(),

--- a/server/test/services/homekit/lib/buildAlarmAccessory.test.js
+++ b/server/test/services/homekit/lib/buildAlarmAccessory.test.js
@@ -1,0 +1,142 @@
+const { expect } = require('chai');
+const sinon = require('sinon').createSandbox();
+
+const { stub } = sinon;
+const { buildAlarmAccessory } = require('../../../../services/homekit/lib/buildAlarmAccessory');
+const { ALARM_MODES } = require('../../../../utils/constants');
+
+const HOUSE = { id: 'e1b0a9cf-3f6f-4f2e-9f6b-2c0a7f4a1d55', name: 'Maison', selector: 'maison' };
+
+const buildAlarmHapStub = () => {
+  const characteristics = {};
+  const getCharacteristic = (name) => {
+    if (!characteristics[name]) {
+      characteristics[name] = { handlers: {}, setProps: stub(), on: stub() };
+      characteristics[name].on = (event, handler) => {
+        characteristics[name].handlers[event] = handler;
+        return characteristics[name];
+      };
+    }
+    return characteristics[name];
+  };
+
+  const service = { getCharacteristic: stub().callsFake(getCharacteristic) };
+  const addService = stub();
+
+  const hap = {
+    Accessory: stub().returns({ addService }),
+    Service: { SecuritySystem: stub().returns(service) },
+    Characteristic: {
+      SecuritySystemCurrentState: 'CURRENTSTATE',
+      SecuritySystemTargetState: 'TARGETSTATE',
+    },
+    CharacteristicEventTypes: { GET: 'get', SET: 'set' },
+  };
+
+  return { hap, characteristics, addService };
+};
+
+const readCharacteristic = (characteristic) =>
+  new Promise((resolve) => {
+    characteristic.handlers.get((error, value) => resolve(value));
+  });
+
+describe('Build alarm accessory', () => {
+  const build = (alarmMode) => {
+    const { hap, characteristics, addService } = buildAlarmHapStub();
+    const homekitHandler = {
+      buildAlarmAccessory,
+      hap,
+      gladys: {
+        house: {
+          getBySelector: stub().resolves({ ...HOUSE, alarm_mode: alarmMode }),
+          arm: stub().resolves(),
+          partialArm: stub().resolves(),
+          disarm: stub().resolves(),
+        },
+      },
+    };
+
+    return { homekitHandler, characteristics, addService, accessory: homekitHandler.buildAlarmAccessory(HOUSE) };
+  };
+
+  it('should build an accessory named after the house and keyed by its id', async () => {
+    const { homekitHandler, addService } = build(ALARM_MODES.DISARMED);
+
+    expect(homekitHandler.hap.Accessory.args[0]).to.eql(['Maison', HOUSE.id]);
+    expect(addService.callCount).to.equal(1);
+  });
+
+  it('should report every alarm mode Gladys knows', async () => {
+    const cases = [
+      [ALARM_MODES.DISARMED, 3],
+      [ALARM_MODES.ARMED, 1],
+      // Gladys arms part of the house where HomeKit calls it staying home: the same idea seen from
+      // the other side
+      [ALARM_MODES.PARTIALLY_ARMED, 0],
+      [ALARM_MODES.PANIC, 4],
+    ];
+
+    await Promise.all(
+      cases.map(async ([alarmMode, expected]) => {
+        const { characteristics } = build(alarmMode);
+        expect(await readCharacteristic(characteristics.CURRENTSTATE)).to.equal(expected);
+      }),
+    );
+  });
+
+  it('should report the target the house was set to', async () => {
+    const { characteristics } = build(ALARM_MODES.PARTIALLY_ARMED);
+
+    expect(await readCharacteristic(characteristics.TARGETSTATE)).to.equal(0);
+  });
+
+  it('should keep the target armed while the alarm is going off', async () => {
+    const { characteristics } = build(ALARM_MODES.PANIC);
+
+    // HomeKit has no triggered target, and reporting disarmed there would show the alarm as
+    // switched off while it rings
+    expect(await readCharacteristic(characteristics.CURRENTSTATE)).to.equal(4);
+    expect(await readCharacteristic(characteristics.TARGETSTATE)).to.equal(1);
+  });
+
+  it('should not offer the night mode Gladys has no equivalent for', async () => {
+    const { characteristics } = build(ALARM_MODES.DISARMED);
+
+    expect(characteristics.TARGETSTATE.setProps.args[0][0]).to.eql({ validValues: [0, 1, 3] });
+  });
+
+  it('should report an unknown alarm mode as disarmed', async () => {
+    const { characteristics } = build('something-else');
+
+    // announcing a break-in that is not happening is the worse of the two mistakes
+    expect(await readCharacteristic(characteristics.CURRENTSTATE)).to.equal(3);
+  });
+
+  it('should arm, partially arm and disarm the house', async () => {
+    const { homekitHandler, characteristics } = build(ALARM_MODES.DISARMED);
+    const cb = stub();
+
+    await characteristics.TARGETSTATE.handlers.set(1, cb);
+    await characteristics.TARGETSTATE.handlers.set(0, cb);
+    await characteristics.TARGETSTATE.handlers.set(3, cb);
+
+    expect(homekitHandler.gladys.house.arm.args).to.eql([['maison']]);
+    expect(homekitHandler.gladys.house.partialArm.args).to.eql([['maison']]);
+    expect(homekitHandler.gladys.house.disarm.args).to.eql([['maison']]);
+    expect(cb.callCount).to.equal(3);
+  });
+
+  it('should answer without failing when the house is already in the mode asked for', async () => {
+    const { homekitHandler, characteristics } = build(ALARM_MODES.ARMED);
+    homekitHandler.gladys.house.arm = stub().rejects(new Error('House is already armed'));
+    const cb = stub();
+
+    await characteristics.TARGETSTATE.handlers.set(1, cb);
+
+    // the Home app does this whenever two people press the same button: the house is in the state
+    // that was asked for either way
+    expect(cb.callCount).to.equal(1);
+    expect(cb.args[0]).to.eql([]);
+  });
+});

--- a/server/test/services/homekit/lib/buildAlarmAccessory.test.js
+++ b/server/test/services/homekit/lib/buildAlarmAccessory.test.js
@@ -92,13 +92,38 @@ describe('Build alarm accessory', () => {
     expect(await readCharacteristic(characteristics.TARGETSTATE)).to.equal(0);
   });
 
-  it('should keep the target armed while the alarm is going off', async () => {
+  it('should assume away for a house that went off before the bridge started', async () => {
     const { characteristics } = build(ALARM_MODES.PANIC);
 
     // HomeKit has no triggered target, and reporting disarmed there would show the alarm as
-    // switched off while it rings
+    // switched off while it rings. Nothing records what preceded the panic, so away is assumed —
+    // the stricter of the two.
     expect(await readCharacteristic(characteristics.CURRENTSTATE)).to.equal(4);
     expect(await readCharacteristic(characteristics.TARGETSTATE)).to.equal(1);
+  });
+
+  it('should keep the target the house was armed with while the alarm is going off', async () => {
+    const { homekitHandler, characteristics } = build(ALARM_MODES.PARTIALLY_ARMED);
+
+    // read once while partially armed, so the accessory knows what the house is running
+    expect(await readCharacteristic(characteristics.TARGETSTATE)).to.equal(0);
+
+    homekitHandler.gladys.house.getBySelector = stub().resolves({ ...HOUSE, alarm_mode: ALARM_MODES.PANIC });
+
+    // a house armed in part that goes off must not be shown as armed away
+    expect(await readCharacteristic(characteristics.CURRENTSTATE)).to.equal(4);
+    expect(await readCharacteristic(characteristics.TARGETSTATE)).to.equal(0);
+  });
+
+  it('should remember the target the Home app asked for', async () => {
+    const { homekitHandler, characteristics } = build(ALARM_MODES.DISARMED);
+    const cb = stub();
+
+    await characteristics.TARGETSTATE.handlers.set(0, cb);
+    homekitHandler.gladys.house.getBySelector = stub().resolves({ ...HOUSE, alarm_mode: ALARM_MODES.PANIC });
+
+    // the mode it was armed with is what it goes back to showing, without waiting for a read first
+    expect(await readCharacteristic(characteristics.TARGETSTATE)).to.equal(0);
   });
 
   it('should not offer the night mode Gladys has no equivalent for', async () => {

--- a/server/test/services/homekit/lib/buildAlarmAccessory.test.js
+++ b/server/test/services/homekit/lib/buildAlarmAccessory.test.js
@@ -159,8 +159,12 @@ describe('Build alarm accessory', () => {
     homekitHandler.gladys.house.getBySelector = stub().rejects(failure);
 
     // a callback that is never called leaves the HAP request hanging until it times out
-    const current = await new Promise((resolve) => characteristics.CURRENTSTATE.handlers.get(resolve));
-    const target = await new Promise((resolve) => characteristics.TARGETSTATE.handlers.get(resolve));
+    const current = await new Promise((resolve) => {
+      characteristics.CURRENTSTATE.handlers.get(resolve);
+    });
+    const target = await new Promise((resolve) => {
+      characteristics.TARGETSTATE.handlers.get(resolve);
+    });
 
     expect(current).to.equal(failure);
     expect(target).to.equal(failure);

--- a/server/test/services/homekit/lib/buildAlarmAccessory.test.js
+++ b/server/test/services/homekit/lib/buildAlarmAccessory.test.js
@@ -4,6 +4,7 @@ const sinon = require('sinon').createSandbox();
 const { stub } = sinon;
 const { buildAlarmAccessory } = require('../../../../services/homekit/lib/buildAlarmAccessory');
 const { ALARM_MODES } = require('../../../../utils/constants');
+const { ConflictError, NotFoundError } = require('../../../../utils/coreErrors');
 
 const HOUSE = { id: 'e1b0a9cf-3f6f-4f2e-9f6b-2c0a7f4a1d55', name: 'Maison', selector: 'maison' };
 
@@ -129,7 +130,7 @@ describe('Build alarm accessory', () => {
 
   it('should answer without failing when the house is already in the mode asked for', async () => {
     const { homekitHandler, characteristics } = build(ALARM_MODES.ARMED);
-    homekitHandler.gladys.house.arm = stub().rejects(new Error('House is already armed'));
+    homekitHandler.gladys.house.arm = stub().rejects(new ConflictError('House is already armed'));
     const cb = stub();
 
     await characteristics.TARGETSTATE.handlers.set(1, cb);
@@ -138,5 +139,30 @@ describe('Build alarm accessory', () => {
     // that was asked for either way
     expect(cb.callCount).to.equal(1);
     expect(cb.args[0]).to.eql([]);
+  });
+
+  it('should report a command that really failed', async () => {
+    const { homekitHandler, characteristics } = build(ALARM_MODES.ARMED);
+    const failure = new NotFoundError('House not found');
+    homekitHandler.gladys.house.disarm = stub().rejects(failure);
+    const cb = stub();
+
+    await characteristics.TARGETSTATE.handlers.set(3, cb);
+
+    // answering a failed disarm with a success would show the alarm off while the house stays armed
+    expect(cb.args[0]).to.eql([failure]);
+  });
+
+  it('should answer a read that failed instead of leaving it hanging', async () => {
+    const { homekitHandler, characteristics } = build(ALARM_MODES.ARMED);
+    const failure = new NotFoundError('House not found');
+    homekitHandler.gladys.house.getBySelector = stub().rejects(failure);
+
+    // a callback that is never called leaves the HAP request hanging until it times out
+    const current = await new Promise((resolve) => characteristics.CURRENTSTATE.handlers.get(resolve));
+    const target = await new Promise((resolve) => characteristics.TARGETSTATE.handlers.get(resolve));
+
+    expect(current).to.equal(failure);
+    expect(target).to.equal(failure);
   });
 });

--- a/server/test/services/homekit/lib/createBridge.test.js
+++ b/server/test/services/homekit/lib/createBridge.test.js
@@ -13,6 +13,7 @@ describe('Create bridge', () => {
       serviceId: '7056e3d4-31cc-4d2a-bbdd-128cd49755e6',
       createBridge,
       buildAccessory: stub().returns({ UUID: '78a7b724-18e8-4c15-ab30-c8486c253f36' }),
+      buildAlarmAccessory: stub().returns({ UUID: 'e1b0a9cf-3f6f-4f2e-9f6b-2c0a7f4a1d55' }),
       getExposedDevices: stub().resolves([
         {
           id: '07f16117-8556-4b50-b9f0-e190d08f8d92',
@@ -28,6 +29,9 @@ describe('Create bridge', () => {
         },
         event: {
           on: stub().returns(),
+        },
+        house: {
+          get: stub().resolves([{ id: 'e1b0a9cf-3f6f-4f2e-9f6b-2c0a7f4a1d55', name: 'Maison', selector: 'maison' }]),
         },
       },
       newUsername: stub().resolves('C4:D0:AB:12:BC:51'),
@@ -48,7 +52,13 @@ describe('Create bridge', () => {
 
     expect(homekitHandler.hap.Bridge.args[0][0]).to.equal('Gladys');
     expect(homekitHandler.hap.Bridge.args[0][1]).not.equal(null);
-    expect(addBridgedAccessories.args[0][0]).to.deep.members([{ UUID: '78a7b724-18e8-4c15-ab30-c8486c253f36' }]);
+    // the house alarm is exposed alongside the devices, and is indexed by selector so an alarm
+    // event can find its accessory again
+    expect(addBridgedAccessories.args[0][0]).to.deep.members([
+      { UUID: '78a7b724-18e8-4c15-ab30-c8486c253f36' },
+      { UUID: 'e1b0a9cf-3f6f-4f2e-9f6b-2c0a7f4a1d55' },
+    ]);
+    expect(homekitHandler.alarmAccessories.get('maison')).to.eql({ UUID: 'e1b0a9cf-3f6f-4f2e-9f6b-2c0a7f4a1d55' });
     expect(publish.args[0][0]).to.eql({
       username: 'C4:D0:AB:12:BC:51',
       pincode: '123-45-678',

--- a/server/test/services/homekit/lib/createBridge.test.js
+++ b/server/test/services/homekit/lib/createBridge.test.js
@@ -14,6 +14,13 @@ describe('Create bridge', () => {
       createBridge,
       buildAccessory: stub().returns({ UUID: '78a7b724-18e8-4c15-ab30-c8486c253f36' }),
       buildAlarmAccessory: stub().returns({ UUID: 'e1b0a9cf-3f6f-4f2e-9f6b-2c0a7f4a1d55' }),
+      getExposedAlarms: stub().resolves([
+        {
+          name: 'Maison',
+          selector: 'house-alarm:maison',
+          house: { id: 'e1b0a9cf', name: 'Maison', selector: 'maison' },
+        },
+      ]),
       getExposedDevices: stub().resolves([
         {
           id: '07f16117-8556-4b50-b9f0-e190d08f8d92',
@@ -29,9 +36,6 @@ describe('Create bridge', () => {
         },
         event: {
           on: stub().returns(),
-        },
-        house: {
-          get: stub().resolves([{ id: 'e1b0a9cf-3f6f-4f2e-9f6b-2c0a7f4a1d55', name: 'Maison', selector: 'maison' }]),
         },
       },
       newUsername: stub().resolves('C4:D0:AB:12:BC:51'),

--- a/server/test/services/homekit/lib/exposedDevices.test.js
+++ b/server/test/services/homekit/lib/exposedDevices.test.js
@@ -7,7 +7,9 @@ const {
   EXPOSURE_MODE_VARIABLE,
   EXPOSED_DEVICES_VARIABLE,
   getCompatibleDevices,
+  getCompatibleAlarms,
   getExposedDevices,
+  getExposedAlarms,
 } = require('../../../../services/homekit/lib/exposedDevices');
 const { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } = require('../../../../utils/constants');
 
@@ -47,13 +49,20 @@ const NOT_COMPATIBLE = {
   ],
 };
 
+const HOUSE = { id: 'e1b0a9cf-3f6f-4f2e-9f6b-2c0a7f4a1d55', name: 'Maison', selector: 'maison' };
+
 const buildHandler = () => ({
   serviceId: '7056e3d4-31cc-4d2a-bbdd-128cd49755e6',
   getCompatibleDevices,
+  getCompatibleAlarms,
   getExposedDevices,
+  getExposedAlarms,
   gladys: {
     device: {
       get: stub().resolves([LAMP, SWITCH, NOT_COMPATIBLE]),
+    },
+    house: {
+      get: stub().resolves([HOUSE]),
     },
     variable: {
       getValue: stub().resolves(null),
@@ -142,5 +151,49 @@ describe('Exposed devices', () => {
     const devices = await homekitHandler.getExposedDevices();
 
     expect(devices).to.deep.equal([]);
+  });
+  it('should offer the alarm of every house under a selector of its own', async () => {
+    const homekitHandler = buildHandler();
+
+    const alarms = await homekitHandler.getCompatibleAlarms();
+
+    // prefixed so it cannot collide with a device selector in the same allow list
+    expect(alarms).to.eql([{ name: 'Maison', selector: 'house-alarm:maison', house: HOUSE }]);
+  });
+
+  it('should expose every alarm when no selection is made', async () => {
+    const homekitHandler = buildHandler();
+
+    const alarms = await homekitHandler.getExposedAlarms();
+
+    expect(alarms.map(({ selector }) => selector)).to.eql(['house-alarm:maison']);
+  });
+
+  it('should leave the alarm out when the user did not pick it', async () => {
+    const homekitHandler = buildHandler();
+    homekitHandler.gladys.variable.getValue
+      .withArgs(EXPOSURE_MODE_VARIABLE, homekitHandler.serviceId)
+      .resolves(EXPOSURE_MODES.SELECTION);
+    homekitHandler.gladys.variable.getValue
+      .withArgs(EXPOSED_DEVICES_VARIABLE, homekitHandler.serviceId)
+      .resolves(JSON.stringify(['lampe-bureau']));
+
+    // someone who does not use the Gladys alarm must be able to keep it out of the Home app, like
+    // any other accessory
+    expect(await homekitHandler.getExposedAlarms()).to.eql([]);
+    expect((await homekitHandler.getExposedDevices()).map(({ selector }) => selector)).to.eql(['lampe-bureau']);
+  });
+
+  it('should expose the alarm when the user picked it', async () => {
+    const homekitHandler = buildHandler();
+    homekitHandler.gladys.variable.getValue
+      .withArgs(EXPOSURE_MODE_VARIABLE, homekitHandler.serviceId)
+      .resolves(EXPOSURE_MODES.SELECTION);
+    homekitHandler.gladys.variable.getValue
+      .withArgs(EXPOSED_DEVICES_VARIABLE, homekitHandler.serviceId)
+      .resolves(JSON.stringify(['house-alarm:maison']));
+
+    expect((await homekitHandler.getExposedAlarms()).map(({ selector }) => selector)).to.eql(['house-alarm:maison']);
+    expect(await homekitHandler.getExposedDevices()).to.eql([]);
   });
 });

--- a/server/test/services/homekit/lib/notifyChange.test.js
+++ b/server/test/services/homekit/lib/notifyChange.test.js
@@ -274,7 +274,7 @@ describe('Notify change to HomeKit', () => {
     ]);
   });
   it('should forward an alarm change without any debounce', async () => {
-    homekitHandler.sendAlarmState = stub();
+    homekitHandler.sendAlarmState = stub().resolves();
 
     await homekitHandler.notifyChange([], { type: EVENTS.ALARM.ARM, house: 'maison' });
     await homekitHandler.notifyChange([], { type: EVENTS.ALARM.DISARM, house: 'maison' });
@@ -288,5 +288,15 @@ describe('Notify change to HomeKit', () => {
     await homekitHandler.notifyChange([], { type: EVENTS.ALARM.ARMING, house: 'maison' });
 
     expect(homekitHandler.sendAlarmState.callCount).to.equal(4);
+  });
+
+  it('should not leave an alarm forwarding failure unhandled', async () => {
+    homekitHandler.sendAlarmState = stub().rejects(new Error('House not found'));
+
+    // this runs from an event listener: a dropped rejection would go unhandled
+    await homekitHandler.notifyChange([], { type: EVENTS.ALARM.ARM, house: 'maison' });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(homekitHandler.sendAlarmState.callCount).to.equal(1);
   });
 });

--- a/server/test/services/homekit/lib/notifyChange.test.js
+++ b/server/test/services/homekit/lib/notifyChange.test.js
@@ -295,7 +295,9 @@ describe('Notify change to HomeKit', () => {
 
     // this runs from an event listener: a dropped rejection would go unhandled
     await homekitHandler.notifyChange([], { type: EVENTS.ALARM.ARM, house: 'maison' });
-    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
 
     expect(homekitHandler.sendAlarmState.callCount).to.equal(1);
   });

--- a/server/test/services/homekit/lib/notifyChange.test.js
+++ b/server/test/services/homekit/lib/notifyChange.test.js
@@ -273,4 +273,20 @@ describe('Notify change to HomeKit', () => {
       },
     ]);
   });
+  it('should forward an alarm change without any debounce', async () => {
+    homekitHandler.sendAlarmState = stub();
+
+    await homekitHandler.notifyChange([], { type: EVENTS.ALARM.ARM, house: 'maison' });
+    await homekitHandler.notifyChange([], { type: EVENTS.ALARM.DISARM, house: 'maison' });
+    await homekitHandler.notifyChange([], { type: EVENTS.ALARM.PARTIAL_ARM, house: 'maison' });
+    await homekitHandler.notifyChange([], { type: EVENTS.ALARM.PANIC, house: 'maison' });
+
+    // an alarm arming or going off is exactly what HomeKit must hear about at once
+    expect(homekitHandler.sendAlarmState.args).to.eql([['maison'], ['maison'], ['maison'], ['maison']]);
+
+    // arming only announces the delay before the house actually arms: the mode has not changed yet
+    await homekitHandler.notifyChange([], { type: EVENTS.ALARM.ARMING, house: 'maison' });
+
+    expect(homekitHandler.sendAlarmState.callCount).to.equal(4);
+  });
 });

--- a/server/test/services/homekit/lib/sendAlarmState.test.js
+++ b/server/test/services/homekit/lib/sendAlarmState.test.js
@@ -6,15 +6,20 @@ const { sendAlarmState } = require('../../../../services/homekit/lib/sendAlarmSt
 const { ALARM_MODES } = require('../../../../utils/constants');
 
 describe('Send alarm state to HomeKit', () => {
-  const build = (alarmMode) => {
+  const build = (alarmMode, targetFromHandler = 1) => {
     const updateCharacteristic = stub();
     updateCharacteristic.returns({ updateCharacteristic });
-    const accessory = { getService: stub().returns({ updateCharacteristic }) };
+    // the target is refreshed through its own GET handler, as the accessory builds it
+    const emit = stub().callsFake((event, cb) => cb(undefined, targetFromHandler));
+    const accessory = {
+      getService: stub().returns({ updateCharacteristic, getCharacteristic: stub().returns({ emit }) }),
+    };
 
     const homekitHandler = {
       sendAlarmState,
       alarmAccessories: new Map([['maison', accessory]]),
       hap: {
+        CharacteristicEventTypes: { GET: 'get' },
         Service: { SecuritySystem: 'SECURITYSYSTEM' },
         Characteristic: {
           SecuritySystemCurrentState: 'CURRENTSTATE',
@@ -40,13 +45,17 @@ describe('Send alarm state to HomeKit', () => {
     ]);
   });
 
-  it('should leave the target alone when the alarm goes off', async () => {
-    const { homekitHandler, updateCharacteristic } = build(ALARM_MODES.PANIC);
+  it('should take the target from the accessory when the alarm goes off', async () => {
+    // the accessory knows the house was armed in part, which this module cannot derive from the
+    // alarm mode alone — deciding it in both places is how the two came to disagree
+    const { homekitHandler, updateCharacteristic } = build(ALARM_MODES.PANIC, 0);
 
     await homekitHandler.sendAlarmState('maison');
 
-    // pushing disarmed on the target would show the alarm as switched off while it rings
-    expect(updateCharacteristic.args).to.eql([['CURRENTSTATE', 4]]);
+    expect(updateCharacteristic.args).to.eql([
+      ['CURRENTSTATE', 4],
+      ['TARGETSTATE', 0],
+    ]);
   });
 
   it('should do nothing for a house the bridge has no accessory for', async () => {
@@ -60,7 +69,7 @@ describe('Send alarm state to HomeKit', () => {
   });
 
   it('should report an alarm mode it does not know as disarmed', async () => {
-    const { homekitHandler, updateCharacteristic } = build('something-else');
+    const { homekitHandler, updateCharacteristic } = build('something-else', 3);
 
     await homekitHandler.sendAlarmState('maison');
 

--- a/server/test/services/homekit/lib/sendAlarmState.test.js
+++ b/server/test/services/homekit/lib/sendAlarmState.test.js
@@ -59,11 +59,15 @@ describe('Send alarm state to HomeKit', () => {
     expect(homekitHandler.gladys.house.getBySelector.callCount).to.equal(0);
   });
 
-  it('should do nothing for an alarm mode it does not know', async () => {
+  it('should report an alarm mode it does not know as disarmed', async () => {
     const { homekitHandler, updateCharacteristic } = build('something-else');
 
     await homekitHandler.sendAlarmState('maison');
 
-    expect(updateCharacteristic.callCount).to.equal(0);
+    // leaving HomeKit alone would keep it showing a stale armed state
+    expect(updateCharacteristic.args).to.eql([
+      ['CURRENTSTATE', 3],
+      ['TARGETSTATE', 3],
+    ]);
   });
 });

--- a/server/test/services/homekit/lib/sendAlarmState.test.js
+++ b/server/test/services/homekit/lib/sendAlarmState.test.js
@@ -1,0 +1,69 @@
+const { expect } = require('chai');
+const sinon = require('sinon').createSandbox();
+
+const { stub } = sinon;
+const { sendAlarmState } = require('../../../../services/homekit/lib/sendAlarmState');
+const { ALARM_MODES } = require('../../../../utils/constants');
+
+describe('Send alarm state to HomeKit', () => {
+  const build = (alarmMode) => {
+    const updateCharacteristic = stub();
+    updateCharacteristic.returns({ updateCharacteristic });
+    const accessory = { getService: stub().returns({ updateCharacteristic }) };
+
+    const homekitHandler = {
+      sendAlarmState,
+      alarmAccessories: new Map([['maison', accessory]]),
+      hap: {
+        Service: { SecuritySystem: 'SECURITYSYSTEM' },
+        Characteristic: {
+          SecuritySystemCurrentState: 'CURRENTSTATE',
+          SecuritySystemTargetState: 'TARGETSTATE',
+        },
+      },
+      gladys: {
+        house: { getBySelector: stub().resolves({ selector: 'maison', alarm_mode: alarmMode }) },
+      },
+    };
+
+    return { homekitHandler, updateCharacteristic };
+  };
+
+  it('should push both states when the house is armed', async () => {
+    const { homekitHandler, updateCharacteristic } = build(ALARM_MODES.ARMED);
+
+    await homekitHandler.sendAlarmState('maison');
+
+    expect(updateCharacteristic.args).to.eql([
+      ['CURRENTSTATE', 1],
+      ['TARGETSTATE', 1],
+    ]);
+  });
+
+  it('should leave the target alone when the alarm goes off', async () => {
+    const { homekitHandler, updateCharacteristic } = build(ALARM_MODES.PANIC);
+
+    await homekitHandler.sendAlarmState('maison');
+
+    // pushing disarmed on the target would show the alarm as switched off while it rings
+    expect(updateCharacteristic.args).to.eql([['CURRENTSTATE', 4]]);
+  });
+
+  it('should do nothing for a house the bridge has no accessory for', async () => {
+    const { homekitHandler, updateCharacteristic } = build(ALARM_MODES.ARMED);
+
+    // a house created since the bridge was built has no accessory until the next reload
+    await homekitHandler.sendAlarmState('maison-secondaire');
+
+    expect(updateCharacteristic.callCount).to.equal(0);
+    expect(homekitHandler.gladys.house.getBySelector.callCount).to.equal(0);
+  });
+
+  it('should do nothing for an alarm mode it does not know', async () => {
+    const { homekitHandler, updateCharacteristic } = build('something-else');
+
+    await homekitHandler.sendAlarmState('maison');
+
+    expect(updateCharacteristic.callCount).to.equal(0);
+  });
+});


### PR DESCRIPTION
Follow-up from the forum discussion — @Pierre-Gilles said mapping the alarm mode
looked fine to him.

### What made this one different

The alarm is the only thing HomeKit models that Gladys keeps outside the device tree:
it lives on the house, in `t_house.alarm_mode`. So it cannot be reached by the device
mapping the rest of the bridge is built on.

`createBridge` now builds one accessory per house, keyed by the house id and named
after it. Several houses give several alarms in the Home app.

### The mapping

| Gladys | HomeKit |
|---|---|
| `armed` | `AWAY_ARM` |
| `partially-armed` | `STAY_ARM` |
| `disarmed` | `DISARMED` |
| `panic` | `ALARM_TRIGGERED` |

`partially-armed` onto `STAY_ARM` is the same idea seen from the other side: a house
armed in part is one its occupants are still living in.

### It goes through the exposure setting

The first version appended the alarm accessories straight to the bridge, bypassing the
setting added in #2800 entirely: someone who picked three devices in selection mode got
four accessories, and the fail-closed policy that setting documents did not hold.

House alarms now go through the same allow list as the devices, under a `house-alarm:`
prefixed selector that cannot collide with a device one. Whoever does not use the
Gladys alarm simply leaves it unticked.

The selection screen needed no change — it lists whatever `GET /service/homekit/device`
returns, and the alarms are now in that response. They are labelled in the front, since
the server has no translations; the HomeKit accessory keeps the plain house name, where
the Home app already shows an alarm icon.

### Three decisions worth reviewing

**HomeKit's night mode is removed from the values offered**, with `setProps`, rather
than accepted and silently ignored. Gladys has no equivalent, and offering a state the
house cannot honour is the defect Cursor caught on the thermostat in #2799.

**A ringing alarm keeps its armed target.** `SecuritySystemTargetState` has no triggered
value — its fourth is `DISARM`, not `DISARMED` — so reporting disarmed there would show
the alarm as switched off while it goes off.

**An unknown alarm mode is reported as disarmed**, not as an alarm going off: announcing
a break-in that is not happening is the worse of the two mistakes.

### On exposing the alarm by default

The alarm follows the same `all` default as every other accessory, so an existing
install gains it on the next bridge restart. HomeKit has no notion of an arming code —
`SecuritySystem` carries only the two state characteristics — so `disarmWithCode`
cannot be wired to it; the protection is the per-accessory "Require Authentication"
setting on the iPhone. #2794 already exposes door locks through the same default,
which is at least as sensitive. Whoever does not want the alarm unticks it in
selection mode. Say the word if you would rather have it opt-in — one line in
`getExposedAlarms`.

### Notes

Alarm changes reach the bridge on the same trigger stream as device states, under
`EVENTS.ALARM.*`, and are forwarded without debounce. `ARMING` is deliberately not
forwarded: it announces the delay before the house arms, and the mode has not changed
yet when it fires.

Setting the mode the house is already in throws a conflict, which the Home app triggers
whenever two people press the same button. That is answered as done rather than as
failed.

149 tests pass. `buildAlarmAccessory.js`, `sendAlarmState.js`, `exposedDevices.js` and
`homekit.controller.js` at 100% including branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added HomeKit support for Gladys house alarms.
- View and control disarmed, stay, away, and panic alarm states.
- Alarm state changes now update HomeKit promptly.
- Added English, French, and German alarm labels.
- Added alarm discovery, selection, and exposure controls alongside other HomeKit devices.

## Tests
- Added coverage for alarm discovery, controls, state updates, exposure settings, and bridge integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->