### PR TITLE
fix: stop re-queuing a state-purge job on every device save (#2900)

### DIFF
--- a/server/lib/device/device.create.js
+++ b/server/lib/device/device.create.js
@@ -185,10 +185,20 @@ async function create(device) {
               id: matchedFeature.id,
             },
           });
+          // The purge below is a background JOB: a t_job row, several DuckDB &
+          // SQLite counts and their websocket broadcasts, per feature. It is only
+          // worth running when the feature JUST stopped keeping history. A feature
+          // already saved with keep_history = false has nothing left to purge
+          // (device.saveState / device.saveHistoricalState never write a state for
+          // it), so re-purging it on every save was pure background load: a user
+          // assigning a room to one device after another queued one such job per
+          // keep_history = false feature per save, and those jobs pile up behind the
+          // single DuckDB connection until the whole instance stops responding.
+          const keepHistoryBeforeUpdate = deviceFeature.keep_history;
           const featureToUpdate = { ...feature };
           delete featureToUpdate.selector;
           await deviceFeature.update(featureToUpdate, { transaction });
-          if (deviceFeature.keep_history === false) {
+          if (keepHistoryBeforeUpdate !== false && deviceFeature.keep_history === false) {
             deviceFeaturesIdsToPurge.push(deviceFeature.id);
           }
           return deviceFeature.get({ plain: true });

--- a/server/test/lib/device/device.create.test.js
+++ b/server/test/lib/device/device.create.test.js
@@ -725,6 +725,49 @@ describe('Device', () => {
       'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4',
     );
   });
