### PR TITLE
docs: address review feedback on the autofix cadence change

### DIFF
--- a/.github/CLAUDE_AUTOFIX.md
+++ b/.github/CLAUDE_AUTOFIX.md
@@ -49,12 +49,13 @@ what a previous one already answered, and feedback the bots post after an
 autofix push can trigger at most one more pass. There is deliberately **no
 lower date bound** on comments: markers, not dates, are the source of truth
 for "handled", so a session that pushed but died before posting its replies
-leaves its comments eligible — they are retried the next day (burning another
-pass) instead of silently falling out of a date window. A stuck PR therefore
-always ends up either fixed or visibly `exhausted`; feedback is never
-orphaned. `MAX_PASSES` bounds the total no matter what. (A fire that fails
-before a session starts — daily routine cap, bad token — burns no pass and
-simply retries the next day, at the cost of one HTTP call and a red job.)
+leaves its comments eligible — they are retried at the next run (burning
+another pass) instead of silently falling out of a date window. A stuck PR
+therefore always ends up either fixed or visibly `exhausted`; feedback is
+never orphaned. `MAX_PASSES` bounds the total no matter what. (A fire that
+fails before a session starts — daily routine cap, bad token — burns no pass
+and simply retries at the next run, at the cost of one HTTP call and a red
+job.)
 
 ## How a comment is marked handled
 
@@ -81,7 +82,7 @@ also marks the whole thread, and resolving a thread by hand excludes it too.
 | `REVIEW_BOT_LOGINS` | `cursor[bot]`, `coderabbitai[bot]` | Whose comments count as actionable feedback. |
 | `AUTOFIX_ACTOR_LOGINS` | `Pierre-Gilles`, `github-actions[bot]`, `claude[bot]` | Whose replies/markers count as "handled". Cloud sessions post as the routine owner (first login). |
 | `HEAD_BRANCH_PREFIX` | `claude/` | Cloud sessions can only push branches with this prefix; other PRs are skipped. |
-| `FIRE_STAGGER_MINUTES` | 8 | How long each matrix slot is held after firing. With `max-parallel: 2`, staggers session *launches* (~2 fires per window); it does not bound how many sessions run concurrently. |
+| `FIRE_STAGGER_MINUTES` | 5 | How long each matrix slot is held after firing. With `max-parallel: 3`, staggers session *launches* (~3 fires per window); it does not bound how many sessions run concurrently. |
 | `EXHAUSTED_LABEL` | `claude:autofix-exhausted` | Permanently stops the autofix on a PR. Posted automatically. |
 | `SKIP_LABEL` | `claude:autofix-skip` | Manual opt-out for a PR. |
 | `NOISE_MARKER` | `This is an auto-generated comment` | Filters CodeRabbit's non-actionable issue comments (walkthroughs, status notes). |

