### PR TITLE
fix: answer device.get-state when the model targets the house instead of a room (#2850)

### DIFF
--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -46,6 +46,35 @@ const intervalByName = {
 };
 
 /**
+ * @description Resolve a device type sent by the model to a feature category of this home.
+ * @param {string} requestedType - Device type as sent by the model.
+ * @param {Array<string>} availableDeviceTypes - Feature categories available in this home.
+ * @returns {string} Matching feature category, or the requested type when nothing matches.
+ * @example
+ * resolveDeviceType('temperature', ['temperature-sensor']);
+ */
+function resolveDeviceType(requestedType, availableDeviceTypes) {
+  const normalized = String(requestedType)
+    .trim()
+    .toLowerCase();
+
+  const exactMatch = availableDeviceTypes.find((category) => category.toLowerCase() === normalized);
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  // Models routinely drop the category suffix and ask for "temperature" instead of
+  // "temperature-sensor". Returning the requested type untouched when nothing
+  // matches keeps "this category does not exist in this home" a distinct outcome.
+  const prefixMatch = availableDeviceTypes.find((category) => category.toLowerCase().startsWith(`${normalized}-`));
+  if (prefixMatch) {
+    return prefixMatch;
+  }
+
+  return requestedType;
+}
+
+/**
  * @description Get all resources (room and devices) available for the MCP service.
  * @returns {Promise<Array>} Array of resources with home schema configuration.
  * @example
@@ -241,7 +270,12 @@ async function getAllResources() {
  * getAllTools('0cd30aef-9c4e-4a23-88e3-3547971296e5')
  */
 async function getAllTools(userId) {
-  const rooms = (await this.gladys.room.getAll()).map(({ id, name, selector }) => ({ id, name, selector }));
+  const rooms = (await this.gladys.room.getAll()).map(({ id, name, selector, house_id: houseId }) => ({
+    id,
+    name,
+    selector,
+    house_id: houseId,
+  }));
   rooms.push(noRoom);
   const scenes = (await this.gladys.scene.get()).map(({ id, name, selector }) => ({ id, name, selector }));
   const users = (await this.gladys.user.get()).map(({ id, name, selector }) => ({ id, name, selector }));
@@ -324,6 +358,14 @@ async function getAllTools(userId) {
         })
         .flat(),
     ),
+  ];
+  const availableDeviceTypes = [
+    ...new Set([
+      ...availableSensorFeatureCategories,
+      ...availableSwitchableFeatureCategories,
+      ...availableLightControlFeatureCategories,
+      ...availableShutterFeatureCategories,
+    ]),
   ];
   const deviceFeatureSelectors = allDevices
     .map((device) => device.features.map((feature) => feature.selector))
@@ -504,16 +546,12 @@ async function getAllTools(userId) {
           room: z
             .enum(rooms.map(({ name }) => name))
             .optional()
-            .describe('Room to get information from, leave empty to select multiple rooms.'),
+            .describe(
+              'Room to get information from. Only a room name from the list is accepted, ' +
+                'leave empty to cover the whole home.',
+            ),
           device_type: z
-            .enum([
-              ...new Set([
-                ...availableSensorFeatureCategories,
-                ...availableSwitchableFeatureCategories,
-                ...availableLightControlFeatureCategories,
-                ...availableShutterFeatureCategories,
-              ]),
-            ])
+            .enum(availableDeviceTypes)
             .optional()
             .describe('Type of device to query, leave empty to retrieve all devices.'),
         },
