### PR TITLE
ci: make the pull request tests workflow merge-queue ready

### DIFF
--- a/.github/workflows/docker-pr-build.yml
+++ b/.github/workflows/docker-pr-build.yml
@@ -7,9 +7,15 @@ on:
     # instead of master) run the same CI as regular pull requests
     branches: [master, 'claude/**']
     types: [opened, synchronize, reopened, ready_for_review]
+  # Merge queue builds: the queue only merges a group once the required
+  # checks of this workflow have passed on the merge_group ref.
+  merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  # github.head_ref is empty on merge_group events, so fall back to
+  # github.ref (unique per queue entry): without the fallback every queue
+  # build would share one concurrency group and cancel the others.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -143,7 +149,11 @@ jobs:
       - name: 📄 Codecov report upload
         uses: codecov/codecov-action@v4
         with:
-          fail_ci_if_error: true
+          # Codecov uploads are flaky (rate limits, see below). Failing the
+          # job is fine on a pull request, but in the merge queue it would
+          # block every group behind an external service, so only enforce
+          # the upload on pull_request builds.
+          fail_ci_if_error: ${{ github.event_name != 'merge_group' }}
           token: 08cd0d46-0291-42ed-b352-50924cb6cca6
 
           ## Yes, we are storing the CODECOV token in plain text here and not as a secret.
@@ -203,7 +213,12 @@ jobs:
           project: ./front
           command: npm run cypress:run
   build-front:
-    if: github.event.pull_request.draft == false
+    # Runs on merge queue builds (the front must build before merging) and on
+    # non-draft pull requests. The event check must be explicit: on
+    # merge_group there is no pull_request payload and GitHub expressions
+    # coerce null == false to TRUE, so the old draft-only condition would
+    # silently match every non-PR event.
+    if: github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     name: Front build
     runs-on: ubuntu-22.04
     steps:
@@ -229,7 +244,12 @@ jobs:
           name: static
           path: front/build
   docker:
-    if: github.event.pull_request.draft == false
+    # Preview images only make sense for pull requests: on merge_group there
+    # is no branch to tag the image with and nobody to comment to. The
+    # explicit event check matters (null == false is TRUE in GitHub
+    # expressions, see build-front above), otherwise this job would run on
+    # queue builds with an empty, invalid image tag.
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     needs: build-front
     name: Docker magic !
     runs-on: ubuntu-22.04


### PR DESCRIPTION
### Description

Prepares the "Pull request tests" workflow for enabling the GitHub merge queue on `master`. Four changes, all in `.github/workflows/docker-pr-build.yml`:

- **Trigger on `merge_group`**: the merge queue emits `merge_group` events, not `pull_request`. Without this trigger, queued groups would wait forever on required checks that never start — the classic failure mode of a first merge-queue setup.
- **Concurrency group fallback**: `github.head_ref` is empty on `merge_group` events, so all queue builds would have shared a single concurrency group and cancelled each other (`cancel-in-progress: true`). The group now falls back to `github.ref`, which is unique per queue entry.
- **Explicit event checks on `build-front` and `docker`**: GitHub expressions coerce `null == false` to **true**, so the previous `github.event.pull_request.draft == false` conditions would have accidentally matched `merge_group` events. `build-front` now runs on queue builds too (the front must build before merging), while the `docker` preview-image job stays PR-only — on a queue build it would have run with an empty, invalid image tag and no branch to comment on.
- **Codecov upload no longer fails queue builds**: the upload is known to be flaky (rate limits, see the existing comment in the workflow). Failing a PR build is fine; failing a queue build would block every group behind an external service. `fail_ci_if_error` is now false only for `merge_group` events.

No behavior change for regular pull request builds.

**After merging, to actually enable the queue** (repo settings → branch protection / ruleset on `master`):
- Require merge queue, squash merge method
- Suggested parameters: build concurrency 3, min group size 1 (wait 5 min), max group size 5, status check timeout 40 min
- Required checks: `Front test`, `Server lint`, `Server test`, `Cypress run`, `Front build` — and **not** `Docker magic !` (PR-only, would block the queue)

## Forum

### Checklist

- [x] Tests pass: CI-only change, no server or front code touched
- [x] Linter and prettier pass on both front and server: no JS code changed
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_01VU6y2pzeyAXZWPrS4YNGwx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated validation for changes entering the merge queue.
  - Front-end builds now run for eligible merge queue entries and non-draft pull requests.
  - Code coverage reporting no longer blocks merge queue validation when coverage services fail.
  - Docker preview builds continue to run only for non-draft pull requests, preventing invalid preview images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->