### PR TITLE
ci: run the scheduled autofix every 3 hours and raise its per-run cap

### DIFF
--- a/.github/CLAUDE_AUTOFIX.md
+++ b/.github/CLAUDE_AUTOFIX.md
@@ -1,6 +1,7 @@
 # Scheduled Claude autofix
 
-`claude-scheduled-autofix.yml` runs once a day and launches Claude Code
+`claude-scheduled-autofix.yml` runs every 3 hours (04:30–19:30 UTC, 6
+runs a day; an empty run is free since nothing is fired) and launches Claude Code
 **cloud sessions** (claude.ai/code) to address the review-bot feedback
 (Cursor, CodeRabbit) left on open pull requests — with hard caps, and without
 the runaway loop of the event-driven mode (Claude pushes → the bots re-review
@@ -75,7 +76,7 @@ also marks the whole thread, and resolving a thread by hand excludes it too.
 | Constant | Value | Role |
 | --- | --- | --- |
 | `MAX_PASSES` | 3 | Hard cap of autofix passes per PR (highest trailer value). Reached with feedback still pending → exhausted. |
-| `MAX_PRS` | 8 | Budget circuit breaker: max PRs per daily run, oldest activity first. Each fire also draws down the account's daily routine-run allowance. |
+| `MAX_PRS` | 10 | Budget circuit breaker: max PRs per run, oldest activity first. Each fire also draws down the account's daily routine-run allowance. |
 | `QUIET_PERIOD_HOURS` | 2 | A comment younger than this is left for the next run, so a review round can finish (and a human can veto). |
 | `REVIEW_BOT_LOGINS` | `cursor[bot]`, `coderabbitai[bot]` | Whose comments count as actionable feedback. |
 | `AUTOFIX_ACTOR_LOGINS` | `Pierre-Gilles`, `github-actions[bot]`, `claude[bot]` | Whose replies/markers count as "handled". Cloud sessions post as the routine owner (first login). |
@@ -153,20 +154,22 @@ excerpt). Nothing is written and no cloud session is fired.
 - **Fire and forget**: the `/fire` API returns the session URL (logged in the
   job summary) but there is no public endpoint to poll for completion, so the
   workflow cannot fail when a session fails — check claude.ai/code or the
-  next day's selection (an untouched PR simply comes back).
+  next run's selection (an untouched PR simply comes back).
 - The `/fire` endpoint is in research preview behind the
   `experimental-cc-routine-2026-04-01` beta header; Anthropic may change it.
 - Routine runs count against the account's **daily routine-run cap** and
   subscription usage; HTTP 429 on the fire call means the cap was hit.