--- a/.github/workflows/claude-scheduled-autofix.yml
+++ b/.github/workflows/claude-scheduled-autofix.yml
@@ -14,11 +14,11 @@ run-name: Scheduled Claude autofix${{ inputs.dry_run == true && ' (dry run)' || 
 #     selected again, even when the fix was declined;
 #   - markers, not dates, are the source of truth for "handled": a session
 #     that pushed but died before replying leaves its comments unmarked, so
-#     they come back the next day and burn another pass until MAX_PASSES
+#     they come back at the next run and burn another pass until MAX_PASSES
 #     flips the PR to "exhausted" for a human. A wasted pass is visible;
 #     silently orphaned feedback is not possible.
 # Hard caps on top: MAX_PASSES autofix passes per PR (then the PR is
-# labeled and left to a human) and MAX_PRS PRs per day.
+# labeled and left to a human) and MAX_PRS PRs per run.
 #
 # Two jobs:
 #   select - pure bash + gh api, no LLM call. Computes the eligible PR list
@@ -46,15 +46,18 @@ on:
     # Every 3 hours across the (European) day. Frequent runs are cheap:
     # the select job is pure bash + gh api, and when it finds nothing the
     # fire job is skipped entirely — an empty run costs ~1 minute of free
-    # runner time. Real spend is bounded PER PR, not per run: the
-    # Autofix-Handled markers plus MAX_PASSES cap every PR at MAX_PASSES
-    # sessions total, however often the schedule fires. More runs only
-    # cut the latency between a bot comment and its fix.
+    # runner time. Per-PR spend stays bounded: MAX_PASSES caps the highest
+    # Autofix-Pass trailer a PR can reach, so more runs mostly cut the
+    # latency between a bot comment and its fix. It is a budget, not an
+    # exact session count — overlapping sessions can reuse a pass number,
+    # and markers are dedup for LATER selects, not concurrency control.
     # Do NOT go much denser than this (e.g. hourly): a session still
     # working on a PR has not posted its markers yet, so a run firing
     # while it is in flight would select the same PR again and push a
-    # second session onto the same branch. Three hours is comfortably
-    # longer than any session's lifetime.
+    # second session onto the same branch. Three hours is usually enough
+    # for a session to finish and reply — a mitigation, not a mutex, and
+    # GitHub's cron jitter (often tens of minutes on public repos) eats
+    # into it, which is one more reason not to tighten the interval.
     - cron: '30 4,7,10,13,16,19 * * *'
   workflow_dispatch:
     inputs:
@@ -74,11 +77,15 @@ env:
   # this many passes, it gets EXHAUSTED_LABEL and a human takes over.
   MAX_PASSES: 3
   # Budget circuit breaker: at most this many PRs processed per run. This
-  # caps the burst size of one run, not the daily spend — that is bounded
-  # per PR by MAX_PASSES (see the schedule comment above). The eligible
-  # list is sorted by last activity (oldest first) before truncating, so
-  # long-waiting PRs are served first. Cloud sessions also count against
-  # the account's daily routine-run allowance.
+  # caps the burst size of one run, NOT the daily spend: the theoretical
+  # ceiling is runs-per-day * MAX_PRS fires (6 * 10 = 60), far above the
+  # old single-run cap of 8 — in practice the number of eligible PRs and
+  # their per-PR MAX_PASSES budget keep it much lower, but a busy claude/
+  # queue can burn many passes in one day. The eligible list is sorted by
+  # last activity (oldest first) before truncating, so long-waiting PRs
+  # are served first. Cloud sessions also count against the account's
+  # daily routine-run allowance (HTTP 429 on the fire call when it is
+  # hit).
   MAX_PRS: 10
   # A comment younger than this many hours is not processed yet: it lets a
   # review round finish (and a human veto it) before Claude reacts.
@@ -428,7 +435,7 @@ jobs:
       - name: ⏳ Hold the slot to stagger launches
         run: |
           # No public API exposes the cloud session's completion, so this
-          # only staggers the LAUNCHES (with max-parallel 2, about two
+          # only staggers the LAUNCHES (with max-parallel 3, about three
           # fires per window) instead of starting MAX_PRS sessions at the
           # same instant. It spreads the review-bot and CI load of the
           # resulting pushes; it does not bound how many sessions are


### PR DESCRIPTION
### Description

Follow-up to #2890, which was merged while its review round was still open. This addresses all the CodeRabbit and Cursor feedback left on it — comment/doc accuracy only, no behavior change:

- **Stop overclaiming what the 3-hour spacing guarantees** (Cursor + CodeRabbit): the schedule comment now presents 3h as a mitigation against overlapping sessions, not a mutex — GitHub cron jitter (often tens of minutes on public repos) eats into the buffer, the `Autofix-Handled` markers are dedup for *later* selects rather than concurrency control, and `MAX_PASSES` caps the highest `Autofix-Pass` trailer (a budget), not an exact session count.
- **State the real daily ceiling** (Cursor): the `MAX_PRS` comment now says explicitly that the theoretical ceiling is runs × `MAX_PRS` (6 × 10 = 60 fires/day) instead of implying the spend is bounded by `MAX_PASSES` alone, and the stale "MAX_PRS PRs per day" header line now reads "per run".
- **Sync the leftover stale values** (CodeRabbit + Cursor): the hold-step comment (`max-parallel 2` → 3), the `FIRE_STAGGER_MINUTES` constants-table row in `CLAUDE_AUTOFIX.md` (8 min / max-parallel 2 → 5 min / max-parallel 3), and the "retried the next day" wording in "How it works" (retries happen at the next run).

## Forum

### Checklist

- [x] Tests pass: comments/docs only, no server or front code touched
- [x] Linter and prettier pass on both front and server: no JS code changed
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_01VU6y2pzeyAXZWPrS4YNGwx)_