### PR TITLE
Display integration names on the devices list

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -103,7 +103,6 @@
     "room": "Raum",
     "integration": "Integration",
     "features": "Funktionen",
-    "openInIntegration": "In der Integration öffnen",
     "emptyState": "Keine Geräte gefunden. Füge Geräte über die Integrationsseite hinzu oder passe deine Suche und Filter an.",
     "emptyStateButton": "Integrationen durchsuchen",
     "error": "Beim Laden der Geräte ist ein Fehler aufgetreten. Bitte versuche es später erneut."

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -97,6 +97,8 @@
     "allRooms": "Alle Räume",
     "noRoom": "Kein Raum",
     "allIntegrations": "Alle Integrationen",
+    "nativeIntegrations": "Native Integrationen",
+    "communityIntegrations": "Community-Integrationen",
     "device": "Gerät",
     "room": "Raum",
     "integration": "Integration",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -97,6 +97,8 @@
     "allRooms": "All rooms",
     "noRoom": "No room",
     "allIntegrations": "All integrations",
+    "nativeIntegrations": "Native integrations",
+    "communityIntegrations": "Community integrations",
     "device": "Device",
     "room": "Room",
     "integration": "Integration",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -103,7 +103,6 @@
     "room": "Room",
     "integration": "Integration",
     "features": "Features",
-    "openInIntegration": "Open in integration",
     "emptyState": "No device found. Add devices from the integrations page, or adjust your search and filters.",
     "emptyStateButton": "Browse integrations",
     "error": "There was an error loading the devices. Please try again later."

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -97,6 +97,8 @@
     "allRooms": "Toutes les pièces",
     "noRoom": "Aucune pièce",
     "allIntegrations": "Toutes les intégrations",
+    "nativeIntegrations": "Intégrations natives",
+    "communityIntegrations": "Intégrations communautaires",
     "device": "Appareil",
     "room": "Pièce",
     "integration": "Intégration",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -103,7 +103,6 @@
     "room": "Pièce",
     "integration": "Intégration",
     "features": "Fonctionnalités",
-    "openInIntegration": "Ouvrir dans l'intégration",
     "emptyState": "Aucun appareil trouvé. Ajoutez des appareils depuis la page des intégrations, ou modifiez votre recherche et vos filtres.",
     "emptyStateButton": "Parcourir les intégrations",
     "error": "Une erreur est survenue lors du chargement des appareils. Veuillez réessayer plus tard."

--- a/front/src/routes/devices/DeviceRow.jsx
+++ b/front/src/routes/devices/DeviceRow.jsx
@@ -1,4 +1,5 @@
 import { Text } from 'preact-i18n';
+import { Link } from 'preact-router/match';
 
 import { DeviceStamp, FeatureIcons, IntegrationName } from './helpers';
 
