### PR TITLE
Add a random part to the selector of new dashboards, like scenes

### DIFF
--- a/front/cypress/e2e/routes/dashboard/Dashboard.cy.js
+++ b/front/cypress/e2e/routes/dashboard/Dashboard.cy.js
@@ -22,7 +22,8 @@ describe('Dashboard', () => {
       .should('have.class', 'btn-primary')
       .click();
 
-    cy.url().should('eq', `${Cypress.config().baseUrl}/dashboard/my-new-dashboard/edit`);
+    // The selector of a new dashboard ends with 4 random characters, like scenes
+    cy.url().should('match', new RegExp(`^${Cypress.config().baseUrl}/dashboard/my-new-dashboard-[a-z0-9]{4}/edit$`));
   });
   it('Should add new boxes', () => {
     cy.contains('.btn-primary', 'dashboard.addBoxButton').click();

--- a/server/lib/dashboard/dashboard.create.js
+++ b/server/lib/dashboard/dashboard.create.js
@@ -1,4 +1,5 @@
 const db = require('../../models');
+const { slugify } = require('../../utils/slugify');
 
 /**
  * @description Create a new dashboard.
@@ -26,7 +27,18 @@ async function create(userId, dashboard) {
   if (dashboardWithTheHighestPosition.length > 0) {
     dashboard.position = dashboardWithTheHighestPosition[0].position + 1;
   }
-  return db.Dashboard.create({ ...dashboard, user_id: userId });
+  let dashboardWithSelector = dashboard;
+  // Like scenes, the selector of a new dashboard gets random characters at the
+  // end so two dashboards with names sharing the same slug don't collide.
+  // A selector explicitly given by the caller is always kept as is, and
+  // existing dashboards keep the selector they were created with.
+  if (!dashboard.selector && dashboard.name) {
+    dashboardWithSelector = {
+      ...dashboard,
+      selector: slugify(dashboard.name, true),
+    };
+  }
+  return db.Dashboard.create({ ...dashboardWithSelector, user_id: userId });
 }
 
 module.exports = {

--- a/server/test/lib/dashboard/dashboard.create.test.js
+++ b/server/test/lib/dashboard/dashboard.create.test.js
@@ -5,7 +5,7 @@ const Dashboard = require('../../../lib/dashboard');
 
 describe('dashboard.create', () => {
   const dashboard = new Dashboard();
-  it('should create a dashboard', async () => {
+  it('should create a dashboard with a random selector', async () => {
     const newDashboard = await dashboard.create('0cd30aef-9c4e-4a23-88e3-3547971296e5', {
       name: 'My new dashboard',
       type: DASHBOARD_TYPE.MAIN,
@@ -20,7 +20,47 @@ describe('dashboard.create', () => {
       ],
     });
     expect(newDashboard).to.have.property('name', 'My new dashboard');
-    expect(newDashboard).to.have.property('selector', 'my-new-dashboard');
+    expect(newDashboard.selector).to.contain('my-new-dashboard');
+    // selector should have 4 random characters at the end + dash
+    expect(newDashboard.selector).to.have.lengthOf('my-new-dashboard'.length + 5);
+  });
+  it('should create a dashboard with the selector given', async () => {
+    const newDashboard = await dashboard.create('0cd30aef-9c4e-4a23-88e3-3547971296e5', {
+      name: 'My dashboard with a custom selector',
+      selector: 'my-custom-dashboard-selector',
+      type: DASHBOARD_TYPE.MAIN,
+      position: 0,
+      visibility: DASHBOARD_VISIBILITY.PRIVATE,
+      boxes: [[]],
+    });
+    expect(newDashboard).to.have.property('selector', 'my-custom-dashboard-selector');
+  });
+  it('should create two dashboards with names sharing the same slug', async () => {
+    const firstDashboard = await dashboard.create('0cd30aef-9c4e-4a23-88e3-3547971296e5', {
+      name: 'Salon',
+      type: DASHBOARD_TYPE.MAIN,
+      position: 0,
+      visibility: DASHBOARD_VISIBILITY.PRIVATE,
+      boxes: [[]],
+    });
+    const secondDashboard = await dashboard.create('0cd30aef-9c4e-4a23-88e3-3547971296e5', {
+      name: 'Salôn',
+      type: DASHBOARD_TYPE.MAIN,
+      position: 0,
+      visibility: DASHBOARD_VISIBILITY.PRIVATE,
+      boxes: [[]],
+    });
+    expect(firstDashboard.selector).to.contain('salon');
+    expect(secondDashboard.selector).to.contain('salon');
+    expect(firstDashboard.selector).to.not.equal(secondDashboard.selector);
+  });
+  it('should return error, missing name', async () => {
+    const promise = dashboard.create('0cd30aef-9c4e-4a23-88e3-3547971296e5', {
+      type: DASHBOARD_TYPE.MAIN,
+      visibility: DASHBOARD_VISIBILITY.PRIVATE,
+      boxes: [[]],
+    });
+    return assert.isRejected(promise);
   });
   it('should return error, missing box type', async () => {
     const promise = dashboard.create('0cd30aef-9c4e-4a23-88e3-3547971296e5', {

--- a/server/test/lib/dashboard/dashboard.create.test.js
+++ b/server/test/lib/dashboard/dashboard.create.test.js
@@ -20,9 +20,8 @@ describe('dashboard.create', () => {
       ],
     });
     expect(newDashboard).to.have.property('name', 'My new dashboard');
-    expect(newDashboard.selector).to.contain('my-new-dashboard');
-    // selector should have 4 random characters at the end + dash
-    expect(newDashboard.selector).to.have.lengthOf('my-new-dashboard'.length + 5);
+    // selector should be the slug of the name + a dash + 4 random characters
+    expect(newDashboard.selector).to.match(/^my-new-dashboard-[a-z0-9]{4}$/);
   });
   it('should create a dashboard with the selector given', async () => {
     const newDashboard = await dashboard.create('0cd30aef-9c4e-4a23-88e3-3547971296e5', {

--- a/server/test/lib/dashboard/dashboard.updateOrder.test.js
+++ b/server/test/lib/dashboard/dashboard.updateOrder.test.js
@@ -39,7 +39,7 @@ describe('dashboard.updateOrder', () => {
       raw: true,
     });
     expect(dashboardsInNewOrder).to.deep.equal([
-      { selector: 'my-new-dashboard', position: 0 },
+      { selector: newDashboard.selector, position: 0 },
       { selector: 'test-dashboard', position: 1 },
       { selector: 'my-new-public-dashoard', position: 2 },
     ]);


### PR DESCRIPTION
Implements feature request: ``https://community.gladysassistant.com/t/tableau-de-bord-lidentifiant-unique-devrait-contenir-une-partie-aleatoire-comme-les-scenes``/9829

### Description

Scenes generate their URL `selector` with 4 random characters at the end (`slugify(name, true)`) so two scenes whose names slugify to the same value never collide. Dashboards used the plain slug of their name (through the `addSelectorBeforeValidateHook` model hook), so two dashboards with names sharing the same slug (`Salon` / `Salôn`, `Étage 1` / `Etage 1`, …) collided on the unique `selector` column.

`dashboard.create` now generates the selector the same way scenes do:

- `server/lib/dashboard/dashboard.create.js`: when no selector is passed and the dashboard has a name, the selector is `slugify(dashboard.name, true)` — e.g. `my-new-dashboard-a3f9`.
- A selector explicitly given by the caller (REST API, Cypress fixtures, imports) is still used as is — same behavior as `scene.create`.
- A creation without a name still fails on the existing model validation, unchanged.

**Backward compatibility (no migration):** existing dashboards keep the selector they were created with. Their selectors live in URLs, in bookmarks and in tablet-mode configurations, so no migration rewrites existing rows — a rewrite would break every saved link for zero benefit. Lookups need no change either: `dashboard.getBySelector`, `update`, `destroy` and `updateOrder` all query the `selector` column directly, so the old form and the new form work identically. Only newly created dashboards get the random suffix.

**Front-end:** nothing to change on the creation path — `front/src/routes/dashboard/new-dashboard/index.js` already routes to the selector returned by the server, and no front code derives a dashboard selector from a name (`front/src/utils/slugify.js` is only used for users). The only adjustment is the Cypress spec, which asserted the exact URL `/dashboard/my-new-dashboard/edit` and now matches `/dashboard/my-new-dashboard-[a-z0-9]{4}/edit`. The dashboard box specs pass an explicit `selector: 'test'` on creation, so they are unaffected.

## Forum

Forum: ``https://community.gladysassistant.com/t/tableau-de-bord-lidentifiant-unique-devrait-contenir-une-partie-aleatoire-comme-les-scenes``/9829

### Checklist

- [x] Server tests pass for the changed area, with tests covering every added line/branch (random selector generated, explicit selector kept, two names sharing the same slug both created, missing name rejected). The remaining failures in the local full run are environment-only (`sqlite3` CLI missing in the sandbox, Docker/network tests) and unrelated to this change. Cypress was not run locally.
- [x] Linter and prettier pass on both front and server (`npm run prettier`, `npm run prettier-check`, `npm run eslint`), plus `npm run compare-translations` and `npm run build` on the front.
- [x] No undocumented breaking change (existing dashboard selectors are untouched, see above).

---

This pull request was opened by an automated Claude Code run and needs human review before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard selectors are now automatically generated from the dashboard name with a unique suffix when no selector is provided.
  * Explicitly provided selectors continue to be preserved.

* **Bug Fixes**
  * Improved dashboard creation and ordering behavior for generated selectors.
  * Added handling for dashboards with missing names.

* **Tests**
  * Expanded coverage for selector uniqueness, custom selectors, and generated dashboard URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->