### PR TITLE
feat(scene): support more math functions in scene formulas

### DIFF
--- a/front/src/components/scene/FormulaFunctionsHelp.css
+++ b/front/src/components/scene/FormulaFunctionsHelp.css
@@ -10,5 +10,5 @@
 .formulaHelp code {
   background: none;
   padding: 0;
-  word-break: break-word;
+  overflow-wrap: anywhere;
 }

--- a/front/src/components/scene/FormulaFunctionsHelp.css
+++ b/front/src/components/scene/FormulaFunctionsHelp.css
@@ -1,0 +1,14 @@
+/* Kept smaller and dimmer than the explanation text above it: this is a reference list the
+   user only scans when writing a formula, it must not compete with the input itself. */
+.formulaHelp {
+  font-size: 11px;
+  line-height: 1.5;
+  opacity: .75;
+  margin-bottom: .375rem;
+}
+
+.formulaHelp code {
+  background: none;
+  padding: 0;
+  word-break: break-word;
+}

--- a/front/src/components/scene/FormulaFunctionsHelp.css
+++ b/front/src/components/scene/FormulaFunctionsHelp.css
@@ -7,7 +7,17 @@
   margin-bottom: .375rem;
 }
 
-.formulaHelp code {
+/* Collapsed, the whole block is just this one clickable line. */
+.summary {
+  cursor: pointer;
+  user-select: none;
+}
+
+.content {
+  margin-top: .25rem;
+}
+
+.content code {
   background: none;
   padding: 0;
   overflow-wrap: anywhere;

--- a/front/src/components/scene/FormulaFunctionsHelp.jsx
+++ b/front/src/components/scene/FormulaFunctionsHelp.jsx
@@ -10,24 +10,31 @@ const FUNCTIONS =
   'sin, cos, tan, asin, acos, atan, atan2';
 const CONSTANTS = 'pi, e, tau';
 
+// A native <details> keeps the reference collapsed by default so it costs one line in the action
+// box, and opens on click without any state or JS. It also stays keyboard-reachable for free.
 const FormulaFunctionsHelp = () => (
-  <div class={style.formulaHelp}>
-    <div>
-      <Text id="editScene.actionsCard.formulaHelp.operators" /> <code>{OPERATORS}</code>
+  <details class={style.formulaHelp}>
+    <summary class={style.summary}>
+      <Text id="editScene.actionsCard.formulaHelp.toggle" />
+    </summary>
+    <div class={style.content}>
+      <div>
+        <Text id="editScene.actionsCard.formulaHelp.operators" /> <code>{OPERATORS}</code>
+      </div>
+      <div>
+        <Text id="editScene.actionsCard.formulaHelp.functions" /> <code>{FUNCTIONS}</code>
+      </div>
+      <div>
+        <Text id="editScene.actionsCard.formulaHelp.constants" /> <code>{CONSTANTS}</code>
+      </div>
+      <div>
+        <Text id="editScene.actionsCard.formulaHelp.example" />
+      </div>
+      <div>
+        <Text id="editScene.actionsCard.formulaHelp.caveats" />
+      </div>
     </div>
-    <div>
-      <Text id="editScene.actionsCard.formulaHelp.functions" /> <code>{FUNCTIONS}</code>
-    </div>
-    <div>
-      <Text id="editScene.actionsCard.formulaHelp.constants" /> <code>{CONSTANTS}</code>
-    </div>
-    <div>
-      <Text id="editScene.actionsCard.formulaHelp.example" />
-    </div>
-    <div>
-      <Text id="editScene.actionsCard.formulaHelp.caveats" />
-    </div>
-  </div>
+  </details>
 );
 
 export default FormulaFunctionsHelp;

--- a/front/src/components/scene/FormulaFunctionsHelp.jsx
+++ b/front/src/components/scene/FormulaFunctionsHelp.jsx
@@ -1,0 +1,30 @@
+import { Text } from 'preact-i18n';
+import style from './FormulaFunctionsHelp.css';
+
+// Mirrors the restricted mathjs namespace built in server/lib/scene/scene.formula.js.
+// Function and constant names are not translated, so they live here instead of the i18n files.
+const OPERATORS = '+  -  *  /  %  ^  ( )  >  >=  <  <=';
+const FUNCTIONS =
+  'abs, ceil, floor, fix, round, sign, sqrt, cbrt, square, cube, pow, nthRoot, hypot, ' +
+  'exp, log, log2, log10, min, max, mean, median, sum, prod, gcd, lcm, random, randomInt, ' +
+  'sin, cos, tan, asin, acos, atan, atan2';
+const CONSTANTS = 'pi, e, tau';
+
+const FormulaFunctionsHelp = () => (
+  <div class={style.formulaHelp}>
+    <div>
+      <Text id="editScene.actionsCard.formulaHelp.operators" /> <code>{OPERATORS}</code>
+    </div>
+    <div>
+      <Text id="editScene.actionsCard.formulaHelp.functions" /> <code>{FUNCTIONS}</code>
+    </div>
+    <div>
+      <Text id="editScene.actionsCard.formulaHelp.constants" /> <code>{CONSTANTS}</code>
+    </div>
+    <div>
+      <Text id="editScene.actionsCard.formulaHelp.example" />
+    </div>
+  </div>
+);
+
+export default FormulaFunctionsHelp;

--- a/front/src/components/scene/FormulaFunctionsHelp.jsx
+++ b/front/src/components/scene/FormulaFunctionsHelp.jsx
@@ -24,6 +24,9 @@ const FormulaFunctionsHelp = () => (
     <div>
       <Text id="editScene.actionsCard.formulaHelp.example" />
     </div>
+    <div>
+      <Text id="editScene.actionsCard.formulaHelp.caveats" />
+    </div>
   </div>
 );
 

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -3092,6 +3092,7 @@
     "saveSceneError": "Beim Sichern deiner Szene ist ein Fehler aufgetreten. Bitte überprüfe, ob alle Aktionen/Auslöser ausgefüllt und korrekt sind.",
     "actionsCard": {
       "formulaHelp": {
+        "toggle": "Verfügbare Funktionen und Syntax",
         "operators": "Verfügbare Operatoren:",
         "functions": "Verfügbare Funktionen:",
         "constants": "Verfügbare Konstanten:",

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -3095,7 +3095,8 @@
         "operators": "Verfügbare Operatoren:",
         "functions": "Verfügbare Funktionen:",
         "constants": "Verfügbare Konstanten:",
-        "example": "Eine Funktion nimmt ihre Argumente in Klammern, durch Kommas getrennt. Z.B.: round(min(100, 3 * 45) / 2)"
+        "example": "Eine Funktion nimmt ihre Argumente in Klammern, durch Kommas getrennt. Z.B.: round(min(100, 3 * 45) / 2)",
+        "caveats": "Achtung: Trigonometrische Funktionen arbeiten im Bogenmaß (sin(pi/2), nicht sin(90)), log ist der natürliche Logarithmus (nutze log10 für Basis 10), randomInt(min, max) gibt nie max zurück, und Konstanten müssen explizit multipliziert werden (2*pi, nicht 2 pi)."
       },
       "delay": {
         "label": " Dieser Block wartet für die angegebene Dauer.",

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -3091,6 +3091,12 @@
     "addNewTriggerButton": "Auslöser hinzufügen",
     "saveSceneError": "Beim Sichern deiner Szene ist ein Fehler aufgetreten. Bitte überprüfe, ob alle Aktionen/Auslöser ausgefüllt und korrekt sind.",
     "actionsCard": {
+      "formulaHelp": {
+        "operators": "Verfügbare Operatoren:",
+        "functions": "Verfügbare Funktionen:",
+        "constants": "Verfügbare Konstanten:",
+        "example": "Eine Funktion nimmt ihre Argumente in Klammern, durch Kommas getrennt. Z.B.: round(min(100, 3 * 45) / 2)"
+      },
       "delay": {
         "label": " Dieser Block wartet für die angegebene Dauer.",
         "inputPlaceholder": "Dauer",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -3095,7 +3095,8 @@
         "operators": "Available operators:",
         "functions": "Available functions:",
         "constants": "Available constants:",
-        "example": "A function takes its arguments between parenthesis, separated by commas. Ex: round(min(100, 3 * 45) / 2)"
+        "example": "A function takes its arguments between parenthesis, separated by commas. Ex: round(min(100, 3 * 45) / 2)",
+        "caveats": "Watch out: trigonometric functions work in radians (sin(pi/2), not sin(90)), log is the natural logarithm (use log10 for base 10), randomInt(min, max) never returns max, and constants must be multiplied explicitly (2*pi, not 2 pi)."
       },
       "delay": {
         "label": " This block will wait the specified duration.",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -3091,6 +3091,12 @@
     "addNewTriggerButton": "Add trigger",
     "saveSceneError": "There was an error saving your scene. Please check that all actions/triggers are filled and correct.",
     "actionsCard": {
+      "formulaHelp": {
+        "operators": "Available operators:",
+        "functions": "Available functions:",
+        "constants": "Available constants:",
+        "example": "A function takes its arguments between parenthesis, separated by commas. Ex: round(min(100, 3 * 45) / 2)"
+      },
       "delay": {
         "label": " This block will wait the specified duration.",
         "inputPlaceholder": "Duration",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -3092,6 +3092,7 @@
     "saveSceneError": "There was an error saving your scene. Please check that all actions/triggers are filled and correct.",
     "actionsCard": {
       "formulaHelp": {
+        "toggle": "Available functions and syntax",
         "operators": "Available operators:",
         "functions": "Available functions:",
         "constants": "Available constants:",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -3091,6 +3091,12 @@
     "addNewTriggerButton": "Nouveau déclencheur",
     "saveSceneError": "Une erreur s'est produite lors de l'enregistrement de votre scène. Veuillez vérifier que toutes les actions / déclencheurs sont remplis et corrects.",
     "actionsCard": {
+      "formulaHelp": {
+        "operators": "Opérateurs disponibles :",
+        "functions": "Fonctions disponibles :",
+        "constants": "Constantes disponibles :",
+        "example": "Une fonction prend ses arguments entre parenthèses, séparés par des virgules. Ex : round(min(100, 3 * 45) / 2)"
+      },
       "delay": {
         "label": " Ce bloc attendra la durée spécifiée.",
         "inputPlaceholder": "Durée",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -3092,6 +3092,7 @@
     "saveSceneError": "Une erreur s'est produite lors de l'enregistrement de votre scène. Veuillez vérifier que toutes les actions / déclencheurs sont remplis et corrects.",
     "actionsCard": {
       "formulaHelp": {
+        "toggle": "Fonctions disponibles et syntaxe",
         "operators": "Opérateurs disponibles :",
         "functions": "Fonctions disponibles :",
         "constants": "Constantes disponibles :",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -3095,7 +3095,8 @@
         "operators": "Opérateurs disponibles :",
         "functions": "Fonctions disponibles :",
         "constants": "Constantes disponibles :",
-        "example": "Une fonction prend ses arguments entre parenthèses, séparés par des virgules. Ex : round(min(100, 3 * 45) / 2)"
+        "example": "Une fonction prend ses arguments entre parenthèses, séparés par des virgules. Ex : round(min(100, 3 * 45) / 2)",
+        "caveats": "Attention : les fonctions trigonométriques travaillent en radians (sin(pi/2), et non sin(90)), log est le logarithme népérien (utilisez log10 pour la base 10), randomInt(min, max) ne renvoie jamais max, et les constantes doivent être multipliées explicitement (2*pi, et non 2 pi)."
       },
       "delay": {
         "label": " Ce bloc attendra la durée spécifiée.",

--- a/front/src/routes/scene/edit-scene/actions/DelayActionParams.jsx
+++ b/front/src/routes/scene/edit-scene/actions/DelayActionParams.jsx
@@ -3,6 +3,7 @@ import { connect } from 'unistore/preact';
 import { Text, Localizer } from 'preact-i18n';
 import cx from 'classnames';
 import TextWithVariablesInjected from '../../../../components/scene/TextWithVariablesInjected';
+import FormulaFunctionsHelp from '../../../../components/scene/FormulaFunctionsHelp';
 import style from './DeviceSetValue.css';
 
 class WaitActionParams extends Component {
@@ -43,6 +44,7 @@ class WaitActionParams extends Component {
           <div className={style.explanationText}>
             <Text id="editScene.actionsCard.delay.computedExplanationText" />
           </div>
+          <FormulaFunctionsHelp />
           <div class="input-group">
             <Localizer>
               <TextWithVariablesInjected

--- a/front/src/routes/scene/edit-scene/actions/DeviceSetValue.jsx
+++ b/front/src/routes/scene/edit-scene/actions/DeviceSetValue.jsx
@@ -11,6 +11,7 @@ import withIntlAsProp from '../../../../utils/withIntlAsProp';
 
 import { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } from '../../../../../../server/utils/constants';
 import TextWithVariablesInjected from '../../../../components/scene/TextWithVariablesInjected';
+import FormulaFunctionsHelp from '../../../../components/scene/FormulaFunctionsHelp';
 
 import '../../../../components/boxs/device-in-room/device-features/style.css';
 import style from './DeviceSetValue.css';
@@ -159,6 +160,7 @@ class DeviceSetValue extends Component {
           <div className={style.explanationText}>
             <Text id="editScene.actionsCard.deviceSetValue.computedExplanationText" />
           </div>
+          <FormulaFunctionsHelp />
           <div class="input-group">
             <Localizer>
               <TextWithVariablesInjected

--- a/front/src/routes/scene/edit-scene/actions/SetVariable.jsx
+++ b/front/src/routes/scene/edit-scene/actions/SetVariable.jsx
@@ -6,6 +6,7 @@ import get from 'get-value';
 
 import withIntlAsProp from '../../../../utils/withIntlAsProp';
 import TextWithVariablesInjected from '../../../../components/scene/TextWithVariablesInjected';
+import FormulaFunctionsHelp from '../../../../components/scene/FormulaFunctionsHelp';
 import style from './DeviceSetValue.css';
 
 class SetVariable extends Component {
@@ -71,6 +72,7 @@ class SetVariable extends Component {
           <div className={style.explanationText}>
             <Text id="editScene.actionsCard.setVariable.computedExplanationText" />
           </div>
+          <FormulaFunctionsHelp />
           <div className="tags-input">
             <Localizer>
               <TextWithVariablesInjected

--- a/front/src/routes/scene/edit-scene/actions/only-continue-if/OnlyContinueIfParams.jsx
+++ b/front/src/routes/scene/edit-scene/actions/only-continue-if/OnlyContinueIfParams.jsx
@@ -5,6 +5,7 @@ import update from 'immutability-helper';
 import get from 'get-value';
 
 import withIntlAsProp from '../../../../../utils/withIntlAsProp';
+import FormulaFunctionsHelp from '../../../../../components/scene/FormulaFunctionsHelp';
 
 import { isVariableAvailableAtThisPath, convertPathToText } from '../../sceneUtils';
 
@@ -73,6 +74,9 @@ class OnlyContinueIf extends Component {
           </div>
           <div class="mt-2">
             <Text id="editScene.actionsCard.onlyContinueIf.explanationText" />
+          </div>
+          <div class="mt-2">
+            <FormulaFunctionsHelp />
           </div>
         </div>
         {props.action.conditions &&

--- a/server/lib/scene/scene.actions.js
+++ b/server/lib/scene/scene.actions.js
@@ -427,9 +427,12 @@ const actionsFunc = {
         }
       }
 
-      // For numeric comparison operators (>, >=, <, <=), value must be a number
+      // For numeric comparison operators (>, >=, <, <=), value must be a number.
+      // Infinity is rejected like NaN, as in the three other formula actions: a formula
+      // overflowing to it (exp(1000)) or reaching it through log(0) would otherwise make
+      // the comparison silently always true or always false instead of failing the scene.
       const numericOperators = ['>', '>=', '<', '<='];
-      if (numericOperators.includes(condition.operator) && Number.isNaN(Number(value))) {
+      if (numericOperators.includes(condition.operator) && !Number.isFinite(Number(value))) {
         throw new AbortScene('CONDITION_VALUE_NOT_A_NUMBER');
       }
 

--- a/server/lib/scene/scene.actions.js
+++ b/server/lib/scene/scene.actions.js
@@ -93,7 +93,9 @@ const actionsFunc = {
       }
     }
 
-    if (Number.isNaN(Number(value))) {
+    // Infinity is rejected like NaN: a formula can overflow to it (exp(1000)) or reach it
+    // through a logarithm of zero (log(0)), and a device cannot be set to an infinite value.
+    if (!Number.isFinite(Number(value))) {
       throw new AbortScene('ACTION_VALUE_NOT_A_NUMBER');
     }
 
@@ -258,7 +260,10 @@ const actionsFunc = {
       }
     }
 
-    if (Number.isNaN(Number(value))) {
+    // Infinity is rejected like NaN: a formula can overflow to it (exp(1000)) or reach it
+    // through a logarithm of zero (log(0)), and waiting for an infinite delay would hang
+    // the scene instead of failing it.
+    if (!Number.isFinite(Number(value))) {
       logger.warn(`Delay: Value is not a number: ${value}`);
       throw new AbortScene('ACTION_VALUE_NOT_A_NUMBER');
     }

--- a/server/lib/scene/scene.actions.js
+++ b/server/lib/scene/scene.actions.js
@@ -1,22 +1,6 @@
 const Promise = require('bluebird');
 const Handlebars = require('handlebars');
 const cloneDeep = require('lodash.clonedeep');
-const {
-  create,
-  addDependencies,
-  divideDependencies,
-  evaluateDependencies,
-  largerDependencies,
-  largerEqDependencies,
-  modDependencies,
-  multiplyDependencies,
-  roundDependencies,
-  smallerDependencies,
-  smallerEqDependencies,
-  subtractDependencies,
-  unaryMinusDependencies,
-  randomDependencies,
-} = require('mathjs');
 const set = require('set-value');
 const get = require('get-value');
 const dayjs = require('dayjs');
@@ -30,29 +14,10 @@ const { compare } = require('../../utils/compare');
 const { parseJsonIfJson } = require('../../utils/json');
 const logger = require('../../utils/logger');
 const executeActionsFactory = require('./scene.executeActions');
+const { evaluate } = require('./scene.formula');
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
-
-// Every operator the formula engine supports must be listed explicitly here.
-// mathjs only exposes in the "math" namespace what is passed to create(), so an operator
-// that is only pulled in transitively by another factory (multiply through divide, for example)
-// is not guaranteed to stay available across mathjs releases.
-const { evaluate } = create({
-  addDependencies,
-  divideDependencies,
-  evaluateDependencies,
-  largerDependencies,
-  smallerDependencies,
-  largerEqDependencies,
-  modDependencies,
-  multiplyDependencies,
-  smallerEqDependencies,
-  subtractDependencies,
-  unaryMinusDependencies,
-  roundDependencies,
-  randomDependencies,
-});
 
 // Safety limits for the "while" loop action
 const WHILE_DEFAULT_MAX_ITERATIONS = 1000;
@@ -112,11 +77,20 @@ const actionsFunc = {
     }
 
     if (action.evaluate_value !== undefined) {
-      value = evaluate(
-        Handlebars.compile(action.evaluate_value, {
-          noEscape: true,
-        })(scope).replace(/\s/g, ''),
-      );
+      // A formula which cannot be evaluated (unknown function, wrong number of arguments)
+      // must not let the scene continue with the previous value: like the other formula
+      // actions, we abort the scene.
+      try {
+        value = evaluate(
+          Handlebars.compile(action.evaluate_value, {
+            noEscape: true,
+          })(scope).replace(/\s/g, ''),
+        );
+      } catch (e) {
+        logger.warn(`Device set value: Error evaluating value: ${action.evaluate_value}`);
+        logger.warn(e);
+        throw new AbortScene('ACTION_VALUE_NOT_A_NUMBER');
+      }
     }
 
     if (Number.isNaN(Number(value))) {

--- a/server/lib/scene/scene.formula.js
+++ b/server/lib/scene/scene.formula.js
@@ -1,0 +1,123 @@
+const {
+  create,
+  // Arithmetic operators
+  addDependencies,
+  subtractDependencies,
+  multiplyDependencies,
+  divideDependencies,
+  unaryMinusDependencies,
+  modDependencies,
+  // Comparison operators (>, >=, <, <=)
+  largerDependencies,
+  largerEqDependencies,
+  smallerDependencies,
+  smallerEqDependencies,
+  // Rounding and sign
+  absDependencies,
+  ceilDependencies,
+  floorDependencies,
+  fixDependencies,
+  roundDependencies,
+  signDependencies,
+  // Powers and roots
+  powDependencies,
+  sqrtDependencies,
+  cbrtDependencies,
+  squareDependencies,
+  cubeDependencies,
+  nthRootDependencies,
+  hypotDependencies,
+  // Exponential and logarithm
+  expDependencies,
+  logDependencies,
+  log2Dependencies,
+  log10Dependencies,
+  // Statistics
+  minDependencies,
+  maxDependencies,
+  meanDependencies,
+  medianDependencies,
+  sumDependencies,
+  prodDependencies,
+  // Integer arithmetic
+  gcdDependencies,
+  lcmDependencies,
+  // Random
+  randomDependencies,
+  randomIntDependencies,
+  // Trigonometry
+  sinDependencies,
+  cosDependencies,
+  tanDependencies,
+  asinDependencies,
+  acosDependencies,
+  atanDependencies,
+  atan2Dependencies,
+  // Constants
+  piDependencies,
+  eDependencies,
+  tauDependencies,
+  // The expression parser itself
+  evaluateDependencies,
+} = require('mathjs');
+
+// Every operator, function and constant the formula engine supports must be listed explicitly
+// here. mathjs only exposes in the "math" namespace what is passed to create(), so a function
+// that is only pulled in transitively by another factory (multiply through divide, or abs
+// through round, for example) is not guaranteed to stay available across mathjs releases.
+// Every entry below is covered by a test in test/lib/scene/actions/scene.action.formula.test.js
+// so that a mathjs upgrade dropping one fails CI instead of failing silently in production.
+const { evaluate } = create({
+  addDependencies,
+  subtractDependencies,
+  multiplyDependencies,
+  divideDependencies,
+  unaryMinusDependencies,
+  modDependencies,
+  largerDependencies,
+  largerEqDependencies,
+  smallerDependencies,
+  smallerEqDependencies,
+  absDependencies,
+  ceilDependencies,
+  floorDependencies,
+  fixDependencies,
+  roundDependencies,
+  signDependencies,
+  powDependencies,
+  sqrtDependencies,
+  cbrtDependencies,
+  squareDependencies,
+  cubeDependencies,
+  nthRootDependencies,
+  hypotDependencies,
+  expDependencies,
+  logDependencies,
+  log2Dependencies,
+  log10Dependencies,
+  minDependencies,
+  maxDependencies,
+  meanDependencies,
+  medianDependencies,
+  sumDependencies,
+  prodDependencies,
+  gcdDependencies,
+  lcmDependencies,
+  randomDependencies,
+  randomIntDependencies,
+  sinDependencies,
+  cosDependencies,
+  tanDependencies,
+  asinDependencies,
+  acosDependencies,
+  atanDependencies,
+  atan2Dependencies,
+  piDependencies,
+  eDependencies,
+  tauDependencies,
+  evaluateDependencies,
+});
+
+module.exports = {
+  evaluate,
+};

--- a/server/test/lib/scene/actions/scene.action.continueOnlyIf.test.js
+++ b/server/test/lib/scene/actions/scene.action.continueOnlyIf.test.js
@@ -119,9 +119,10 @@ describe('scene.continue-only-if', () => {
               {
                 variable: '0.0.last_value',
                 operator: '=',
-                // "sqrt" is not part of the restricted formula engine namespace,
-                // so evaluating this condition throws.
-                evaluate_value: 'sqrt(400)',
+                // "unknownFunction" is not part of the restricted formula engine namespace,
+                // so evaluating this condition throws. It is deliberately a name mathjs will
+                // never define, so extending the namespace cannot make this formula valid.
+                evaluate_value: 'unknownFunction(400)',
               },
             ],
           },

--- a/server/test/lib/scene/actions/scene.action.continueOnlyIf.test.js
+++ b/server/test/lib/scene/actions/scene.action.continueOnlyIf.test.js
@@ -141,6 +141,53 @@ describe('scene.continue-only-if', () => {
     // The guard must fail closed: the action after it must not have been executed.
     assert.notCalled(device.setValue);
   });
+  it('should abort scene when the condition formula returns a non-finite number', async () => {
+    stateManager.setState('deviceFeature', 'my-device-feature', {
+      category: 'light',
+      type: 'binary',
+      last_value: 15,
+    });
+    const device = {
+      setValue: fake.resolves(null),
+    };
+    const scope = {};
+    const promise = executeActions(
+      { stateManager, event, device },
+      [
+        [
+          {
+            type: ACTIONS.DEVICE.GET_VALUE,
+            device_feature: 'my-device-feature',
+          },
+        ],
+        [
+          {
+            type: ACTIONS.CONDITION.ONLY_CONTINUE_IF,
+            conditions: [
+              {
+                variable: '0.0.last_value',
+                operator: '<',
+                // exp() overflows to Infinity without throwing: comparing against it would
+                // silently always be true instead of surfacing the broken formula.
+                evaluate_value: 'exp(1000)',
+              },
+            ],
+          },
+        ],
+        [
+          {
+            type: ACTIONS.DEVICE.SET_VALUE,
+            device_feature: 'my-device-feature',
+            value: 99,
+          },
+        ],
+      ],
+      scope,
+    );
+    await chaiAssert.isRejected(promise, AbortScene, 'CONDITION_VALUE_NOT_A_NUMBER');
+    // The guard must fail closed: the action after it must not have been executed.
+    assert.notCalled(device.setValue);
+  });
   it('should finish scene, condition is verified', async () => {
     stateManager.setState('deviceFeature', 'my-device-feature', {
       category: 'light',

--- a/server/test/lib/scene/actions/scene.action.formula.test.js
+++ b/server/test/lib/scene/actions/scene.action.formula.test.js
@@ -2,18 +2,19 @@ const sinon = require('sinon').createSandbox();
 
 const { fake } = sinon;
 const EventEmitter = require('events');
-const { expect } = require('chai');
+const { expect, assert: chaiAssert } = require('chai');
 
 const { ACTIONS } = require('../../../../utils/constants');
 const executeActionsFactory = require('../../../../lib/scene/scene.executeActions');
+const { AbortScene } = require('../../../../utils/coreErrors');
 
 const StateManager = require('../../../../lib/state');
 const actionsFunc = require('../../../../lib/scene/scene.actions');
 
-// The scene formula engine is a restricted mathjs instance built in scene.actions.js.
-// Only the operators explicitly passed to create() are guaranteed to stay in the "math"
-// namespace across mathjs releases, so every supported operator needs a test here:
-// a mathjs upgrade that drops one must fail CI instead of failing silently in production.
+// The scene formula engine is a restricted mathjs instance built in scene.formula.js.
+// Only the operators, functions and constants explicitly passed to create() are guaranteed to
+// stay in the "math" namespace across mathjs releases, so every supported entry needs a test
+// here: a mathjs upgrade that drops one must fail CI instead of failing silently in production.
 describe('scene.formula', () => {
   let event;
   let stateManager;
@@ -85,12 +86,193 @@ describe('scene.formula', () => {
     expect(await evaluateFormula('-5')).to.equal(-5);
   });
 
-  it('should support round', async () => {
-    expect(await evaluateFormula('round(1.4)')).to.equal(1);
+  it('should support power', async () => {
+    expect(await evaluateFormula('2 ^ 10')).to.equal(1024);
   });
 
   it('should support parenthesis and operator precedence', async () => {
     expect(await evaluateFormula('(10 - 4) * 2')).to.equal(12);
+  });
+
+  it('should support greater than', async () => {
+    expect(await evaluateFormula('5 > 3')).to.equal(1);
+  });
+
+  it('should support greater than or equal', async () => {
+    expect(await evaluateFormula('3 >= 3')).to.equal(1);
+  });
+
+  it('should support less than', async () => {
+    expect(await evaluateFormula('5 < 3')).to.equal(0);
+  });
+
+  it('should support less than or equal', async () => {
+    expect(await evaluateFormula('3 <= 3')).to.equal(1);
+  });
+
+  it('should support abs', async () => {
+    expect(await evaluateFormula('abs(-4)')).to.equal(4);
+  });
+
+  it('should support ceil', async () => {
+    expect(await evaluateFormula('ceil(1.2)')).to.equal(2);
+  });
+
+  it('should support floor', async () => {
+    expect(await evaluateFormula('floor(1.8)')).to.equal(1);
+  });
+
+  it('should support fix', async () => {
+    expect(await evaluateFormula('fix(-1.8)')).to.equal(-1);
+  });
+
+  it('should support round', async () => {
+    expect(await evaluateFormula('round(1.4)')).to.equal(1);
+  });
+
+  it('should support round with a number of decimals', async () => {
+    expect(await evaluateFormula('round(1.567, 2)')).to.equal(1.57);
+  });
+
+  it('should support sign', async () => {
+    expect(await evaluateFormula('sign(-3)')).to.equal(-1);
+  });
+
+  it('should support pow', async () => {
+    expect(await evaluateFormula('pow(2, 10)')).to.equal(1024);
+  });
+
+  it('should support sqrt', async () => {
+    expect(await evaluateFormula('sqrt(400)')).to.equal(20);
+  });
+
+  it('should support cbrt', async () => {
+    expect(await evaluateFormula('cbrt(27)')).to.equal(3);
+  });
+
+  it('should support square', async () => {
+    expect(await evaluateFormula('square(5)')).to.equal(25);
+  });
+
+  it('should support cube', async () => {
+    expect(await evaluateFormula('cube(3)')).to.equal(27);
+  });
+
+  it('should support nthRoot', async () => {
+    expect(await evaluateFormula('nthRoot(81, 4)')).to.equal(3);
+  });
+
+  it('should support hypot', async () => {
+    expect(await evaluateFormula('hypot(3, 4)')).to.equal(5);
+  });
+
+  it('should support exp', async () => {
+    expect(await evaluateFormula('exp(0)')).to.equal(1);
+  });
+
+  it('should support log', async () => {
+    expect(await evaluateFormula('log(1)')).to.equal(0);
+  });
+
+  it('should support log with a base', async () => {
+    expect(await evaluateFormula('log(8, 2)')).to.equal(3);
+  });
+
+  it('should support log2', async () => {
+    expect(await evaluateFormula('log2(8)')).to.equal(3);
+  });
+
+  it('should support log10', async () => {
+    expect(await evaluateFormula('log10(1000)')).to.equal(3);
+  });
+
+  it('should support min', async () => {
+    expect(await evaluateFormula('min(12, 4, 9)')).to.equal(4);
+  });
+
+  it('should support max', async () => {
+    expect(await evaluateFormula('max(12, 4, 9)')).to.equal(12);
+  });
+
+  it('should support mean', async () => {
+    expect(await evaluateFormula('mean(2, 4, 6)')).to.equal(4);
+  });
+
+  it('should support median', async () => {
+    expect(await evaluateFormula('median(1, 3, 10)')).to.equal(3);
+  });
+
+  it('should support sum', async () => {
+    expect(await evaluateFormula('sum(1, 2, 3)')).to.equal(6);
+  });
+
+  it('should support prod', async () => {
+    expect(await evaluateFormula('prod(2, 3, 4)')).to.equal(24);
+  });
+
+  it('should support gcd', async () => {
+    expect(await evaluateFormula('gcd(12, 18)')).to.equal(6);
+  });
+
+  it('should support lcm', async () => {
+    expect(await evaluateFormula('lcm(4, 6)')).to.equal(12);
+  });
+
+  it('should support random', async () => {
+    const value = await evaluateFormula('random()');
+    expect(value).to.be.at.least(0);
+    expect(value).to.be.below(1);
+  });
+
+  it('should support randomInt', async () => {
+    // randomInt(min, max) excludes the upper bound, so this can only return 5
+    expect(await evaluateFormula('randomInt(5, 6)')).to.equal(5);
+  });
+
+  it('should support sin', async () => {
+    expect(await evaluateFormula('sin(0)')).to.equal(0);
+  });
+
+  it('should support cos', async () => {
+    expect(await evaluateFormula('cos(0)')).to.equal(1);
+  });
+
+  it('should support tan', async () => {
+    expect(await evaluateFormula('tan(0)')).to.equal(0);
+  });
+
+  it('should support asin', async () => {
+    expect(await evaluateFormula('asin(0)')).to.equal(0);
+  });
+
+  it('should support acos', async () => {
+    expect(await evaluateFormula('acos(1)')).to.equal(0);
+  });
+
+  it('should support atan', async () => {
+    expect(await evaluateFormula('atan(0)')).to.equal(0);
+  });
+
+  it('should support atan2', async () => {
+    expect(await evaluateFormula('round(atan2(1, 1) * 4, 5)')).to.equal(3.14159);
+  });
+
+  it('should support the pi constant', async () => {
+    expect(await evaluateFormula('round(pi, 5)')).to.equal(3.14159);
+  });
+
+  it('should support the e constant', async () => {
+    expect(await evaluateFormula('round(e, 5)')).to.equal(2.71828);
+  });
+
+  it('should support the tau constant', async () => {
+    expect(await evaluateFormula('round(tau, 5)')).to.equal(6.28319);
+  });
+
+  it('should compute a watering duration from a tank level', async () => {
+    // Use case from the community request: the watering duration grows with the tank level,
+    // capped at 15 minutes and rounded to a whole number of seconds.
+    expect(await evaluateFormula('round(min(15, exp(80 / 25)) * 60)')).to.equal(900);
   });
 
   it('should subtract from a scene variable', async () => {
@@ -122,5 +304,34 @@ describe('scene.formula', () => {
       {},
     );
     expect(device.setValue.firstCall.args[2]).to.equal(10);
+  });
+
+  it('should abort the scene when the formula cannot be evaluated', async () => {
+    stateManager.setState('deviceFeature', 'my-device-feature', {
+      category: 'light',
+      type: 'brightness',
+      last_value: 15,
+    });
+    const device = {
+      setValue: fake.resolves(null),
+    };
+    const promise = executeActions(
+      { stateManager, event, device },
+      [
+        [
+          {
+            type: ACTIONS.DEVICE.SET_VALUE,
+            device_feature: 'my-device-feature',
+            // "compareText" is not part of the restricted formula engine namespace,
+            // so evaluating this formula throws.
+            evaluate_value: 'compareText("a", "b")',
+          },
+        ],
+      ],
+      {},
+    );
+    await chaiAssert.isRejected(promise, AbortScene, 'ACTION_VALUE_NOT_A_NUMBER');
+    // The guard must fail closed: the device value must not have been changed.
+    expect(device.setValue.callCount).to.equal(0);
   });
 });

--- a/server/test/lib/scene/actions/scene.action.formula.test.js
+++ b/server/test/lib/scene/actions/scene.action.formula.test.js
@@ -322,9 +322,10 @@ describe('scene.formula', () => {
           {
             type: ACTIONS.DEVICE.SET_VALUE,
             device_feature: 'my-device-feature',
-            // "compareText" is not part of the restricted formula engine namespace,
-            // so evaluating this formula throws.
-            evaluate_value: 'compareText("a", "b")',
+            // "unknownFunction" is not part of the restricted formula engine namespace,
+            // so evaluating this formula throws. It is deliberately a name mathjs will never
+            // define, so extending the namespace cannot make this formula valid.
+            evaluate_value: 'unknownFunction(1)',
           },
         ],
       ],
@@ -333,5 +334,50 @@ describe('scene.formula', () => {
     await chaiAssert.isRejected(promise, AbortScene, 'ACTION_VALUE_NOT_A_NUMBER');
     // The guard must fail closed: the device value must not have been changed.
     expect(device.setValue.callCount).to.equal(0);
+  });
+
+  it('should abort the scene when the formula overflows to a non-finite number', async () => {
+    stateManager.setState('deviceFeature', 'my-device-feature', {
+      category: 'light',
+      type: 'brightness',
+      last_value: 15,
+    });
+    const device = {
+      setValue: fake.resolves(null),
+    };
+    const promise = executeActions(
+      { stateManager, event, device },
+      [
+        [
+          {
+            type: ACTIONS.DEVICE.SET_VALUE,
+            device_feature: 'my-device-feature',
+            // exp() overflows to Infinity without throwing: a device cannot be set to it.
+            evaluate_value: 'exp(1000)',
+          },
+        ],
+      ],
+      {},
+    );
+    await chaiAssert.isRejected(promise, AbortScene, 'ACTION_VALUE_NOT_A_NUMBER');
+    expect(device.setValue.callCount).to.equal(0);
+  });
+
+  it('should abort the scene when a delay formula returns a non-finite number', async () => {
+    const promise = executeActions(
+      { stateManager, event },
+      [
+        [
+          {
+            type: ACTIONS.TIME.DELAY,
+            unit: 'seconds',
+            // log(0) is -Infinity: waiting for it would hang the scene instead of failing it.
+            evaluate_value: 'log(0)',
+          },
+        ],
+      ],
+      {},
+    );
+    await chaiAssert.isRejected(promise, AbortScene, 'ACTION_VALUE_NOT_A_NUMBER');
   });
 });

--- a/server/test/lib/scene/scene.formula.test.js
+++ b/server/test/lib/scene/scene.formula.test.js
@@ -1,0 +1,37 @@
+const { expect } = require('chai');
+
+const { evaluate } = require('../../../lib/scene/scene.formula');
+
+// Scene formulas are written by authenticated administrators, but they are persisted and then
+// evaluated server-side, so the expression parser is the only thing standing between a stored
+// string and the Node process. mathjs blocks property/method access on its own values; these
+// probes are the escape shapes from the mathjs security test suite, kept here so that growing
+// the allowed namespace (or upgrading mathjs) cannot quietly reopen the sandbox.
+describe('scene.formula sandbox', () => {
+  const ESCAPE_ATTEMPTS = [
+    'round.constructor',
+    'round["constructor"]',
+    'round["\\u0063onstructor"]',
+    'f=sqrt.constructor("1+1"); f()',
+    'f(x)=x; f.constructor',
+    '[].map.constructor',
+    'sqrt.call',
+    'sqrt.apply',
+    'sqrt.bind',
+    'obj={}; obj.constructor',
+  ];
+
+  ESCAPE_ATTEMPTS.forEach((formula) => {
+    it(`should refuse to evaluate "${formula}"`, () => {
+      expect(() => evaluate(formula)).to.throw();
+    });
+  });
+
+  it('should not expose a function absent from the allowed namespace', () => {
+    expect(() => evaluate('compareText("a","b")')).to.throw(/Undefined function/);
+  });
+
+  it('should still evaluate a legitimate formula', () => {
+    expect(evaluate('round(min(15, sqrt(400)) * 60)')).to.equal(900);
+  });
+});


### PR DESCRIPTION
### Description

Scene formulas — the "Computed" value of **Set a variable**, **Control a device**, **Wait** and **Condition on variables** — run on a deliberately restricted `mathjs` instance. Until now that namespace only contained the four arithmetic operators, `%`, `^`, the comparison operators and `round()` / `random()`, so a formula like `sqrt(400)` or `min(15, x)` aborted the scene with "value is not a number".

This PR extends the namespace with the functions asked for in the forum topic, and makes the whole supported surface discoverable directly in the scene editor.

**Functions added**

| Group | Functions |
|---|---|
| Rounding & sign | `abs`, `ceil`, `floor`, `fix`, `sign` |
| Powers & roots | `pow`, `sqrt`, `cbrt`, `square`, `cube`, `nthRoot`, `hypot` |
| Exponential & logarithm | `exp`, `log` (with optional base), `log2`, `log10` |
| Statistics | `min`, `max`, `mean`, `median`, `sum`, `prod` |
| Integer arithmetic | `gcd`, `lcm` |
| Random | `randomInt` |
| Trigonometry | `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2` |
| Constants | `pi`, `e`, `tau` |

`abs`, `ceil` and `floor` happened to work already because `mathjs` pulled them in transitively through `round`; they are now pinned explicitly like the rest, so a `mathjs` upgrade cannot silently remove them.

The use case from the forum topic now works as a single formula, no HTTP request needed:

```
round(min(15, exp({{tankLevel}} / 25)) * 60)
```

### Technical changes

- **`server/lib/scene/scene.formula.js`** (new): the restricted formula engine moves out of `scene.actions.js` into its own module, so the supported surface lives in one documented place. Every operator, function and constant is passed explicitly to `create()` — `mathjs` only guarantees the "math" namespace for what it is given, so anything only reachable transitively could disappear on an upgrade.
- **`server/lib/scene/scene.actions.js`**: imports the shared `evaluate`. The **Control a device** action now wraps the evaluation in a `try/catch` and aborts the scene with `ACTION_VALUE_NOT_A_NUMBER` when the formula cannot be evaluated — the three other formula actions already did this, and this action was the only one that let a `mathjs` parse error escape. A wider function surface means more ways to write an invalid call (`gcd(4)`, a typo'd name), so it now fails closed too.
- **Front**: new `FormulaFunctionsHelp` component rendered under every formula input (Set a variable, Control a device, Wait, Condition on variables). It lists the available operators, functions and constants, plus a short syntax reminder. Function names are not translatable, so they live in the component and mirror the server module; only the three labels and the example sentence go through i18n (`en`, `fr`, `de`).
- **Tests**: `scene.action.formula.test.js` grows one case per operator, function and constant (54 tests), so a `mathjs` upgrade that drops one fails CI instead of failing silently in production. Plus a fail-closed test for the new `try/catch`.

### Not included

`and` / `or` / `not` / `xor` / `equal` / `unequal` and `compareText` were mentioned in the forum thread but are left out on purpose:

- The formula string is whitespace-stripped before evaluation, so the operator form (`1 and 0` → `1and0`) cannot parse, and string arguments would be mangled.
- They return booleans rather than numbers, which does not fit a pipeline whose four call sites all expect a number — and Gladys already has dedicated "Condition on variables" boxes with AND / OR semantics for that job.

Every function added here returns a number, so it behaves identically in all four formula actions.

## Forum

Forum: https://community.gladysassistant.com/t/scenes-supporter-quelques-fonctions-supplementaires-de-math-js/9509

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

Notes on the checklist: the full server suite passes locally and coverage on the two changed server files is 100% for `scene.formula.js` and leaves no new uncovered line in `scene.actions.js`. `front` passes `prettier-check`, `eslint`, `compare-translations` and `npm run build`. Cypress was not run locally (its binary is unavailable in this environment) — the change only adds a static help block under existing inputs and touches no route or form control.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Twh2gVvdbLtoLLQRukvNvh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added formula assistance to scene action editors, documenting supported operators, functions, constants, syntax, and examples.
  * Added English, French, and German translations for formula help.
  * Expanded formula support for calculations, comparisons, rounding, powers, statistics, trigonometry, and constants.

* **Bug Fixes**
  * Invalid or non-finite formulas now safely stop scenes without changing affected device values or causing execution to hang.
  * Restricted unsupported formula operations to improve safety and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->