### PR TITLE
fix(front): keep camera true colors in fullscreen in dark mode

### DIFF
--- a/front/src/style/dark-mode.css
+++ b/front/src/style/dark-mode.css
@@ -214,3 +214,24 @@ body.dark-mode {
 .dark-mode .weather-real-colors {
   filter: brightness(0.7) invert(100%) hue-rotate(180deg) !important;
 }
+
+/* A fullscreen element is painted in the browser's top layer, where the global
+   html.dark-mode inversion does not apply anymore. Every counter-inversion above only
+   exists to cancel that global filter, so in fullscreen it inverts the media for real:
+   the camera live stream was displayed as a photo negative once put in fullscreen.
+   Kept last in the file so it wins over the other !important filters. */
+.dark-mode video:fullscreen,
+.dark-mode img:fullscreen,
+.dark-mode iframe:fullscreen,
+.dark-mode .dark-mode-no-invert:fullscreen {
+  filter: none !important;
+}
+
+/* Same rule for Safari < 16.4, which only knows the prefixed pseudo-class. It has to
+   live in its own block: an unknown pseudo-class invalidates the whole selector list. */
+.dark-mode video:-webkit-full-screen,
+.dark-mode img:-webkit-full-screen,
+.dark-mode iframe:-webkit-full-screen,
+.dark-mode .dark-mode-no-invert:-webkit-full-screen {
+  filter: none !important;
+}


### PR DESCRIPTION
### Description

Fixes #2874 — in dark mode, a camera opened in fullscreen was displayed as a photo negative.

Dark mode inverts the whole page with `filter: invert(100%) hue-rotate(180deg)` on `html`, and cancels that inversion on media elements (`img`, `video`, `iframe`, `.dark-mode-no-invert`) with a second inversion. A fullscreen element is painted in the browser's **top layer**, where the ancestor filter on `html` no longer applies — so only the counter-inversion was left, and the video was really inverted.

The fix cancels the counter-inversion on elements that are themselves in fullscreen, in `front/src/style/dark-mode.css`:

```css
.dark-mode video:fullscreen,
.dark-mode img:fullscreen,
.dark-mode iframe:fullscreen,
.dark-mode .dark-mode-no-invert:fullscreen {
  filter: none !important;
}
```

with the same block repeated for `:-webkit-full-screen` (Safari < 16.4) — it needs its own rule, since an unknown pseudo-class invalidates the whole selector list. The rules are kept at the end of the file so they win over the other `!important` filters (`.white-bg`, `.weather-provider-image`, `.weather-real-colors`).

Tablet mode is unaffected: it fullscreens `document.documentElement`, so the video is a descendant of the fullscreen element rather than the fullscreen element itself, and the global filter still applies to it.

Verified in Chromium (Playwright) against the real stylesheet, with a video whose poster is a red/green image:

| scenario | computed `filter` on the video | result |
| --- | --- | --- |
| dark mode, not fullscreen | `invert(1) hue-rotate(180deg)` | true colors (unchanged) |
| dark mode, video fullscreen | `none` | true colors (was inverted before the fix) |
| dark mode, tablet mode (`html` fullscreen) | `invert(1) hue-rotate(180deg)` | true colors (unchanged) |
| light mode, video fullscreen | `none` | true colors (unchanged) |

## Forum

<!-- Not applicable: bug fix reported on GitHub. -->

### Checklist

- [ ] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

CSS-only change, so there is no changed line for Codecov and no test suite covers the stylesheet; validation was done in a real browser as described above.

---
_Generated by [Claude Code](https://claude.ai/code/session_012fGKxD5J9uQEAkHaR8uyG5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fullscreen videos, images, and embedded content appearing with inverted colors in dark mode.
  * Ensured media marked to avoid inversion maintains its intended appearance in fullscreen across supported browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->