### PR TITLE
Energy consumption widget: allow the tracking period to start on any day of the month (billing period)

### DIFF
--- a/front/src/components/boxs/energy-consumption/EditEnergyConsumption.jsx
+++ b/front/src/components/boxs/energy-consumption/EditEnergyConsumption.jsx
@@ -7,8 +7,18 @@ import BaseEditBox from '../baseEditBox';
 import EnergyConsumption from './EnergyConsumption';
 import { getDeviceFeatureName } from '../../../utils/device';
 import { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } from '../../../../../server/utils/constants';
+import {
+  DEFAULT_ENERGY_PERIOD_START_DAY,
+  MIN_ENERGY_PERIOD_START_DAY,
+  MAX_ENERGY_PERIOD_START_DAY
+} from '../../../../../server/utils/energyPeriod';
 import withIntlAsProp from '../../../utils/withIntlAsProp';
 import { DEFAULT_COLORS, DEFAULT_COLORS_NAME } from '../chart/ApexChartComponent';
+
+const PERIOD_START_DAY_OPTIONS = [];
+for (let day = MIN_ENERGY_PERIOD_START_DAY; day <= MAX_ENERGY_PERIOD_START_DAY; day += 1) {
+  PERIOD_START_DAY_OPTIONS.push(day);
+}
 
 const square = (color = 'transparent') => ({
   alignItems: 'center',
@@ -90,6 +100,12 @@ class EditEnergyConsumption extends Component {
         device_features: []
       });
     }
+  };
+
+  updatePeriodStartDay = e => {
+    this.props.updateBoxConfig(this.props.x, this.props.y, {
+      period_start_day: parseInt(e.target.value, 10)
+    });
   };
 
   updateShowSubscriptionPrices = e => {
@@ -232,6 +248,25 @@ class EditEnergyConsumption extends Component {
               />
             </div>
           ))}
+        <div class="form-group">
+          <label>
+            <Text id="dashboard.boxes.energyConsumption.periodStartDay" />
+          </label>
+          <select
+            class="form-control"
+            value={props.box.period_start_day || DEFAULT_ENERGY_PERIOD_START_DAY}
+            onChange={this.updatePeriodStartDay}
+          >
+            {PERIOD_START_DAY_OPTIONS.map(day => (
+              <option key={day} value={day}>
+                {day}
+              </option>
+            ))}
+          </select>
+          <small class="form-text text-muted">
+            <Text id="dashboard.boxes.energyConsumption.periodStartDayDescription" />
+          </small>
+        </div>
         <div class="form-group">
           <label class="custom-switch">
             <input

