### PR TITLE
fix(front): make drag & drop work with a mouse on touchscreen PCs

### DIFF
--- a/front/src/components/boxs/chart/EditChart.jsx
+++ b/front/src/components/boxs/chart/EditChart.jsx
@@ -499,7 +499,6 @@ class EditChart extends Component {
                   moveDevice={this.moveDevice}
                   removeDevice={this.removeDevice}
                   updateDeviceFeatureName={this.updateDeviceFeatureName}
-                  isTouchDevice={false}
                 />
               )}
             </div>

--- a/front/src/components/boxs/device-in-room/EditDevices.jsx
+++ b/front/src/components/boxs/device-in-room/EditDevices.jsx
@@ -202,7 +202,6 @@ class EditDevices extends Component {
                   moveDevice={this.moveDevice}
                   removeDevice={this.removeDevice}
                   updateDeviceFeatureName={this.updateDeviceFeatureName}
-                  isTouchDevice={false}
                 />
               )}
             </div>

--- a/front/src/components/drag-and-drop/DeviceListWithDragAndDrop.jsx
+++ b/front/src/components/drag-and-drop/DeviceListWithDragAndDrop.jsx
@@ -1,9 +1,8 @@
 import { DndProvider, useDrag, useDrop } from 'react-dnd';
-import { TouchBackend } from 'react-dnd-touch-backend';
-import { HTML5Backend } from 'react-dnd-html5-backend';
 import { useRef, useState } from 'preact/hooks';
 import cx from 'classnames';
 import style from './style.css';
+import { getDragAndDropBackend } from '../../utils/dragAndDropBackend';
 
 const DEVICE_TYPE = 'DEVICE_TYPE';
 
@@ -76,14 +75,15 @@ const DeviceRow = ({ selectedDeviceFeature, moveDevice, index, removeDevice, upd
   );
 };
 