-- The fire is not idempotent: manually re-running the workflow while the
-  daily run's sessions are still working can fire a second session for the
-  same PR and pass. Consequences are bounded (the pass counter takes the
+- The fire is not idempotent: manually re-running the workflow while a
+  previous run's sessions are still working can fire a second session for
+  the same PR and pass. Consequences are bounded (the pass counter takes the
   highest trailer, and markers prevent re-selection on *later* runs — they
   are not concurrency control, so two live sessions can post duplicate
-  replies and overlapping commits). Avoid manual dispatches right after the
-  scheduled run.
-- A comment posted less than `QUIET_PERIOD_HOURS` before the daily run waits
-  for the next day: worst-case latency is ~26 h.
+  replies and overlapping commits). Avoid manual dispatches right after a
+  scheduled run — and keep the schedule spacing well above a session's
+  lifetime (3 h is fine, hourly would not be) for the same reason.
+- A comment posted less than `QUIET_PERIOD_HOURS` before a run waits for the
+  next one: worst-case latency is ~5 h (2 h quiet period + 3 h to the next
+  run, ~11 h across the overnight gap).
 - Review threads with more than 100 replies are read truncated when looking
   for autofix replies (unreachable in practice on this repo's PRs).
 - `mergeable_state` is computed asynchronously by GitHub; a PR in `unknown`

--- a/.github/workflows/claude-scheduled-autofix.yml
+++ b/.github/workflows/claude-scheduled-autofix.yml
@@ -1,7 +1,7 @@
 name: Scheduled Claude autofix
 run-name: Scheduled Claude autofix${{ inputs.dry_run == true && ' (dry run)' || '' }}
 
-# Twice a day, find the open pull requests that carry review-bot feedback
+# Every few hours, find the open pull requests that carry review-bot feedback
 # (Cursor, CodeRabbit) nobody has handled yet, and launch ONE Claude Code
 # cloud session per PR to address it. This replaces the event-driven Claude
 # automation, whose cost was unbounded: a PR left open for two weeks kept
@@ -43,13 +43,19 @@ run-name: Scheduled Claude autofix${{ inputs.dry_run == true && ' (dry run)' || 
 
 on:
   schedule:
-    # Twice a day: before the (European) workday starts, so overnight
-    # review-bot feedback is fixed by morning, and around European midday,
-    # so feedback from the morning review round is fixed the same
-    # afternoon instead of waiting for the next day. Each run has its own
-    # MAX_PRS budget, so the daily ceiling is 2 * MAX_PRS sessions.
-    - cron: '30 4 * * *'
-    - cron: '30 11 * * *'
+    # Every 3 hours across the (European) day. Frequent runs are cheap:
+    # the select job is pure bash + gh api, and when it finds nothing the
+    # fire job is skipped entirely — an empty run costs ~1 minute of free
+    # runner time. Real spend is bounded PER PR, not per run: the
+    # Autofix-Handled markers plus MAX_PASSES cap every PR at MAX_PASSES
+    # sessions total, however often the schedule fires. More runs only
+    # cut the latency between a bot comment and its fix.
+    # Do NOT go much denser than this (e.g. hourly): a session still
+    # working on a PR has not posted its markers yet, so a run firing
+    # while it is in flight would select the same PR again and push a
+    # second session onto the same branch. Three hours is comfortably
+    # longer than any session's lifetime.
+    - cron: '30 4,7,10,13,16,19 * * *'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -67,11 +73,12 @@ env:
   # commit-message trailer. When a PR still has unhandled feedback after
   # this many passes, it gets EXHAUSTED_LABEL and a human takes over.
   MAX_PASSES: 3
-  # Budget circuit breaker: at most this many PRs processed per run (the
-  # schedule fires twice a day, so up to 2 * MAX_PRS sessions daily). The
-  # eligible list is sorted by last activity (oldest first) before
-  # truncating, so long-waiting PRs are served first. Cloud sessions also
-  # count against the account's daily routine-run allowance.
+  # Budget circuit breaker: at most this many PRs processed per run. This
+  # caps the burst size of one run, not the daily spend — that is bounded
+  # per PR by MAX_PASSES (see the schedule comment above). The eligible
+  # list is sorted by last activity (oldest first) before truncating, so
+  # long-waiting PRs are served first. Cloud sessions also count against
+  # the account's daily routine-run allowance.
   MAX_PRS: 10
   # A comment younger than this many hours is not processed yet: it lets a
   # review round finish (and a human veto it) before Claude reacts.

--- a/.github/workflows/claude-scheduled-autofix.yml
+++ b/.github/workflows/claude-scheduled-autofix.yml
@@ -1,7 +1,7 @@
 name: Scheduled Claude autofix
 run-name: Scheduled Claude autofix${{ inputs.dry_run == true && ' (dry run)' || '' }}
 
-# Once a day, find the open pull requests that carry review-bot feedback
+# Twice a day, find the open pull requests that carry review-bot feedback
 # (Cursor, CodeRabbit) nobody has handled yet, and launch ONE Claude Code
 # cloud session per PR to address it. This replaces the event-driven Claude
 # automation, whose cost was unbounded: a PR left open for two weeks kept
@@ -43,8 +43,13 @@ run-name: Scheduled Claude autofix${{ inputs.dry_run == true && ' (dry run)' || 
 
 on:
   schedule:
-    # Daily, before the (European) workday starts.
+    # Twice a day: before the (European) workday starts, so overnight
+    # review-bot feedback is fixed by morning, and around European midday,
+    # so feedback from the morning review round is fixed the same
+    # afternoon instead of waiting for the next day. Each run has its own
+    # MAX_PRS budget, so the daily ceiling is 2 * MAX_PRS sessions.
     - cron: '30 4 * * *'
+    - cron: '30 11 * * *'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -62,11 +67,12 @@ env:
   # commit-message trailer. When a PR still has unhandled feedback after
   # this many passes, it gets EXHAUSTED_LABEL and a human takes over.
   MAX_PASSES: 3
-  # Budget circuit breaker: at most this many PRs processed per run. The
+  # Budget circuit breaker: at most this many PRs processed per run (the
+  # schedule fires twice a day, so up to 2 * MAX_PRS sessions daily). The
   # eligible list is sorted by last activity (oldest first) before
   # truncating, so long-waiting PRs are served first. Cloud sessions also
   # count against the account's daily routine-run allowance.
-  MAX_PRS: 8
+  MAX_PRS: 10
   # A comment younger than this many hours is not processed yet: it lets a
   # review round finish (and a human veto it) before Claude reacts.
   QUIET_PERIOD_HOURS: 2
@@ -83,11 +89,11 @@ env:
   # only PRs from such branches are eligible.
   HEAD_BRANCH_PREFIX: 'claude/'
   # Minutes each matrix slot is held after firing. Combined with
-  # max-parallel 2 this staggers session LAUNCHES (about two fires per
+  # max-parallel 3 this staggers session LAUNCHES (about three fires per
   # window) so pushes do not all land at once; it does NOT bound how many
   # sessions are alive concurrently, since sessions outlive the job and no
   # public API exposes their completion.
-  FIRE_STAGGER_MINUTES: 8
+  FIRE_STAGGER_MINUTES: 5
   # Label that permanently stops the scheduled autofix on a PR (posed
   # automatically at MAX_PASSES).
   EXHAUSTED_LABEL: 'claude:autofix-exhausted'
@@ -344,8 +350,8 @@ jobs:
     strategy:
       fail-fast: false
       # Together with the stagger hold, spaces the session launches out
-      # (about two fires per stagger window).
-      max-parallel: 2
+      # (about three fires per stagger window).
+      max-parallel: 3
       matrix:
         pr: ${{ fromJSON(needs.select.outputs.matrix) }}
     # One autofix fire at a time per PR, whatever run it belongs to.


### PR DESCRIPTION
### Description

The scheduled Claude autofix was becoming the pipeline's bottleneck at the current merge rate: one run per day with `MAX_PRS: 8` means a PR needing two fix passes mechanically takes 2-3 days, and the queue saturates around 8 PRs/day — a glass ceiling on the way to 100+ merges/week.

Three changes in `.github/workflows/claude-scheduled-autofix.yml`:

- **Run the schedule every 3 hours** (04:30 → 19:30 UTC, 6 runs/day) instead of once a day. Denser scheduling is essentially free: the `select` job is pure bash + `gh api`, and when nothing is eligible the `fire` job is skipped entirely — an empty run costs ~1 minute of free runner time. Real spend stays bounded **per PR** (not per run) by the `Autofix-Handled` markers + `MAX_PASSES`, so more runs only cut the latency between a bot comment and its fix. A PR needing 2 passes now cycles in hours instead of days. Going much denser than 3h (e.g. hourly) would be unsafe: a run could select a PR whose previous session is still in flight and hasn't posted its markers yet, firing a second session onto the same branch — the comment on the schedule documents this limit.
- **Raise `MAX_PRS` from 8 to 10** per run — this now caps the burst size of one run, not the daily spend. Note: cloud sessions count against the account's daily routine-run allowance; worth checking the plan covers the higher potential fire rate on top of the other routines.
- **Tighten the launch stagger** (`max-parallel: 3`, 5-minute hold instead of 2 × 8 min) so a full 10-PR run fires in ~20 minutes instead of ~40, keeping each window compact.

`MAX_PASSES` and the 2h quiet period are deliberately unchanged: they are quality controls, not throughput knobs. The `concurrency` group already prevents two runs from overlapping.

## Forum

### Checklist

- [x] Tests pass: CI-only change, no server or front code touched
- [x] Linter and prettier pass on both front and server: no JS code changed
- [x] No undocumented breaking change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Scheduled automated fixes now run every three hours during the configured daytime window, up to six times daily.
  * Each run can process up to 10 pull requests.
  * Increased parallel processing capacity and added staggered launches to improve throughput.
  * Updated usage and budget guidance for retry timing, run limits, and manual reruns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->