@@ -522,15 +560,58 @@ async function getAllTools(userId) {
         const states = [];
 
         let selectedDevices = [...sensorDevices, ...switchableDevices, ...lightControlDevices, ...shutterDevices];
+        let scopeLabel = '';
 
+        // The chat gateway runs this callback with the raw arguments produced by the
+        // model, which is not bound by the enums above. "Températures de la maison"
+        // makes it pass the house as a room: that used to resolve to no selector at
+        // all, filter every device out, and the empty result then reads as "no
+        // temperature sensor is configured at home".
         if (room && room !== '') {
-          const { selector } = this.findBySimilarity(rooms, room);
-          selectedDevices = selectedDevices.filter((d) => (d.room?.selector || noRoom.selector) === selector);
+          const selectedRoom = this.findBySimilarity(rooms, room);
+
+          if (selectedRoom?.selector) {
+            selectedDevices = selectedDevices.filter(
+              (d) => (d.room?.selector || noRoom.selector) === selectedRoom.selector,
+            );
+            scopeLabel = ` in room "${selectedRoom.name}"`;
+          } else {
+            const selectedHouse = this.findBySimilarity(houses, room);
+
+            if (selectedHouse?.id) {
+              // A house is the whole home, not a room: keep every device of its rooms,
+              // plus the devices that are not assigned to a room.
+              const houseRoomSelectors = rooms
+                .filter((r) => r.house_id === selectedHouse.id)
+                .map(({ selector }) => selector);
+              selectedDevices = selectedDevices.filter(
+                (d) => !d.room?.selector || houseRoomSelectors.includes(d.room.selector),
+              );
+              scopeLabel = ` in house "${selectedHouse.name}"`;
+            } else {
+              return {
+                content: [
+                  {
+                    type: 'text',
+                    text:
+                      `device.get-state: "${room}" is not a room of this home, no state was read. ` +
+                      `Available rooms: ${rooms.map(({ name }) => name).join(', ')}. ` +
+                      'Call this tool again with one of them, or without the room parameter to cover the whole home.',
+                  },
+                ],
+              };
+            }
+          }
         }
 
-        if (deviceType && deviceType.length > 0) {
+        const requestedDeviceTypes = (Array.isArray(deviceType) ? deviceType : [deviceType]).filter(Boolean);
+        const deviceTypes = requestedDeviceTypes.map((requestedType) =>
+          resolveDeviceType(requestedType, availableDeviceTypes),
+        );
+
+        if (deviceTypes.length > 0) {
           selectedDevices = selectedDevices.filter((device) => {
-            return device.features.some((feature) => deviceType.includes(feature.category));
+            return device.features.some((feature) => deviceTypes.includes(feature.category));
           });
         }
 
@@ -538,7 +619,7 @@ async function getAllTools(userId) {
           selectedDevices.map(async (device) => {
             const deviceLastState = await this.gladys.device.getBySelector(device.selector);
             return device.features.map((feature) => {
-              if (!deviceType || deviceType.length === 0 || deviceType.includes(feature.category)) {
+              if (deviceTypes.length === 0 || deviceTypes.includes(feature.category)) {
                 const featureLastState = deviceLastState.features.find((feat) => feat.id === feature.id);
 
                 states.push({
@@ -560,15 +641,14 @@ async function getAllTools(userId) {
         // An empty list is an ambiguous signal for the model, which tends to fill the
         // gap with a plausible value. Say explicitly that nothing is configured.
         if (states.length === 0) {
-          const typeLabel = deviceType && deviceType.length > 0 ? ` of type "${deviceType}"` : '';
-          const roomLabel = room && room !== '' ? ` in room "${room}"` : '';
+          const typeLabel = deviceTypes.length > 0 ? ` of type "${deviceTypes.join('", "')}"` : '';
 
           return {
             content: [
               {
                 type: 'text',
                 text:
-                  `device.get-state: no device${typeLabel} is configured${roomLabel}. ` +
+                  `device.get-state: no device${typeLabel} is configured${scopeLabel}. ` +
                   'No measurement exists for this query, do not report any value.',
               },
             ],

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -46,32 +46,34 @@ const intervalByName = {
 };
 
 /**
- * @description Resolve a device type sent by the model to a feature category of this home.
+ * @description Resolve a device type sent by the model to the feature categories of this home.
  * @param {string} requestedType - Device type as sent by the model.
  * @param {Array<string>} availableDeviceTypes - Feature categories available in this home.
- * @returns {string} Matching feature category, or the requested type when nothing matches.
+ * @returns {Array<string>} Matching feature categories, or the requested type when nothing matches.
  * @example
- * resolveDeviceType('temperature', ['temperature-sensor']);
+ * resolveDeviceTypes('temperature', ['temperature-sensor']);
  */
-function resolveDeviceType(requestedType, availableDeviceTypes) {
+function resolveDeviceTypes(requestedType, availableDeviceTypes) {
   const normalized = String(requestedType)
     .trim()
     .toLowerCase();
 
   const exactMatch = availableDeviceTypes.find((category) => category.toLowerCase() === normalized);
   if (exactMatch) {
-    return exactMatch;
+    return [exactMatch];
   }
 
   // Models routinely drop the category suffix and ask for "temperature" instead of
-  // "temperature-sensor". Returning the requested type untouched when nothing
-  // matches keeps "this category does not exist in this home" a distinct outcome.
-  const prefixMatch = availableDeviceTypes.find((category) => category.toLowerCase().startsWith(`${normalized}-`));
-  if (prefixMatch) {
-    return prefixMatch;
+  // "temperature-sensor". Several categories can share a prefix ("energy-sensor" and
+  // "energy-production-sensor"), so keep them all instead of silently picking whichever
+  // comes first. Returning the requested type untouched when nothing matches keeps
+  // "this category does not exist in this home" a distinct outcome.
+  const prefixMatches = availableDeviceTypes.filter((category) => category.toLowerCase().startsWith(`${normalized}-`));
+  if (prefixMatches.length > 0) {
+    return prefixMatches;
   }
 
-  return requestedType;
+  return [requestedType];
 }
 
 /**
@@ -595,7 +597,12 @@ async function getAllTools(userId) {
                     type: 'text',
                     text:
                       `device.get-state: "${room}" is not a room of this home, no state was read. ` +
-                      `Available rooms: ${rooms.map(({ name }) => name).join(', ')}. ` +
+                      // "No room" is the sentinel holding the devices that were never assigned
+                      // to a room, not a room the model should be invited to retry with.
+                      `Available rooms: ${rooms
+                        .filter(({ selector }) => selector !== noRoom.selector)
+                        .map(({ name }) => name)
+                        .join(', ')}. ` +
                       'Call this tool again with one of them, or without the room parameter to cover the whole home.',
                   },
                 ],
@@ -605,9 +612,11 @@ async function getAllTools(userId) {
         }
 
         const requestedDeviceTypes = (Array.isArray(deviceType) ? deviceType : [deviceType]).filter(Boolean);
-        const deviceTypes = requestedDeviceTypes.map((requestedType) =>
-          resolveDeviceType(requestedType, availableDeviceTypes),
-        );
+        const deviceTypes = [
+          ...new Set(
+            requestedDeviceTypes.flatMap((requestedType) => resolveDeviceTypes(requestedType, availableDeviceTypes)),
+          ),
+        ];
 
         if (deviceTypes.length > 0) {
           selectedDevices = selectedDevices.filter((device) => {

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -3601,4 +3601,104 @@ describe('build schemas', () => {
     const withSensor = await getStateTool.cb({ room: 'Salon', device_type: 'humidity-sensor' });
     expect(withSensor.content[0].text).to.eq('toonmockdata');
   });
+
+  it('should answer device.get-state when the model targets the house or shortens the device type', async () => {
+    const rooms = [
+      { id: 'room-1', name: 'Salon', selector: 'salon', house_id: 'house-1' },
+      { id: 'room-2', name: 'Cuisine', selector: 'cuisine', house_id: 'house-1' },
+    ];
+    const houses = [{ id: 'house-1', name: 'Maison', selector: 'maison' }];
+
+    const buildSensor = (suffix, roomSelector, roomName, value) => ({
+      selector: `capteur-${suffix}`,
+      name: `Capteur ${suffix}`,
+      room: roomSelector ? { selector: roomSelector, name: roomName } : null,
+      features: [
+        {
+          id: `feature-${suffix}`,
+          selector: `capteur-${suffix}-temperature`,
+          name: 'Température',
+          category: 'temperature-sensor',
+          type: 'decimal',
+          unit: 'celsius',
+          last_value: value,
+        },
+      ],
+    });
+
+    // One sensor per room, plus one that was never assigned to a room.
+    const sensors = [
+      buildSensor('salon', 'salon', 'Salon', 21),
+      buildSensor('cuisine', 'cuisine', 'Cuisine', 23),
+      buildSensor('garage', null, null, 17),
+    ];
+
+    const mcpHandler = {
+      serviceId: 'test',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isLightControlFeature,
+      isShutterFeature,
+      isHistoryFeature,
+      isWritableSensorFeature,
+      formatValue: stub().callsFake((feature) => ({ value: feature.last_value, unit: feature.unit, age: '2min' })),
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves(rooms) },
+        user: { get: stub().resolves([]) },
+        house: { get: stub().resolves(houses) },
+        calendar: { get: stub().resolves([]) },
+        area: { get: stub().resolves([]) },
+        scene: { get: stub().resolves([]), create: stub().resolves({}) },
+        device: {
+          get: stub().resolves(sensors),
+          getBySelector: stub().callsFake(async (selector) => sensors.find((s) => s.selector === selector)),
+          setValue: stub().resolves(),
+          getDeviceFeaturesAggregates: stub().resolves({ values: [] }),
+          camera: { getImagesInRoom: stub().resolves([]) },
+        },
+        event: { emit: fake() },
+      },
+      levenshtein: { distance: stub().returns(10) },
+      toon: stub().callsFake((data) => JSON.stringify(data)),
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    const getStateTool = tools.find((tool) => tool.intent === 'device.get-state');
+
+    // "Températures de la maison": the model targets the house, which is not a room,
+    // and shortens the category. Both used to return "no sensor is configured".
+    const wholeHome = await getStateTool.cb({ room: 'maison', device_type: 'temperature' });
+    const wholeHomeStates = JSON.parse(wholeHome.content[0].text);
+    expect(wholeHomeStates.map(({ room, value }) => ({ room, value }))).to.deep.equal([
+      { room: 'Salon', value: 21 },
+      { room: 'Cuisine', value: 23 },
+      { room: 'No room', value: 17 },
+    ]);
+    expect(wholeHomeStates.every(({ category }) => category === 'temperature-sensor')).to.eq(true);
+
+    // The shortened category alone resolves too.
+    const shortType = await getStateTool.cb({ room: undefined, device_type: 'temperature' });
+    expect(JSON.parse(shortType.content[0].text).length).to.eq(3);
+
+    // A real room is still the narrow filter it used to be.
+    const inRoom = await getStateTool.cb({ room: 'Salon', device_type: 'temperature' });
+    expect(JSON.parse(inRoom.content[0].text).map(({ room }) => room)).to.deep.equal(['Salon']);
+
+    // An unknown target is reported as such instead of claiming nothing is configured.
+    const unknownRoom = await getStateTool.cb({ room: 'Véranda', device_type: 'temperature' });
+    expect(unknownRoom.content[0].text).to.eq(
+      'device.get-state: "Véranda" is not a room of this home, no state was read. ' +
+        'Available rooms: Salon, Cuisine, No room. ' +
+        'Call this tool again with one of them, or without the room parameter to cover the whole home.',
+    );
+
+    // A category that does not exist in this home keeps the explicit empty answer.
+    const unknownType = await getStateTool.cb({ room: 'maison', device_type: 'co2' });
+    expect(unknownType.content[0].text).to.eq(
+      'device.get-state: no device of type "co2" is configured in house "Maison". ' +
+        'No measurement exists for this query, do not report any value.',
+    );
+  });
 });

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -3690,7 +3690,7 @@ describe('build schemas', () => {
     const unknownRoom = await getStateTool.cb({ room: 'Véranda', device_type: 'temperature' });
     expect(unknownRoom.content[0].text).to.eq(
       'device.get-state: "Véranda" is not a room of this home, no state was read. ' +
-        'Available rooms: Salon, Cuisine, No room. ' +
+        'Available rooms: Salon, Cuisine. ' +
         'Call this tool again with one of them, or without the room parameter to cover the whole home.',
     );
 


### PR DESCRIPTION
> **This pull request was produced by an automated routine and has not been reviewed by a human.** Please review it carefully before merging.

Fixes #2850

### Description

**(a) What changed and why**

`gateway.forwardMessageToAiChat` executes the MCP tool callbacks with the raw arguments the model produced (`await cb(toolArgs)`), so `device.get-state` is never validated against its own Zod enums.

"Températures de la maison" makes the model pass the *house* as the `room` argument. `findBySimilarity(rooms, 'maison')` returned `{}`, the resulting `undefined` selector made `selectedDevices.filter((d) => (d.room?.selector || noRoom.selector) === selector)` drop **every** device, and the empty result was then reported through the anti-hallucination message as `no device of type "temperature-sensor" is configured` — which the model faithfully relayed as "Il n'y a pas de capteur de température configuré dans la maison".

In `server/services/mcp/lib/buildSchemas.js`, `device.get-state` now:

- resolves a `room` that is not a room but matches a **house name** to the whole home (that house's rooms, plus the devices that are not assigned to any room);
- answers an **unresolvable** `room` with an explicit `"X" is not a room of this home` message listing the available rooms, instead of an empty result the model reads as "nothing is configured";
- resolves a **shortened `device_type`** (`temperature` → `temperature-sensor`) by exact match first, then by category prefix; a category that genuinely does not exist in the home still gets the existing "no device of type X is configured / do not report any value" answer;
- replaces the `deviceType.includes(feature.category)` substring test with an explicit list of resolved categories (this also keeps working when the model sends an array).

The `room` parameter description now says "leave empty to cover the whole home", which is the behaviour the model should have picked in the first place.

**(b) What was verified locally**

- `mocha test/services/mcp/lib/buildSchemas.test.js` → **31 passing, 0 failing** (30 pre-existing + 1 new).
- New test `should answer device.get-state when the model targets the house or shortens the device type` reproduces the issue: reverting only `buildSchemas.js` makes it fail, because `cb({ room: 'maison', device_type: 'temperature' })` returns the `device.get-state: no device ... is configured` text instead of the three temperature states.
- Wider run: `test/services/mcp/**` + `test/lib/gateway/*` → **351 passing, 8 failing**. All 8 failures are in `gateway.backup` / `gateway.restoreBackup` / `gateway.restoreBackupEvent`; they fail identically on unmodified `master` in this sandbox (DuckDB/Parquet backup environment), and none of them touch the MCP schemas.
- `npx eslint services/mcp/lib/buildSchemas.js test/services/mcp/lib/buildSchemas.test.js` → clean (exit 0).
- `npx prettier --check` on both files → "All matched files use Prettier code style!".
- Full `npm test` and `npm run coverage` were **not** run (the sandbox cannot build every native dependency; the backup suite above is one symptom).

**(c) What a human must check before merge**

- The product decision: is "the model named the house" best answered by *returning the whole home*, or should the tool instead push back and force a room? This PR chose the former, since it is what the user asked for.
- Multi-house installs: the house branch filters on `room.house_id`, and deliberately keeps devices with **no room** in the result. Confirm that is the wanted semantic when several houses exist.
- The unknown-room reply now embeds the full room list in the tool result. Check that this is acceptable for large homes (prompt size) and that the model actually retries rather than surfacing the message verbatim to the user.
- The same "unresolvable name silently filters everything out" pattern also exists in `device.get-history`, `device.turn-on-off`, `device.set-shutter` and `device.set-light`. It was left untouched to keep this fix focused; a human may want to extend it.
- Real-world check on the Telegram/AI chat with the original question, since the trigger is model behaviour and cannot be reproduced end to end in tests.

### Checklist

- [ ] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed — only the MCP + gateway suites were run locally, see above
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`) — run on the changed server files (no front change)
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZxEjvLboa6eoysMQEV9jm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved device state lookups across an entire house, including devices assigned to rooms and unassigned devices.
  - Device categories are now recognized more consistently, including shortened or suffixed category names.
  - Added clearer filtering by room and more explicit responses for unknown rooms or unavailable device types.
  - Updated room descriptions to clarify whole-home behavior and improved scope and device-type labels in empty results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->