+const { backend: dragAndDropBackend, options: dragAndDropBackendOptions } = getDragAndDropBackend();
+
 const DeviceListWithDragAndDrop = ({
   selectedDeviceFeaturesOptions,
-  isTouchDevice,
   moveDevice,
   removeDevice,
   updateDeviceFeatureName
 }) => (
-  <DndProvider backend={isTouchDevice ? TouchBackend : HTML5Backend}>
+  <DndProvider backend={dragAndDropBackend} options={dragAndDropBackendOptions}>
     {selectedDeviceFeaturesOptions.map((selectedDeviceFeature, index) => (
       <DeviceRow
         selectedDeviceFeature={selectedDeviceFeature}

--- a/front/src/routes/dashboard/edit-dashboard/EditBoxColumns.jsx
+++ b/front/src/routes/dashboard/edit-dashboard/EditBoxColumns.jsx
@@ -1,13 +1,12 @@
 import { Text, Localizer } from 'preact-i18n';
 import cx from 'classnames';
 import { DndProvider } from 'react-dnd';
-import { TouchBackend } from 'react-dnd-touch-backend';
-import { HTML5Backend } from 'react-dnd-html5-backend';
 
 import EditBox from './EditBox';
 import EmptyColumnDropZone from './EmptyColumnDropZone';
 import BottomDropZone from './BottomDropZone';
 import AutoScrollMobile from '../../../components/drag-and-drop/AutoScrollMobile';
+import { getDragAndDropBackend } from '../../../utils/dragAndDropBackend';
 import style from './style.css';
 import stylePrimary from '../style.css';
 import { DASHBOARD_VISIBILITY_LIST } from '../../../../../server/utils/constants';
@@ -17,6 +16,8 @@ const maxBoxes = 3;
 const getBoxesLength = props => {
   return props.homeDashboard.boxes.length;
 };
+
+const { backend: dragAndDropBackend, options: dragAndDropBackendOptions } = getDragAndDropBackend();
 
 const EditBoxColumns = ({ children, ...props }) => (
   <div class="pb-6">
@@ -109,7 +110,7 @@ const EditBoxColumns = ({ children, ...props }) => (
         </button>
       </div>
     </div>
-    <DndProvider backend={props.isTouchDevice ? TouchBackend : HTML5Backend}>
+    <DndProvider backend={dragAndDropBackend} options={dragAndDropBackendOptions}>
       {props.isMobileReordering && <AutoScrollMobile position="top" box_type={DASHBOARD_EDIT_BOX_TYPE} />}
       <div class={cx('d-flex align-items-start', style.columnsCard)}>
         {props.homeDashboard &&

--- a/front/src/routes/dashboard/edit-dashboard/EditDashboard.jsx
+++ b/front/src/routes/dashboard/edit-dashboard/EditDashboard.jsx
@@ -48,7 +48,6 @@ const EditDashboard = ({ children, ...props }) => (
                         <EditBoxColumns
                           addBoxAtPosition={props.addBoxAtPosition}
                           user={props.user}
-                          isTouchDevice={props.isTouchDevice}
                           dashboards={props.dashboards}
                           updateCurrentDashboardName={props.updateCurrentDashboardName}
                           updateCurrentDashboardVisibility={props.updateCurrentDashboardVisibility}

--- a/front/src/routes/dashboard/edit-dashboard/ReorderDashbordList.jsx
+++ b/front/src/routes/dashboard/edit-dashboard/ReorderDashbordList.jsx
@@ -4,9 +4,8 @@ import cx from 'classnames';
 import update from 'immutability-helper';
 import { route } from 'preact-router';
 import { DndProvider, useDrag, useDrop } from 'react-dnd';
-import { TouchBackend } from 'react-dnd-touch-backend';
-import { HTML5Backend } from 'react-dnd-html5-backend';
 import { wrapEmojisJSX } from '../../../utils/emojiWrapper';
+import { getDragAndDropBackend } from '../../../utils/dragAndDropBackend';
 
 const DASHBOARD_LIST_ITEM_TYPE = 'DASHBOARD_LIST_ITEM';
 
@@ -58,8 +57,6 @@ const DashboardListItem = ({ children, ...props }) => {
 };
 
 class RedorderDashboardList extends Component {
-  isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0;
-
   insertAtPosition = (sourceIndex, destinationIndex) => {
     const { dashboards } = this.props;
     const element = dashboards[sourceIndex];
@@ -73,8 +70,9 @@ class RedorderDashboardList extends Component {
   };
 
   render({ dashboards, currentDashboard }, {}) {
+    const { backend, options } = getDragAndDropBackend();
     return (
-      <DndProvider backend={this.isTouchDevice ? TouchBackend : HTML5Backend}>
+      <DndProvider backend={backend} options={options}>
         <ul class="list-group">
           {dashboards &&
             dashboards.map((dashboard, index) => (

--- a/front/src/routes/dashboard/edit-dashboard/index.js
+++ b/front/src/routes/dashboard/edit-dashboard/index.js
@@ -366,7 +366,6 @@ class EditDashboard extends Component {
   constructor(props) {
     super(props);
     this.props = props;
-    this.isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0;
     this.state = {
       dashboards: [],
       newSelectedBoxType: {},
@@ -406,7 +405,6 @@ class EditDashboard extends Component {
     return (
       <EditDashboardPage
         user={props.user}
-        isTouchDevice={this.isTouchDevice}
         dashboards={dashboards}
         currentDashboard={currentDashboard}
         loading={loading}

--- a/front/src/routes/scene/edit-scene/index.js
+++ b/front/src/routes/scene/edit-scene/index.js
@@ -3,11 +3,10 @@ import { connect } from 'unistore/preact';
 import update from 'immutability-helper';
 import { route } from 'preact-router';
 import { DndProvider } from 'react-dnd';
-import { TouchBackend } from 'react-dnd-touch-backend';
-import { HTML5Backend } from 'react-dnd-html5-backend';
 import get from 'get-value'; // Import get-value package
 
 import { RequestStatus } from '../../../utils/consts';
+import { getDragAndDropBackend } from '../../../utils/dragAndDropBackend';
 import EditScenePage from './EditScenePage';
 
 import { ACTIONS } from '../../../../../server/utils/constants';
@@ -1126,7 +1125,6 @@ class EditScene extends Component {
 
   constructor(props) {
     super(props);
-    this.isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0;
     this.state = {
       scene: null,
       variables: {},
@@ -1151,10 +1149,11 @@ class EditScene extends Component {
 
   render(props, { saving, error, errorMessage, variables, scene, triggersVariables, tags, askDeleteScene }) {
     const actionsGroupTypes = this.generateActionGroupTypes(scene ? scene.actions : []);
+    const { backend, options } = getDragAndDropBackend();
     return (
       scene && (
         <div>
-          <DndProvider backend={this.isTouchDevice ? TouchBackend : HTML5Backend}>
+          <DndProvider backend={backend} options={options}>
             <EditScenePage
               {...props}
               scene={scene}

--- a/front/src/utils/dragAndDropBackend.js
+++ b/front/src/utils/dragAndDropBackend.js
@@ -1,0 +1,44 @@
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import { TouchBackend } from 'react-dnd-touch-backend';
+
+// Many desktop PCs and laptops now ship with a touchscreen while still being used with a
+// mouse (or a pen). Detecting the touchscreen and switching to the touch backend used to
+// break drag & drop with a mouse on those devices, because the touch backend only listens
+// to touch events by default.
+// Enabling the mouse events of the touch backend gives a unified handling of mouse, touch
+// and pen input, so drag & drop works whatever the pointer used on a hybrid device.
+const TOUCH_BACKEND_OPTIONS = {
+  enableMouseEvents: true,
+  enableTouchEvents: true,
+  // On Windows, long pressing an element with a touchscreen fires a "contextmenu" event.
+  // The touch backend listens to it as soon as mouse events are enabled, and would cancel
+  // the drag right after it started.
+  ignoreContextMenu: true
+};
+
+function isTouchDevice() {
+  try {
+    return 'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0;
+  } catch (e) {
+    return false;
+  }
+}
+
+let cachedBackend = null;
+
+/**
+ * Returns the react-dnd backend and the options to give to a DndProvider.
+ *
+ * react-dnd keeps one single drag & drop manager per window: the first mounted DndProvider
+ * wins, so every DndProvider of the app must use this helper to stay consistent.
+ */
+function getDragAndDropBackend() {
+  if (cachedBackend === null) {
+    cachedBackend = isTouchDevice()
+      ? { backend: TouchBackend, options: TOUCH_BACKEND_OPTIONS }
+      : { backend: HTML5Backend, options: undefined };
+  }
+  return cachedBackend;
+}
+
+export { TOUCH_BACKEND_OPTIONS, getDragAndDropBackend, isTouchDevice };


### PR DESCRIPTION
### Description

Fixes #2870.

Desktop PCs and laptops with a touchscreen were detected as touch devices, so every `DndProvider` of the app switched to the `react-dnd` touch backend:

```js
this.isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0;
// ...
<DndProvider backend={this.isTouchDevice ? TouchBackend : HTML5Backend}>
```

The touch backend only listens to touch events by default (`enableMouseEvents` is `false`), so on those hybrid machines drag & drop became completely unusable **with a mouse** — which is exactly what the issue describes on Chrome, Edge and Firefox, and why disabling touch events in the browser worked around it.

**What changed**

- The touch backend is now configured with `enableMouseEvents: true`, so it handles mouse, touch and pen input at once on hybrid devices — the unified handling asked for in the issue.
- `ignoreContextMenu: true` is also set: on Windows a long press fires a `contextmenu` event, which the touch backend listens to as soon as mouse events are enabled and which would cancel the drag right after it started (the long-press-then-drag scenario from the report).
- The detection and the backend options now live in a single helper, `front/src/utils/dragAndDropBackend.js`, used by all 5 `DndProvider` of the app. `react-dnd` keeps **one** drag & drop manager per window (`createSingletonDndContext`), so the first mounted provider decides the options for the whole app — every provider has to agree on them.
- Side effect of the centralisation: `EditChart` and `EditDevices` hardcoded `isTouchDevice={false}` on `DeviceListWithDragAndDrop`, so reordering the device features of a chart/devices box was impossible with touch. They now use the same detection as the rest of the app.

Non-touch desktops are unaffected: they keep the HTML5 backend with no options.

**How it was verified**

The change is only reachable on a device that reports touch support, so it was checked in Chromium with a touch-capable desktop profile (`hasTouch: true`, `navigator.maxTouchPoints === 1`, 1280×900 viewport) driving a minimal page built on the same helper and `useDrag`/`useDrop` hooks:

| Scenario | Before | After |
|---|---|---|
| Mouse drag, touch-capable desktop | drop never fires | drop fires |
| Touch drag, touch-capable desktop | drop fires | drop fires |
| Mouse drag, plain desktop (no touch) | drop fires | drop fires |

## Forum

<!-- Not applicable: this is a bug fix reported on GitHub. -->

### Checklist

- [x] Tests pass: no server change in this PR, so `npm run coverage` is not impacted. Cypress was not run here (the Cypress binary could not be downloaded in this environment) — it runs on CI.
- [x] Linter and prettier pass on the front (`npm run eslint`, `npm run prettier-check`), plus `npm run compare-translations` and `npm run build`
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCmpBvnEKiXiaQhLwAfunf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop behavior across desktop and touch devices.
  * Touch interactions now support mouse and touch events more reliably.
  * Prevented inconsistent drag-and-drop configuration across dashboard, scene, chart, and device editors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->