### PR TITLE
Allow using the received MQTT topic and message as scene variables

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -3195,6 +3195,7 @@
       },
       "onlyContinueIf": {
         "variableLabel": "Variable",
+        "triggerVariablesLabel": "Auslöser der Szene",
         "operatorLabel": "Operator",
         "valueLabel": "Wert",
         "removeLabel": "Entfernen",
@@ -3463,6 +3464,10 @@
         "count": "Anzahl der Ereignisse",
         "events": "Liste der Ereignisse"
       },
+      "mqtt": {
+        "topic": "Empfangenes MQTT-Topic",
+        "message": "Empfangene MQTT-Message"
+      },
       "askAi": {
         "answer": "AI Antwort"
       },
@@ -3630,6 +3635,7 @@
         "topicPlaceholder": "Gib dein Topic ein",
         "messageLabel": "Message",
         "messagePlaceholder": "Gib die erwartete Message ein",
+        "variablesDescription": "Das empfangene Topic und die empfangene Message können in den folgenden Aktionen der Szene verwendet werden: Gib '{{' in einem Textfeld ein, um sie einzufügen.",
         "messageDescription": "Gib die erwartete Message ein oder lasse das Feld leer, um die Szene unabhängig von der Message auszuführen"
       },
       "weatherAlert": {

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -3635,7 +3635,7 @@
         "topicPlaceholder": "Gib dein Topic ein",
         "messageLabel": "Message",
         "messagePlaceholder": "Gib die erwartete Message ein",
-        "variablesDescription": "Das empfangene Topic und die empfangene Message können in den folgenden Aktionen der Szene verwendet werden: Gib '{{' in einem Textfeld ein, um sie einzufügen.",
+        "variablesDescription": "Das empfangene Topic und die empfangene Message können in den folgenden Aktionen der Szene verwendet werden: Gib '{{' in einem Textfeld ein, um sie einzufügen. Beachte, dass MQTT-Messages immer als Text verglichen werden: Eine Message wie '23' passt daher nicht zu einem numerischen Wert in einer \"Nur fortfahren wenn\"-Bedingung.",
         "messageDescription": "Gib die erwartete Message ein oder lasse das Feld leer, um die Szene unabhängig von der Message auszuführen"
       },
       "weatherAlert": {

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -3635,7 +3635,7 @@
         "topicPlaceholder": "Enter your topic",
         "messageLabel": "Message",
         "messagePlaceholder": "Enter the expected message",
-        "variablesDescription": "The received topic and message can be used in the next actions of the scene: type '{{' in a text field to inject them.",
+        "variablesDescription": "The received topic and message can be used in the next actions of the scene: type '{{' in a text field to inject them. Note that MQTT messages are always compared as text, so a message like '23' will not match a numeric value in an \"Only continue if\" condition.",
         "messageDescription": "Enter the expected message or leave blank to run the scene regardless of the message"
       },
       "weatherAlert": {

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -3195,6 +3195,7 @@
       },
       "onlyContinueIf": {
         "variableLabel": "Variable",
+        "triggerVariablesLabel": "Scene triggers",
         "operatorLabel": "Operator",
         "valueLabel": "Value",
         "removeLabel": "Remove",
@@ -3463,6 +3464,10 @@
         "count": "Number of events",
         "events": "List of events"
       },
+      "mqtt": {
+        "topic": "MQTT topic received",
+        "message": "MQTT message received"
+      },
       "askAi": {
         "answer": "AI answer"
       },
@@ -3630,6 +3635,7 @@
         "topicPlaceholder": "Enter your topic",
         "messageLabel": "Message",
         "messagePlaceholder": "Enter the expected message",
+        "variablesDescription": "The received topic and message can be used in the next actions of the scene: type '{{' in a text field to inject them.",
         "messageDescription": "Enter the expected message or leave blank to run the scene regardless of the message"
       },
       "weatherAlert": {

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -3635,7 +3635,7 @@
         "topicPlaceholder": "Entrez votre topic",
         "messageLabel": "Message",
         "messagePlaceholder": "Entrez le message attendu",
-        "variablesDescription": "Le topic et le message reçus peuvent être utilisés dans les actions suivantes de la scène : tapez '{{' dans un champ texte pour les injecter.",
+        "variablesDescription": "Le topic et le message reçus peuvent être utilisés dans les actions suivantes de la scène : tapez '{{' dans un champ texte pour les injecter. Attention, les messages MQTT sont toujours comparés comme du texte : un message tel que '23' ne correspondra donc pas à une valeur numérique dans une condition « Continuer seulement si ».",
         "messageDescription": "Entrez le message attendu ou laissez vide pour exécuter la scène quelque soit le message"
       },
       "weatherAlert": {

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -3195,6 +3195,7 @@
       },
       "onlyContinueIf": {
         "variableLabel": "Variable",
+        "triggerVariablesLabel": "Déclencheurs de la scène",
         "operatorLabel": "Opérateur",
         "valueLabel": "Valeur",
         "removeLabel": "Effacer",
@@ -3463,6 +3464,10 @@
         "count": "Nombre d'évènements",
         "events": "Liste des évènements"
       },
