### PR TITLE
Add the ability to duplicate a dashboard

### DIFF
--- a/front/cypress/e2e/routes/dashboard/Dashboard.cy.js
+++ b/front/cypress/e2e/routes/dashboard/Dashboard.cy.js
@@ -35,10 +35,10 @@ describe('Dashboard', () => {
     cy.contains('dashboard.editDashboardButton')
       .should('have.class', 'btn-outline-primary')
       .click();
-    cy.contains('dashboard.editDashboardDeleteButton')
+    cy.contains('button', 'dashboard.editDashboardDeleteButton')
       .should('have.class', 'btn-outline-danger')
       .click();
-    cy.contains('dashboard.editDashboardDeleteButton')
+    cy.contains('button', 'dashboard.editDashboardDeleteButton')
       .should('have.class', 'btn-outline-danger')
       .click();
     cy.url().should('eq', `${Cypress.config().baseUrl}/dashboard`);

--- a/front/src/components/app.jsx
+++ b/front/src/components/app.jsx
@@ -46,6 +46,7 @@ import SignupSuccess from '../routes/signup/5-success';
 import Dashboard from '../routes/dashboard';
 import NewDashboard from '../routes/dashboard/new-dashboard';
 import EditDashboard from '../routes/dashboard/edit-dashboard';
+import DuplicateDashboard from '../routes/dashboard/duplicate-dashboard';
 
 import IntegrationPage from '../routes/integration';
 import DevicesListPage from '../routes/devices';
@@ -266,6 +267,7 @@ const AppRouter = connect(
         <SafeAsyncRoute path="/dashboard" component={Dashboard} />
         <SafeAsyncRoute path="/dashboard/:dashboardSelector" component={Dashboard} />
         <EditDashboard path="/dashboard/:dashboardSelector/edit" />
+        <DuplicateDashboard path="/dashboard/:dashboardSelector/duplicate" />
         <NewDashboard path="/dashboard/create/new" />
         <SafeAsyncRoute path="/dashboard/integration" component={IntegrationPage} />
 

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -291,6 +291,7 @@
     "disableFullScreen": "Vollbild beenden",
     "editDashboardTitle": "Dashboard bearbeiten",
     "editDashboardDeleteButton": "Löschen",
+    "editDashboardDuplicateButton": "Duplizieren",
     "editDashboardCancelButton": "Abbrechen",
     "editDashboardDeleteText": "Bist du sicher, dass du dieses Dashboard löschen möchtest?",
     "toggleDefineTabletMode": "Tablet-Modus",
@@ -4006,6 +4007,16 @@
     "invalidName": "Name ist erforderlich und kann nicht \"neu\" sein",
     "invalidIcon": "Symbol ist erforderlich",
     "sceneAlreadyExist": "Eine Szene mit diesem Namen existiert bereits."
+  },
+  "duplicateDashboard": {
+    "cardTitle": "Dashboard \"{{name}}\" duplizieren",
+    "nameLabel": "Name",
+    "namePlaceholder": "Gib einen neuen Namen ein",
+    "duplicateDashboardButton": "Duplizieren",
+    "invalidName": "Name ist erforderlich",
+    "dashboardAlreadyExist": "Ein Dashboard mit diesem Namen existiert bereits.",
+    "unknownError": "Ein unbekannter Fehler ist aufgetreten. Bitte versuche es erneut!",
+    "nameAfterCopy": "Kopie von {{name}}"
   },
   "duplicateScene": {
     "cardTitle": "Szene \"{{name}}\" duplizieren",

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -4016,7 +4016,8 @@
     "invalidName": "Name ist erforderlich",
     "dashboardAlreadyExist": "Ein Dashboard mit diesem Namen existiert bereits.",
     "unknownError": "Ein unbekannter Fehler ist aufgetreten. Bitte versuche es erneut!",
-    "nameAfterCopy": "Kopie von {{name}}"
+    "nameAfterCopy": "Kopie von {{name}}",
+    "savedVersionInfo": "Die Kopie wird von der zuletzt gespeicherten Version dieses Dashboards erstellt. Nicht gespeicherte Änderungen werden nicht kopiert."
   },
   "duplicateScene": {
     "cardTitle": "Szene \"{{name}}\" duplizieren",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -4016,7 +4016,8 @@
     "invalidName": "Name is required",
     "dashboardAlreadyExist": "A dashboard with this name already exists.",
     "unknownError": "An unknown error occurred. Please retry!",
-    "nameAfterCopy": "Copy of {{name}}"
+    "nameAfterCopy": "Copy of {{name}}",
+    "savedVersionInfo": "The copy is made from the last saved version of this dashboard. Any change not saved yet will not be copied."
   },
   "duplicateScene": {
     "cardTitle": "Duplicate scene \"{{name}}\"",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -291,6 +291,7 @@
     "disableFullScreen": "Exit full screen",
     "editDashboardTitle": "Edit dashboard",
     "editDashboardDeleteButton": "Delete",
+    "editDashboardDuplicateButton": "Duplicate",
     "editDashboardCancelButton": "Cancel",
     "editDashboardDeleteText": "Are you sure you want to delete this dashboard?",
     "toggleDefineTabletMode": "Tablet Mode",
@@ -4006,6 +4007,16 @@
     "invalidName": "Name is required and cannot be 'new'",
     "invalidIcon": "Icon is required",
     "sceneAlreadyExist": "A scene with that name already exists."
+  },
+  "duplicateDashboard": {
+    "cardTitle": "Duplicate dashboard \"{{name}}\"",
+    "nameLabel": "Name",
+    "namePlaceholder": "Enter a new name",
+    "duplicateDashboardButton": "Duplicate",
+    "invalidName": "Name is required",
+    "dashboardAlreadyExist": "A dashboard with this name already exists.",
+    "unknownError": "An unknown error occurred. Please retry!",
+    "nameAfterCopy": "Copy of {{name}}"
   },
   "duplicateScene": {
     "cardTitle": "Duplicate scene \"{{name}}\"",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -289,6 +289,7 @@
     "newDashboardButton": "Nouveau",
     "editDashboardCancelButton": "Annuler",
     "editDashboardDeleteButton": "Supprimer",
+    "editDashboardDuplicateButton": "Dupliquer",
     "editDashboardSaveButton": "Sauvegarder",
     "editDashboardDeleteText": "Êtes-vous sûr de vouloir supprimer ce tableau de bord ?",
     "toggleDefineTabletMode": "Mode tablette",
@@ -4006,6 +4007,16 @@
     "invalidName": "Le nom est requis",
     "invalidIcon": "L'icône est requise",
     "sceneAlreadyExist": "Une scène avec le même nom existe déjà."
+  },
+  "duplicateDashboard": {
+    "cardTitle": "Dupliquer le tableau de bord \"{{name}}\"",
+    "nameLabel": "Nom",
+    "namePlaceholder": "Entrez un nouveau nom",
+    "duplicateDashboardButton": "Dupliquer",
+    "invalidName": "Le nom est requis",
+    "dashboardAlreadyExist": "Un tableau de bord avec le même nom existe déjà.",
+    "unknownError": "Une erreur inconnue est survenue. Veuillez réessayer !",
+    "nameAfterCopy": "Copie de {{name}}"
   },
   "duplicateScene": {
     "cardTitle": "Dupliquer la scène \"{{name}}\"",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -4016,7 +4016,8 @@
     "invalidName": "Le nom est requis",
     "dashboardAlreadyExist": "Un tableau de bord avec le même nom existe déjà.",
     "unknownError": "Une erreur inconnue est survenue. Veuillez réessayer !",
-    "nameAfterCopy": "Copie de {{name}}"
+    "nameAfterCopy": "Copie de {{name}}",
+    "savedVersionInfo": "La copie est réalisée à partir de la dernière version enregistrée de ce tableau de bord. Les modifications non enregistrées ne seront pas copiées."
   },
   "duplicateScene": {
     "cardTitle": "Dupliquer la scène \"{{name}}\"",

--- a/front/src/routes/dashboard/duplicate-dashboard/DuplicateDashboardPage.jsx
+++ b/front/src/routes/dashboard/duplicate-dashboard/DuplicateDashboardPage.jsx
@@ -1,0 +1,72 @@
+import { Text, Localizer } from 'preact-i18n';
+import cx from 'classnames';
+import get from 'get-value';
+
+import { RequestStatus } from '../../../utils/consts';
+import style from './style.css';
+
+const DuplicateDashboardPage = ({ children, ...props }) => (
+  <div class={cx('container', style.containerWithMargin)}>
+    <button onClick={props.goBack} class="btn btn-secondary btn-sm">
+      <Text id="global.backButton" />
+    </button>
+
+    <div class="row">
+      <div class="col col-login mx-auto">
+        <form onSubmit={props.duplicateDashboard} class="card">
+          <div class={props.loading ? 'dimmer active' : 'dimmer'}>
+            <div class="loader" />
+            <div class="dimmer-content">
+              <div class="card-body p-6">
+                <div class="card-title">
+                  <Text id="duplicateDashboard.cardTitle" fields={{ name: props.sourceDashboard.name }} />
+                </div>
+                {props.duplicateDashboardStatus === RequestStatus.ConflictError && (
+                  <div class="alert alert-danger">
+                    <Text id="duplicateDashboard.dashboardAlreadyExist" />
+                  </div>
+                )}
+                {props.duplicateDashboardStatus === RequestStatus.Error && (
+                  <div class="alert alert-danger">
+                    <Text id="duplicateDashboard.unknownError" />
+                  </div>
+                )}
+                <div class="form-group">
+                  <label class="form-label">
+                    <Text id="duplicateDashboard.nameLabel" />
+                  </label>
+                  <Localizer>
+                    <input
+                      type="text"
+                      class={cx('form-control', {
+                        'is-invalid': get(props, 'duplicateDashboardErrors.name')
+                      })}
+                      disabled={props.loading}
+                      placeholder={<Text id="duplicateDashboard.namePlaceholder" />}
+                      value={get(props, 'dashboard.name')}
+                      onInput={props.updateDuplicateDashboardName}
+                    />
+                  </Localizer>
+                  <div class="invalid-feedback">
+                    <Text id="duplicateDashboard.invalidName" />
+                  </div>
+                </div>
+                <div class="form-footer">
+                  <button
+                    onClick={props.duplicateDashboard}
+                    class="btn btn-primary btn-block"
+                    disabled={props.duplicateDashboardStatus === RequestStatus.Getting}
+                  >
+                    <Text id="duplicateDashboard.duplicateDashboardButton" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+);
+
+export default DuplicateDashboardPage;

--- a/front/src/routes/dashboard/duplicate-dashboard/DuplicateDashboardPage.jsx
+++ b/front/src/routes/dashboard/duplicate-dashboard/DuplicateDashboardPage.jsx
@@ -21,6 +21,9 @@ const DuplicateDashboardPage = ({ children, ...props }) => (
                 <div class="card-title">
                   <Text id="duplicateDashboard.cardTitle" fields={{ name: props.sourceDashboard.name }} />
                 </div>
+                <div class="alert alert-info">
+                  <Text id="duplicateDashboard.savedVersionInfo" />
+                </div>
                 {props.duplicateDashboardStatus === RequestStatus.ConflictError && (
                   <div class="alert alert-danger">
                     <Text id="duplicateDashboard.dashboardAlreadyExist" />

--- a/front/src/routes/dashboard/duplicate-dashboard/index.js
+++ b/front/src/routes/dashboard/duplicate-dashboard/index.js
@@ -34,9 +34,9 @@ class DuplicateDashboard extends Component {
     }
   };
 
-  checkErrors = () => {
+  checkErrors = (name = this.state.dashboard.name) => {
     const duplicateDashboardErrors = {};
-    if (!this.state.dashboard.name) {
+    if (!name) {
       duplicateDashboardErrors.name = true;
     }
     this.setState({
@@ -46,13 +46,15 @@ class DuplicateDashboard extends Component {
   };
 
   updateDuplicateDashboardName = e => {
+    const { value } = e.target;
     this.setState({
       dashboard: {
-        name: e.target.value
+        name: value
       }
     });
     if (this.state.duplicateDashboardErrors) {
-      this.checkErrors();
+      // setState is asynchronous, so we validate the new value directly
+      this.checkErrors(value);
     }
   };
 

--- a/front/src/routes/dashboard/duplicate-dashboard/index.js
+++ b/front/src/routes/dashboard/duplicate-dashboard/index.js
@@ -1,0 +1,128 @@
+import { Component } from 'preact';
+import { connect } from 'unistore/preact';
+import { route } from 'preact-router';
+import get from 'get-value';
+
+import DuplicateDashboardPage from './DuplicateDashboardPage';
+import { RequestStatus } from '../../../utils/consts';
+import withIntlAsProp from '../../../utils/withIntlAsProp';
+
+class DuplicateDashboard extends Component {
+  goBack = () => {
+    route(`/dashboard/${this.props.dashboardSelector}/edit`);
+  };
+
+  getSourceDashboard = async () => {
+    try {
+      const sourceDashboard = await this.props.httpClient.get(`/api/v1/dashboard/${this.props.dashboardSelector}`);
+      this.setState({
+        sourceDashboard,
+        loading: false,
+        dashboard: {
+          name: get(this.props.intl.dictionary, 'duplicateDashboard.nameAfterCopy').replace(
+            '{{name}}',
+            sourceDashboard.name
+          )
+        }
+      });
+    } catch (e) {
+      console.error(e);
+      this.setState({
+        loading: false,
+        duplicateDashboardStatus: RequestStatus.Error
+      });
+    }
+  };
+
+  checkErrors = () => {
+    const duplicateDashboardErrors = {};
+    if (!this.state.dashboard.name) {
+      duplicateDashboardErrors.name = true;
+    }
+    this.setState({
+      duplicateDashboardErrors
+    });
+    return Object.keys(duplicateDashboardErrors).length > 0;
+  };
+
+  updateDuplicateDashboardName = e => {
+    this.setState({
+      dashboard: {
+        name: e.target.value
+      }
+    });
+    if (this.state.duplicateDashboardErrors) {
+      this.checkErrors();
+    }
+  };
+
+  duplicateDashboard = async e => {
+    e.preventDefault();
+    // if errored, we don't continue
+    if (this.checkErrors()) {
+      return;
+    }
+    this.setState({
+      duplicateDashboardStatus: RequestStatus.Getting
+    });
+    try {
+      const duplicatedDashboard = await this.props.httpClient.post(
+        `/api/v1/dashboard/${this.props.dashboardSelector}/duplicate`,
+        this.state.dashboard
+      );
+      this.setState({
+        duplicateDashboardStatus: RequestStatus.Success
+      });
+      route(`/dashboard/${duplicatedDashboard.selector}/edit`);
+    } catch (e) {
+      console.error(e);
+      const status = get(e, 'response.status');
+      if (status === 409) {
+        this.setState({
+          duplicateDashboardStatus: RequestStatus.ConflictError
+        });
+      } else {
+        this.setState({
+          duplicateDashboardStatus: RequestStatus.Error
+        });
+      }
+    }
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      dashboard: {
+        name: ''
+      },
+      sourceDashboard: {
+        name: ''
+      },
+      loading: true,
+      duplicateDashboardErrors: null,
+      duplicateDashboardStatus: null
+    };
+  }
+
+  componentDidMount() {
+    this.getSourceDashboard();
+  }
+
+  render(props, { dashboard, sourceDashboard, loading, duplicateDashboardErrors, duplicateDashboardStatus }) {
+    return (
+      <DuplicateDashboardPage
+        {...props}
+        goBack={this.goBack}
+        dashboard={dashboard}
+        sourceDashboard={sourceDashboard}
+        loading={loading}
+        updateDuplicateDashboardName={this.updateDuplicateDashboardName}
+        duplicateDashboard={this.duplicateDashboard}
+        duplicateDashboardErrors={duplicateDashboardErrors}
+        duplicateDashboardStatus={duplicateDashboardStatus}
+      />
+    );
+  }
+}
+
+export default withIntlAsProp(connect('httpClient', {})(DuplicateDashboard));

--- a/front/src/routes/dashboard/duplicate-dashboard/style.css
+++ b/front/src/routes/dashboard/duplicate-dashboard/style.css
@@ -1,0 +1,3 @@
+.containerWithMargin {
+  margin-top: 3rem;
+}

--- a/front/src/routes/dashboard/edit-dashboard/EditActions.jsx
+++ b/front/src/routes/dashboard/edit-dashboard/EditActions.jsx
@@ -1,4 +1,4 @@
-import { Text } from 'preact-i18n';
+import { Text, Localizer } from 'preact-i18n';
 
 const EditActions = props => (
   <div class="fixed-bottom footer">
@@ -6,30 +6,54 @@ const EditActions = props => (
       <div class="row align-items-center flex-row-reverse flex-wrap">
         {!props.askDeleteDashboard && (
           <div class="col-auto">
-            <button onClick={props.cancelDashboardEdit} className="btn btn-outline-secondary btn-sm ml-2">
-              <span class="d-none d-md-inline-block">
-                <Text id="dashboard.editDashboardCancelButton" />
-              </span>{' '}
-              <i class="fe fe-slash" />
-            </button>
-            <button onClick={props.askDeleteCurrentDashboard} className="btn btn-outline-danger btn-sm ml-2">
-              <span class="d-none d-md-inline-block">
-                <Text id="dashboard.editDashboardDeleteButton" />
-              </span>{' '}
-              <i class="fe fe-trash" />
-            </button>
-            <button onClick={props.duplicateCurrentDashboard} className="btn btn-outline-secondary btn-sm ml-2">
-              <span class="d-none d-md-inline-block">
-                <Text id="dashboard.editDashboardDuplicateButton" />
-              </span>{' '}
-              <i class="fe fe-copy" />
-            </button>
-            <button onClick={props.saveDashboard} className="btn btn-outline-primary btn-sm ml-2">
-              <span class="d-none d-md-inline-block">
-                <Text id="dashboard.editDashboardSaveButton" />
-              </span>{' '}
-              <i class="fe fe-check" />
-            </button>
+            <Localizer>
+              <button
+                onClick={props.cancelDashboardEdit}
+                className="btn btn-outline-secondary btn-sm ml-2"
+                aria-label={<Text id="dashboard.editDashboardCancelButton" />}
+              >
+                <span class="d-none d-md-inline-block">
+                  <Text id="dashboard.editDashboardCancelButton" />
+                </span>{' '}
+                <i class="fe fe-slash" aria-hidden="true" />
+              </button>
+            </Localizer>
+            <Localizer>
+              <button
+                onClick={props.askDeleteCurrentDashboard}
+                className="btn btn-outline-danger btn-sm ml-2"
+                aria-label={<Text id="dashboard.editDashboardDeleteButton" />}
+              >
+                <span class="d-none d-md-inline-block">
+                  <Text id="dashboard.editDashboardDeleteButton" />
+                </span>{' '}
+                <i class="fe fe-trash" aria-hidden="true" />
+              </button>
+            </Localizer>
+            <Localizer>
+              <button
+                onClick={props.duplicateCurrentDashboard}
+                className="btn btn-outline-secondary btn-sm ml-2"
+                aria-label={<Text id="dashboard.editDashboardDuplicateButton" />}
+              >
+                <span class="d-none d-md-inline-block">
+                  <Text id="dashboard.editDashboardDuplicateButton" />
+                </span>{' '}
+                <i class="fe fe-copy" aria-hidden="true" />
+              </button>
+            </Localizer>
+            <Localizer>
+              <button
+                onClick={props.saveDashboard}
+                className="btn btn-outline-primary btn-sm ml-2"
+                aria-label={<Text id="dashboard.editDashboardSaveButton" />}
+              >
+                <span class="d-none d-md-inline-block">
+                  <Text id="dashboard.editDashboardSaveButton" />
+                </span>{' '}
+                <i class="fe fe-check" aria-hidden="true" />
+              </button>
+            </Localizer>
           </div>
         )}
 

--- a/front/src/routes/dashboard/edit-dashboard/EditActions.jsx
+++ b/front/src/routes/dashboard/edit-dashboard/EditActions.jsx
@@ -12,6 +12,9 @@ const EditActions = props => (
             <button onClick={props.askDeleteCurrentDashboard} className="btn btn-outline-danger btn-sm ml-2">
               <Text id="dashboard.editDashboardDeleteButton" /> <i class="fe fe-trash" />
             </button>
+            <button onClick={props.duplicateCurrentDashboard} className="btn btn-outline-secondary btn-sm ml-2">
+              <Text id="dashboard.editDashboardDuplicateButton" /> <i class="fe fe-copy" />
+            </button>
             <button onClick={props.saveDashboard} className="btn btn-outline-primary btn-sm ml-2">
               <Text id="dashboard.editDashboardSaveButton" /> <i class="fe fe-check" />
             </button>

--- a/front/src/routes/dashboard/edit-dashboard/EditActions.jsx
+++ b/front/src/routes/dashboard/edit-dashboard/EditActions.jsx
@@ -3,20 +3,32 @@ import { Text } from 'preact-i18n';
 const EditActions = props => (
   <div class="fixed-bottom footer">
     <div class="container">
-      <div class="row align-items-center flex-row-reverse">
+      <div class="row align-items-center flex-row-reverse flex-wrap">
         {!props.askDeleteDashboard && (
           <div class="col-auto">
             <button onClick={props.cancelDashboardEdit} className="btn btn-outline-secondary btn-sm ml-2">
-              <Text id="dashboard.editDashboardCancelButton" /> <i class="fe fe-slash" />
+              <span class="d-none d-md-inline-block">
+                <Text id="dashboard.editDashboardCancelButton" />
+              </span>{' '}
+              <i class="fe fe-slash" />
             </button>
             <button onClick={props.askDeleteCurrentDashboard} className="btn btn-outline-danger btn-sm ml-2">
-              <Text id="dashboard.editDashboardDeleteButton" /> <i class="fe fe-trash" />
+              <span class="d-none d-md-inline-block">
+                <Text id="dashboard.editDashboardDeleteButton" />
+              </span>{' '}
+              <i class="fe fe-trash" />
             </button>
             <button onClick={props.duplicateCurrentDashboard} className="btn btn-outline-secondary btn-sm ml-2">
-              <Text id="dashboard.editDashboardDuplicateButton" /> <i class="fe fe-copy" />
+              <span class="d-none d-md-inline-block">
+                <Text id="dashboard.editDashboardDuplicateButton" />
+              </span>{' '}
+              <i class="fe fe-copy" />
             </button>
             <button onClick={props.saveDashboard} className="btn btn-outline-primary btn-sm ml-2">
-              <Text id="dashboard.editDashboardSaveButton" /> <i class="fe fe-check" />
+              <span class="d-none d-md-inline-block">
+                <Text id="dashboard.editDashboardSaveButton" />
+              </span>{' '}
+              <i class="fe fe-check" />
             </button>
           </div>
         )}

--- a/front/src/routes/dashboard/edit-dashboard/index.js
+++ b/front/src/routes/dashboard/edit-dashboard/index.js
@@ -310,6 +310,10 @@ class EditDashboard extends Component {
     }
   };
 
+  duplicateCurrentDashboard = () => {
+    route(`/dashboard/${this.state.currentDashboard.selector}/duplicate`);
+  };
+
   askDeleteCurrentDashboard = async () => {
     await this.setState({
       askDeleteDashboard: true
@@ -426,6 +430,7 @@ class EditDashboard extends Component {
         updateBoxConfig={this.updateBoxConfig}
         updateCurrentDashboardName={this.updateCurrentDashboardName}
         updateCurrentDashboardVisibility={this.updateCurrentDashboardVisibility}
+        duplicateCurrentDashboard={this.duplicateCurrentDashboard}
         askDeleteCurrentDashboard={this.askDeleteCurrentDashboard}
         cancelDeleteCurrentDashboard={this.cancelDeleteCurrentDashboard}
         deleteCurrentDashboard={this.deleteCurrentDashboard}

--- a/server/api/controllers/dashboard.controller.js
+++ b/server/api/controllers/dashboard.controller.js
@@ -52,6 +52,18 @@ module.exports = function DashboardController(gladys) {
   }
 
   /**
+   * @api {post} /api/v1/dashboard/:dashboard_selector/duplicate duplicate
+   * @apiName duplicate
+   * @apiGroup Dashboard
+   * @apiParam {String} name Name of the duplicated dashboard.
+   * @apiUse DashboardSuccess
+   */
+  async function duplicate(req, res) {
+    const dashboard = await gladys.dashboard.duplicate(req.user.id, req.params.dashboard_selector, req.body.name);
+    res.status(201).json(dashboard);
+  }
+
+  /**
    * @api {post} /api/v1/dashboard/order updateOrder
    * @apiName updateOrder
    * @apiGroup Dashboard
@@ -101,6 +113,7 @@ module.exports = function DashboardController(gladys) {
   return Object.freeze({
     create: asyncMiddleware(create),
     destroy: asyncMiddleware(destroy),
+    duplicate: asyncMiddleware(duplicate),
     get: asyncMiddleware(get),
     getBySelector: asyncMiddleware(getBySelector),
     update: asyncMiddleware(update),

--- a/server/api/routes.js
+++ b/server/api/routes.js
@@ -201,6 +201,10 @@ function getRoutes(gladys) {
       authenticated: true,
       controller: dashboardController.destroy,
     },
+    'post /api/v1/dashboard/:dashboard_selector/duplicate': {
+      authenticated: true,
+      controller: dashboardController.duplicate,
+    },
     // device
     'post /api/v1/device': {
       authenticated: true,

--- a/server/lib/dashboard/dashboard.duplicate.js
+++ b/server/lib/dashboard/dashboard.duplicate.js
@@ -1,0 +1,61 @@
+const { Op } = require('sequelize');
+
+const db = require('../../models');
+const { NotFoundError } = require('../../utils/coreErrors');
+const { slugify } = require('../../utils/slugify');
+const { DASHBOARD_VISIBILITY } = require('../../utils/constants');
+
+/**
+ * @description Duplicate a dashboard.
+ * @param {string} userId - The userId querying.
+ * @param {string} selector - The selector of the source dashboard.
+ * @param {string} name - The name of the duplicated dashboard.
+ * @returns {Promise<object>} Resolve with the duplicated dashboard.
+ * @example
+ * gladys.dashboard.duplicate('0cd30aef-9c4e-4a23-88e3-3547971296e5', 'main-dashboard', 'Copy of Main dashboard');
+ */
+async function duplicate(userId, selector, name) {
+  const existingDashboard = await db.Dashboard.findOne({
+    where: {
+      // I can duplicate a dashboard I created or a public dashboard
+      [Op.or]: [
+        {
+          user_id: userId,
+        },
+        {
+          visibility: 'public',
+        },
+      ],
+      selector,
+    },
+  });
+
+  if (existingDashboard === null) {
+    throw new NotFoundError('Dashboard not found');
+  }
+
+  const plainExistingDashboard = existingDashboard.get({ plain: true });
+
+  // The copy belongs to the user asking for it. Duplicating a public dashboard
+  // of someone else should not re-share a second copy with the whole
+  // installation, so only the creator of the source keeps its visibility.
+  const visibility =
+    plainExistingDashboard.user_id === userId ? plainExistingDashboard.visibility : DASHBOARD_VISIBILITY.PRIVATE;
+
+  const newDashboard = {
+    name,
+    selector: slugify(name, true),
+    type: plainExistingDashboard.type,
+    visibility,
+    boxes: plainExistingDashboard.boxes,
+  };
+
+  // create places the new dashboard at the end of the dashboard list of the user
+  const createdDashboard = await this.create(userId, newDashboard);
+
+  return createdDashboard.get({ plain: true });
+}
+
+module.exports = {
+  duplicate,
+};

--- a/server/lib/dashboard/index.js
+++ b/server/lib/dashboard/index.js
@@ -1,6 +1,7 @@
 const { create } = require('./dashboard.create');
 const { get } = require('./dashboard.get');
 const { destroy } = require('./dashboard.destroy');
+const { duplicate } = require('./dashboard.duplicate');
 const { getBySelector } = require('./dashboard.getBySelector');
 const { update } = require('./dashboard.update');
 const { updateOrder } = require('./dashboard.updateOrder');
@@ -10,6 +11,7 @@ const Dashboard = function Dashboard() {};
 
 Dashboard.prototype.create = create;
 Dashboard.prototype.destroy = destroy;
+Dashboard.prototype.duplicate = duplicate;
 Dashboard.prototype.get = get;
 Dashboard.prototype.getBySelector = getBySelector;
 Dashboard.prototype.update = update;

--- a/server/test/controllers/dashboard/dashboard.controller.test.js
+++ b/server/test/controllers/dashboard/dashboard.controller.test.js
@@ -174,6 +174,42 @@ describe('POST /api/v1/dashboard/order', () => {
   });
 });
 
+describe('POST /api/v1/dashboard/:dashboard_selector/duplicate', () => {
+  it('should duplicate a dashboard', async () => {
+    await authenticatedRequest
+      .post('/api/v1/dashboard/test-dashboard/duplicate')
+      .send({
+        name: 'Copy of Test dashboard',
+      })
+      .expect('Content-Type', /json/)
+      .expect(201)
+      .then((res) => {
+        expect(res.body).to.have.property('name', 'Copy of Test dashboard');
+        expect(res.body).to.have.property('type', 'main');
+        expect(res.body).to.have.property('visibility', DASHBOARD_VISIBILITY.PRIVATE);
+        expect(res.body).to.have.property('user_id', '0cd30aef-9c4e-4a23-88e3-3547971296e5');
+        expect(res.body.selector).to.contain('copy-of-test-dashboard');
+        expect(res.body.boxes).to.deep.equal([
+          [
+            {
+              type: 'weather',
+            },
+          ],
+        ]);
+      });
+  });
+
+  it('should return 404, dashboard not found', async () => {
+    await authenticatedRequest
+      .post('/api/v1/dashboard/not-found-dashboard/duplicate')
+      .send({
+        name: 'Copy of a dashboard',
+      })
+      .expect('Content-Type', /json/)
+      .expect(404);
+  });
+});
+
 describe('DELETE /api/v1/dashboard/:dashboard_selector', () => {
   it('should patch dashboard', async () => {
     await authenticatedRequest

--- a/server/test/lib/dashboard/dashboard.duplicate.test.js
+++ b/server/test/lib/dashboard/dashboard.duplicate.test.js
@@ -1,0 +1,72 @@
+const { expect, assert } = require('chai');
+const { DASHBOARD_BOX_TYPE, DASHBOARD_TYPE, DASHBOARD_VISIBILITY } = require('../../../utils/constants');
+
+const Dashboard = require('../../../lib/dashboard');
+
+const USER_ID = '0cd30aef-9c4e-4a23-88e3-3547971296e5';
+const OTHER_USER_ID = '7a137a56-069e-4996-8816-36558174b727';
+
+describe('dashboard.duplicate', () => {
+  const dashboard = new Dashboard();
+
+  it('should duplicate a dashboard', async () => {
+    const duplicatedDashboard = await dashboard.duplicate(USER_ID, 'test-dashboard', 'Copy of Test dashboard');
+    expect(duplicatedDashboard).to.have.property('name', 'Copy of Test dashboard');
+    expect(duplicatedDashboard).to.have.property('type', DASHBOARD_TYPE.MAIN);
+    expect(duplicatedDashboard).to.have.property('user_id', USER_ID);
+    expect(duplicatedDashboard).to.have.property('visibility', DASHBOARD_VISIBILITY.PRIVATE);
+    // The duplicate is placed after the dashboards the user already has
+    expect(duplicatedDashboard).to.have.property('position', 1);
+    // The boxes of the source dashboard are copied as is
+    expect(duplicatedDashboard.boxes).to.deep.equal([[{ type: DASHBOARD_BOX_TYPE.WEATHER }]]);
+    // The selector is new and unique: slug + dash + 4 random characters
+    expect(duplicatedDashboard.selector).to.contain('copy-of-test-dashboard');
+    expect(duplicatedDashboard.selector).to.have.lengthOf('copy-of-test-dashboard'.length + 5);
+  });
+
+  it('should duplicate my own public dashboard and keep it public', async () => {
+    const publicDashboard = await dashboard.create(USER_ID, {
+      name: 'My public dashboard',
+      type: DASHBOARD_TYPE.MAIN,
+      visibility: DASHBOARD_VISIBILITY.PUBLIC,
+      boxes: [[{ type: DASHBOARD_BOX_TYPE.USER_PRESENCE }]],
+    });
+    const duplicatedDashboard = await dashboard.duplicate(
+      USER_ID,
+      publicDashboard.selector,
+      'Copy of my public dashboard',
+    );
+    expect(duplicatedDashboard).to.have.property('user_id', USER_ID);
+    expect(duplicatedDashboard).to.have.property('visibility', DASHBOARD_VISIBILITY.PUBLIC);
+    expect(duplicatedDashboard.boxes).to.deep.equal([[{ type: DASHBOARD_BOX_TYPE.USER_PRESENCE }]]);
+  });
+
+  it('should duplicate a public dashboard of another user as a private dashboard', async () => {
+    const publicDashboard = await dashboard.create(OTHER_USER_ID, {
+      name: 'Public dashboard of another user',
+      type: DASHBOARD_TYPE.MAIN,
+      visibility: DASHBOARD_VISIBILITY.PUBLIC,
+      boxes: [[{ type: DASHBOARD_BOX_TYPE.USER_PRESENCE }]],
+    });
+    const duplicatedDashboard = await dashboard.duplicate(USER_ID, publicDashboard.selector, 'Copy of a public one');
+    // The copy belongs to the user asking for it, and is not re-shared
+    expect(duplicatedDashboard).to.have.property('user_id', USER_ID);
+    expect(duplicatedDashboard).to.have.property('visibility', DASHBOARD_VISIBILITY.PRIVATE);
+  });
+
+  it('should return not found', async () => {
+    const promise = dashboard.duplicate(USER_ID, 'not-found-dashboard', 'New dashboard');
+    return assert.isRejected(promise, 'Dashboard not found');
+  });
+
+  it('should return not found for a private dashboard I cannot see', async () => {
+    const privateDashboard = await dashboard.create(OTHER_USER_ID, {
+      name: 'Private dashboard of another user',
+      type: DASHBOARD_TYPE.MAIN,
+      visibility: DASHBOARD_VISIBILITY.PRIVATE,
+      boxes: [[{ type: DASHBOARD_BOX_TYPE.USER_PRESENCE }]],
+    });
+    const promise = dashboard.duplicate(USER_ID, privateDashboard.selector, 'New dashboard');
+    return assert.isRejected(promise, 'Dashboard not found');
+  });
+});


### PR DESCRIPTION
Implements feature request: https://community.gladysassistant.com/t/possibilite-de-dupliquer-un-tableau-de-bord/10393

### Description

A user asked on the forum to be able to duplicate a dashboard, the way scenes can already be duplicated. This PR mirrors the scene duplication design end to end for dashboards.

**Server**

- New `server/lib/dashboard/dashboard.duplicate.js`, modelled on `scene.duplicate`:
  - the source dashboard is looked up with the same permission rule the existing dashboard `getBySelector`/`update`/`updateOrder` code uses (a dashboard I created, or a public one), and a `NotFoundError` is thrown otherwise;
  - the copy keeps the `type` and the `boxes` of the source dashboard (faithful copy of the widgets/content);
  - the copy gets a brand new unique selector built with `slugify(name, true)` (slug + 4 random characters), like scenes do;
  - the copy is created through `dashboard.create` for the user asking for it, so it is placed at the end of *their* dashboard list (position = highest position + 1);
  - visibility: a dashboard you own keeps its visibility, while a public dashboard belonging to another user is duplicated as a **private** dashboard, so duplicating never re-shares a second copy with the whole installation.
- New route `POST /api/v1/dashboard/:dashboard_selector/duplicate` (authenticated) and its controller, returning `201` with the new dashboard.

**Front**

- New "Duplicate" button in the dashboard edit page actions (next to Cancel / Delete / Save), which opens the new page `/dashboard/:dashboardSelector/duplicate`.
- New `front/src/routes/dashboard/duplicate-dashboard/` page, built like the scene duplication page: it loads the source dashboard, prefills the name with `Copy of <name>`, lets the user change it, calls the new endpoint and redirects to the edit page of the new dashboard. Name conflicts (`409`, dashboard names are unique) and unknown errors are displayed.
- New i18n keys (`duplicateDashboard.*` and `dashboard.editDashboardDuplicateButton`) added to `en.json`, `fr.json` and `de.json`.

**Tests**

- `server/test/lib/dashboard/dashboard.duplicate.test.js`: duplicating my dashboard (name, type, boxes, position, unique selector with random suffix), duplicating my own public dashboard (stays public), duplicating a public dashboard of another user (becomes private and belongs to me), unknown selector and private dashboard of another user (both not found).
- `server/test/controllers/dashboard/dashboard.controller.test.js`: `POST /api/v1/dashboard/:dashboard_selector/duplicate` success (201) and 404 cases.
- Patch coverage of the changed server files verified locally at 100 % (statements, branches, functions, lines).

## Forum

Forum: https://community.gladysassistant.com/t/possibilite-de-dupliquer-un-tableau-de-bord/10393

### Checklist

- [x] Server tests pass: new `dashboard.duplicate` lib and controller tests pass, and the full `npm test` suite shows no new failure (the only failures in my sandbox are pre-existing environment ones: gateway backup/restore shelling out to the `sqlite3` CLI, Docker and network tests)
- [x] Coverage: `c8` run on the changed server files reports 100 % on `lib/dashboard/dashboard.duplicate.js` and `api/controllers/dashboard.controller.js`
- [x] Linter and prettier pass on both front and server (`npm run prettier`, `npm run prettier-check`, `npm run eslint`)
- [x] `npm run compare-translations` passes and `npm run build` (front) succeeds
- [x] No undocumented breaking change (only additive: one new endpoint, one new front route)
- [ ] Cypress not run in my environment (no browser binary). The existing dashboard specs under `front/cypress/e2e/routes/dashboard/` were reviewed: they target the Save/Delete/Edit buttons by their own translation keys, which the new Duplicate button does not collide with.

Note: this pull request was opened by an automated Claude Code run. It needs a human review before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BRdJPgpjHkz9LKu39n8fm8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to duplicate dashboards from the dashboard editor.
  * Users can customize the copied dashboard’s name with validation and conflict feedback.
  * Public dashboards can be copied, while copies from another owner’s dashboard are private by default.
  * Added localized duplication flows in English, French, and German.
* **Bug Fixes**
  * Added handling for missing dashboards and duplication errors.
  * Improved dashboard action layout and accessibility on smaller screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->