@@ -8,7 +9,11 @@ const DeviceRow = ({ device, integration }) => (
       <DeviceStamp device={device} integration={integration} />
     </td>
     <td>
-      <div>{device.name}</div>
+      {/* the device name opens the most specific page this device has in its
+          integration, while the integration column links to the integration */}
+      <div>
+        {integration && integration.deviceUrl ? <Link href={integration.deviceUrl}>{device.name}</Link> : device.name}
+      </div>
       <div class="small text-muted">{device.selector}</div>
     </td>
     <td class="text-nowrap">

--- a/front/src/routes/devices/DeviceRow.jsx
+++ b/front/src/routes/devices/DeviceRow.jsx
@@ -1,5 +1,4 @@
 import { Text } from 'preact-i18n';
-import { Link } from 'preact-router/match';
 
 import { DeviceStamp, FeatureIcons, IntegrationName } from './helpers';
 
@@ -26,14 +25,6 @@ const DeviceRow = ({ device, integration }) => (
     </td>
     <td>
       <FeatureIcons device={device} />
-    </td>
-    <td class="text-right text-nowrap">
-      {integration && integration.deviceUrl && (
-        <Link href={integration.deviceUrl} class="btn btn-sm btn-outline-primary">
-          <i class="fe fe-external-link mr-1" />
-          <Text id="devicesList.openInIntegration" />
-        </Link>
-      )}
     </td>
   </tr>
 );

--- a/front/src/routes/devices/DevicesPage.jsx
+++ b/front/src/routes/devices/DevicesPage.jsx
@@ -7,6 +7,12 @@ import DeviceMobileItem from './DeviceMobileItem';
 import EmptyState from './EmptyState';
 import style from './style.css';
 
+const IntegrationOption = ({ integration, selectedIntegration }) => (
+  <option value={integration.slug} selected={selectedIntegration === integration.slug}>
+    {integration.i18nKey ? <Text id={integration.i18nKey}>{integration.name}</Text> : integration.name}
+  </option>
+);
+
 const DevicesPage = ({ children, ...props }) => (
   <div class="page">
     <div class="page-main">
@@ -43,11 +49,26 @@ const DevicesPage = ({ children, ...props }) => (
                 <option value="">
                   <Text id="devicesList.allIntegrations" />
                 </option>
-                {props.integrationOptions.map(integration => (
-                  <option value={integration.slug} selected={props.selectedIntegration === integration.slug}>
-                    {integration.i18nKey ? <Text id={integration.i18nKey}>{integration.name}</Text> : integration.name}
-                  </option>
-                ))}
+                {/* built-in and community integrations are grouped, so both
+                    families stay identifiable even when they share a name */}
+                {props.nativeIntegrationOptions.length > 0 && (
+                  <Localizer>
+                    <optgroup label={<Text id="devicesList.nativeIntegrations" />}>
+                      {props.nativeIntegrationOptions.map(integration => (
+                        <IntegrationOption integration={integration} selectedIntegration={props.selectedIntegration} />
+                      ))}
+                    </optgroup>
+                  </Localizer>
+                )}
+                {props.communityIntegrationOptions.length > 0 && (
+                  <Localizer>
+                    <optgroup label={<Text id="devicesList.communityIntegrations" />}>
+                      {props.communityIntegrationOptions.map(integration => (
+                        <IntegrationOption integration={integration} selectedIntegration={props.selectedIntegration} />
+                      ))}
+                    </optgroup>
+                  </Localizer>
+                )}
               </select>
               <Localizer>
                 <CardFilter

--- a/front/src/routes/devices/DevicesPage.jsx
+++ b/front/src/routes/devices/DevicesPage.jsx
@@ -121,7 +121,6 @@ const DevicesPage = ({ children, ...props }) => (
                           <th>
                             <Text id="devicesList.features" />
                           </th>
-                          <th class="text-right" />
                         </tr>
                       </thead>
                       <tbody>

--- a/front/src/routes/devices/helpers.jsx
+++ b/front/src/routes/devices/helpers.jsx
@@ -75,8 +75,18 @@ export const IntegrationName = ({ integration, link = true }) => {
     return <span class="text-muted">-</span>;
   }
   const name = integration.i18nKey ? <Text id={integration.i18nKey}>{integration.name}</Text> : integration.name;
-  if (!link || !integration.url) {
-    return <span>{name}</span>;
+  const label = link && integration.url ? <Link href={integration.url}>{name}</Link> : <span>{name}</span>;
+  if (!integration.external) {
+    return label;
   }
-  return <Link href={integration.url}>{name}</Link>;
+  // same tag as in the integration catalog: the list mixes both families, and
+  // a community integration can be named like a built-in one
+  return (
+    <span class={style.integrationName}>
+      {label}
+      <span class="badge badge-secondary">
+        <Text id="integration.tags.external" />
+      </span>
+    </span>
+  );
 };

--- a/front/src/routes/devices/index.js
+++ b/front/src/routes/devices/index.js
@@ -2,7 +2,7 @@ import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 
 import DevicesPage from './DevicesPage';
-import { getDeviceIntegration } from './integrationLinks';
+import { getDeviceIntegration, disambiguateIntegrationNames } from './integrationLinks';
 
 class Devices extends Component {
   // The endpoint returns the whole list: load it once, then search, order
@@ -85,10 +85,17 @@ class Devices extends Component {
   }
 
   render(props, state) {
-    const devicesWithIntegration = (state.devices || []).map(device => ({
-      device,
-      integration: getDeviceIntegration(device)
-    }));
+    const integrations = (state.devices || []).map(device => getDeviceIntegration(device));
+    // names are resolved on the whole list: whether an integration needs its
+    // technical identity displayed depends on the other integrations present
+    const nameBySlug = disambiguateIntegrationNames(integrations);
+    const devicesWithIntegration = (state.devices || []).map((device, index) => {
+      const integration = integrations[index];
+      return {
+        device,
+        integration: integration ? { ...integration, name: nameBySlug.get(integration.slug) } : null
+      };
+    });
 
     // The integration filter options are built from the full device list, so
     // it only shows integrations the user actually has devices in, and a
@@ -101,7 +108,12 @@ class Devices extends Component {
         integrationOptions.push(integration);
       }
     });
-    integrationOptions.sort((a, b) => a.slug.localeCompare(b.slug));
+    integrationOptions.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+    // Built-in and community integrations live in the same list: the filter
+    // groups them so a community integration named like a built-in one (or
+    // like another community one) is still identifiable
+    const nativeIntegrationOptions = integrationOptions.filter(integration => !integration.external);
+    const communityIntegrationOptions = integrationOptions.filter(integration => integration.external);
 
     const filteredDevices = devicesWithIntegration
       .filter(({ device }) => this.matchSearch(device))
@@ -122,7 +134,8 @@ class Devices extends Component {
         {...state}
         initialized={state.devices !== null}
         filteredDevices={filteredDevices}
-        integrationOptions={integrationOptions}
+        nativeIntegrationOptions={nativeIntegrationOptions}
+        communityIntegrationOptions={communityIntegrationOptions}
         searchValue={state.search}
         search={this.search}
         changeOrderDir={this.changeOrderDir}

--- a/front/src/routes/devices/index.js
+++ b/front/src/routes/devices/index.js
@@ -1,6 +1,8 @@
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
+import get from 'get-value';
 
+import withIntlAsProp from '../../utils/withIntlAsProp';
 import DevicesPage from './DevicesPage';
 import { getDeviceIntegration, disambiguateIntegrationNames } from './integrationLinks';
 
@@ -108,7 +110,14 @@ class Devices extends Component {
         integrationOptions.push(integration);
       }
     });
-    integrationOptions.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+    // sorted on the label the option actually displays: a built-in integration
+    // is listed under its translated title, which its service name does not
+    // always match (in French, the "rtsp-camera" service reads "Caméras")
+    const getOptionLabel = integration =>
+      (integration.i18nKey && get(props.intl.dictionary, integration.i18nKey)) || integration.name;
+    integrationOptions.sort((a, b) =>
+      getOptionLabel(a).localeCompare(getOptionLabel(b), undefined, { sensitivity: 'base' })
+    );
     // Built-in and community integrations live in the same list: the filter
     // groups them so a community integration named like a built-in one (or
     // like another community one) is still identifiable
@@ -146,4 +155,4 @@ class Devices extends Component {
   }
 }
 
-export default connect('httpClient', {})(Devices);
+export default withIntlAsProp(connect('httpClient', {})(Devices));

--- a/front/src/routes/devices/integrationLinks.js
+++ b/front/src/routes/devices/integrationLinks.js
@@ -34,6 +34,9 @@ const DEVICE_EDIT_LINKS = {
  * - slug: identifier used to filter devices by integration
  * - i18nKey: translation key of the integration name (built-in integrations)
  * - name: raw name to display when there is no translation
+ * - external: true for a community integration (own group in the filter)
+ * - discriminant: technical identity, displayed only when two integrations
+ *   share the same name (see disambiguateIntegrationNames)
  * - url: integration page listing the devices
  * - deviceUrl: most specific page for this device in its integration
  */
@@ -46,7 +49,19 @@ export function getDeviceIntegration(device) {
     // External integrations (Docker containers) all share the same routes,
     // parameterized by the service selector (which is also its name)
     const url = `/dashboard/integration/device/external/${service.selector || service.name}`;
-    return { slug: service.name, name: service.name, url, deviceUrl: url };
+    // The service name is the technical selector (ext-<owner>-<repo>): display
+    // the manifest name, the same title as the integration card in the catalog
+    const name = (service.manifest && service.manifest.name) || service.name;
+    return {
+      slug: service.name,
+      name,
+      external: true,
+      // the store slug (owner/repo) reads better than the selector built from
+      // it; dev installs have none, their selector is the only identity
+      discriminant: service.store_slug || service.selector || service.name,
+      url,
+      deviceUrl: url
+    };
   }
   const slug = service.name.toLowerCase();
   const integration = integrationBySlug[slug];
@@ -63,4 +78,40 @@ export function getDeviceIntegration(device) {
     url,
     deviceUrl: buildDeviceLink ? buildDeviceLink(device.selector) : url
   };
+}
+
+/**
+ * Two community integrations can display the same name (two repositories
+ * publishing a manifest with the same name, or two dev installs of the same
+ * integration): those are the only ones that carry their technical identity
+ * next to their name, so the common case stays readable. Built-in integrations
+ * have unique names, and are told apart from community ones by their own group
+ * in the filter and by the "community" tag in the list.
+ * @param {Array} integrations - Integrations of the listed devices, with duplicates.
+ * @returns {Map} Name to display, by integration slug.
+ */
+export function disambiguateIntegrationNames(integrations) {
+  // names are compared lowercased: two manifests differing only by case read
+  // as the same name in the list
+  const slugsByName = new Map();
+  integrations.forEach(integration => {
+    if (integration && integration.external) {
+      const key = integration.name.toLowerCase();
+      const slugs = slugsByName.get(key) || new Set();
+      slugs.add(integration.slug);
+      slugsByName.set(key, slugs);
+    }
+  });
+  const nameBySlug = new Map();
+  integrations.forEach(integration => {
+    if (!integration || nameBySlug.has(integration.slug)) {
+      return;
+    }
+    const isDuplicated = integration.external && slugsByName.get(integration.name.toLowerCase()).size > 1;
+    nameBySlug.set(
+      integration.slug,
+      isDuplicated ? `${integration.name} (${integration.discriminant})` : integration.name
+    );
+  });
+  return nameBySlug;
 }

--- a/front/src/routes/devices/style.css
+++ b/front/src/routes/devices/style.css
@@ -50,6 +50,12 @@
   flex-shrink: 0;
 }
 
+.integrationName {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .mobileItem {
   display: flex;
   align-items: center;


### PR DESCRIPTION
### Description

The devices list showed community integrations under their technical service name — `ext-gboulvin-gladys-immich` rather than `Immich Slideshow` — both in the table and in the integration filter. This PR displays the manifest name instead, the same title the integration card carries in the catalog. The manifest already travels with every device (`GET /api/v1/device` includes the service row), so no extra request is involved.

Displayed names can then collide, in two different ways, and each is handled on its own:

- **A community integration named like a built-in one.** The filter now groups its options under *Native integrations* and *Community integrations*, and every community integration carries the catalog's *Community* tag in the list. Both families stay identifiable wherever they are shown.
- **Two community integrations sharing a name** — two repositories publishing the same manifest name, or two dev installs of the same integration. Those, and only those, display their technical identity next to their name: the store slug (`owner/repo`), or the selector for dev installs, which have none. Integrations with no homonym stay clean.

Filter options are now sorted by displayed name rather than by technical slug, which no longer matches what the user reads.

The trailing "Open in integration" column was also dropped: the integration column already links to the integration a device comes from, so the button duplicated that link while taking the table's widest column. On mobile the whole row stays tappable, as before.

### Screenshots

The UI language is French here, and the devices are simulated so that two integrations named "Overkiz" appear at once — one installed from the store, one installed as a dev image — which is the case that triggers the technical identity.

![Devices list on desktop](https://raw.githubusercontent.com/cicoub13/Gladys/assets/devices-list-integration-names/pr-assets/pr-devices-desktop.png)

The integration filter, in the same state:

```
Native integrations         -> Philips Hue | Zigbee2mqtt
Community integrations      -> Immich Slideshow | Overkiz (cicoub13/gladys-overkiz) | Overkiz (ext-dev-overkiz-2)
```

![Devices list on mobile](https://raw.githubusercontent.com/cicoub13/Gladys/assets/devices-list-integration-names/pr-assets/pr-devices-mobile.png)

### i18n

Two keys added to `en`, `fr` and `de`: `devicesList.nativeIntegrations` and `devicesList.communityIntegrations`. `devicesList.openInIntegration` is removed along with the column it labelled. The *Community* tag reuses the existing `integration.tags.external` key. `npm run compare-translations` passes.

### Checklist

- [ ] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

On the first box: this is a front-only change, so `npm run coverage` does not apply — no server file is touched. Cypress was not run locally because ports 1443/1444 were in use by a running dev session; no spec under `front/cypress/e2e/` visits `/dashboard/devices`, and CI runs the suite anyway. `npm run eslint`, `npm run prettier-check`, `npm run compare-translations` and `npm run build` all pass on the front.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device integrations are grouped into localized Native and Community categories.
  * Integration options are sorted by their displayed labels.
  * Device names link directly to their integration when available.
  * Integration names are clarified when external integrations share the same name.
  * Community integrations display an external-integration indicator.

* **Style**
  * Improved alignment and spacing for integration labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->