### PR TITLE
fix(front): align integrations badge with its label in the mobile menu

### DIFF
--- a/front/src/style/index.css
+++ b/front/src/style/index.css
@@ -517,3 +517,14 @@ body .apexcharts-tooltip {
   font-size: 0.7rem;
   margin-right: 6px;
 }
+
+/* The theme pins nav badges to the top-right corner of the nav item. That looks
+   right on the horizontal desktop tabs, where the item hugs its link, but the
+   collapsed mobile menu stacks full-width items, so the badge drifts to the
+   edge of the screen, away from the label it counts. Below the lg breakpoint,
+   let it flow inline after the text instead (spacing comes from its ml-2). */
+@media (max-width: 991.98px) {
+  #headerMenuCollapse .nav-tabs .nav-link .badge {
+    position: static;
+  }
+}


### PR DESCRIPTION
### Description

The "integrations to update" counter badge in the header menu looked misplaced on mobile: it floated at the far right edge of the screen, vertically offset above the "Intégrations" row, disconnected from the label it counts.

The theme styles all nav badges as `position: absolute; top: 0; right: 0` relative to the `.nav-item` (`.nav-link .badge, .nav-item .badge` in `dashboard.css`). On desktop the nav item hugs its link, so the badge lands neatly next to the text. In the collapsed mobile menu the items are stacked full-width, so the same rule sends the badge to the edge of the viewport.

This makes the badge flow inline after the label below the `lg` breakpoint (the breakpoint at which `#headerMenuCollapse` switches to the stacked menu). The existing `ml-2` on the badge provides the spacing, and the `.nav-link` flex centering keeps it aligned with the text. At 390px the badge now sits directly after "Intégrations", vertically centered with it.

Desktop rendering is untouched — I rendered the header markup against the theme CSS at 1200px with and without the override, and the two screenshots are byte-identical.

### Forum

N/A

### Checklist

- [x] Tests pass: no test touched — the change is a single CSS rule in `front/src/style/index.css`, no JS/JSX changed, so coverage on changed lines is unaffected
- [x] Linter and prettier pass on both front and server — `prettier`/`eslint` are scoped to `**/*.js`, `**/*.jsx` and `**/*.json` in this repo, and no such file is modified
- [x] No undocumented breaking change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile header navigation layout by displaying badges inline on smaller screens.
  * Enhanced responsiveness for viewport widths below 991.98px.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->