### PR TITLE
chore: upgrade to Node.js 24

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
 {
   "name": "Gladys Assistant - Node.js",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:24",
   "forwardPorts": [1443, 1444],
   "extensions": [
     "dbaeumer.vscode-eslint",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ ARG TARGET
 ARG VERSION
 ARG BUILD_DATE
 
-FROM ${TARGET}/node:22-slim
+FROM ${TARGET}/node:24-slim
 
 LABEL \
   org.label-schema.build-date=$BUILD_DATE \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get install -y \
          python3-pip \
          git \
          libffi-dev \
-         && npm ci --unsafe-perm --production \
+         && npm ci --production \
          && npm cache clean --force \
          && apt-get autoremove -y build-essential python3 python3-pip git libffi-dev \
          && apt-get purge -y --auto-remove \

--- a/docker/Dockerfile.buildx
+++ b/docker/Dockerfile.buildx
@@ -1,6 +1,6 @@
 # STEP 1
 # Prepare server package*.json files
-FROM node:22-slim as json-files
+FROM node:24-slim as json-files
 COPY ./server /json-files/server
 WORKDIR /json-files/server/
 RUN find . -type f \! -name "package*.json" -exec rm -r {} \;
@@ -9,7 +9,7 @@ COPY ./server/utils /json-files/server/utils
 
 # STEP 3
 # Gladys Bundle
-FROM node:22-slim as gladys
+FROM node:24-slim as gladys
 
 # System dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile.buildx
+++ b/docker/Dockerfile.buildx
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y \
          python3-pip \
          git \
          libffi-dev \
-         && npm ci --unsafe-perm --production \
+         && npm ci --production \
          && npm cache clean --force \
          && apt-get autoremove -y build-essential python3 python3-pip git libffi-dev \
          && apt-get purge -y --auto-remove \

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -67,8 +67,8 @@
         "vite-plugin-static-copy": "^2.3.2"
       },
       "engines": {
-        "node": "22.x",
-        "npm": "10.x"
+        "node": "24.x",
+        "npm": "11.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/front/package.json
+++ b/front/package.json
@@ -1,8 +1,8 @@
 {
   "name": "gladys-front",
   "engines": {
-    "node": "22.x",
-    "npm": "10.x"
+    "node": "24.x",
+    "npm": "11.x"
   },
   "scripts": {
     "start": "per-env",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
         "shx": "^0.3.2"
       },
       "engines": {
-        "node": "22.x",
-        "npm": "10.x"
+        "node": "24.x",
+        "npm": "11.x"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A privacy-first, open-source home assistant",
   "main": "index.js",
   "engines": {
-    "node": "22.x",
-    "npm": "10.x"
+    "node": "24.x",
+    "npm": "11.x"
   },
   "scripts": {
     "postinstall": "npm run install-front:dev",

--- a/server/cli/install_service_dependencies.js
+++ b/server/cli/install_service_dependencies.js
@@ -26,7 +26,7 @@ async function installServiceDependencies() {
     async (directory) => {
       logger.info(`Installing dependencies in folder ${directory}`);
       try {
-        await exec(`cd "${directory}" && npm install --unsafe-perm`);
+        await exec(`cd "${directory}" && npm install`);
       } catch (e) {
         logger.warn(e);
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -82,8 +82,8 @@
         "undici": "^7.5.0"
       },
       "engines": {
-        "node": "22.x",
-        "npm": "10.x"
+        "node": "24.x",
+        "npm": "11.x"
       }
     },
     "node_modules/@babel/parser": {

--- a/server/package.json
+++ b/server/package.json
@@ -3,8 +3,8 @@
   "description": "",
   "main": "index.js",
   "engines": {
-    "node": "22.x",
-    "npm": "10.x"
+    "node": "24.x",
+    "npm": "11.x"
   },
   "scripts": {
     "postinstall": "node ./cli/install_service_dependencies.js",


### PR DESCRIPTION
### Description

Upgrade the project from Node.js 22 to Node.js 24:

- `engines` in root, `server/` and `front/` `package.json`: `node` `22.x` → `24.x`, and `npm` `10.x` → `11.x` (npm 11 is the version bundled with Node 24)
- `docker/Dockerfile` and `docker/Dockerfile.buildx`: base images `node:22-slim` → `node:24-slim`
- `.devcontainer/devcontainer.json`: image `javascript-node:22` → `javascript-node:24`

GitHub Actions workflows all use `node-version-file` pointing to the `package.json` files, so they pick up Node 24 automatically without any workflow change. The `engines` fields are advisory (no `engine-strict` configured), so existing local setups won't break.

## Forum

### Checklist

- [ ] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change (the Node 24 runtime bump is documented here; full test suite runs in CI on Node 24 via this PR)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXUHbdUF6q8hHaDb1L8EDs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the supported runtime environment to Node.js 24 and npm 11.
  * Updated development and container environments to use Node.js 24.
  * Streamlined dependency installation across supported environments.
  * No user-facing functionality changes are included in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->