### PR TITLE
feat(scene): allow sending text to a device from the control-device action

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -3109,7 +3109,8 @@
         "useCustomValue": "Eigenen Wert eingeben",
         "useValueList": "Aus der Werteliste auswählen",
         "valueTypeComputed": "Berechnet",
-        "computedExplanationText": "Anstelle eines festen Werts kannst du hier eine Berechnung auf Basis einer Szenenvariable eingeben. Um eine Variable in den Text einzufügen, gib \"{{\" ein. Um einen Variablenwert festzulegen, musst du zuerst das Feld \"Gerätewert abrufen\" verwenden."
+        "computedExplanationText": "Anstelle eines festen Werts kannst du hier eine Berechnung auf Basis einer Szenenvariable eingeben. Um eine Variable in den Text einzufügen, gib \"{{\" ein. Um einen Variablenwert festzulegen, musst du zuerst das Feld \"Gerätewert abrufen\" verwenden.",
+        "textExplanationText": "Gib hier den Text ein, der an dein Gerät gesendet werden soll. Um eine Szenenvariable in den Text einzufügen, gib \"{{\" ein. Um einen Variablenwert festzulegen, musst du zuerst das Feld \"Gerätewert abrufen\" verwenden."
       },
       "onlyContinueIf": {
         "variableLabel": "Variable",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -3109,7 +3109,8 @@
         "useCustomValue": "Enter a custom value",
         "useValueList": "Choose from the list of values",
         "valueTypeComputed": "Computed",
-        "computedExplanationText": "Instead of a fixed value, you can enter here a calculation based on a scene variable. To inject a variable in the text, press '{{'. To set a variable value, you need to use the 'Get device value' box before this one."
+        "computedExplanationText": "Instead of a fixed value, you can enter here a calculation based on a scene variable. To inject a variable in the text, press '{{'. To set a variable value, you need to use the 'Get device value' box before this one.",
+        "textExplanationText": "Enter here the text to send to your device. To inject a scene variable in the text, press '{{'. To set a variable value, you need to use the 'Get device value' box before this one."
       },
       "onlyContinueIf": {
         "variableLabel": "Variable",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -3109,7 +3109,8 @@
         "useCustomValue": "Saisir une valeur personnalisée",
         "useValueList": "Choisir dans la liste des valeurs",
         "valueTypeComputed": "Calculée",
-        "computedExplanationText": "À la place d'une valeur fixe, vous pouvez entrer ici un calcul basé sur une variable de scène. Pour injecter une variable, tapez '{{'. Attention, vous devez avoir défini une variable auparavant dans une action 'Récupérer le dernier état' placé avant ce bloc."
+        "computedExplanationText": "À la place d'une valeur fixe, vous pouvez entrer ici un calcul basé sur une variable de scène. Pour injecter une variable, tapez '{{'. Attention, vous devez avoir défini une variable auparavant dans une action 'Récupérer le dernier état' placé avant ce bloc.",
+        "textExplanationText": "Entrez ici le texte à envoyer à votre appareil. Pour injecter une variable de scène dans le texte, tapez '{{'. Attention, vous devez avoir défini une variable auparavant dans une action 'Récupérer le dernier état' placée avant ce bloc."
       },
       "onlyContinueIf": {
         "variableLabel": "Variable",

--- a/front/src/routes/scene/edit-scene/actions/DeviceSetValue.jsx
+++ b/front/src/routes/scene/edit-scene/actions/DeviceSetValue.jsx
@@ -115,9 +115,42 @@ class DeviceSetValue extends Component {
     this.props.updateActionProperty(this.props.path, 'evaluate_value', text);
   };
 
+  isTextFeature = () =>
+    this.state.deviceFeature &&
+    this.state.deviceFeature.category === DEVICE_FEATURE_CATEGORIES.TEXT &&
+    this.state.deviceFeature.type === DEVICE_FEATURE_TYPES.TEXT.TEXT;
+
   getDeviceFeatureControl = () => {
     if (!this.state.deviceFeature) {
       return null;
+    }
+
+    // A text feature always receives free text with scene variables injected,
+    // the simple/computed distinction does not apply
+    if (this.isTextFeature()) {
+      return (
+        <div>
+          <div className={style.explanationText}>
+            <Text id="editScene.actionsCard.deviceSetValue.textExplanationText" />
+          </div>
+          <div class="input-group">
+            <Localizer>
+              <TextWithVariablesInjected
+                text={
+                  this.props.action.evaluate_value !== undefined
+                    ? this.props.action.evaluate_value
+                    : this.props.action.value
+                }
+                triggersVariables={this.props.triggersVariables}
+                actionsGroupsBefore={this.props.actionsGroupsBefore}
+                variables={this.props.variables}
+                path={this.props.path}
+                updateText={this.handleNewEvalValue}
+              />
+            </Localizer>
+          </div>
+        </div>
+      );
     }
 
     if (this.state.computed) {
@@ -334,22 +367,24 @@ class DeviceSetValue extends Component {
             onDeviceFeatureChange={this.onDeviceFeatureChange}
           />
         </div>
-        <div class="form-group">
-          <div className={cx('nav-tabs', style.valueTypeTab)}>
-            <span
-              class={cx('nav-link', style.valueTypeLink, { active: !this.state.computed })}
-              onClick={this.toggleType}
-            >
-              <Text id="editScene.actionsCard.deviceSetValue.valueTypeSimple" />
-            </span>
-            <span
-              class={cx('nav-link', style.valueTypeLink, { active: this.state.computed })}
-              onClick={this.toggleType}
-            >
-              <Text id="editScene.actionsCard.deviceSetValue.valueTypeComputed" />
-            </span>
+        {!this.isTextFeature() && (
+          <div class="form-group">
+            <div className={cx('nav-tabs', style.valueTypeTab)}>
+              <span
+                class={cx('nav-link', style.valueTypeLink, { active: !this.state.computed })}
+                onClick={this.toggleType}
+              >
+                <Text id="editScene.actionsCard.deviceSetValue.valueTypeSimple" />
+              </span>
+              <span
+                class={cx('nav-link', style.valueTypeLink, { active: this.state.computed })}
+                onClick={this.toggleType}
+              >
+                <Text id="editScene.actionsCard.deviceSetValue.valueTypeComputed" />
+              </span>
+            </div>
           </div>
-        </div>
+        )}
         <div class="form-group">{this.getDeviceFeatureControl()}</div>
       </div>
     );

--- a/server/lib/device/device.setValue.js
+++ b/server/lib/device/device.setValue.js
@@ -1,6 +1,7 @@
 const get = require('get-value');
 
 const { NotFoundError } = require('../../utils/coreErrors');
+const { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } = require('../../utils/constants');
 
 /**
  * @description Control a specific device.
@@ -21,11 +22,20 @@ async function setValue(device, deviceFeature, value, options = {}) {
   }
   await service.device.setValue(device, deviceFeature, value, options);
   // If device has feedback, the feedback will be sent and saved
-  // If value is a string, no need to save it
   // @ts-ignore
   const valueIsString = typeof value === 'string' || value instanceof String;
-  if (!deviceFeature.has_feedback && !valueIsString) {
-    await this.saveState(deviceFeature, value);
+  const isTextFeature =
+    deviceFeature.category === DEVICE_FEATURE_CATEGORIES.TEXT && deviceFeature.type === DEVICE_FEATURE_TYPES.TEXT.TEXT;
+  if (!deviceFeature.has_feedback) {
+    if (valueIsString) {
+      // A string is only a state on a text feature; on any other feature it is a
+      // one-shot command (a music notification URL for example): nothing to save
+      if (isTextFeature) {
+        await this.saveStringState(device, deviceFeature, String(value));
+      }
+    } else {
+      await this.saveState(deviceFeature, value);
+    }
   }
 }
 

--- a/server/lib/scene/scene.actions.js
+++ b/server/lib/scene/scene.actions.js
@@ -99,7 +99,7 @@ const actionsFunc = {
           noEscape: true,
         })(scope);
       }
-      if (value === undefined || value === null) {
+      if (value === undefined || value === null || value === '') {
         throw new AbortScene('ACTION_VALUE_EMPTY');
       }
       return self.device.setValue(device, deviceFeature, String(value));

--- a/server/lib/scene/scene.actions.js
+++ b/server/lib/scene/scene.actions.js
@@ -86,6 +86,25 @@ const actionsFunc = {
     }
 
     let { value } = action;
+
+    // A text feature (a message displayed on a TV, a text virtual sensor...) receives the
+    // value as a raw string with scene variables injected, and skips the math evaluation
+    // below which would reject any non-numeric text
+    if (
+      deviceFeature.category === DEVICE_FEATURE_CATEGORIES.TEXT &&
+      deviceFeature.type === DEVICE_FEATURE_TYPES.TEXT.TEXT
+    ) {
+      if (action.evaluate_value !== undefined) {
+        value = Handlebars.compile(action.evaluate_value, {
+          noEscape: true,
+        })(scope);
+      }
+      if (value === undefined || value === null) {
+        throw new AbortScene('ACTION_VALUE_EMPTY');
+      }
+      return self.device.setValue(device, deviceFeature, String(value));
+    }
+
     if (action.evaluate_value !== undefined) {
       value = evaluate(
         Handlebars.compile(action.evaluate_value, {

--- a/server/models/scene.js
+++ b/server/models/scene.js
@@ -18,7 +18,7 @@ const actionSchema = Joi.object()
     scene: Joi.string(),
     camera: Joi.string(),
     text: Joi.string(),
-    value: Joi.number(),
+    value: Joi.alternatives().try(Joi.number(), Joi.string()),
     evaluate_value: Joi.string(),
     minutes: Joi.number(),
     unit: Joi.string(),

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -1222,9 +1222,7 @@ async function getAllTools(userId) {
           };
         }
 
-        if (useStringValue) {
-          await this.gladys.device.saveStringState(selectedDevice, selectedFeature, parsedValue);
-        }
+        // device.setValue persists string states of text features itself, nothing more to save
 
         return {
           content: [

--- a/server/services/mcp/lib/sceneSchemas.js
+++ b/server/services/mcp/lib/sceneSchemas.js
@@ -155,7 +155,7 @@ function createSceneCreateInputSchema(
         device: z.string().optional(),
         feature_category: z.string().optional(),
         feature_type: z.string().optional(),
-        value: z.number().optional(),
+        value: z.union([z.number(), z.string()]).optional(),
         evaluate_value: z.string().optional(),
       }),
       actionSchemaByType(ACTIONS.LIGHT.TURN_ON, {

--- a/server/test/lib/device/device.setValue.test.js
+++ b/server/test/lib/device/device.setValue.test.js
@@ -1,16 +1,22 @@
 const EventEmitter = require('events');
-// const { fake } = require('sinon');
+const sinon = require('sinon').createSandbox();
 const { assert } = require('chai');
+
+const { fake, assert: sinonAssert } = sinon;
 
 const Device = require('../../../lib/device');
 
 const StateManager = require('../../../lib/state');
 const Job = require('../../../lib/job');
+const { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } = require('../../../utils/constants');
 
 const event = new EventEmitter();
 const job = new Job(event);
 
 describe('Device', () => {
+  afterEach(() => {
+    sinon.reset();
+  });
   it('should throw an error, service does not exist', async () => {
     const stateManager = new StateManager(event);
     const service = {
@@ -46,5 +52,94 @@ describe('Device', () => {
       1,
     );
     return assert.isRejected(promise, 'Function device.setValue in service my-service does not exist.');
+  });
+  it('should save numeric state when device has no feedback', async () => {
+    const stateManager = new StateManager(event);
+    const serviceSetValue = fake.resolves(null);
+    const service = {
+      getService: () => ({
+        device: {
+          setValue: serviceSetValue,
+        },
+      }),
+    };
+    const device = new Device(event, {}, stateManager, service, {}, {}, job);
+    device.saveState = fake.resolves(null);
+    device.saveStringState = fake.resolves(null);
+    const deviceFeature = {
+      category: DEVICE_FEATURE_CATEGORIES.LIGHT,
+      type: DEVICE_FEATURE_TYPES.LIGHT.BINARY,
+      has_feedback: false,
+    };
+    await device.setValue({ service: { name: 'my-service' } }, deviceFeature, 1);
+    sinonAssert.calledWith(serviceSetValue, { service: { name: 'my-service' } }, deviceFeature, 1);
+    sinonAssert.calledWith(device.saveState, deviceFeature, 1);
+    sinonAssert.notCalled(device.saveStringState);
+  });
+  it('should save string state when setting a text value on a text feature', async () => {
+    const stateManager = new StateManager(event);
+    const serviceSetValue = fake.resolves(null);
+    const service = {
+      getService: () => ({
+        device: {
+          setValue: serviceSetValue,
+        },
+      }),
+    };
+    const device = new Device(event, {}, stateManager, service, {}, {}, job);
+    device.saveState = fake.resolves(null);
+    device.saveStringState = fake.resolves(null);
+    const gladysDevice = { service: { name: 'my-service' } };
+    const deviceFeature = {
+      category: DEVICE_FEATURE_CATEGORIES.TEXT,
+      type: DEVICE_FEATURE_TYPES.TEXT.TEXT,
+      has_feedback: false,
+    };
+    await device.setValue(gladysDevice, deviceFeature, 'The meal is ready!');
+    sinonAssert.calledWith(serviceSetValue, gladysDevice, deviceFeature, 'The meal is ready!');
+    sinonAssert.calledWith(device.saveStringState, gladysDevice, deviceFeature, 'The meal is ready!');
+    sinonAssert.notCalled(device.saveState);
+  });
+  it('should not save string state on a text feature with feedback', async () => {
+    const stateManager = new StateManager(event);
+    const service = {
+      getService: () => ({
+        device: {
+          setValue: fake.resolves(null),
+        },
+      }),
+    };
+    const device = new Device(event, {}, stateManager, service, {}, {}, job);
+    device.saveState = fake.resolves(null);
+    device.saveStringState = fake.resolves(null);
+    const deviceFeature = {
+      category: DEVICE_FEATURE_CATEGORIES.TEXT,
+      type: DEVICE_FEATURE_TYPES.TEXT.TEXT,
+      has_feedback: true,
+    };
+    await device.setValue({ service: { name: 'my-service' } }, deviceFeature, 'The meal is ready!');
+    sinonAssert.notCalled(device.saveStringState);
+    sinonAssert.notCalled(device.saveState);
+  });
+  it('should not save a string value sent to a non-text feature', async () => {
+    const stateManager = new StateManager(event);
+    const service = {
+      getService: () => ({
+        device: {
+          setValue: fake.resolves(null),
+        },
+      }),
+    };
+    const device = new Device(event, {}, stateManager, service, {}, {}, job);
+    device.saveState = fake.resolves(null);
+    device.saveStringState = fake.resolves(null);
+    const deviceFeature = {
+      category: DEVICE_FEATURE_CATEGORIES.MUSIC,
+      type: DEVICE_FEATURE_TYPES.MUSIC.PLAY_NOTIFICATION,
+      has_feedback: false,
+    };
+    await device.setValue({ service: { name: 'my-service' } }, deviceFeature, 'http://example.com/notification.mp3');
+    sinonAssert.notCalled(device.saveStringState);
+    sinonAssert.notCalled(device.saveState);
   });
 });

--- a/server/test/lib/scene/scene.create.test.js
+++ b/server/test/lib/scene/scene.create.test.js
@@ -53,6 +53,24 @@ describe('SceneManager', () => {
     });
     expect(scene).to.have.property('selector', 'my-custom-selector');
   });
+  it('should create one scene with a text value in a device.set-value action', async () => {
+    const scene = await sceneManager.create({
+      name: 'Send message to TV',
+      icon: 'bell',
+      triggers: [],
+      actions: [
+        [
+          {
+            type: ACTIONS.DEVICE.SET_VALUE,
+            device_feature: 'my-tv-text-feature',
+            value: 'The meal is ready!',
+          },
+        ],
+      ],
+      tags: [],
+    });
+    expect(scene).to.have.property('selector');
+  });
   it('should return validation error, invalid actions', async () => {
     const promise = sceneManager.create({
       name: 'My living room',

--- a/server/test/lib/scene/scene.executeActions.test.js
+++ b/server/test/lib/scene/scene.executeActions.test.js
@@ -595,6 +595,63 @@ describe('scene.executeActions', () => {
     );
     return chaiAssert.isRejected(promise, AbortScene, 'ACTION_VALUE_EMPTY');
   });
+  it('should abort scene when the value is an empty string on a text feature', async () => {
+    stateManager.setState('deviceFeature', 'my-text-feature', {
+      device_id: 'device-id',
+      category: DEVICE_FEATURE_CATEGORIES.TEXT,
+      type: DEVICE_FEATURE_TYPES.TEXT.TEXT,
+    });
+    stateManager.setState('deviceById', 'device-id', {
+      id: 'device-id',
+      features: [],
+    });
+    const device = {
+      setValue: fake.resolves(null),
+    };
+    const promise = executeActions(
+      { stateManager, event, device },
+      [
+        [
+          {
+            type: ACTIONS.DEVICE.SET_VALUE,
+            device_feature: 'my-text-feature',
+            value: '',
+          },
+        ],
+      ],
+      {},
+    );
+    return chaiAssert.isRejected(promise, AbortScene, 'ACTION_VALUE_EMPTY');
+  });
+  it('should abort scene when the text renders to an empty string on a text feature', async () => {
+    stateManager.setState('deviceFeature', 'my-text-feature', {
+      device_id: 'device-id',
+      category: DEVICE_FEATURE_CATEGORIES.TEXT,
+      type: DEVICE_FEATURE_TYPES.TEXT.TEXT,
+    });
+    stateManager.setState('deviceById', 'device-id', {
+      id: 'device-id',
+      features: [],
+    });
+    const device = {
+      setValue: fake.resolves(null),
+    };
+    // A variable which cannot be resolved is rendered as an empty string by Handlebars
+    const promise = executeActions(
+      { stateManager, event, device },
+      [
+        [
+          {
+            type: ACTIONS.DEVICE.SET_VALUE,
+            device_feature: 'my-text-feature',
+            evaluate_value: '{{missing.variable}}',
+          },
+        ],
+      ],
+      {},
+    );
+    return chaiAssert.isRejected(promise, AbortScene, 'ACTION_VALUE_EMPTY');
+  });
   it('should execute action device.setValue', async () => {
     const example = {
       stop: fake.resolves(null),

--- a/server/test/lib/scene/scene.executeActions.test.js
+++ b/server/test/lib/scene/scene.executeActions.test.js
@@ -445,6 +445,156 @@ describe('scene.executeActions', () => {
       11,
     );
   });
+  it('should execute action device.setValue with text on a text feature', async () => {
+    stateManager.setState('deviceFeature', 'my-text-feature', {
+      device_id: 'device-id',
+      category: DEVICE_FEATURE_CATEGORIES.TEXT,
+      type: DEVICE_FEATURE_TYPES.TEXT.TEXT,
+    });
+    stateManager.setState('deviceById', 'device-id', {
+      id: 'device-id',
+      features: [],
+    });
+    const device = {
+      setValue: fake.resolves(null),
+    };
+    await executeActions(
+      { stateManager, event, device },
+      [
+        [
+          {
+            type: ACTIONS.DEVICE.SET_VALUE,
+            device_feature: 'my-text-feature',
+            value: 'The meal is ready!',
+          },
+        ],
+      ],
+      {},
+    );
+    assert.calledWith(
+      device.setValue,
+      {
+        id: 'device-id',
+        features: [],
+      },
+      {
+        device_id: 'device-id',
+        category: DEVICE_FEATURE_CATEGORIES.TEXT,
+        type: DEVICE_FEATURE_TYPES.TEXT.TEXT,
+      },
+      'The meal is ready!',
+    );
+  });
+  it('should execute action device.setValue with text and variables on a text feature', async () => {
+    stateManager.setState('deviceFeature', 'my-text-feature', {
+      device_id: 'device-id',
+      category: DEVICE_FEATURE_CATEGORIES.TEXT,
+      type: DEVICE_FEATURE_TYPES.TEXT.TEXT,
+    });
+    stateManager.setState('deviceById', 'device-id', {
+      id: 'device-id',
+      features: [],
+    });
+    const device = {
+      setValue: fake.resolves(null),
+    };
+    await executeActions(
+      { stateManager, event, device },
+      [
+        [
+          {
+            type: ACTIONS.DEVICE.SET_VALUE,
+            device_feature: 'my-text-feature',
+            evaluate_value: 'Temperature is {{0.0.last_value}} °C',
+          },
+        ],
+      ],
+      {
+        '0': { '0': { last_value: 21.5 } },
+      },
+    );
+    // Spaces are preserved, no math evaluation is applied
+    assert.calledWith(
+      device.setValue,
+      {
+        id: 'device-id',
+        features: [],
+      },
+      {
+        device_id: 'device-id',
+        category: DEVICE_FEATURE_CATEGORIES.TEXT,
+        type: DEVICE_FEATURE_TYPES.TEXT.TEXT,
+      },
+      'Temperature is 21.5 °C',
+    );
+  });
+  it('should convert a numeric value to string on a text feature', async () => {
+    stateManager.setState('deviceFeature', 'my-text-feature', {
+      device_id: 'device-id',
+      category: DEVICE_FEATURE_CATEGORIES.TEXT,
+      type: DEVICE_FEATURE_TYPES.TEXT.TEXT,
+    });
+    stateManager.setState('deviceById', 'device-id', {
+      id: 'device-id',
+      features: [],
+    });
+    const device = {
+      setValue: fake.resolves(null),
+    };
+    await executeActions(
+      { stateManager, event, device },
+      [
+        [
+          {
+            type: ACTIONS.DEVICE.SET_VALUE,
+            device_feature: 'my-text-feature',
+            value: 42,
+          },
+        ],
+      ],
+      {},
+    );
+    assert.calledWith(
+      device.setValue,
+      {
+        id: 'device-id',
+        features: [],
+      },
+      {
+        device_id: 'device-id',
+        category: DEVICE_FEATURE_CATEGORIES.TEXT,
+        type: DEVICE_FEATURE_TYPES.TEXT.TEXT,
+      },
+      '42',
+    );
+  });
+  it('should abort scene when no value is provided on a text feature', async () => {
+    stateManager.setState('deviceFeature', 'my-text-feature', {
+      device_id: 'device-id',
+      category: DEVICE_FEATURE_CATEGORIES.TEXT,
+      type: DEVICE_FEATURE_TYPES.TEXT.TEXT,
+    });
+    stateManager.setState('deviceById', 'device-id', {
+      id: 'device-id',
+      features: [],
+    });
+    const device = {
+      setValue: fake.resolves(null),
+    };
+    const promise = executeActions(
+      { stateManager, event, device },
+      [
+        [
+          {
+            type: ACTIONS.DEVICE.SET_VALUE,
+            device_feature: 'my-text-feature',
+          },
+        ],
+      ],
+      {},
+    );
+    return chaiAssert.isRejected(promise, AbortScene, 'ACTION_VALUE_EMPTY');
+  });
   it('should execute action device.setValue', async () => {
     const example = {
       stop: fake.resolves(null),

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -2151,8 +2151,8 @@ describe('build schemas', () => {
     });
     expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);
     expect(mcpHandler.gladys.device.setValue.firstCall.args[2]).to.eq('AB-123-CD');
-    expect(mcpHandler.gladys.device.saveStringState.callCount).to.eq(1);
-    expect(mcpHandler.gladys.device.saveStringState.firstCall.args[2]).to.eq('AB-123-CD');
+    // device.setValue persists string states of text features itself
+    expect(mcpHandler.gladys.device.saveStringState.callCount).to.eq(0);
     expect(textResult.content[0].text).to.eq('sensor.set-state: set License Plate Sensor / Plate to AB-123-CD');
   });
 
@@ -2701,7 +2701,10 @@ describe('build schemas', () => {
       value: 'AB-123-CD',
     });
 
-    expect(mcpHandler.gladys.device.saveStringState.callCount).to.eq(1);
+    expect(mcpHandler.gladys.device.setValue.callCount).to.eq(1);
+    expect(mcpHandler.gladys.device.setValue.firstCall.args[2]).to.eq('AB-123-CD');
+    // device.setValue persists string states of text features itself
+    expect(mcpHandler.gladys.device.saveStringState.callCount).to.eq(0);
   });
 
   it('should expose shutters in home schema and device.set-shutter tool', async () => {


### PR DESCRIPTION
### Description

The "control a device" scene action only accepted numeric values: any text was rejected with `ACTION_VALUE_NOT_A_NUMBER`, so there was no way to send a message to a device exposing a text feature (a native TV notification for example). Instead of adding a dedicated "send a message to a device" action, this PR teaches the existing control-device action to handle text features, so an integration (like the upcoming LG webOS one) only needs to expose a non-read-only `text`/`text` feature.

**Server**
- `scene.actions.js` (`device.set-value`): values targeting a text feature (`category: text` / `type: text`) are sent as raw strings. Scene variables are injected with Handlebars (same pattern as `message.send`), without the math evaluation and whitespace stripping of the numeric path, so `Temperature is {{0.0.last_value}} °C` works as expected. An empty value aborts the scene with `ACTION_VALUE_EMPTY`.
- `device.setValue.js`: string values on a text feature are now persisted with `saveStringState`, symmetric to the numeric `saveState` when the feature has no feedback. Strings sent to other features (a music notification URL for example) remain one-shot commands and are still not persisted.
- MCP service: removed the manual `saveStringState` on the `sensor.set-state` success path (now handled inside `device.setValue`, avoiding a double save and duplicated trigger checks), and widened the `device.set-value` scene action schema to accept string values. The fallback save when `setValue` throws is unchanged.

**Front**
- `DeviceSetValue.jsx`: selecting a text feature displays a free-text input with scene variable injection (`TextWithVariablesInjected`) instead of the numeric simple/computed controls, which are hidden since the distinction does not apply to text.
- New `textExplanationText` translation key in `en`, `fr` and `de`.

**Tests**
- Scene action: text value passthrough, variable injection with spaces preserved, numeric-to-string conversion, abort on missing value.
- `device.setValue`: numeric save, text save, no save with feedback, no save for strings on non-text features.
- MCP: success-path assertions updated to reflect the centralized persistence; the setValue-unavailable fallback tests are unchanged.

## Forum

Forum: https://community.gladysassistant.com/t/action-de-scene-envoyer-un-message-sur-un-appareil/10534

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxHVAonHVdJgB5JwD5BQum

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxHVAonHVdJgB5JwD5BQum)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Scene actions now support entering text values for text-based device features.
  - Scene variables can be inserted into text values without numeric calculation.
  - Device value actions accept both text and numeric values.

- **Bug Fixes**
  - Text values are saved reliably while preventing incorrect persistence for non-text features.
  - Empty text values are rejected with clear validation.

- **Documentation**
  - Updated English, German, and French guidance explains text entry and variable usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->