### PR TITLE
Fix flaky zigbee2mqtt/mqtt publish logging tests (require cache leak)

### DIFF
--- a/server/test/hooks.js
+++ b/server/test/hooks.js
@@ -67,6 +67,19 @@ const boot = async () => {
   global.TEST_GLADYS_INSTANCE = gladys;
 };
 
+// utils/logger is a singleton, and a handful of test files rely on that:
+// they run sinon.stub(logger, 'debug') on the module object and expect the
+// production code under test to log through the very same object. proxyquire
+// in noPreserveCache mode deletes every module it stubbed from require.cache
+// once the call returns, so a single test stubbing '../../utils/logger' would
+// leave the next require() building a brand new logger while the production
+// modules already loaded keep the old one — the stub then sits on an object
+// nobody logs to, and the assertion fails with an empty call list in whatever
+// file mocha happens to schedule next on that worker. Pin the original module
+// back after every file so the singleton stays a singleton for the worker.
+const loggerModuleId = require.resolve('../utils/logger');
+const loggerModule = require.cache[loggerModuleId];
+
 exports.mochaHooks = {
   beforeAll: async function beforeAll() {
     this.timeout(30000);
@@ -86,6 +99,14 @@ exports.mochaHooks = {
     } catch (e) {
       logger.trace(e);
       throw e;
+    }
+  },
+  // In parallel mode mocha runs this once per test FILE, before the worker
+  // requires the next one: that is exactly where an evicted logger has to be
+  // put back, since the damage only shows up in the files loaded afterwards.
+  afterAll: function afterAll() {
+    if (require.cache[loggerModuleId] !== loggerModule) {
+      require.cache[loggerModuleId] = loggerModule;
     }
   },
 };

--- a/server/test/services/tuya/lib/device/tuya.localMapping.test.js
+++ b/server/test/services/tuya/lib/device/tuya.localMapping.test.js
@@ -1,9 +1,10 @@
 /* eslint-disable require-jsdoc, jsdoc/require-jsdoc */
 const { expect } = require('chai');
 
-const proxyquire = require('proxyquire')
-  .noCallThru()
-  .noPreserveCache();
+// No .noPreserveCache(): it would evict the stubbed '../mappings' module from
+// require.cache after each call, handing every module loaded later a second
+// copy of it (see tuya.setValue.test.js for the failure this causes).
+const proxyquire = require('proxyquire').noCallThru();
 
 const {
   addFallbackBinaryFeature,

--- a/server/test/services/tuya/lib/tuya.setValue.fixtures.test.js
+++ b/server/test/services/tuya/lib/tuya.setValue.fixtures.test.js
@@ -1,8 +1,9 @@
 const sinon = require('sinon').createSandbox();
 const { expect } = require('chai');
-const proxyquire = require('proxyquire')
-  .noCallThru()
-  .noPreserveCache();
+// No .noPreserveCache(): it would evict the stubbed dependencies from
+// require.cache after each call, handing every module loaded later a second
+// copy of them (see tuya.setValue.test.js for the failure this causes).
+const proxyquire = require('proxyquire').noCallThru();
 
 const { loadFixtureCases } = require('../fixtures/fixtureHelper');
 

--- a/server/test/services/tuya/lib/tuya.setValue.test.js
+++ b/server/test/services/tuya/lib/tuya.setValue.test.js
@@ -1,8 +1,13 @@
 /* eslint-disable require-jsdoc, jsdoc/require-jsdoc */
 const sinon = require('sinon').createSandbox();
-const proxyquire = require('proxyquire')
-  .noCallThru()
-  .noPreserveCache();
+// No .noPreserveCache() here: proxyquire already compiles a fresh copy of the
+// module under test on every call, and in noPreserveCache mode it also evicts
+// every *stubbed* dependency from require.cache once the call is done. This
+// file stubs '../../../utils/logger', a singleton several other test files
+// stub methods on: evicting it makes the next require() return a brand new
+// logger object while the production modules already loaded keep the old one,
+// so those stubs end up installed on an object nobody ever logs to.
+const proxyquire = require('proxyquire').noCallThru();
 
 const { assert, fake } = sinon;
 
@@ -550,5 +555,29 @@ describe('TuyaHandler.setValue', () => {
     // a TypeError.
     const warnMessages = logger.warn.getCalls().map((c) => c.args[0]);
     expect(warnMessages.some((msg) => msg.includes('connector unavailable'))).to.equal(true);
+  });
+
+  it('should leave the shared logger in the require cache after stubbing it', () => {
+    // Guards the proxyquire configuration at the top of this file. In
+    // noPreserveCache mode proxyquire evicts every stubbed dependency from
+    // require.cache once the call returns: the tests above stub
+    // '../../../utils/logger', so the next require() of the logger anywhere in
+    // the worker would build a second, unrelated logger object. Test files
+    // loaded after this one (mqtt/zigbee2mqtt publish, tuya.convertDevice)
+    // run sinon.stub(logger, 'debug') and assert the code under test logs
+    // through that stub — with two logger objects around, the stub is
+    // installed on the one the production modules never use and the assertion
+    // fails with an empty call list, in whichever file mocha happened to
+    // schedule next on that worker.
+    // eslint-disable-next-line global-require
+    const sharedLogger = require('../../../../utils/logger');
+    proxyquire('../../../../services/tuya/lib/tuya.setValue', {
+      tuyapi: function TuyAPIStub() {},
+      '@demirdeniz/tuyapi-newgen': function TuyAPINewGenStub() {},
+      '../../../utils/logger': { debug: sinon.stub(), warn: sinon.stub(), info: sinon.stub() },
+    });
+
+    // eslint-disable-next-line global-require
+    expect(require('../../../../utils/logger')).to.equal(sharedLogger);
   });
 });