+      "mqtt": {
+        "topic": "Topic MQTT reçu",
+        "message": "Message MQTT reçu"
+      },
       "askAi": {
         "answer": "Réponse de l'IA"
       },
@@ -3630,6 +3635,7 @@
         "topicPlaceholder": "Entrez votre topic",
         "messageLabel": "Message",
         "messagePlaceholder": "Entrez le message attendu",
+        "variablesDescription": "Le topic et le message reçus peuvent être utilisés dans les actions suivantes de la scène : tapez '{{' dans un champ texte pour les injecter.",
         "messageDescription": "Entrez le message attendu ou laissez vide pour exécuter la scène quelque soit le message"
       },
       "weatherAlert": {

--- a/front/src/routes/scene/edit-scene/TriggerCard.jsx
+++ b/front/src/routes/scene/edit-scene/TriggerCard.jsx
@@ -177,6 +177,8 @@ const TriggerCard = ({ children, ...props }) => (
           updateTriggerProperty={props.updateTriggerProperty}
           index={props.index}
           trigger={props.trigger}
+          variables={props.variables}
+          setVariablesTrigger={props.setVariablesTrigger}
         />
       )}
       {WEATHER_ALERT_TRIGGERS.includes(props.trigger.type) && (

--- a/front/src/routes/scene/edit-scene/actions/only-continue-if/OnlyContinueIfParams.jsx
+++ b/front/src/routes/scene/edit-scene/actions/only-continue-if/OnlyContinueIfParams.jsx
@@ -43,6 +43,26 @@ class OnlyContinueIf extends Component {
   render(props, {}) {
     const variableOptions = [];
 
+    // Variables coming from the triggers of the scene are always available,
+    // whatever the position of this action in the scene
+    const triggersVariablesOptions = [];
+    (props.triggersVariables || []).forEach((triggerVariables, index) => {
+      triggerVariables.forEach(option => {
+        triggersVariablesOptions.push({
+          label: `${index + 1}. ${option.label}`,
+          value: `triggerEvent.${option.name}`,
+          type: option.type,
+          data: option.data
+        });
+      });
+    });
+    if (triggersVariablesOptions.length > 0) {
+      variableOptions.push({
+        label: get(this, 'props.intl.dictionary.editScene.actionsCard.onlyContinueIf.triggerVariablesLabel'),
+        options: triggersVariablesOptions
+      });
+    }
+
     Object.keys(props.variables).forEach(variablePath => {
       // If the variable is defined before the current path, we can use it
       if (isVariableAvailableAtThisPath(variablePath, props.path)) {

--- a/front/src/routes/scene/edit-scene/triggers/MQTTReceivedTrigger.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/MQTTReceivedTrigger.jsx
@@ -1,6 +1,9 @@
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
+import get from 'get-value';
 import { Text, Localizer } from 'preact-i18n';
+
+import withIntlAsProp from '../../../../utils/withIntlAsProp';
 
 class MQTTReceived extends Component {
   updateTopicName = e => {
@@ -10,6 +13,31 @@ class MQTTReceived extends Component {
   updateMessage = e => {
     this.props.updateTriggerProperty(this.props.index, 'message', e.target.value);
   };
+
+  setVariables = () => {
+    const TOPIC_VARIABLE = get(this.props.intl.dictionary, 'editScene.variables.mqtt.topic');
+    const MESSAGE_VARIABLE = get(this.props.intl.dictionary, 'editScene.variables.mqtt.message');
+    this.props.setVariablesTrigger(this.props.index, [
+      {
+        name: 'topic',
+        type: 'mqtt',
+        ready: true,
+        label: TOPIC_VARIABLE,
+        data: {}
+      },
+      {
+        name: 'message',
+        type: 'mqtt',
+        ready: true,
+        label: MESSAGE_VARIABLE,
+        data: {}
+      }
+    ]);
+  };
+
+  componentDidMount() {
+    this.setVariables();
+  }
 
   render({}, {}) {
     return (
@@ -48,9 +76,12 @@ class MQTTReceived extends Component {
             />
           </Localizer>
         </div>
+        <div class="alert alert-secondary">
+          <Text id="editScene.triggersCard.mqttReceived.variablesDescription" />
+        </div>
       </div>
     );
   }
 }
 
-export default connect('httpClient,user', {})(MQTTReceived);
+export default connect('httpClient,user', {})(withIntlAsProp(MQTTReceived));

--- a/server/test/lib/scene/triggers/scene.trigger.mqttReceived.test.js
+++ b/server/test/lib/scene/triggers/scene.trigger.mqttReceived.test.js
@@ -18,6 +18,10 @@ describe('Scene.triggers.mqttReceived', () => {
 
   const brain = {};
 
+  const message = {
+    sendToUser: fake.resolves(null),
+  };
+
   const service = {
     getService: fake.returns({
       device: {
@@ -46,7 +50,20 @@ describe('Scene.triggers.mqttReceived', () => {
 
     const stateManager = new StateManager();
 
-    sceneManager = new SceneManager(stateManager, event, device, {}, {}, house, {}, {}, {}, scheduler, brain, service);
+    sceneManager = new SceneManager(
+      stateManager,
+      event,
+      device,
+      message,
+      {},
+      house,
+      {},
+      {},
+      {},
+      scheduler,
+      brain,
+      service,
+    );
   });
 
   afterEach(() => {
@@ -119,6 +136,143 @@ describe('Scene.triggers.mqttReceived', () => {
       sceneManager.queue.start(() => {
         try {
           assert.calledOnce(device.setValue);
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  });
+
+  it('should inject the received topic and message as variables in the scene actions', async () => {
+    await sceneManager.addScene({
+      selector: 'my-scene',
+      active: true,
+      actions: [
+        [
+          {
+            type: ACTIONS.MESSAGE.SEND,
+            user: 'john',
+            text: 'Received on {{triggerEvent.topic}}: {{triggerEvent.message}}',
+          },
+        ],
+      ],
+      triggers: [
+        {
+          type: EVENTS.MQTT.RECEIVED,
+          topic: 'my/topic',
+        },
+      ],
+    });
+    sceneManager.checkTrigger({
+      type: EVENTS.MQTT.RECEIVED,
+      topic: 'my/topic',
+      message: 'Hello world',
+    });
+    return new Promise((resolve, reject) => {
+      sceneManager.queue.start(() => {
+        try {
+          assert.calledWith(message.sendToUser, 'john', 'Received on my/topic: Hello world', null, {
+            service: undefined,
+          });
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  });
+
+  it('should not continue the scene if the received message does not verify the condition', async () => {
+    await sceneManager.addScene({
+      selector: 'my-scene',
+      active: true,
+      actions: [
+        [
+          {
+            type: ACTIONS.CONDITION.ONLY_CONTINUE_IF,
+            conditions: [
+              {
+                variable: 'triggerEvent.message',
+                operator: '=',
+                value: 'ON',
+              },
+            ],
+          },
+        ],
+        [
+          {
+            type: ACTIONS.MESSAGE.SEND,
+            user: 'john',
+            text: 'The light is {{triggerEvent.message}}',
+          },
+        ],
+      ],
+      triggers: [
+        {
+          type: EVENTS.MQTT.RECEIVED,
+          topic: 'my/topic',
+        },
+      ],
+    });
+    sceneManager.checkTrigger({
+      type: EVENTS.MQTT.RECEIVED,
+      topic: 'my/topic',
+      message: 'OFF',
+    });
+    return new Promise((resolve, reject) => {
+      sceneManager.queue.start(() => {
+        try {
+          assert.notCalled(message.sendToUser);
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  });
+
+  it('should continue the scene if the received message verifies the condition', async () => {
+    await sceneManager.addScene({
+      selector: 'my-scene',
+      active: true,
+      actions: [
+        [
+          {
+            type: ACTIONS.CONDITION.ONLY_CONTINUE_IF,
+            conditions: [
+              {
+                variable: 'triggerEvent.message',
+                operator: '=',
+                value: 'ON',
+              },
+            ],
+          },
+        ],
+        [
+          {
+            type: ACTIONS.MESSAGE.SEND,
+            user: 'john',
+            text: 'The light is {{triggerEvent.message}}',
+          },
+        ],
+      ],
+      triggers: [
+        {
+          type: EVENTS.MQTT.RECEIVED,
+          topic: 'my/topic',
+        },
+      ],
+    });
+    sceneManager.checkTrigger({
+      type: EVENTS.MQTT.RECEIVED,
+      topic: 'my/topic',
+      message: 'ON',
+    });
+    return new Promise((resolve, reject) => {
+      sceneManager.queue.start(() => {
+        try {
+          assert.calledWith(message.sendToUser, 'john', 'The light is ON', null, { service: undefined });
           resolve();
         } catch (e) {
           reject(e);


### PR DESCRIPTION
Implements feature request: https://community.gladysassistant.com/t/pouvoir-utiliser-le-message-mqtt-dans-une-scene/8590

> **Note:** this PR was opened by an automated Claude Code run. It needs human review and real-life testing (an actual MQTT broker + a scene using the trigger) before being merged.

### Description

When a scene is triggered by the **"MQTT message received"** trigger, the received message was only usable as an exact-match filter on the trigger itself. Users asked to be able to *use* the received payload inside the scene (forum topic above): the example given is listening on a `tts` topic and forwarding the received text to another action, instead of creating one scene per possible message.

This PR exposes the trigger event data as scene variables, following the same pattern as the calendar trigger (`setVariablesTrigger`):

- `{{triggerEvent.topic}}` — the topic the message was received on
- `{{triggerEvent.message}}` — the received message

They now appear in the variable picker of every action input built on `TextWithVariablesInjected` (send a message, HTTP request, publish an MQTT message, set a device value, ask AI, set a variable, delay, ...), so they can be injected anywhere by typing `{{`.

They can also be selected as the **left side of a condition in the "Only continue if" box**: trigger variables were previously only available on the right side (value field). Since trigger variables are set before the scene runs, they are offered whatever the position of the box in the scene, in a dedicated "Scene triggers" group of the variable dropdown. This benefits the calendar trigger as well, which already declared trigger variables.

Changes:

- `front/src/routes/scene/edit-scene/triggers/MQTTReceivedTrigger.jsx`: declare the two trigger variables via `setVariablesTrigger`, plus a short hint in the trigger card explaining they can be injected in the next actions.
- `front/src/routes/scene/edit-scene/TriggerCard.jsx`: pass `variables` / `setVariablesTrigger` down to the MQTT trigger component.
- `front/src/routes/scene/edit-scene/actions/only-continue-if/OnlyContinueIfParams.jsx`: add the triggers variables to the condition variable dropdown.
- `front/src/config/i18n/{en,fr,de}.json`: new labels.
- `server/test/lib/scene/triggers/scene.trigger.mqttReceived.test.js`: new end-to-end tests.

No server change was needed: `checkTrigger` already executes the scene with `{ triggerEvent: event }` as scope, and the `mqtt.received` event already carries `topic` and `message` (emitted from `scene.addScene.js`), so Handlebars resolves `{{triggerEvent.topic}}` / `{{triggerEvent.message}}` and `get(scope, 'triggerEvent.message')` works in "Only continue if". The new server tests verify that end to end so the behaviour cannot silently regress.

## Forum

Forum: https://community.gladysassistant.com/t/pouvoir-utiliser-le-message-mqtt-dans-une-scene/8590

### Checklist

- [x] Tests pass: ran the scene test suites (`test/lib/scene/**`, 302 passing, including 3 new tests in `scene.trigger.mqttReceived.test.js`). Full `npm run coverage` and Cypress were **not** run in this environment — the only non-test change is front-end, which Codecov does not gate, but CI should confirm.
- [x] Linter and prettier pass on both front and server (`npm run eslint` → 0 errors on both, `prettier --check` clean on the changed files)
- [x] No undocumented breaking change


---
_Generated by [Claude Code](https://claude.ai/code/session_013yxguVaLdJ8ZKmw5x3HePT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MQTT trigger variables for the received topic and message.
  * Use MQTT data in subsequent scene actions and conditions.
  * Added localized labels and guidance in English, German, and French.

* **Bug Fixes**
  * Improved MQTT-triggered scene behavior, including conditional continuation and user message delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->