### PR TITLE
Scenes: show device state trigger variables as a single generic set

### DIFF
--- a/front/src/components/scene/TextWithVariablesInjected.jsx
+++ b/front/src/components/scene/TextWithVariablesInjected.jsx
@@ -5,6 +5,7 @@ import './TextWithVariablesInjected.css';
 import get from 'get-value';
 
 import withIntlAsProp from '../../utils/withIntlAsProp';
+import { EVENTS } from '../../../../server/utils/constants';
 import { isVariableAvailableAtThisPath, convertPathToText } from '../../routes/scene/edit-scene/sceneUtils';
 
 const OPENING_VARIABLE = '{{';
@@ -68,6 +69,10 @@ class TextWithVariablesInjected extends Component {
     });
 
     // Triggers variables
+    // Device state variables always describe the trigger which fired the scene, whichever
+    // it is, so they are displayed once, without a trigger number, even when several
+    // device state triggers exist.
+    const genericTriggerVariableIds = new Set();
     nextProps.triggersVariables.forEach((triggerVariables, index) => {
       triggerVariables.forEach(triggerVariable => {
         if (triggerVariable.ready && variableReady === null) {
@@ -76,14 +81,27 @@ class TextWithVariablesInjected extends Component {
         if (!triggerVariable.ready) {
           variableReady = false;
         }
+        const variableId = `triggerEvent.${triggerVariable.name}`;
+        const isGenericTriggerVariable = triggerVariable.type === EVENTS.DEVICE.NEW_STATE;
+        if (isGenericTriggerVariable) {
+          if (genericTriggerVariableIds.has(variableId)) {
+            return;
+          }
+          genericTriggerVariableIds.add(variableId);
+        }
+        const variableLabel = isGenericTriggerVariable
+          ? triggerVariable.label
+          : `${index + 1}. ${triggerVariable.label}`;
         // we create a "variablesKey" string to quickly compare the variables displayed
         // instead of having to loop through 2 arrays. It's quicker :)
-        variablesKey += `trigger.${index}.${triggerVariable.name}.${triggerVariable.label}.${triggerVariable.ready}`;
+        variablesKey += `trigger.${isGenericTriggerVariable ? 'any' : index}.${triggerVariable.name}.${
+          triggerVariable.label
+        }.${triggerVariable.ready}`;
         variableWhileList.push({
-          id: `triggerEvent.${triggerVariable.name}`,
-          text: `${index + 1}. ${triggerVariable.label}`,
-          title: `${index + 1}. ${triggerVariable.label}`,
-          value: `triggerEvent.${triggerVariable.name}`
+          id: variableId,
+          text: variableLabel,
+          title: variableLabel,
+          value: variableId
         });
       });
     });

--- a/front/src/routes/scene/edit-scene/triggers/DeviceFeatureState.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/DeviceFeatureState.jsx
@@ -3,7 +3,7 @@ import { connect } from 'unistore/preact';
 import { Text, Localizer } from 'preact-i18n';
 import get from 'get-value';
 
-import { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } from '../../../../../../server/utils/constants';
+import { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES, EVENTS } from '../../../../../../server/utils/constants';
 
 import withIntlAsProp from '../../../../utils/withIntlAsProp';
 import SelectDeviceFeature from '../../../../components/device/SelectDeviceFeature';
@@ -36,28 +36,28 @@ class TurnOnLight extends Component {
     this.props.setVariablesTrigger(this.props.index, [
       {
         name: 'device.name',
-        type: 'device.new-state',
+        type: EVENTS.DEVICE.NEW_STATE,
         ready: true,
         label: DEVICE_NAME_VARIABLE,
         data: {}
       },
       {
         name: 'deviceFeature.name',
-        type: 'device.new-state',
+        type: EVENTS.DEVICE.NEW_STATE,
         ready: true,
         label: DEVICE_FEATURE_NAME_VARIABLE,
         data: {}
       },
       {
         name: 'last_value',
-        type: 'device.new-state',
+        type: EVENTS.DEVICE.NEW_STATE,
         ready: true,
         label: LAST_VALUE_VARIABLE,
         data: {}
       },
       {
         name: 'previous_value',
-        type: 'device.new-state',
+        type: EVENTS.DEVICE.NEW_STATE,
         ready: true,
         label: PREVIOUS_VALUE_VARIABLE,
         data: {}


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affect the code, did you write the tests? (front-only UI change in the scene editor variable picker; no server code changed. The server behaviour — a single `triggerEvent` scope for whichever trigger fired — is already covered by the tests added in #2708)
- [ ] Are server tests passing with coverage? (`cd server &amp;&amp; npm run coverage`) — no server change in this PR
- [ ] Did Cypress E2E tests pass? (`npm run cypress:run` from repo root, if UI changed)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [ ] If you are adding a new feature/service, did you run the integration comparator? (`npm run compare-translations` on front) — no translation change
- [ ] Did you test this pull request in real life? With real devices?
- [ ] If your changes modify the API (REST or Node.js), did you modify the API documentation? — no API change
- [ ] If you are adding a new features/services which needs explanation, did you modify the user documentation?
- [ ] Did you add fake requests data for the demo mode (`front/src/config/demo.js`)? — not needed

### Description of change

Addresses the review feedback on #2708:

> It doesn't really solve the initial problem as it creates variables for each trigger. The user wants to know which trigger "triggered" the scene, and doesn't know in advance which one it is

The variable picker was registering one set of variables per device state trigger card, displayed with the trigger number as prefix ("1. Trigger device name", "2. Trigger device name", …). That presentation implied each entry was bound to a specific trigger, while at runtime every entry resolves to the same `triggerEvent` — the trigger which actually fired the scene, which the user cannot know in advance.

**`front/src/components/scene/TextWithVariablesInjected.jsx`**: device state trigger variables (type `device.new-state`) are now deduplicated across triggers and displayed once, without a trigger number, so the picker reads as "the trigger that fired the scene": *Trigger device name*, *Trigger feature name*, *New value*, *Previous value* — a single generic set whatever the number of device state triggers. Calendar trigger variables keep their existing numbered presentation.

**`front/src/routes/scene/edit-scene/triggers/DeviceFeatureState.jsx`**: uses the `EVENTS.DEVICE.NEW_STATE` constant instead of a hardcoded string so the comparison cannot drift.

No server change: `scene.checkTrigger.js` already injects a single enriched `triggerEvent` for whichever trigger fired, covered by the tests added in #2708. Saved scene texts are unchanged (`{{triggerEvent.device.name}}` etc. keep the same paths), so existing scenes are unaffected.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oUtZefxfAYZNSF2CWPNho

---
_Generated by [Claude Code](https://claude.ai/code/session_015oUtZefxfAYZNSF2CWPNho)_