### PR DESCRIPTION
### Description

`zigbee2mqttManager.publish > should log the topic and the message published` fails at random in CI:

```
1) zigbee2mqttManager.publish
     should log the topic and the message published:
   AssertError: expected debug to be called with arguments
    at Context.<anonymous> (test/services/zigbee2mqtt/lib/publish.test.js:63:14)
```

Nothing is printed after `arguments`, which in sinon means the stub recorded **zero** calls — even though the assertion on the line just above (`mqttClient.publish` was called) passes, so `logger.debug()` in `services/zigbee2mqtt/lib/publish.js` definitely ran, and the real log line does show up in the mocha output.

**Root cause is a `require.cache` leak, not a timing issue.** `test/services/tuya/lib/tuya.setValue.test.js` configured proxyquire with `.noPreserveCache()` and stubs `'../../../utils/logger'`. In that mode proxyquire deletes every *stubbed* module from `require.cache` once the call returns:

```js
var ids = [resolvedPath].concat(Object.keys(stubs).filter(Boolean))
ids.forEach(function (id) { delete require.cache[id] })
```

So `server/utils/logger.js` got evicted. Every module required afterwards then built a **brand new** logger object, while the production modules already loaded (here `services/zigbee2mqtt/lib/publish.js`) kept the old one. `sinon.stub(logger, 'debug')` in a spec file loaded after the eviction landed on an object the code under test never logs to, hence the empty call list.

Reproduced deterministically:

```
$ node -e "... require zigbee2mqtt lib; proxyquire(tuya.setValue, {logger: fake}); stub logger.debug; publish()"
<debug> publish.js:14 Publishing MQTT message on topic zigbee2mqtt/my-device/set: {"state":"ON"}
debug callCount = 0
```

Only mocha's `--parallel` mode is affected: it requires each spec file right before running it, so the eviction can land between two files. In serial mode every file is loaded up front, which is why this never reproduces with `npm run test-serial` or when running the file alone. Which files get hit depends on how mocha distributes them across workers — that is what made it look flaky. `mqtt/lib/publish.test.js` and `tuya/lib/device/tuya.convertDevice.test.js` stub the logger the same way and were equally exposed.

Changes:

- Drop `.noPreserveCache()` from the three tuya spec files that used it. proxyquire already compiles a fresh copy of the module under test on every call (it deletes and restores the SUT around the load), so nothing here needed the extra eviction. `tuya.localMapping.test.js` was leaking `services/tuya/lib/mappings` the same way.
- Add a regression test in `tuya.setValue.test.js` asserting the shared logger survives a proxyquire call. It fails deterministically if `.noPreserveCache()` comes back.
- Pin the logger module entry back in the `afterAll` root hook of `test/hooks.js`, so a future proxyquire stub of a shared singleton cannot split its identity for the files a worker loads next.

After the fix the same repro reports `debug callCount = 1`.

### Checklist

- [x] Tests pass: tuya (264), zigbee2mqtt + mqtt + tuya together (807) and the full `npm test` suite were run locally. Only test files changed, so there are no new production lines for Codecov to cover. Cypress not run — no UI change.
- [x] Linter and prettier pass on the changed server files (`npx eslint`, `npx prettier --check`)
- [x] No undocumented breaking change


---
_Generated by [Claude Code](https://claude.ai/code/session_01PC4LJcCsoSzAFNSytg71wx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test isolation and module cache handling to prevent shared logger instances from being replaced unexpectedly.
  * Added regression coverage for logger stubbing behavior.

* **Tests**
  * Updated service tests to preserve dependency stubs consistently.
  * Added cleanup handling to restore shared modules after test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->