### PR TITLE
fix(front): stop showing last state report time as last motion on motion sensors

### DIFF
--- a/front/src/components/boxs/device-in-room/device-features/sensor-value/MotionSensorDeviceValue.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/sensor-value/MotionSensorDeviceValue.jsx
@@ -1,20 +1,26 @@
 import { Text } from 'preact-i18n';
 
-import RelativeTime from '../../../../device/RelativeTime';
+// last_value_changed is refreshed on every state report, even when the sensor
+// re-publishes "no motion", so it cannot be displayed as the time of the last motion.
+const MotionSensorDeviceValue = ({ deviceFeature }) => {
+  const { last_value: lastValue = null } = deviceFeature;
+  if (lastValue === null) {
+    return <Text id="dashboard.boxes.devicesInRoom.noValue" />;
+  }
 
-const MotionSensorDeviceValue = ({ deviceFeature, user }) => {
-  const { last_value: lastValue, last_value_changed: lastValueChanged } = deviceFeature;
   if (lastValue) {
     return (
       <span class="badge badge-info">
         <Text id="dashboard.boxes.devicesInRoom.motionDetected" />
       </span>
     );
-  } else if (lastValueChanged) {
-    return <RelativeTime datetime={lastValueChanged} language={user ? user.language : null} futureDisabled />;
   }
 
-  return <Text id="dashboard.boxes.devicesInRoom.noValue" />;
+  return (
+    <span class="badge badge-secondary">
+      <Text id="dashboard.boxes.devicesInRoom.noMotionDetected" />
+    </span>
+  );
 };
 
 export default MotionSensorDeviceValue;

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -414,6 +414,7 @@
         "addButton": "+",
         "substractButton": "-",
         "motionDetected": "Bewegung erkannt",
+        "noMotionDetected": "Keine Bewegung",
         "doorbellRinging": "Klingelt",
         "pushButton": "Schieben",
         "vacuumDock": "Zurück zur Ladestation"

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -414,6 +414,7 @@
         "addButton": "+",
         "substractButton": "-",
         "motionDetected": "Motion detected",
+        "noMotionDetected": "No motion",
         "doorbellRinging": "Ringing",
         "pushButton": "Push",
         "vacuumDock": "Return to Dock"

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -414,6 +414,7 @@
         "addButton": "+",
         "substractButton": "-",
         "motionDetected": "Mouvement détecté",
+        "noMotionDetected": "Pas de mouvement",
         "doorbellRinging": "Sonne",
         "pushButton": "Appuyer",
         "vacuumDock": "Retour à la base"


### PR DESCRIPTION
### Description

On the "Devices in room" dashboard box, a motion sensor with no current motion displayed a relative time ("2 minutes ago") based on `last_value_changed`. That timestamp is refreshed by `device.saveState` on **every** state report — including repeated "no motion" reports or re-published states — so it does not represent the time of the last motion, and users read it as "last motion 2 minutes ago".

This PR replaces the misleading relative time with an explicit "No motion" badge (`badge-secondary`), keeping:

- "Motion detected" badge when `last_value` is truthy (unchanged)
- "No value recorded" when no value was ever received
- The existing `NoRecentValueBadge` behavior for outdated values (unchanged, handled upstream in `SensorDeviceFeature`)

New i18n key `dashboard.boxes.devicesInRoom.noMotionDetected` added in `en` ("No motion"), `fr` ("Pas de mouvement") and `de` ("Keine Bewegung").

## Forum

Forum: ``https://community.gladysassistant.com/t/armer-lalarme-si-tous-les-detecteurs-douverture-et-ou-de-mouvement-sont-en-bonne-position``/10437/10

### Checklist

- [x] Tests pass: no server change; front component change only, no Cypress test relies on the previous display
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`, `npm run compare-translations` on front)
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_013vznXc1Csb73D3gVxoY37t)_