+  it('should not re-purge the states of a feature already saved with keep_history = false', async () => {
+    const stateManager = new StateManager(event);
+    const serviceManager = new ServiceManager({}, stateManager);
+    const fakeEvent = {
+      emit: fake.returns(null),
+      on: fake.returns(null),
+    };
+    const device = new Device(fakeEvent, {}, stateManager, serviceManager, {}, {}, job, brain);
+    const deviceToSave = {
+      id: '7f85c2f8-86cc-4600-84db-6c074dadb4e8',
+      name: 'Test device',
+      selector: 'test-device',
+      external_id: 'test-device-external',
+      service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
+      features: [
+        {
+          name: 'New device feature',
+          selector: 'new-device-feature',
+          external_id: 'hue:binary:1',
+          category: 'temperature',
+          type: 'decimal',
+          keep_history: false,
+          read_only: false,
+          has_feedback: false,
+          min: 0,
+          max: 100,
+        },
+      ],
+    };
+    // First save: the feature switches from keep_history = true to false, its
+    // states must be purged.
+    await device.create({ ...deviceToSave });
+    assert.calledWith(
+      fakeEvent.emit,
+      EVENTS.DEVICE.PURGE_STATES_SINGLE_FEATURE,
+      'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e4',
+    );
+    fakeEvent.emit.resetHistory();
+    // Second save (assigning a room, renaming...): nothing changed on the
+    // feature, no purge job should be queued again.
+    await device.create({ ...deviceToSave, room_id: '2398c689-8b47-43cc-ad32-e98d9be098b5' });
+    assert.neverCalledWith(fakeEvent.emit, EVENTS.DEVICE.PURGE_STATES_SINGLE_FEATURE);
+  });
   it('should ignore invalid energy_parent_id when updating a device', async () => {
     const stateManager = new StateManager(event);
     const serviceManager = new ServiceManager({}, stateManager);


### PR DESCRIPTION
Fixes #2900

> ⚠️ **This pull request was produced by an automated routine (Claude Code) and has NOT been reviewed by a human.** Please review it carefully before merging — in particular the "What a human must check before merge" section below, which lists what could not be verified without a live Overkiz account.

## What changed and why

`server/lib/device/device.create.js` queued a `DEVICE_STATES_PURGE_SINGLE_FEATURE` background job for **every** feature whose `keep_history` is `false`, on **every** save of the device — not only when the flag actually switched off:

```js
await deviceFeature.update(featureToUpdate, { transaction });
if (deviceFeature.keep_history === false) {
  deviceFeaturesIdsToPurge.push(deviceFeature.id);
}
```

A feature already stored with `keep_history = false` has nothing left to purge: `device.saveState` and `device.saveHistoricalState` both guard on `keep_history`, so no state is ever written for it after the first purge. Each of these no-op jobs is nevertheless expensive:

- a `t_job` row (INSERT) + `job.finish` (SELECT + UPDATE),
- 3 `job.updateProgress` calls (SELECT + UPDATE each) before any deletion is even attempted,
- a `COUNT(*)` on DuckDB `t_device_feature_state` plus a probe query, both serialized on the **single shared DuckDB read connection**,
- a `SELECT 1` probe on the **single shared DuckDB write connection**,
- a `COUNT` on SQLite `t_device_feature_state` and one on `t_device_feature_state_aggregate`,
- ~5 `WEBSOCKET.SEND_ALL` broadcasts to every connected client.

They are fired with `eventManager.emit` (fire-and-forget, no concurrency limit), so they keep running in the background after the HTTP response. Saving one device queues `N` of them, where `N` is its number of `keep_history = false` features. A user assigning rooms to device after device — exactly the gesture in #2900 — queues a new batch every few seconds while the previous ones are still draining, so the backlog grows monotonically. Since every one of those jobs competes for the same single DuckDB connections and the same SQLite write lock that `device.create`'s own transaction needs, each subsequent save waits longer than the last, and eventually the instance stops responding. Restarting the container drops the in-memory backlog, which matches the reported workaround.

The fix is minimal: capture `keep_history` before the update and only queue the purge on the `true → false` transition, which is what the existing comment in the file already describes ("features that **were marked as** `keep_history = false`").

No `docs/specs/*` file documents this trigger, so no spec update is included (checked `keep_history` / `purge` across `docs/specs/`).

## What was verified locally

Using the repo's pinned binaries in `server/node_modules/.bin` (not global ones):

- `prettier --check` on both touched files → clean.
- `eslint` on both touched files → clean, exit 0.
- `mocha test/lib/device/device.create.test.js` → **33 passing**, 0 failing.
- `mocha --recursive test/lib/device/** test/lib/external-integration/** test/controllers/device/**` → **944 passing**, 0 failing.
- A new regression test was added, `should not re-purge the states of a feature already saved with keep_history = false`. It was confirmed to **fail on the unpatched code** (stashed the `device.create.js` change → 32 passing / 1 failing) and to pass with the fix, so it is not vacuous.
- The pre-existing test `should update a feature with keep_history = false and check that background job to delete states is called` still passes: its seeded feature has `keep_history = true`, so it exercises the real `true → false` transition.

Not run: the full `npm run coverage` suite, the front build, and Cypress (unchanged areas — this PR touches one server file plus its test).

## What a human must check before merge

1. **This is a code-level root cause, not a reproduced one.** The issue involves a third-party Overkiz/Somfy cloud account, which could not be used here. The mechanism above is established from the code alone; that it is *the* dominant cost in the reporter's instance is an inference. It requires that Overkiz devices publish at least some features with `keep_history: false` — plausible for command/button-style features, but unverified. Worth confirming against the reporter's `t_job` table (`SELECT type, count(*) FROM t_job GROUP BY type`) or the attached logs, which contain `Purging states of device feature <id>` lines if this path is the one firing.
2. **Whether the backlog is the whole story.** The reporter is running Docker on a NAS with HDD storage (per the linked forum thread), which amplifies every SQLite fsync. If saves are still slow after this fix, there may be a second contributor — the per-save cost of `device.create` itself, or something on the external-integration side.
3. **The semantics of the narrowed trigger.** With this change, a purge no longer re-runs on a subsequent save if a previous purge job *failed* (e.g. a DB error). That is the intended behaviour, but if you want a self-healing retry it should be an explicit mechanism rather than a side effect of re-saving the device.
4. **Codecov patch coverage.** The new branch is covered by the added test, but please confirm the CI patch-coverage check goes green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSnP4WUgedpXr2AsFBvAQ7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated feature history-purge jobs when history is already disabled.
  * History is purged only when changing from enabled to disabled, reducing unnecessary background processing.

* **Tests**
  * Added regression coverage for feature updates that do not change history settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->