--- a/front/src/components/boxs/energy-consumption/EnergyConsumption.jsx
+++ b/front/src/components/boxs/energy-consumption/EnergyConsumption.jsx
@@ -406,12 +406,13 @@ class EnergyConsumption extends Component {
     const from = dayjs(startDate)
       .locale(this.props.user.language)
       .format('DD MMM YYYY');
-    // The end date is exclusive: display the last day included in the period
+    // The end date is exclusive (the period stops at midnight on that day): display it as-is and
+    // separate it with an arrow, so the label reads like the bill it is compared with
+    // ("from the 5th to the 5th") instead of looking like a day is missing.
     const to = dayjs(endDate)
-      .subtract(1, 'day')
       .locale(this.props.user.language)
       .format('DD MMM YYYY');
-    return `${from} - ${to}`;
+    return `${from} → ${to}`;
   };
 
   getDatePickerView = () => {

--- a/front/src/components/boxs/energy-consumption/EnergyConsumption.jsx
+++ b/front/src/components/boxs/energy-consumption/EnergyConsumption.jsx
@@ -7,6 +7,14 @@ import withIntlAsProp from '../../../utils/withIntlAsProp';
 import ApexChartComponent, { DEFAULT_COLORS } from '../chart/ApexChartComponent';
 import { formatHttpError } from '../../../utils/formatErrors';
 import dayjs from 'dayjs';
+import {
+  DEFAULT_ENERGY_PERIOD_START_DAY,
+  parseEnergyPeriodStartDay,
+  getEnergyPeriodStart,
+  getEnergyPeriodStartInCalendarUnit,
+  getNextEnergyPeriodStart,
+  getPreviousEnergyPeriodStart
+} from '../../../../../server/utils/energyPeriod';
 
 import fr from 'date-fns/locale/fr';
 
@@ -16,6 +24,11 @@ const PERIODS = {
   YEAR: 'year',
   MONTH: 'month',
   DAY: 'day'
+};
+
+const getPeriodStartDay = box => {
+  const periodStartDay = parseEnergyPeriodStartDay(box && box.period_start_day);
+  return periodStartDay === null ? DEFAULT_ENERGY_PERIOD_START_DAY : periodStartDay;
 };
 
 const DISPLAY_MODES = {
@@ -104,6 +117,8 @@ class EnergyConsumption extends Component {
       seriesColors: [],
       emptySeries: true,
       selectedPeriod: PERIODS.MONTH,
+      // Any date inside the displayed period: the exact start of the period is
+      // always derived from it and from the billing period start day
       selectedDate: now,
       displayMode: DISPLAY_MODES.CURRENCY,
       currencyUnit: null
@@ -117,7 +132,8 @@ class EnergyConsumption extends Component {
   componentDidUpdate(prevProps) {
     if (
       prevProps.box.device_features !== this.props.box.device_features ||
-      prevProps.box.title !== this.props.box.title
+      prevProps.box.title !== this.props.box.title ||
+      prevProps.box.period_start_day !== this.props.box.period_start_day
     ) {
       this.refreshData();
     }
@@ -143,7 +159,8 @@ class EnergyConsumption extends Component {
         from: startDate.toISOString(),
         to: endDate.toISOString(),
         group_by: this.getGroupBy(),
-        display_mode: this.state.displayMode
+        display_mode: this.state.displayMode,
+        period_start_day: getPeriodStartDay(this.props.box)
       });
 
       let emptySeries = true;
@@ -252,27 +269,17 @@ class EnergyConsumption extends Component {
     }
   };
 
-  getDateRange = () => {
+  getPeriodStart = () => {
     const { selectedPeriod, selectedDate } = this.state;
-    let startDate, endDate;
+    return getEnergyPeriodStart(selectedDate, selectedPeriod, getPeriodStartDay(this.props.box));
+  };
 
-    switch (selectedPeriod) {
-      case PERIODS.YEAR:
-        startDate = new Date(selectedDate.getFullYear(), 0, 1, 0, 0, 0, 0);
-        endDate = new Date(selectedDate.getFullYear() + 1, 0, 1, 0, 0, 0, 0);
-        break;
-      case PERIODS.MONTH:
-        startDate = new Date(selectedDate.getFullYear(), selectedDate.getMonth(), 1, 0, 0, 0, 0);
-        endDate = new Date(selectedDate.getFullYear(), selectedDate.getMonth() + 1, 1, 0, 0, 0, 0);
-        break;
-      case PERIODS.DAY:
-        startDate = new Date(selectedDate.getFullYear(), selectedDate.getMonth(), selectedDate.getDate(), 0, 0, 0, 0);
-        endDate = new Date(selectedDate.getFullYear(), selectedDate.getMonth(), selectedDate.getDate() + 1, 0, 0, 0, 0);
-        break;
-      default:
-        startDate = new Date(selectedDate.getFullYear(), selectedDate.getMonth(), 1, 0, 0, 0, 0);
-        endDate = new Date(selectedDate.getFullYear(), selectedDate.getMonth() + 1, 1, 0, 0, 0, 0);
-    }
+  getDateRange = () => {
+    const { selectedPeriod } = this.state;
+    const periodStartDay = getPeriodStartDay(this.props.box);
+
+    const startDate = this.getPeriodStart();
+    const endDate = getNextEnergyPeriodStart(startDate, selectedPeriod, periodStartDay);
 
     return { startDate, endDate };
   };
@@ -312,45 +319,28 @@ class EnergyConsumption extends Component {
   };
 
   navigatePrevious = () => {
-    const { selectedPeriod, selectedDate } = this.state;
-    let newDate = new Date(selectedDate);
-
-    switch (selectedPeriod) {
-      case PERIODS.YEAR:
-        newDate.setFullYear(selectedDate.getFullYear() - 1);
-        break;
-      case PERIODS.MONTH:
-        newDate.setMonth(selectedDate.getMonth() - 1);
-        break;
-      case PERIODS.DAY:
-        newDate.setDate(selectedDate.getDate() - 1);
-        break;
-    }
+    const { selectedPeriod } = this.state;
+    const periodStartDay = getPeriodStartDay(this.props.box);
+    const newDate = getPreviousEnergyPeriodStart(this.getPeriodStart(), selectedPeriod, periodStartDay);
 
     this.setState({ selectedDate: newDate }, this.refreshData);
   };
 
   navigateNext = () => {
-    const { selectedPeriod, selectedDate } = this.state;
-    let newDate = new Date(selectedDate);
-
-    switch (selectedPeriod) {
-      case PERIODS.YEAR:
-        newDate.setFullYear(selectedDate.getFullYear() + 1);
-        break;
-      case PERIODS.MONTH:
-        newDate.setMonth(selectedDate.getMonth() + 1);
-        break;
-      case PERIODS.DAY:
-        newDate.setDate(selectedDate.getDate() + 1);
-        break;
-    }
+    const { selectedPeriod } = this.state;
+    const periodStartDay = getPeriodStartDay(this.props.box);
+    const newDate = getNextEnergyPeriodStart(this.getPeriodStart(), selectedPeriod, periodStartDay);
 
     this.setState({ selectedDate: newDate }, this.refreshData);
   };
 
   onDateChange = date => {
-    this.setState({ selectedDate: date }, this.refreshData);
+    const periodStartDay = getPeriodStartDay(this.props.box);
+    // The date picker returns a month (or a year): display the billing period starting in it
+    this.setState(
+      { selectedDate: getEnergyPeriodStartInCalendarUnit(date, this.state.selectedPeriod, periodStartDay) },
+      this.refreshData
+    );
   };
 
   changeDisplayMode = mode => {
@@ -409,6 +399,19 @@ class EnergyConsumption extends Component {
         .locale(this.props.user.language)
         .format('MMM YYYY');
     }
+  };
+
+  getPeriodRangeLabel = () => {
+    const { startDate, endDate } = this.getDateRange();
+    const from = dayjs(startDate)
+      .locale(this.props.user.language)
+      .format('DD MMM YYYY');
+    // The end date is exclusive: display the last day included in the period
+    const to = dayjs(endDate)
+      .subtract(1, 'day')
+      .locale(this.props.user.language)
+      .format('DD MMM YYYY');
+    return `${from} - ${to}`;
   };
 
   getDatePickerView = () => {
@@ -495,7 +498,7 @@ class EnergyConsumption extends Component {
                 <div class="flex-fill mx-3">
                   <DatePicker
                     locale={localeSet}
-                    selected={this.state.selectedDate}
+                    selected={this.getPeriodStart()}
                     onChange={this.onDateChange}
                     dateFormat={this.getDateFormat()}
                     showMonthYearPicker={selectedPeriod === PERIODS.MONTH}
@@ -511,6 +514,15 @@ class EnergyConsumption extends Component {
               </div>
             </div>
           </div>
+
+          {/* Billing period range, only displayed when the period does not start on the 1st */}
+          {getPeriodStartDay(props.box) !== DEFAULT_ENERGY_PERIOD_START_DAY && selectedPeriod !== PERIODS.DAY && (
+            <div class="row mb-2">
+              <div class="col-12 text-center">
+                <small class="text-muted">{this.getPeriodRangeLabel()}</small>
+              </div>
+            </div>
+          )}
 
           {/* Display Mode Toggle */}
           <div class="row mb-3">

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -677,7 +677,9 @@
         "error": "Fehler beim Laden der Energieverbrauchsdaten",
         "noData": "Keine Energieverbrauchsdaten für diesen Zeitraum verfügbar",
         "showSubscriptionPrices": "Abonnementpreise anzeigen",
-        "showSubscriptionPricesDescription": "Zeigt die monatlichen Abonnementkosten zusammen mit den Verbrauchsdaten im Diagramm an."
+        "showSubscriptionPricesDescription": "Zeigt die monatlichen Abonnementkosten zusammen mit den Verbrauchsdaten im Diagramm an.",
+        "periodStartDay": "Starttag des Abrechnungszeitraums",
+        "periodStartDayDescription": "Tag des Monats, an dem der Abrechnungszeitraum Ihres Energieversorgers beginnt. Die Monats- und Jahresansicht laufen dann von diesem Tag bis zum gleichen Tag des nächsten Zeitraums (z. B. vom 5. bis zum 5.), damit sie mit Ihrer Rechnung verglichen werden können. Ist ein Monat kürzer als dieser Tag, beginnt der Zeitraum am letzten Tag dieses Monats."
       },
       "voice-assistant": {
         "speak": "Sprechen",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -621,7 +621,9 @@
         "error": "Error loading energy consumption data",
         "noData": "No energy consumption data available for this period",
         "showSubscriptionPrices": "Show subscription prices",
-        "showSubscriptionPricesDescription": "Display the monthly subscription cost alongside consumption data in the chart."
+        "showSubscriptionPricesDescription": "Display the monthly subscription cost alongside consumption data in the chart.",
+        "periodStartDay": "Billing period start day",
+        "periodStartDayDescription": "Day of the month your energy bill period starts on. The monthly and yearly views then run from this day to the same day of the next period (ex: from the 5th to the 5th), so they can be compared with your bill. If a month is shorter than this day, the period starts on the last day of that month."
       },
       "scene": {
         "editNameLabel": "Widget Name (optional)",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -677,7 +677,9 @@
         "error": "Erreur lors du chargement des données de consommation énergétique",
         "noData": "Aucune donnée de consommation énergétique disponible pour cette période",
         "showSubscriptionPrices": "Afficher les prix d'abonnement",
-        "showSubscriptionPricesDescription": "Affiche le coût mensuel de l'abonnement en plus des données de consommation dans le graphique."
+        "showSubscriptionPricesDescription": "Affiche le coût mensuel de l'abonnement en plus des données de consommation dans le graphique.",
+        "periodStartDay": "Jour de départ de la période de facturation",
+        "periodStartDayDescription": "Jour du mois où commence la période de facturation de votre fournisseur d'énergie. Les vues mensuelle et annuelle iront alors de ce jour au même jour de la période suivante (ex : du 5 au 5), afin de pouvoir les comparer à votre facture. Si un mois est plus court que ce jour, la période démarre le dernier jour de ce mois."
       },
       "voice-assistant": {
         "speak": "Parler",

--- a/server/lib/device/energy-sensor/energy-sensor.getConsumptionByDates.js
+++ b/server/lib/device/energy-sensor/energy-sensor.getConsumptionByDates.js
@@ -9,11 +9,7 @@ const {
   DEVICE_FEATURE_UNITS,
   ENERGY_PRICE_TYPES,
 } = require('../../../utils/constants');
-const {
-  DEFAULT_ENERGY_PERIOD_START_DAY,
-  parseEnergyPeriodStartDay,
-  getNextEnergyPeriodStart,
-} = require('../../../utils/energyPeriod');
+const { DEFAULT_ENERGY_PERIOD_START_DAY, parseEnergyPeriodStartDay } = require('../../../utils/energyPeriod');
 
 /**
  * @description Build the query grouping device feature states by a date expression.
@@ -92,6 +88,25 @@ const shouldOffsetPeriods = (groupBy, periodStartDay) =>
   periodStartDay !== DEFAULT_ENERGY_PERIOD_START_DAY && (groupBy === 'month' || groupBy === 'year');
 
 /**
+ * @description Return the start of the nth offset billing period of a date range.
+ * Periods are always derived from the start of the range, never from the previous period, so that
+ * a month shorter than the configured start day (ex: the 31st in February) does not shift all the
+ * following periods: Day.js clamps to the last day of the target month exactly like the `LEAST()`
+ * of the SQL expression. Deriving from the range start also keeps the time of day of the range
+ * start on every boundary, which is what keeps these labels aligned with the buckets returned by
+ * DuckDB: the range start is the local midnight of the billing day, and DuckDB truncates in the
+ * Gladys timezone, so both sides move together instead of being re-anchored on the timezone of the
+ * Node process.
+ * @param {object} rangeStart - Start of the date range, as a Day.js object.
+ * @param {number} periodIndex - Index of the wanted period (0 being the start of the range).
+ * @param {string} groupBy - Grouping period: 'month' or 'year'.
+ * @returns {object} Start of the period, as a Day.js object.
+ * @example
+ * getOffsetPeriodStart(dayjs('2023-01-31'), 1, 'month'); // 2023-02-28
+ */
+const getOffsetPeriodStart = (rangeStart, periodIndex, groupBy) => rangeStart.add(periodIndex, groupBy);
+
+/**
  * @description Calculate subscription prices for each time period.
  * @param {Array} subscriptionPrices - Array of subscription price entries from DB.
  * @param {Date} fromDate - Start date of the range.
@@ -110,10 +125,12 @@ function calculateSubscriptionPrices(
   periodStartDay = DEFAULT_ENERGY_PERIOD_START_DAY,
 ) {
   const subscriptionValues = [];
-  let currentDate = dayjs(fromDate);
+  const rangeStart = dayjs(fromDate);
+  let currentDate = rangeStart;
   const endDate = dayjs(toDate);
   // Monthly/yearly periods must follow the same boundaries as the consumption buckets.
   const useOffsetPeriods = shouldOffsetPeriods(groupBy, periodStartDay);
+  let periodIndex = 0;
 
   while (currentDate.isBefore(endDate)) {
     let nextDate;
@@ -134,13 +151,13 @@ function calculateSubscriptionPrices(
         break;
       case 'month':
         nextDate = useOffsetPeriods
-          ? dayjs(getNextEnergyPeriodStart(currentDate.toDate(), 'month', periodStartDay))
+          ? getOffsetPeriodStart(rangeStart, periodIndex + 1, 'month')
           : currentDate.add(1, 'month');
         periodLabel = currentDate.toISOString();
         break;
       case 'year':
         nextDate = useOffsetPeriods
-          ? dayjs(getNextEnergyPeriodStart(currentDate.toDate(), 'year', periodStartDay))
+          ? getOffsetPeriodStart(rangeStart, periodIndex + 1, 'year')
           : currentDate.add(1, 'year');
         periodLabel = currentDate.toISOString();
         break;
@@ -203,6 +220,7 @@ function calculateSubscriptionPrices(
     }
 
     currentDate = nextDate;
+    periodIndex += 1;
   }
 
   return subscriptionValues;

--- a/server/lib/device/energy-sensor/energy-sensor.getConsumptionByDates.js
+++ b/server/lib/device/energy-sensor/energy-sensor.getConsumptionByDates.js
@@ -9,10 +9,22 @@ const {
   DEVICE_FEATURE_UNITS,
   ENERGY_PRICE_TYPES,
 } = require('../../../utils/constants');
+const {
+  DEFAULT_ENERGY_PERIOD_START_DAY,
+  parseEnergyPeriodStartDay,
+  getNextEnergyPeriodStart,
+} = require('../../../utils/energyPeriod');
 
-const GROUPED_QUERY_DATE_RANGE = `
+/**
+ * @description Build the query grouping device feature states by a date expression.
+ * @param {string} dateExpression - SQL expression returning the start of the period a state belongs to.
+ * @returns {string} The SQL query.
+ * @example
+ * buildGroupedQuery('DATE_TRUNC(?, created_at)');
+ */
+const buildGroupedQuery = (dateExpression) => `
   SELECT
-    DATE_TRUNC(?, created_at) AS grouped_date,
+    ${dateExpression} AS grouped_date,
     AVG(value) AS value,
     MAX(value) AS max_value,
     MIN(value) AS min_value,
@@ -30,20 +42,78 @@ const GROUPED_QUERY_DATE_RANGE = `
     grouped_date;
 `;
 
+const GROUPED_QUERY_DATE_RANGE = buildGroupedQuery('DATE_TRUNC(?, created_at)');
+
+/**
+ * @description Build the SQL expression returning the start of the billing period a state belongs to.
+ * Periods start on `periodStartDay` at local midnight (the DuckDB session timezone is set to the
+ * Gladys system timezone). When a month is shorter than the configured start day (ex: the 31st in
+ * February), the period starts on the last day of that month.
+ * @param {string} groupBy - Grouping period: 'month' or 'year'.
+ * @param {number} periodStartDay - Day of the month the billing period starts on (2-31).
+ * @returns {string} The SQL expression.
+ * @example
+ * buildOffsetDateExpression('month', 5);
+ */
+const buildOffsetDateExpression = (groupBy, periodStartDay) => {
+  // Number of days between the first day of the month/year and the start of the period.
+  const offsetInDays = periodStartDay - 1;
+  if (groupBy === 'year') {
+    // January always has 31 days, so the start day never needs to be clamped here.
+    return `
+    CASE
+      WHEN created_at >= DATE_TRUNC('year', created_at) + TO_DAYS(${offsetInDays})
+        THEN DATE_TRUNC('year', created_at) + TO_DAYS(${offsetInDays})
+      ELSE DATE_TRUNC('year', created_at - INTERVAL 1 YEAR) + TO_DAYS(${offsetInDays})
+    END`;
+  }
+  return `
+    CASE
+      WHEN EXTRACT('day' FROM created_at) >= LEAST(${periodStartDay}, EXTRACT('day' FROM LAST_DAY(created_at)))
+        THEN DATE_TRUNC('month', created_at)
+          + TO_DAYS(CAST(LEAST(${periodStartDay}, EXTRACT('day' FROM LAST_DAY(created_at))) - 1 AS INTEGER))
+      ELSE DATE_TRUNC('month', created_at - INTERVAL 1 MONTH)
+        + TO_DAYS(
+          CAST(LEAST(${periodStartDay}, EXTRACT('day' FROM LAST_DAY(created_at - INTERVAL 1 MONTH))) - 1 AS INTEGER)
+        )
+    END`;
+};
+
+/**
+ * @description Tell if the monthly/yearly buckets must be offset to match the billing period.
+ * Hourly, daily and weekly buckets are never affected by the start day of the billing period.
+ * @param {string} groupBy - Grouping period ('hour', 'day', 'week', 'month', 'year').
+ * @param {number} periodStartDay - Day of the month the billing period starts on (1-31).
+ * @returns {boolean} True if the buckets must be offset.
+ * @example
+ * shouldOffsetPeriods('month', 5);
+ */
+const shouldOffsetPeriods = (groupBy, periodStartDay) =>
+  periodStartDay !== DEFAULT_ENERGY_PERIOD_START_DAY && (groupBy === 'month' || groupBy === 'year');
+
 /**
  * @description Calculate subscription prices for each time period.
  * @param {Array} subscriptionPrices - Array of subscription price entries from DB.
  * @param {Date} fromDate - Start date of the range.
  * @param {Date} toDate - End date of the range.
  * @param {string} groupBy - Grouping period ('hour', 'day', 'month', 'year').
+ * @param {number} [periodStartDay] - Day of the month the billing period starts on (1-31).
  * @returns {Array} Array of subscription values per period.
  * @example
  * calculateSubscriptionPrices(prices, new Date('2023-01-01'), new Date('2023-01-31'), 'day');
  */
-function calculateSubscriptionPrices(subscriptionPrices, fromDate, toDate, groupBy) {
+function calculateSubscriptionPrices(
+  subscriptionPrices,
+  fromDate,
+  toDate,
+  groupBy,
+  periodStartDay = DEFAULT_ENERGY_PERIOD_START_DAY,
+) {
   const subscriptionValues = [];
   let currentDate = dayjs(fromDate);
   const endDate = dayjs(toDate);
+  // Monthly/yearly periods must follow the same boundaries as the consumption buckets.
+  const useOffsetPeriods = shouldOffsetPeriods(groupBy, periodStartDay);
 
   while (currentDate.isBefore(endDate)) {
     let nextDate;
@@ -63,11 +133,15 @@ function calculateSubscriptionPrices(subscriptionPrices, fromDate, toDate, group
         periodLabel = currentDate.toISOString();
         break;
       case 'month':
-        nextDate = currentDate.add(1, 'month');
+        nextDate = useOffsetPeriods
+          ? dayjs(getNextEnergyPeriodStart(currentDate.toDate(), 'month', periodStartDay))
+          : currentDate.add(1, 'month');
         periodLabel = currentDate.toISOString();
         break;
       case 'year':
-        nextDate = currentDate.add(1, 'year');
+        nextDate = useOffsetPeriods
+          ? dayjs(getNextEnergyPeriodStart(currentDate.toDate(), 'year', periodStartDay))
+          : currentDate.add(1, 'year');
         periodLabel = currentDate.toISOString();
         break;
       default:
@@ -142,6 +216,7 @@ function calculateSubscriptionPrices(subscriptionPrices, fromDate, toDate, group
  * @param {Date} [options.to] - End date for date range approach.
  * @param {string} [options.group_by] - Group results by time period ('hour', 'day', 'week', 'month', 'year').
  * @param {string} [options.display_mode] - Display mode: 'currency' (default) or 'kwh'.
+ * @param {number} [options.period_start_day] - Day of the month monthly/yearly periods start on (1-31).
  * @returns {Promise<object>} - Resolve with an object containing consumption and subscription data.
  * @example
  * device.getConsumptionByDates(['test-device'], {
@@ -152,6 +227,11 @@ function calculateSubscriptionPrices(subscriptionPrices, fromDate, toDate, group
  */
 async function getConsumptionByDates(selectors, options = {}) {
   const { display_mode: displayMode = 'currency' } = options;
+
+  const periodStartDay = parseEnergyPeriodStartDay(options.period_start_day);
+  if (periodStartDay === null) {
+    throw new BadParameters('"period_start_day" must be an integer between 1 and 31');
+  }
 
   const consumptionResults = await Promise.map(
     selectors,
@@ -208,13 +288,23 @@ async function getConsumptionByDates(selectors, options = {}) {
         throw new BadParameters(`Invalid groupBy parameter. Must be one of: ${validGroupByOptions.join(', ')}`);
       }
 
-      values = await db.duckDbReadConnectionAllAsync(
-        GROUPED_QUERY_DATE_RANGE,
-        groupBy,
-        deviceFeature.id,
-        fromDate,
-        toDate,
-      );
+      if (shouldOffsetPeriods(groupBy, periodStartDay)) {
+        // The billing period does not start on the 1st: group on offset month/year boundaries.
+        values = await db.duckDbReadConnectionAllAsync(
+          buildGroupedQuery(buildOffsetDateExpression(groupBy, periodStartDay)),
+          deviceFeature.id,
+          fromDate,
+          toDate,
+        );
+      } else {
+        values = await db.duckDbReadConnectionAllAsync(
+          GROUPED_QUERY_DATE_RANGE,
+          groupBy,
+          deviceFeature.id,
+          fromDate,
+          toDate,
+        );
+      }
 
       // Check if we need to convert from Wh to kWh (when display_mode is 'kwh' and unit is WATT_HOUR)
       const needsWhToKwhConversion = displayMode === 'kwh' && deviceFeature.unit === DEVICE_FEATURE_UNITS.WATT_HOUR;
@@ -276,7 +366,13 @@ async function getConsumptionByDates(selectors, options = {}) {
         const { from, to, group_by: groupBy = 'day' } = options;
         const fromDate = new Date(from);
         const toDate = new Date(to);
-        let subscriptionValues = calculateSubscriptionPrices(subscriptionPrices, fromDate, toDate, groupBy);
+        let subscriptionValues = calculateSubscriptionPrices(
+          subscriptionPrices,
+          fromDate,
+          toDate,
+          groupBy,
+          periodStartDay,
+        );
 
         // Filter subscription values to only include dates within the range of actual consumption data
         // This prevents showing subscription prices for future dates or dates without data
@@ -322,4 +418,6 @@ async function getConsumptionByDates(selectors, options = {}) {
 module.exports = {
   getConsumptionByDates,
   calculateSubscriptionPrices,
+  buildOffsetDateExpression,
+  shouldOffsetPeriods,
 };

--- a/server/models/dashboard.js
+++ b/server/models/dashboard.js
@@ -48,6 +48,10 @@ const boxesSchema = Joi.array().items(
       gauge_color_high: Joi.string(),
       colors: Joi.array().items(Joi.string()),
       show_subscription_prices: Joi.boolean(),
+      period_start_day: Joi.number()
+        .integer()
+        .min(1)
+        .max(31),
       url: Joi.string().uri({ scheme: ['http', 'https'] }),
       icon: Joi.string(),
       photos: Joi.array()

--- a/server/test/lib/dashboard/dashboard.update.test.js
+++ b/server/test/lib/dashboard/dashboard.update.test.js
@@ -58,6 +58,21 @@ describe('dashboard.update', () => {
     expect(updatedDashboard.boxes[1][0]).to.have.property('provider', '');
   });
 
+  it('should save an energy consumption box carrying a billing period start day', async () => {
+    const updatedDashboard = await dashboard.update('0cd30aef-9c4e-4a23-88e3-3547971296e5', 'test-dashboard', {
+      boxes: [
+        [
+          {
+            type: DASHBOARD_BOX_TYPE.ENERGY_CONSUMPTION,
+            device_features: ['test-device-feature'],
+            period_start_day: 5,
+          },
+        ],
+      ],
+    });
+    expect(updatedDashboard.boxes[0][0]).to.have.property('period_start_day', 5);
+  });
+
   it('should return not found', async () => {
     const promise = dashboard.update('0cd30aef-9c4e-4a23-88e3-3547971296e5', 'not-found-dashboard', {
       name: 'new name',

--- a/server/test/lib/device/energy-sensor/energy-sensor.getConsumptionByDates.test.js
+++ b/server/test/lib/device/energy-sensor/energy-sensor.getConsumptionByDates.test.js
@@ -2128,6 +2128,116 @@ describe('EnergySensorManager.getConsumptionByDates', function Describe() {
           '2023-02-01T00:00:00.000Z',
         ]);
       });
+
+      describe('in a non-UTC timezone', () => {
+        // DuckDB truncates in the Gladys timezone, and the date range starts at the local midnight
+        // of the billing day: the subscription boundaries must stay on that local midnight instead
+        // of being re-anchored on the timezone of the Node process.
+        const TIMEZONE = 'Europe/Paris';
+        const originalTimezone = process.env.TZ;
+
+        const localMidnight = (date) => dayjs.tz(date, TIMEZONE).toDate();
+        const inLocalTimezone = (values) =>
+          values.map((value) =>
+            dayjs(value.created_at)
+              .tz(TIMEZONE)
+              .format('YYYY-MM-DD HH:mm'),
+          );
+
+        before(() => {
+          process.env.TZ = TIMEZONE;
+        });
+
+        after(() => {
+          process.env.TZ = originalTimezone;
+        });
+
+        it('should return exactly 12 monthly periods over a year, on the billing day', () => {
+          const result = calculateSubscriptionPrices(
+            subscriptionPrices,
+            localMidnight('2023-01-05'),
+            localMidnight('2024-01-05'),
+            'month',
+            5,
+          );
+
+          expect(inLocalTimezone(result)).to.deep.equal([
+            '2023-01-05 00:00',
+            '2023-02-05 00:00',
+            '2023-03-05 00:00',
+            '2023-04-05 00:00',
+            '2023-05-05 00:00',
+            '2023-06-05 00:00',
+            '2023-07-05 00:00',
+            '2023-08-05 00:00',
+            '2023-09-05 00:00',
+            '2023-10-05 00:00',
+            '2023-11-05 00:00',
+            '2023-12-05 00:00',
+          ]);
+        });
+
+        it('should not shift the following periods when a month is too short', () => {
+          const result = calculateSubscriptionPrices(
+            subscriptionPrices,
+            localMidnight('2023-01-31'),
+            localMidnight('2023-05-31'),
+            'month',
+            31,
+          );
+
+          expect(inLocalTimezone(result)).to.deep.equal([
+            '2023-01-31 00:00',
+            '2023-02-28 00:00',
+            '2023-03-31 00:00',
+            '2023-04-30 00:00',
+          ]);
+        });
+
+        it('should follow the offset yearly periods', () => {
+          const result = calculateSubscriptionPrices(
+            subscriptionPrices,
+            localMidnight('2023-01-05'),
+            localMidnight('2025-01-05'),
+            'year',
+            5,
+          );
+
+          expect(inLocalTimezone(result)).to.deep.equal(['2023-01-05 00:00', '2024-01-05 00:00']);
+        });
+
+        it('should keep calendar months when the start day is 1', () => {
+          const result = calculateSubscriptionPrices(
+            subscriptionPrices,
+            localMidnight('2023-01-01'),
+            localMidnight('2023-05-01'),
+            'month',
+          );
+
+          expect(inLocalTimezone(result)).to.deep.equal([
+            '2023-01-01 00:00',
+            '2023-02-01 00:00',
+            '2023-03-01 00:00',
+            '2023-04-01 00:00',
+          ]);
+        });
+
+        it('should still return 12 monthly periods when the range is not on the process midnight', () => {
+          // The Gladys timezone (the one DuckDB truncates in, and the one the date range is built
+          // in) is not always the timezone of the Node process: the boundaries must stay relative
+          // to the start of the range instead of being snapped to the midnight of the process.
+          const rangeStart = new Date('2023-01-05T00:00:00.000Z');
+          const rangeEnd = new Date('2024-01-05T00:00:00.000Z');
+
+          const result = calculateSubscriptionPrices(subscriptionPrices, rangeStart, rangeEnd, 'month', 5);
+
+          const timestamps = result.map((value) => new Date(value.created_at).getTime());
+          expect(timestamps).to.have.lengthOf(12);
+          expect(timestamps).to.deep.equal([...timestamps].sort((a, b) => a - b));
+          expect(timestamps[0]).to.equal(rangeStart.getTime());
+          expect(timestamps[timestamps.length - 1]).to.be.below(rangeEnd.getTime());
+        });
+      });
     });
   });
 });

--- a/server/test/lib/device/energy-sensor/energy-sensor.getConsumptionByDates.test.js
+++ b/server/test/lib/device/energy-sensor/energy-sensor.getConsumptionByDates.test.js
@@ -11,6 +11,8 @@ const db = require('../../../../models');
 const EnergySensorManager = require('../../../../lib/device/energy-sensor');
 const {
   calculateSubscriptionPrices,
+  buildOffsetDateExpression,
+  shouldOffsetPeriods,
 } = require('../../../../lib/device/energy-sensor/energy-sensor.getConsumptionByDates');
 
 // Extend Day.js with plugins
@@ -1833,6 +1835,299 @@ describe('EnergySensorManager.getConsumptionByDates', function Describe() {
       const expectedDailyPrice = 15 / 31;
       expect(result[0].sum_value).to.be.closeTo(expectedDailyPrice, 0.001);
       expect(result[0].contract_name).to.equal('Test Contract');
+    });
+  });
+
+  describe('Billing period start day', () => {
+    const DEVICE_FEATURE_ID = 'ca91dfdf-55b2-4cf8-a58b-99c0fbf6f5e7';
+
+    const buildStateManager = () => ({
+      get: fake((type) => {
+        if (type === 'deviceFeature') {
+          return {
+            id: DEVICE_FEATURE_ID,
+            name: 'Energy Consumption',
+            device_id: 'device-1',
+          };
+        }
+        if (type === 'deviceById') {
+          return {
+            name: 'Smart Meter',
+          };
+        }
+        return null;
+      }),
+    });
+
+    const insertStatesAtDates = async (dates) => {
+      await db.duckDbBatchInsertState(
+        DEVICE_FEATURE_ID,
+        dates.map((date) => ({ value: 1, created_at: new Date(date) })),
+      );
+    };
+
+    // The tests run with the process timezone (UTC in CI), which is also the
+    // DuckDB session timezone: period boundaries are at midnight UTC.
+    const bucketDates = (values) => values.map((value) => new Date(value.created_at).toISOString());
+
+    it('should group months on the billing start day', async () => {
+      await insertStatesAtDates([
+        '2023-01-05T00:00:00.000Z',
+        '2023-01-20T10:00:00.000Z',
+        '2023-02-04T23:00:00.000Z',
+        '2023-02-05T00:00:00.000Z',
+        '2023-03-01T10:00:00.000Z',
+      ]);
+
+      const energySensorManager = new EnergySensorManager(buildStateManager());
+
+      const results = await energySensorManager.getConsumptionByDates(['test-device-feature'], {
+        from: new Date('2023-01-05T00:00:00.000Z'),
+        to: new Date('2023-03-05T00:00:00.000Z'),
+        group_by: 'month',
+        display_mode: 'kwh',
+        period_start_day: 5,
+      });
+
+      expect(bucketDates(results[0].values)).to.deep.equal(['2023-01-05T00:00:00.000Z', '2023-02-05T00:00:00.000Z']);
+      // 5th of January, 20th of January and 4th of February are in the first period
+      expect(results[0].values[0].count_value).to.equal(3);
+      expect(results[0].values[1].count_value).to.equal(2);
+    });
+
+    it('should keep calendar months when the start day is 1', async () => {
+      await insertStatesAtDates([
+        '2023-01-05T00:00:00.000Z',
+        '2023-01-20T10:00:00.000Z',
+        '2023-02-04T23:00:00.000Z',
+        '2023-02-05T00:00:00.000Z',
+      ]);
+
+      const energySensorManager = new EnergySensorManager(buildStateManager());
+
+      const results = await energySensorManager.getConsumptionByDates(['test-device-feature'], {
+        from: new Date('2023-01-01T00:00:00.000Z'),
+        to: new Date('2023-03-01T00:00:00.000Z'),
+        group_by: 'month',
+        display_mode: 'kwh',
+        period_start_day: 1,
+      });
+
+      expect(bucketDates(results[0].values)).to.deep.equal(['2023-01-01T00:00:00.000Z', '2023-02-01T00:00:00.000Z']);
+      expect(results[0].values[0].count_value).to.equal(2);
+      expect(results[0].values[1].count_value).to.equal(2);
+    });
+
+    it('should start the period on the last day of the month when the month is too short', async () => {
+      await insertStatesAtDates([
+        '2023-01-31T00:00:00.000Z',
+        '2023-02-27T10:00:00.000Z',
+        '2023-02-28T00:00:00.000Z',
+        '2023-03-30T10:00:00.000Z',
+      ]);
+
+      const energySensorManager = new EnergySensorManager(buildStateManager());
+
+      const results = await energySensorManager.getConsumptionByDates(['test-device-feature'], {
+        from: new Date('2023-01-31T00:00:00.000Z'),
+        to: new Date('2023-03-31T00:00:00.000Z'),
+        group_by: 'month',
+        display_mode: 'kwh',
+        period_start_day: 31,
+      });
+
+      // February 2023 has 28 days: the period starts on the 28th
+      expect(bucketDates(results[0].values)).to.deep.equal(['2023-01-31T00:00:00.000Z', '2023-02-28T00:00:00.000Z']);
+      expect(results[0].values[0].count_value).to.equal(2);
+      expect(results[0].values[1].count_value).to.equal(2);
+    });
+
+    it('should start the period on the 29th of February on a leap year', async () => {
+      await insertStatesAtDates([
+        '2024-01-31T00:00:00.000Z',
+        '2024-02-28T10:00:00.000Z',
+        '2024-02-29T00:00:00.000Z',
+        '2024-03-15T10:00:00.000Z',
+      ]);
+
+      const energySensorManager = new EnergySensorManager(buildStateManager());
+
+      const results = await energySensorManager.getConsumptionByDates(['test-device-feature'], {
+        from: new Date('2024-01-31T00:00:00.000Z'),
+        to: new Date('2024-03-31T00:00:00.000Z'),
+        group_by: 'month',
+        display_mode: 'kwh',
+        period_start_day: 31,
+      });
+
+      expect(bucketDates(results[0].values)).to.deep.equal(['2024-01-31T00:00:00.000Z', '2024-02-29T00:00:00.000Z']);
+      expect(results[0].values[0].count_value).to.equal(2);
+      expect(results[0].values[1].count_value).to.equal(2);
+    });
+
+    it('should group years on the billing start day', async () => {
+      await insertStatesAtDates([
+        '2023-01-05T00:00:00.000Z',
+        '2023-06-15T10:00:00.000Z',
+        '2024-01-04T23:00:00.000Z',
+        '2024-01-05T00:00:00.000Z',
+        '2024-06-15T10:00:00.000Z',
+      ]);
+
+      const energySensorManager = new EnergySensorManager(buildStateManager());
+
+      const results = await energySensorManager.getConsumptionByDates(['test-device-feature'], {
+        from: new Date('2023-01-05T00:00:00.000Z'),
+        to: new Date('2025-01-05T00:00:00.000Z'),
+        group_by: 'year',
+        display_mode: 'kwh',
+        period_start_day: 5,
+      });
+
+      expect(bucketDates(results[0].values)).to.deep.equal(['2023-01-05T00:00:00.000Z', '2024-01-05T00:00:00.000Z']);
+      // 5th of January 2023, 15th of June 2023 and 4th of January 2024 are in the first period
+      expect(results[0].values[0].count_value).to.equal(3);
+      expect(results[0].values[1].count_value).to.equal(2);
+    });
+
+    it('should not change daily buckets', async () => {
+      await insertStatesAtDates(['2023-01-05T00:00:00.000Z', '2023-01-05T10:00:00.000Z', '2023-01-06T10:00:00.000Z']);
+
+      const energySensorManager = new EnergySensorManager(buildStateManager());
+
+      const results = await energySensorManager.getConsumptionByDates(['test-device-feature'], {
+        from: new Date('2023-01-05T00:00:00.000Z'),
+        to: new Date('2023-01-07T00:00:00.000Z'),
+        group_by: 'day',
+        display_mode: 'kwh',
+        period_start_day: 5,
+      });
+
+      expect(bucketDates(results[0].values)).to.deep.equal(['2023-01-05T00:00:00.000Z', '2023-01-06T00:00:00.000Z']);
+    });
+
+    it('should throw an error when the start day is not a valid day of month', async () => {
+      const energySensorManager = new EnergySensorManager(buildStateManager());
+
+      const promise = energySensorManager.getConsumptionByDates(['test-device-feature'], {
+        from: new Date('2023-01-05T00:00:00.000Z'),
+        to: new Date('2023-02-05T00:00:00.000Z'),
+        group_by: 'month',
+        period_start_day: 32,
+      });
+
+      return assert.isRejected(promise, '"period_start_day" must be an integer between 1 and 31');
+    });
+
+    it('should throw an error when the start day is not a number', async () => {
+      const energySensorManager = new EnergySensorManager(buildStateManager());
+
+      const promise = energySensorManager.getConsumptionByDates(['test-device-feature'], {
+        from: new Date('2023-01-05T00:00:00.000Z'),
+        to: new Date('2023-02-05T00:00:00.000Z'),
+        group_by: 'month',
+        period_start_day: 'not-a-day',
+      });
+
+      return assert.isRejected(promise, '"period_start_day" must be an integer between 1 and 31');
+    });
+
+    describe('shouldOffsetPeriods', () => {
+      it('should not offset when the start day is the 1st', () => {
+        expect(shouldOffsetPeriods('month', 1)).to.equal(false);
+        expect(shouldOffsetPeriods('year', 1)).to.equal(false);
+      });
+      it('should not offset hourly, daily and weekly buckets', () => {
+        expect(shouldOffsetPeriods('hour', 5)).to.equal(false);
+        expect(shouldOffsetPeriods('day', 5)).to.equal(false);
+        expect(shouldOffsetPeriods('week', 5)).to.equal(false);
+        expect(shouldOffsetPeriods(null, 5)).to.equal(false);
+      });
+      it('should offset monthly and yearly buckets', () => {
+        expect(shouldOffsetPeriods('month', 5)).to.equal(true);
+        expect(shouldOffsetPeriods('year', 5)).to.equal(true);
+      });
+    });
+
+    describe('buildOffsetDateExpression', () => {
+      it('should build a yearly expression', () => {
+        expect(buildOffsetDateExpression('year', 5)).to.contain("DATE_TRUNC('year', created_at)");
+        expect(buildOffsetDateExpression('year', 5)).to.contain('TO_DAYS(4)');
+      });
+      it('should build a monthly expression', () => {
+        expect(buildOffsetDateExpression('month', 5)).to.contain("DATE_TRUNC('month', created_at)");
+        expect(buildOffsetDateExpression('month', 5)).to.contain('LEAST(5,');
+      });
+    });
+
+    describe('subscription prices', () => {
+      const subscriptionPrices = [
+        {
+          price: 150000, // 15€/month
+          start_date: '2023-01-01',
+          end_date: null,
+          contract_name: 'Test Contract',
+        },
+      ];
+
+      it('should follow the offset monthly periods', () => {
+        const result = calculateSubscriptionPrices(
+          subscriptionPrices,
+          new Date('2023-01-05T00:00:00.000Z'),
+          new Date('2023-03-05T00:00:00.000Z'),
+          'month',
+          5,
+        );
+
+        expect(result.map((value) => value.created_at)).to.deep.equal([
+          '2023-01-05T00:00:00.000Z',
+          '2023-02-05T00:00:00.000Z',
+        ]);
+      });
+
+      it('should follow the offset monthly periods when a month is too short', () => {
+        const result = calculateSubscriptionPrices(
+          subscriptionPrices,
+          new Date('2023-01-31T00:00:00.000Z'),
+          new Date('2023-03-31T00:00:00.000Z'),
+          'month',
+          31,
+        );
+
+        expect(result.map((value) => value.created_at)).to.deep.equal([
+          '2023-01-31T00:00:00.000Z',
+          '2023-02-28T00:00:00.000Z',
+        ]);
+      });
+
+      it('should follow the offset yearly periods', () => {
+        const result = calculateSubscriptionPrices(
+          subscriptionPrices,
+          new Date('2023-01-05T00:00:00.000Z'),
+          new Date('2025-01-05T00:00:00.000Z'),
+          'year',
+          5,
+        );
+
+        expect(result.map((value) => value.created_at)).to.deep.equal([
+          '2023-01-05T00:00:00.000Z',
+          '2024-01-05T00:00:00.000Z',
+        ]);
+      });
+
+      it('should keep calendar months when the start day is 1', () => {
+        const result = calculateSubscriptionPrices(
+          subscriptionPrices,
+          new Date('2023-01-01T00:00:00.000Z'),
+          new Date('2023-03-01T00:00:00.000Z'),
+          'month',
+        );
+
+        expect(result.map((value) => value.created_at)).to.deep.equal([
+          '2023-01-01T00:00:00.000Z',
+          '2023-02-01T00:00:00.000Z',
+        ]);
+      });
     });
   });
 });

--- a/server/test/lib/device/energy-sensor/energy-sensor.getConsumptionByDates.test.js
+++ b/server/test/lib/device/energy-sensor/energy-sensor.getConsumptionByDates.test.js
@@ -2149,7 +2149,13 @@ describe('EnergySensorManager.getConsumptionByDates', function Describe() {
         });
 
         after(() => {
-          process.env.TZ = originalTimezone;
+          // TZ is often unset in CI: assigning undefined would store the string 'undefined'
+          // and leave the rest of the run in UTC.
+          if (originalTimezone === undefined) {
+            delete process.env.TZ;
+          } else {
+            process.env.TZ = originalTimezone;
+          }
         });
 
         it('should return exactly 12 monthly periods over a year, on the billing day', () => {

--- a/server/test/utils/energyPeriod.test.js
+++ b/server/test/utils/energyPeriod.test.js
@@ -1,0 +1,265 @@
+const { expect } = require('chai');
+
+const {
+  ENERGY_PERIODS,
+  DEFAULT_ENERGY_PERIOD_START_DAY,
+  MIN_ENERGY_PERIOD_START_DAY,
+  MAX_ENERGY_PERIOD_START_DAY,
+  getDaysInMonth,
+  getPeriodStartDayInMonth,
+  parseEnergyPeriodStartDay,
+  getEnergyPeriodStartInCalendarUnit,
+  getEnergyPeriodStart,
+  getNextEnergyPeriodStart,
+  getPreviousEnergyPeriodStart,
+} = require('../../utils/energyPeriod');
+
+// Local date, without any timezone conversion: the widget and the DuckDB
+// buckets both work on local midnights.
+const localDate = (year, monthIndex, day) => new Date(year, monthIndex, day, 0, 0, 0, 0);
+
+describe('utils/energyPeriod', () => {
+  describe('constants', () => {
+    it('should expose the default and the boundaries of the start day', () => {
+      expect(DEFAULT_ENERGY_PERIOD_START_DAY).to.equal(1);
+      expect(MIN_ENERGY_PERIOD_START_DAY).to.equal(1);
+      expect(MAX_ENERGY_PERIOD_START_DAY).to.equal(31);
+      expect(ENERGY_PERIODS).to.deep.equal({ DAY: 'day', MONTH: 'month', YEAR: 'year' });
+    });
+  });
+
+  describe('getDaysInMonth', () => {
+    it('should return the number of days of a 31 days month', () => {
+      expect(getDaysInMonth(2023, 0)).to.equal(31);
+    });
+    it('should return the number of days of a 30 days month', () => {
+      expect(getDaysInMonth(2023, 3)).to.equal(30);
+    });
+    it('should return 28 days in February on a non leap year', () => {
+      expect(getDaysInMonth(2023, 1)).to.equal(28);
+    });
+    it('should return 29 days in February on a leap year', () => {
+      expect(getDaysInMonth(2024, 1)).to.equal(29);
+    });
+    it('should roll over to December of the previous year', () => {
+      expect(getDaysInMonth(2023, -1)).to.equal(31);
+    });
+    it('should roll over to January of the next year', () => {
+      expect(getDaysInMonth(2023, 12)).to.equal(31);
+    });
+  });
+
+  describe('getPeriodStartDayInMonth', () => {
+    it('should return the start day when the month is long enough', () => {
+      expect(getPeriodStartDayInMonth(2023, 0, 5)).to.equal(5);
+    });
+    it('should clamp the start day to the last day of February', () => {
+      expect(getPeriodStartDayInMonth(2023, 1, 31)).to.equal(28);
+    });
+    it('should clamp the start day to the last day of February on a leap year', () => {
+      expect(getPeriodStartDayInMonth(2024, 1, 31)).to.equal(29);
+    });
+    it('should clamp the start day to the last day of a 30 days month', () => {
+      expect(getPeriodStartDayInMonth(2023, 3, 31)).to.equal(30);
+    });
+  });
+
+  describe('parseEnergyPeriodStartDay', () => {
+    it('should default to 1 when undefined', () => {
+      expect(parseEnergyPeriodStartDay(undefined)).to.equal(1);
+    });
+    it('should default to 1 when null', () => {
+      expect(parseEnergyPeriodStartDay(null)).to.equal(1);
+    });
+    it('should default to 1 when empty string', () => {
+      expect(parseEnergyPeriodStartDay('')).to.equal(1);
+    });
+    it('should parse a number', () => {
+      expect(parseEnergyPeriodStartDay(5)).to.equal(5);
+    });
+    it('should parse a string coming from an HTTP query', () => {
+      expect(parseEnergyPeriodStartDay('31')).to.equal(31);
+    });
+    it('should return null when not a number', () => {
+      expect(parseEnergyPeriodStartDay('not-a-number')).to.equal(null);
+    });
+    it('should return null when not an integer', () => {
+      expect(parseEnergyPeriodStartDay(5.5)).to.equal(null);
+    });
+    it('should return null when too small', () => {
+      expect(parseEnergyPeriodStartDay(0)).to.equal(null);
+    });
+    it('should return null when too big', () => {
+      expect(parseEnergyPeriodStartDay(32)).to.equal(null);
+    });
+  });
+
+  describe('getEnergyPeriodStartInCalendarUnit', () => {
+    it('should return the start of the period beginning in this month', () => {
+      expect(getEnergyPeriodStartInCalendarUnit(localDate(2023, 2, 1), 'month', 5)).to.deep.equal(
+        localDate(2023, 2, 5),
+      );
+    });
+    it('should clamp the start day in February', () => {
+      expect(getEnergyPeriodStartInCalendarUnit(localDate(2023, 1, 1), 'month', 31)).to.deep.equal(
+        localDate(2023, 1, 28),
+      );
+    });
+    it('should return the start of the period beginning in this year', () => {
+      expect(getEnergyPeriodStartInCalendarUnit(localDate(2023, 6, 20), 'year', 5)).to.deep.equal(
+        localDate(2023, 0, 5),
+      );
+    });
+    it('should return the day at midnight for a day period', () => {
+      expect(getEnergyPeriodStartInCalendarUnit(new Date(2023, 6, 20, 15, 32, 12), 'day', 5)).to.deep.equal(
+        localDate(2023, 6, 20),
+      );
+    });
+    it('should default to a start day of 1', () => {
+      expect(getEnergyPeriodStartInCalendarUnit(localDate(2023, 2, 18), 'month')).to.deep.equal(localDate(2023, 2, 1));
+    });
+  });
+
+  describe('getEnergyPeriodStart', () => {
+    it('should keep the calendar month when the start day is 1', () => {
+      expect(getEnergyPeriodStart(localDate(2023, 2, 18), 'month', 1)).to.deep.equal(localDate(2023, 2, 1));
+    });
+    it('should keep the calendar year when the start day is 1', () => {
+      expect(getEnergyPeriodStart(localDate(2023, 2, 18), 'year', 1)).to.deep.equal(localDate(2023, 0, 1));
+    });
+    it('should return the current month period when the date is after the start day', () => {
+      expect(getEnergyPeriodStart(localDate(2023, 2, 18), 'month', 5)).to.deep.equal(localDate(2023, 2, 5));
+    });
+    it('should return the current month period when the date is exactly the start day', () => {
+      expect(getEnergyPeriodStart(localDate(2023, 2, 5), 'month', 5)).to.deep.equal(localDate(2023, 2, 5));
+    });
+    it('should return the previous month period when the date is before the start day', () => {
+      expect(getEnergyPeriodStart(localDate(2023, 2, 4), 'month', 5)).to.deep.equal(localDate(2023, 1, 5));
+    });
+    it('should cross the year boundary backward', () => {
+      expect(getEnergyPeriodStart(localDate(2023, 0, 2), 'month', 5)).to.deep.equal(localDate(2022, 11, 5));
+    });
+    it('should clamp the start day on February for a start day of 31', () => {
+      expect(getEnergyPeriodStart(localDate(2023, 1, 28), 'month', 31)).to.deep.equal(localDate(2023, 1, 28));
+    });
+    it('should return the January period on the 27th of February with a start day of 31', () => {
+      expect(getEnergyPeriodStart(localDate(2023, 1, 27), 'month', 31)).to.deep.equal(localDate(2023, 0, 31));
+    });
+    it('should clamp the start day on February of a leap year', () => {
+      expect(getEnergyPeriodStart(localDate(2024, 1, 29), 'month', 30)).to.deep.equal(localDate(2024, 1, 29));
+    });
+    it('should return the current year period when the date is after the start day', () => {
+      expect(getEnergyPeriodStart(localDate(2023, 5, 18), 'year', 5)).to.deep.equal(localDate(2023, 0, 5));
+    });
+    it('should return the previous year period when the date is before the start day', () => {
+      expect(getEnergyPeriodStart(localDate(2023, 0, 4), 'year', 5)).to.deep.equal(localDate(2022, 0, 5));
+    });
+    it('should return the day at midnight for a day period', () => {
+      expect(getEnergyPeriodStart(new Date(2023, 6, 20, 15, 32, 12), 'day', 5)).to.deep.equal(localDate(2023, 6, 20));
+    });
+    it('should be idempotent on a period start', () => {
+      const periodStart = getEnergyPeriodStart(localDate(2023, 1, 10), 'month', 31);
+      expect(getEnergyPeriodStart(periodStart, 'month', 31)).to.deep.equal(periodStart);
+    });
+  });
+
+  describe('getNextEnergyPeriodStart', () => {
+    it('should return the next calendar month when the start day is 1', () => {
+      expect(getNextEnergyPeriodStart(localDate(2023, 2, 1), 'month', 1)).to.deep.equal(localDate(2023, 3, 1));
+    });
+    it('should return the next offset month', () => {
+      expect(getNextEnergyPeriodStart(localDate(2023, 2, 5), 'month', 5)).to.deep.equal(localDate(2023, 3, 5));
+    });
+    it('should cross the year boundary forward', () => {
+      expect(getNextEnergyPeriodStart(localDate(2023, 11, 5), 'month', 5)).to.deep.equal(localDate(2024, 0, 5));
+    });
+    it('should clamp the next month start day in February', () => {
+      expect(getNextEnergyPeriodStart(localDate(2023, 0, 31), 'month', 31)).to.deep.equal(localDate(2023, 1, 28));
+    });
+    it('should go back to the 31st after a clamped February', () => {
+      expect(getNextEnergyPeriodStart(localDate(2023, 1, 28), 'month', 31)).to.deep.equal(localDate(2023, 2, 31));
+    });
+    it('should return the next year', () => {
+      expect(getNextEnergyPeriodStart(localDate(2023, 0, 5), 'year', 5)).to.deep.equal(localDate(2024, 0, 5));
+    });
+    it('should return the next day', () => {
+      expect(getNextEnergyPeriodStart(localDate(2023, 0, 31), 'day', 5)).to.deep.equal(localDate(2023, 1, 1));
+    });
+    it('should default to a start day of 1', () => {
+      expect(getNextEnergyPeriodStart(localDate(2023, 2, 1), 'month')).to.deep.equal(localDate(2023, 3, 1));
+    });
+  });
+
+  describe('getPreviousEnergyPeriodStart', () => {
+    it('should return the previous calendar month when the start day is 1', () => {
+      expect(getPreviousEnergyPeriodStart(localDate(2023, 2, 1), 'month', 1)).to.deep.equal(localDate(2023, 1, 1));
+    });
+    it('should return the previous offset month', () => {
+      expect(getPreviousEnergyPeriodStart(localDate(2023, 2, 5), 'month', 5)).to.deep.equal(localDate(2023, 1, 5));
+    });
+    it('should cross the year boundary backward', () => {
+      expect(getPreviousEnergyPeriodStart(localDate(2023, 0, 5), 'month', 5)).to.deep.equal(localDate(2022, 11, 5));
+    });
+    it('should clamp the previous month start day in February', () => {
+      expect(getPreviousEnergyPeriodStart(localDate(2023, 2, 31), 'month', 31)).to.deep.equal(localDate(2023, 1, 28));
+    });
+    it('should return the previous year', () => {
+      expect(getPreviousEnergyPeriodStart(localDate(2023, 0, 5), 'year', 5)).to.deep.equal(localDate(2022, 0, 5));
+    });
+    it('should return the previous day', () => {
+      expect(getPreviousEnergyPeriodStart(localDate(2023, 1, 1), 'day', 5)).to.deep.equal(localDate(2023, 0, 31));
+    });
+    it('should default to a start day of 1', () => {
+      expect(getPreviousEnergyPeriodStart(localDate(2023, 2, 1), 'month')).to.deep.equal(localDate(2023, 1, 1));
+    });
+  });
+
+  describe('period continuity', () => {
+    it('should chain months without any gap or overlap for every start day', () => {
+      for (let startDay = 1; startDay <= 31; startDay += 1) {
+        let periodStart = getEnergyPeriodStart(localDate(2023, 0, 15), 'month', startDay);
+        // Walk two full years, including a leap year
+        for (let i = 0; i < 24; i += 1) {
+          const nextPeriodStart = getNextEnergyPeriodStart(periodStart, 'month', startDay);
+          expect(nextPeriodStart.getTime()).to.be.above(periodStart.getTime());
+          // The last millisecond of the period belongs to the period
+          const lastInstant = new Date(nextPeriodStart.getTime() - 1);
+          expect(getEnergyPeriodStart(lastInstant, 'month', startDay)).to.deep.equal(periodStart);
+          // The first millisecond of the next period belongs to the next period
+          expect(getEnergyPeriodStart(nextPeriodStart, 'month', startDay)).to.deep.equal(nextPeriodStart);
+          // Going back returns to the previous period
+          expect(getPreviousEnergyPeriodStart(nextPeriodStart, 'month', startDay)).to.deep.equal(periodStart);
+          periodStart = nextPeriodStart;
+        }
+      }
+    });
+
+    it('should chain years without any gap or overlap for every start day', () => {
+      for (let startDay = 1; startDay <= 31; startDay += 1) {
+        let periodStart = getEnergyPeriodStart(localDate(2022, 5, 15), 'year', startDay);
+        for (let i = 0; i < 4; i += 1) {
+          const nextPeriodStart = getNextEnergyPeriodStart(periodStart, 'year', startDay);
+          const lastInstant = new Date(nextPeriodStart.getTime() - 1);
+          expect(getEnergyPeriodStart(lastInstant, 'year', startDay)).to.deep.equal(periodStart);
+          expect(getEnergyPeriodStart(nextPeriodStart, 'year', startDay)).to.deep.equal(nextPeriodStart);
+          expect(getPreviousEnergyPeriodStart(nextPeriodStart, 'year', startDay)).to.deep.equal(periodStart);
+          periodStart = nextPeriodStart;
+        }
+      }
+    });
+
+    it('should always start a period at local midnight, even across DST changes', () => {
+      // Europe/Paris switches to summer time on the 26th of March 2023
+      for (let startDay = 1; startDay <= 31; startDay += 1) {
+        let periodStart = getEnergyPeriodStart(localDate(2023, 0, 15), 'month', startDay);
+        for (let i = 0; i < 12; i += 1) {
+          expect(periodStart.getHours()).to.equal(0);
+          expect(periodStart.getMinutes()).to.equal(0);
+          expect(periodStart.getSeconds()).to.equal(0);
+          expect(periodStart.getMilliseconds()).to.equal(0);
+          periodStart = getNextEnergyPeriodStart(periodStart, 'month', startDay);
+        }
+      }
+    });
+  });
+});

--- a/server/utils/energyPeriod.js
+++ b/server/utils/energyPeriod.js
@@ -1,0 +1,172 @@
+const ENERGY_PERIODS = {
+  DAY: 'day',
+  MONTH: 'month',
+  YEAR: 'year',
+};
+
+const DEFAULT_ENERGY_PERIOD_START_DAY = 1;
+const MIN_ENERGY_PERIOD_START_DAY = 1;
+const MAX_ENERGY_PERIOD_START_DAY = 31;
+
+/**
+ * @description Return the number of days of a month.
+ * The month index follows the JavaScript convention (0 = January), and values
+ * outside of [0, 11] roll over to the previous/next year.
+ * @param {number} year - Full year.
+ * @param {number} monthIndex - Month index (0 = January).
+ * @returns {number} Number of days in this month.
+ * @example
+ * getDaysInMonth(2024, 1); // 29
+ */
+function getDaysInMonth(year, monthIndex) {
+  return new Date(year, monthIndex + 1, 0).getDate();
+}
+
+/**
+ * @description Return the day of the month a billing period starts on for a given month.
+ * Months are 28 to 31 days long: when the configured start day does not exist in
+ * this month (ex: the 31st in February), the period starts on the last day of the month.
+ * @param {number} year - Full year.
+ * @param {number} monthIndex - Month index (0 = January).
+ * @param {number} startDay - Configured start day of the billing period (1-31).
+ * @returns {number} Day of the month the period starts on.
+ * @example
+ * getPeriodStartDayInMonth(2023, 1, 31); // 28 (February 2023)
+ */
+function getPeriodStartDayInMonth(year, monthIndex, startDay) {
+  return Math.min(startDay, getDaysInMonth(year, monthIndex));
+}
+
+/**
+ * @description Validate a billing period start day coming from a user input or an HTTP query.
+ * @param {*} value - Value to validate. `undefined`, `null` and `''` fall back to the default (1).
+ * @returns {number | null} The start day as an integer, or null if the value is invalid.
+ * @example
+ * parseEnergyPeriodStartDay('5'); // 5
+ */
+function parseEnergyPeriodStartDay(value) {
+  if (value === undefined || value === null || value === '') {
+    return DEFAULT_ENERGY_PERIOD_START_DAY;
+  }
+  const parsedValue = Number(value);
+  if (
+    !Number.isInteger(parsedValue) ||
+    parsedValue < MIN_ENERGY_PERIOD_START_DAY ||
+    parsedValue > MAX_ENERGY_PERIOD_START_DAY
+  ) {
+    return null;
+  }
+  return parsedValue;
+}
+
+/**
+ * @description Return the start of the period beginning in the calendar month (or year) of a date.
+ * Useful when the user picks a month/year and expects the billing period starting in it,
+ * ex: with a start day of 5, picking March returns March 5th.
+ * @param {Date} date - A date inside the wanted calendar month/year.
+ * @param {string} period - Period type: 'day', 'month' or 'year'.
+ * @param {number} [startDay] - Day of the month the monthly/yearly period starts on (1-31).
+ * @returns {Date} Start of the period, at local midnight.
+ * @example
+ * getEnergyPeriodStartInCalendarUnit(new Date(2023, 2, 1), 'month', 5); // 2023-03-05 00:00
+ */
+function getEnergyPeriodStartInCalendarUnit(date, period, startDay = DEFAULT_ENERGY_PERIOD_START_DAY) {
+  const currentDate = new Date(date);
+  const year = currentDate.getFullYear();
+  const monthIndex = currentDate.getMonth();
+
+  if (period === ENERGY_PERIODS.YEAR) {
+    // January always has 31 days, so the start day never needs to be clamped here.
+    return new Date(year, 0, startDay, 0, 0, 0, 0);
+  }
+
+  if (period === ENERGY_PERIODS.MONTH) {
+    return new Date(year, monthIndex, getPeriodStartDayInMonth(year, monthIndex, startDay), 0, 0, 0, 0);
+  }
+
+  return new Date(year, monthIndex, currentDate.getDate(), 0, 0, 0, 0);
+}
+
+/**
+ * @description Return the start of the period containing a given date, at local midnight.
+ * @param {Date} date - Any date inside the wanted period.
+ * @param {string} period - Period type: 'day', 'month' or 'year'.
+ * @param {number} [startDay] - Day of the month the monthly/yearly period starts on (1-31).
+ * @returns {Date} Start of the period, at local midnight.
+ * @example
+ * getEnergyPeriodStart(new Date(2023, 1, 2), 'month', 5); // 2023-01-05 00:00
+ */
+function getEnergyPeriodStart(date, period, startDay = DEFAULT_ENERGY_PERIOD_START_DAY) {
+  const currentDate = new Date(date);
+  const periodStartInCalendarUnit = getEnergyPeriodStartInCalendarUnit(currentDate, period, startDay);
+  if (currentDate >= periodStartInCalendarUnit) {
+    return periodStartInCalendarUnit;
+  }
+  // The date is before the start day of its own month/year: it belongs to the previous period.
+  // eslint-disable-next-line no-use-before-define
+  return getPreviousEnergyPeriodStart(periodStartInCalendarUnit, period, startDay);
+}
+
+/**
+ * @description Return the start of the period following a given period start.
+ * @param {Date} periodStart - Start of a period, as returned by getEnergyPeriodStart.
+ * @param {string} period - Period type: 'day', 'month' or 'year'.
+ * @param {number} [startDay] - Day of the month the monthly/yearly period starts on (1-31).
+ * @returns {Date} Start of the next period, at local midnight.
+ * @example
+ * getNextEnergyPeriodStart(new Date(2023, 0, 5), 'month', 5); // 2023-02-05 00:00
+ */
+function getNextEnergyPeriodStart(periodStart, period, startDay = DEFAULT_ENERGY_PERIOD_START_DAY) {
+  const currentDate = new Date(periodStart);
+  const year = currentDate.getFullYear();
+  const monthIndex = currentDate.getMonth();
+
+  if (period === ENERGY_PERIODS.YEAR) {
+    return new Date(year + 1, 0, startDay, 0, 0, 0, 0);
+  }
+
+  if (period === ENERGY_PERIODS.MONTH) {
+    return new Date(year, monthIndex + 1, getPeriodStartDayInMonth(year, monthIndex + 1, startDay), 0, 0, 0, 0);
+  }
+
+  return new Date(year, monthIndex, currentDate.getDate() + 1, 0, 0, 0, 0);
+}
+
+/**
+ * @description Return the start of the period preceding a given period start.
+ * @param {Date} periodStart - Start of a period, as returned by getEnergyPeriodStart.
+ * @param {string} period - Period type: 'day', 'month' or 'year'.
+ * @param {number} [startDay] - Day of the month the monthly/yearly period starts on (1-31).
+ * @returns {Date} Start of the previous period, at local midnight.
+ * @example
+ * getPreviousEnergyPeriodStart(new Date(2023, 1, 5), 'month', 5); // 2023-01-05 00:00
+ */
+function getPreviousEnergyPeriodStart(periodStart, period, startDay = DEFAULT_ENERGY_PERIOD_START_DAY) {
+  const currentDate = new Date(periodStart);
+  const year = currentDate.getFullYear();
+  const monthIndex = currentDate.getMonth();
+
+  if (period === ENERGY_PERIODS.YEAR) {
+    return new Date(year - 1, 0, startDay, 0, 0, 0, 0);
+  }
+
+  if (period === ENERGY_PERIODS.MONTH) {
+    return new Date(year, monthIndex - 1, getPeriodStartDayInMonth(year, monthIndex - 1, startDay), 0, 0, 0, 0);
+  }
+
+  return new Date(year, monthIndex, currentDate.getDate() - 1, 0, 0, 0, 0);
+}
+
+module.exports = {
+  ENERGY_PERIODS,
+  DEFAULT_ENERGY_PERIOD_START_DAY,
+  MIN_ENERGY_PERIOD_START_DAY,
+  MAX_ENERGY_PERIOD_START_DAY,
+  getDaysInMonth,
+  getPeriodStartDayInMonth,
+  parseEnergyPeriodStartDay,
+  getEnergyPeriodStartInCalendarUnit,
+  getEnergyPeriodStart,
+  getNextEnergyPeriodStart,
+  getPreviousEnergyPeriodStart,
+};


### PR DESCRIPTION
Implements feature request: https://community.gladysassistant.com/t/decaler-le-jour-de-depart-du-suivi-de-lenergie/10392

### Description

Jluc reads their electricity meter index on the **5th of each month**, which is when their supplier's billing period starts, but the "Energy consumption" widget always displays calendar months (and calendar years), which makes the widget impossible to compare with the bill. Pierre-Gilles reformulated the need in the topic (display the consumption over the same period as the bill, e.g. from the 5th to the 5th, for **both** the monthly and the yearly views) and Jluc confirmed it.

**What this PR adds**

A new **"Billing period start day"** setting (1 to 31, default **1**) in the Energy consumption widget configuration, next to the existing widget settings (device features, colors, subscription prices). It is stored in the widget/box config, like `show_subscription_prices`, so no migration and no new settings mechanism.

When the start day is greater than 1:

- **Monthly view**: the range runs from the configured day to the same day of the next month (e.g. 5 March → 5 April), and the previous/next navigation and the date picker follow the same periods (picking "March" shows the period starting in March).
- **Yearly view**: the range runs from the configured day of January to the same day of the next January, and the 12 bars are the offset monthly periods (5 Jan → 5 Feb → …), not calendar months. This is done server-side, in the DuckDB aggregation query, so the buckets themselves are offset.
- **Daily view**: unchanged (a day is a day).
- **Subscription prices** follow exactly the same period boundaries, so they stay aligned with the consumption bars.
- The exact date range of the displayed period is shown under the date picker (only when the start day is not 1, so the default UI is unchanged).

**Date rule (documented in the UI help text and in the JSDoc)**

A period starts at **local midnight on the configured day**. Months are 28 to 31 days long, so when a month is shorter than the configured start day (e.g. the 31st in February), **the period starts on the last day of that month** (28 Feb, or 29 Feb on a leap year). This rule guarantees that periods never overlap and never leave a gap, and that there are always exactly 12 periods per year. January always has 31 days, so the yearly boundary never needs to be clamped.

**Timezone**: boundaries are computed in the Gladys system timezone. The DuckDB session timezone is already set to the Gladys timezone (`system.setDuckDbTimezone`), and the offset expression is built on top of `DATE_TRUNC` / `INTERVAL` arithmetic, which is calendar-aware, so a period always starts at local midnight even across DST changes. The front-end helpers use local `Date` constructors for the same reason.

**Backward compatibility**: a start day of 1 (the default, and the value of every existing widget) takes the exact same code path as before — the same `DATE_TRUNC(?, created_at)` query, the same `dayjs` subscription iteration, the same date ranges. Nothing changes for users who do not touch the setting.

**Implementation**

- `server/utils/energyPeriod.js` (new): pure date helpers shared by the server and the front (the front already imports `server/utils/*` modules), plus validation of the start day.
- `server/lib/device/energy-sensor/energy-sensor.getConsumptionByDates.js`: new optional `period_start_day` option (validated, `BadParameters` on an invalid value), offset SQL grouping expression for `month`/`year`, offset subscription periods.
- `front/src/components/boxs/energy-consumption/EnergyConsumption.jsx`: period start/next/previous derived from the setting, `period_start_day` sent to the API, period range label.
- `front/src/components/boxs/energy-consumption/EditEnergyConsumption.jsx`: the new setting.
- i18n keys added to `en.json`, `fr.json` and `de.json`.

**Out of scope / not covered**

- Only the "Energy consumption" widget is affected. Other places that aggregate energy data (the generic chart widget, the history page, the MCP energy tool) keep using calendar months and years; they do not pass `period_start_day` and therefore behave exactly as before.
- The setting is per widget, not global: a user with two meters billed on different days can configure two widgets. There is no global "energy billing day" system variable.
- The `week` grouping is not offset (a week is not tied to the billing day), and hourly/daily buckets are untouched by design.
- The precomputed energy cost jobs (`energy-monitoring` service) are not changed: the offset is applied at query/aggregation time, which is where it can be done correctly without recomputing stored data.

## Forum

Forum: https://community.gladysassistant.com/t/decaler-le-jour-de-depart-du-suivi-de-lenergie/10392

### Checklist

- [x] Tests pass: `cd server && npm test` — the new `server/test/utils/energyPeriod.test.js` (56 tests, including February/leap years/30-day months, year boundaries, DST, and a continuity check over every start day from 1 to 31) and the new "Billing period start day" tests in `server/test/lib/device/energy-sensor/energy-sensor.getConsumptionByDates.test.js` (real DuckDB queries). Coverage of the changed server files (`utils/energyPeriod.js`, `energy-sensor.getConsumptionByDates.js`) is **100% statements / branches / functions / lines**. The only failures in the full run are pre-existing environment failures of this sandbox (gateway backup/restore requiring the `sqlite3` CLI, Docker/network tests), unrelated to this change.
- [x] Linter and prettier pass on both front and server (`npm run prettier`, `npm run prettier-check`, `npm run eslint` — 0 errors), `npm run compare-translations` passes, and `cd front && npm run build` succeeds.
- [ ] Cypress not run (no browser binary available in this environment). No existing E2E spec covers the energy widget.
- [x] No undocumented breaking change (default start day of 1 preserves the current behaviour exactly).

> [!NOTE]
> This pull request was opened by an automated Claude Code run. It needs human review before merging — in particular a real-life check of the widget with an actual meter and a non-1 billing day.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BRdJPgpjHkz9LKu39n8fm8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Energy consumption periods can start on a configurable day of the month.
  * Monthly and yearly views, subscription prices, navigation, and date selection align with the selected billing period.
  * Short months and leap years are handled automatically.
  * Nonstandard billing ranges are clearly displayed.
* **Translations**
  * Added English, German, and French labels and descriptions for this setting.
* **Validation**
  * Start days are limited to valid values from 1 to 31.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->