### PR TITLE
feat(mqtt): support wildcard state topics in Home Assistant discovery

### DIFF
--- a/server/services/mqtt/lib/handleNewMessage.js
+++ b/server/services/mqtt/lib/handleNewMessage.js
@@ -1,5 +1,6 @@
 const logger = require('../../../utils/logger');
 const { EVENTS, WEBSOCKET_MESSAGE_TYPES } = require('../../../utils/constants');
+const { mqttTopicMatches } = require('./mqttTopicMatches');
 
 /**
  * @description Handle a new message receive in MQTT.
@@ -27,8 +28,7 @@ function handleNewMessage(topic, message) {
 
     // foreach topic, we see if it matches
     Object.keys(this.topicBinds).forEach((key) => {
-      const regexKey = key.replace('+', '[^/]+').replace('#', '.+');
-      if (topic.match(regexKey)) {
+      if (mqttTopicMatches(key, topic)) {
         forwardedMessage = true;
         this.topicBinds[key](topic, message);
       }

--- a/server/services/mqtt/lib/homeAssistant/constants.js
+++ b/server/services/mqtt/lib/homeAssistant/constants.js
@@ -18,9 +18,9 @@ const HOME_ASSISTANT = {
   MAX_ENTITIES_PER_DISCOVERED_DEVICE: 200,
 };
 
-// MQTT wildcards. They are only valid in a subscription filter, never in a concrete topic, so a
-// discovery payload advertising one as a state or command topic is malformed: subscribing to it
-// would pull in unrelated traffic, and publishing to it is rejected by the broker anyway
+// MQTT wildcards. They are only valid in a subscription filter (like a state topic), never in a
+// concrete topic, so a discovery payload advertising one as a command topic is malformed:
+// publishing to it is rejected by the broker anyway
 const MQTT_WILDCARD_REGEX = /[+#]/;
 
 // Components of the Home Assistant discovery protocol handled by Gladys

--- a/server/services/mqtt/lib/homeAssistant/constants.js
+++ b/server/services/mqtt/lib/homeAssistant/constants.js
@@ -18,9 +18,9 @@ const HOME_ASSISTANT = {
   MAX_ENTITIES_PER_DISCOVERED_DEVICE: 200,
 };
 
-// MQTT wildcards. They are only valid in a subscription filter (like a state topic), never in a
-// concrete topic, so a discovery payload advertising one as a command topic is malformed:
-// publishing to it is rejected by the broker anyway
+// MQTT wildcards. They are only valid in a subscription filter, never in a concrete topic, so a
+// discovery payload advertising one as a command topic is malformed: publishing to it is rejected
+// by the broker anyway. A state topic is a filter, so it accepts "+" (see isSubscribableStateTopic)
 const MQTT_WILDCARD_REGEX = /[+#]/;
 
 // Components of the Home Assistant discovery protocol handled by Gladys

--- a/server/services/mqtt/lib/homeAssistant/handleHomeAssistantStateMessage.js
+++ b/server/services/mqtt/lib/homeAssistant/handleHomeAssistantStateMessage.js
@@ -209,15 +209,21 @@ function parseHomeAssistantIncomingState(binding, message) {
  * created through the Home Assistant discovery protocol.
  * @param {string} topic - The topic where the message was published.
  * @param {string} message - The MQTT message.
+ * @param {string} [filter] - The topic filter this handler was subscribed with, which can
+ * contain wildcards. Defaults to the topic itself, for an exact subscription.
  * @example
  * this.handleHomeAssistantStateMessage('my-device/state', 'ON');
  */
-function handleHomeAssistantStateMessage(topic, message) {
-  // Bindings are stored by state topic, which can be a wildcard filter: the message
-  // arrives on a concrete topic, so each binding topic is matched as a filter
-  const bindings = Object.keys(this.haStateBindings)
-    .filter((bindingTopic) => mqttTopicMatches(bindingTopic, topic))
-    .flatMap((bindingTopic) => this.haStateBindings[bindingTopic]);
+function handleHomeAssistantStateMessage(topic, message, filter = topic) {
+  // Bindings are stored by the topic filter they were subscribed with, which can contain
+  // wildcards while the message always arrives on a concrete topic. handleNewMessage
+  // dispatches a message to every matching filter, so handling only the bindings of the
+  // filter this callback was registered for keeps the lookup a single map read and emits
+  // each binding once, even when two filters match the same topic.
+  if (!mqttTopicMatches(filter, topic)) {
+    return;
+  }
+  const bindings = this.haStateBindings[filter] || [];
   bindings.forEach((binding) => {
     try {
       const state = parseHomeAssistantIncomingState(binding, message);

--- a/server/services/mqtt/lib/homeAssistant/handleHomeAssistantStateMessage.js
+++ b/server/services/mqtt/lib/homeAssistant/handleHomeAssistantStateMessage.js
@@ -7,6 +7,7 @@ const {
   BINARY_SENSOR_DEVICE_CLASSES,
 } = require('./constants');
 const { applyValueTemplate } = require('./applyValueTemplate');
+const { mqttTopicMatches } = require('../mqttTopicMatches');
 
 /**
  * @description Convert a Home Assistant RGB color to the Gladys integer format.
@@ -212,7 +213,11 @@ function parseHomeAssistantIncomingState(binding, message) {
  * this.handleHomeAssistantStateMessage('my-device/state', 'ON');
  */
 function handleHomeAssistantStateMessage(topic, message) {
-  const bindings = this.haStateBindings[topic] || [];
+  // Bindings are stored by state topic, which can be a wildcard filter: the message
+  // arrives on a concrete topic, so each binding topic is matched as a filter
+  const bindings = Object.keys(this.haStateBindings)
+    .filter((bindingTopic) => mqttTopicMatches(bindingTopic, topic))
+    .flatMap((bindingTopic) => this.haStateBindings[bindingTopic]);
   bindings.forEach((binding) => {
     try {
       const state = parseHomeAssistantIncomingState(binding, message);

--- a/server/services/mqtt/lib/homeAssistant/listenToHomeAssistantDevice.js
+++ b/server/services/mqtt/lib/homeAssistant/listenToHomeAssistantDevice.js
@@ -42,13 +42,20 @@ function getStateTopic(component, property, config) {
  * same sensor. A discovery payload is untrusted input though, so filters that would pull in
  * traffic far beyond the device they claim to describe are still refused: "#", which matches
  * every remaining level, and filters without a single concrete level ("+", "+/+"...).
- * @param {string} topic - The state topic advertised in the discovery payload.
+ * A discovery payload can also hold anything in "state_topic" ({}, true, 1...), so this
+ * helper never assumes a string and never throws: it just refuses what it cannot subscribe to.
+ * @param {any} topic - The state topic advertised in the discovery payload.
  * @returns {boolean} True when the topic can be subscribed to.
  * @example
  * isSubscribableStateTopic('+/+/BTtoMQTT/A4C138800021');
  */
 function isSubscribableStateTopic(topic) {
-  return !topic.includes('#') && topic.split('/').some((level) => level !== '+');
+  if (typeof topic !== 'string' || topic.length === 0 || topic.includes('#')) {
+    return false;
+  }
+  const levels = topic.split('/');
+  // "+" is a wildcard only when it takes a whole level: "foo+bar" is not a valid filter
+  return levels.every((level) => level === '+' || !level.includes('+')) && levels.some((level) => level !== '+');
 }
 
 /**
@@ -118,7 +125,7 @@ function listenToHomeAssistantDeviceStateIfNeeded(device) {
           return;
         }
         if (!isSubscribableStateTopic(topic)) {
-          logger.warn(`MQTT Home Assistant: ignoring state topic ${topic}, this filter is too broad`);
+          logger.warn(`MQTT Home Assistant: ignoring state topic ${topic}, this filter is invalid or too broad`);
           return;
         }
         if (!this.haStateBindings[topic]) {

--- a/server/services/mqtt/lib/homeAssistant/listenToHomeAssistantDevice.js
+++ b/server/services/mqtt/lib/homeAssistant/listenToHomeAssistantDevice.js
@@ -36,6 +36,22 @@ function getStateTopic(component, property, config) {
 }
 
 /**
+ * @description Check if a state topic advertised in a discovery payload can be subscribed to.
+ * A state topic is a subscription filter, so "+" is valid there: Theengs gateways advertise
+ * topics such as "+/+/BTtoMQTT/<id>" so that several gateways can publish the state of the
+ * same sensor. A discovery payload is untrusted input though, so filters that would pull in
+ * traffic far beyond the device they claim to describe are still refused: "#", which matches
+ * every remaining level, and filters without a single concrete level ("+", "+/+"...).
+ * @param {string} topic - The state topic advertised in the discovery payload.
+ * @returns {boolean} True when the topic can be subscribed to.
+ * @example
+ * isSubscribableStateTopic('+/+/BTtoMQTT/A4C138800021');
+ */
+function isSubscribableStateTopic(topic) {
+  return !topic.includes('#') && topic.split('/').some((level) => level !== '+');
+}
+
+/**
  * @description Stop listening to the state topics of a Home Assistant device.
  * @param {object} device - Gladys device.
  * @example
@@ -101,12 +117,18 @@ function listenToHomeAssistantDeviceStateIfNeeded(device) {
         if (!topic) {
           return;
         }
-        // State topics are subscription filters, so wildcards are valid there: gateways like
-        // Theengs advertise topics such as "+/+/BTtoMQTT/<id>" so that several gateways can
-        // publish the state of the same sensor
+        if (!isSubscribableStateTopic(topic)) {
+          logger.warn(`MQTT Home Assistant: ignoring state topic ${topic}, this filter is too broad`);
+          return;
+        }
         if (!this.haStateBindings[topic]) {
           this.haStateBindings[topic] = [];
-          this.subscribe(topic, this.handleHomeAssistantStateMessage.bind(this));
+          // The callback is bound to the filter it was subscribed with: handleNewMessage
+          // dispatches a message to every matching filter, so each one must only handle
+          // the bindings it holds itself
+          this.subscribe(topic, (receivedTopic, receivedMessage) =>
+            this.handleHomeAssistantStateMessage(receivedTopic, receivedMessage, topic),
+          );
         }
         this.haStateBindings[topic].push({
           deviceExternalId: device.external_id,

--- a/server/services/mqtt/lib/homeAssistant/listenToHomeAssistantDevice.js
+++ b/server/services/mqtt/lib/homeAssistant/listenToHomeAssistantDevice.js
@@ -1,5 +1,5 @@
 const logger = require('../../../../utils/logger');
-const { HOME_ASSISTANT, FEATURE_PROPERTIES, MQTT_WILDCARD_REGEX } = require('./constants');
+const { HOME_ASSISTANT, FEATURE_PROPERTIES } = require('./constants');
 const { convertEntityToFeatures } = require('./convertToGladysDevice');
 
 /**
@@ -101,12 +101,9 @@ function listenToHomeAssistantDeviceStateIfNeeded(device) {
         if (!topic) {
           return;
         }
-        // A discovery payload is whatever was published on the broker: a wildcard state topic
-        // would subscribe Gladys to traffic far beyond the device it claims to describe
-        if (MQTT_WILDCARD_REGEX.test(topic)) {
-          logger.warn(`MQTT Home Assistant: ignoring state topic ${topic}, wildcards are not allowed`);
-          return;
-        }
+        // State topics are subscription filters, so wildcards are valid there: gateways like
+        // Theengs advertise topics such as "+/+/BTtoMQTT/<id>" so that several gateways can
+        // publish the state of the same sensor
         if (!this.haStateBindings[topic]) {
           this.haStateBindings[topic] = [];
           this.subscribe(topic, this.handleHomeAssistantStateMessage.bind(this));

--- a/server/services/mqtt/lib/mqttTopicMatches.js
+++ b/server/services/mqtt/lib/mqttTopicMatches.js
@@ -1,0 +1,35 @@
+/**
+ * @description Check if a concrete MQTT topic matches a topic filter, wildcards included.
+ * Comparison is done level by level, as described in the MQTT specification: "+" matches
+ * exactly one level, "#" matches any number of remaining levels and is only valid as the
+ * last level of the filter.
+ * @param {string} filter - The topic filter, possibly containing "+" and "#" wildcards.
+ * @param {string} topic - The concrete topic a message was received on.
+ * @returns {boolean} True when the topic matches the filter.
+ * @example
+ * mqttTopicMatches('+/+/BTtoMQTT/A4C138800021', 'gateway1/office/BTtoMQTT/A4C138800021');
+ */
+function mqttTopicMatches(filter, topic) {
+  if (filter === topic) {
+    return true;
+  }
+  const filterLevels = filter.split('/');
+  const topicLevels = topic.split('/');
+  for (let i = 0; i < filterLevels.length; i += 1) {
+    const filterLevel = filterLevels[i];
+    if (filterLevel === '#') {
+      return i === filterLevels.length - 1;
+    }
+    if (i >= topicLevels.length) {
+      return false;
+    }
+    if (filterLevel !== '+' && filterLevel !== topicLevels[i]) {
+      return false;
+    }
+  }
+  return filterLevels.length === topicLevels.length;
+}
+
+module.exports = {
+  mqttTopicMatches,
+};

--- a/server/test/services/mqtt/lib/handleNewMessage.test.js
+++ b/server/test/services/mqtt/lib/handleNewMessage.test.js
@@ -106,6 +106,16 @@ describe('Mqtt handle message', () => {
 
     assert.notCalled(gladys.event.emit);
   });
+  it('should forward messages to a bind with several "+" wildcards', () => {
+    const callback = fake.returns(null);
+    mqttHandler.subscribe('+/+/BTtoMQTT/A4C138800021', callback);
+
+    mqttHandler.handleNewMessage('blegateway/office/BTtoMQTT/A4C138800021', '{"tempc": 21.5}');
+    assert.calledWith(callback, 'blegateway/office/BTtoMQTT/A4C138800021', '{"tempc": 21.5}');
+
+    mqttHandler.handleNewMessage('blegateway/office/BTtoMQTT/FFFFFFFFFFFF', '{"tempc": 21.5}');
+    assert.calledOnce(callback);
+  });
   it('handle device with custom topic and debug mode', () => {
     mqttHandler.debugMode = true;
     mqttHandler.deviceFeatureCustomMqttTopics = [];

--- a/server/test/services/mqtt/lib/homeAssistant/handleHomeAssistantStateMessage.test.js
+++ b/server/test/services/mqtt/lib/homeAssistant/handleHomeAssistantStateMessage.test.js
@@ -65,7 +65,11 @@ describe('mqttHandler.handleHomeAssistantStateMessage', () => {
         config: { state_topic: '+/+/BTtoMQTT/A4C138800021', value_template: '{{ value_json.tempc }}' },
       },
     ];
-    mqttHandler.handleHomeAssistantStateMessage('blegateway/office/BTtoMQTT/A4C138800021', '{"tempc": 21.5}');
+    mqttHandler.handleHomeAssistantStateMessage(
+      'blegateway/office/BTtoMQTT/A4C138800021',
+      '{"tempc": 21.5}',
+      '+/+/BTtoMQTT/A4C138800021',
+    );
     assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
       device_feature_external_id: 'homeassistant:A4C138800021:sensor:temperature',
       state: 21.5,
@@ -73,8 +77,45 @@ describe('mqttHandler.handleHomeAssistantStateMessage', () => {
 
     // A message from another sensor must not match the binding
     gladys.event.emit.resetHistory();
-    mqttHandler.handleHomeAssistantStateMessage('blegateway/office/BTtoMQTT/FFFFFFFFFFFF', '{"tempc": 21.5}');
+    mqttHandler.handleHomeAssistantStateMessage(
+      'blegateway/office/BTtoMQTT/FFFFFFFFFFFF',
+      '{"tempc": 21.5}',
+      '+/+/BTtoMQTT/A4C138800021',
+    );
     assert.notCalled(gladys.event.emit);
+  });
+
+  it('should only emit the bindings of the filter it was subscribed with', () => {
+    // handleNewMessage dispatches a message to every matching filter, so a handler must not
+    // emit the bindings of another filter, otherwise overlapping filters emit duplicates
+    mqttHandler.haStateBindings['+/+/BTtoMQTT/A4C138800021'] = [
+      {
+        deviceExternalId: 'homeassistant:A4C138800021',
+        featureExternalId: 'homeassistant:A4C138800021:sensor:temperature',
+        component: 'sensor',
+        property: 'state',
+        config: { state_topic: '+/+/BTtoMQTT/A4C138800021', value_template: '{{ value_json.tempc }}' },
+      },
+    ];
+    mqttHandler.haStateBindings['blegateway/+/BTtoMQTT/A4C138800021'] = [
+      {
+        deviceExternalId: 'homeassistant:A4C138800021',
+        featureExternalId: 'homeassistant:A4C138800021:sensor:humidity',
+        component: 'sensor',
+        property: 'state',
+        config: { state_topic: 'blegateway/+/BTtoMQTT/A4C138800021', value_template: '{{ value_json.hum }}' },
+      },
+    ];
+    mqttHandler.handleHomeAssistantStateMessage(
+      'blegateway/office/BTtoMQTT/A4C138800021',
+      '{"tempc": 21.5, "hum": 55}',
+      '+/+/BTtoMQTT/A4C138800021',
+    );
+    assert.calledOnce(gladys.event.emit);
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'homeassistant:A4C138800021:sensor:temperature',
+      state: 21.5,
+    });
   });
 
   it('should not emit when the state cannot be parsed', () => {

--- a/server/test/services/mqtt/lib/homeAssistant/handleHomeAssistantStateMessage.test.js
+++ b/server/test/services/mqtt/lib/homeAssistant/handleHomeAssistantStateMessage.test.js
@@ -53,6 +53,30 @@ describe('mqttHandler.handleHomeAssistantStateMessage', () => {
     });
   });
 
+  it('should emit a new state event for a wildcard state topic', () => {
+    // Theengs gateways use wildcard state topics such as "+/+/BTtoMQTT/<id>",
+    // while messages arrive on the concrete topic of each gateway
+    mqttHandler.haStateBindings['+/+/BTtoMQTT/A4C138800021'] = [
+      {
+        deviceExternalId: 'homeassistant:A4C138800021',
+        featureExternalId: 'homeassistant:A4C138800021:sensor:temperature',
+        component: 'sensor',
+        property: 'state',
+        config: { state_topic: '+/+/BTtoMQTT/A4C138800021', value_template: '{{ value_json.tempc }}' },
+      },
+    ];
+    mqttHandler.handleHomeAssistantStateMessage('blegateway/office/BTtoMQTT/A4C138800021', '{"tempc": 21.5}');
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'homeassistant:A4C138800021:sensor:temperature',
+      state: 21.5,
+    });
+
+    // A message from another sensor must not match the binding
+    gladys.event.emit.resetHistory();
+    mqttHandler.handleHomeAssistantStateMessage('blegateway/office/BTtoMQTT/FFFFFFFFFFFF', '{"tempc": 21.5}');
+    assert.notCalled(gladys.event.emit);
+  });
+
   it('should not emit when the state cannot be parsed', () => {
     mqttHandler.haStateBindings['my-device/temperature'] = [
       {

--- a/server/test/services/mqtt/lib/homeAssistant/listenToHomeAssistantDevice.test.js
+++ b/server/test/services/mqtt/lib/homeAssistant/listenToHomeAssistantDevice.test.js
@@ -46,21 +46,21 @@ describe('mqttHandler.listenToHomeAssistantDeviceStateIfNeeded', () => {
     expect(mqttHandler.haStateBindings).to.deep.equal({});
   });
 
-  it('should not subscribe to a wildcard state topic', () => {
-    ['#', 'my-device/+/state', 'my-device/#'].forEach((stateTopic) => {
-      mqttHandler.haStateBindings = {};
-      mqttHandler.listenToHomeAssistantDeviceStateIfNeeded({
-        external_id: 'homeassistant:my-device',
-        params: [
-          {
-            name: 'ha_discovery_config:sensor:temperature',
-            value: JSON.stringify({ state_topic: stateTopic, device_class: 'temperature' }),
-          },
-        ],
-        features: [{ external_id: 'homeassistant:my-device:sensor:temperature' }],
-      });
-      expect(mqttHandler.haStateBindings).to.deep.equal({});
+  it('should subscribe to a wildcard state topic', () => {
+    // Theengs gateways advertise wildcard state topics so that several
+    // gateways can publish the state of the same BLE sensor
+    mqttHandler.listenToHomeAssistantDeviceStateIfNeeded({
+      external_id: 'homeassistant:my-device',
+      params: [
+        {
+          name: 'ha_discovery_config:sensor:temperature',
+          value: JSON.stringify({ state_topic: '+/+/BTtoMQTT/A4C138800021', device_class: 'temperature' }),
+        },
+      ],
+      features: [{ external_id: 'homeassistant:my-device:sensor:temperature' }],
     });
+    expect(mqttHandler.haStateBindings['+/+/BTtoMQTT/A4C138800021']).to.have.lengthOf(1);
+    sinon.assert.calledWith(mqttHandler.subscribe, '+/+/BTtoMQTT/A4C138800021');
   });
 
   it('should listen to the state topic of a sensor', () => {

--- a/server/test/services/mqtt/lib/homeAssistant/listenToHomeAssistantDevice.test.js
+++ b/server/test/services/mqtt/lib/homeAssistant/listenToHomeAssistantDevice.test.js
@@ -83,6 +83,59 @@ describe('mqttHandler.listenToHomeAssistantDeviceStateIfNeeded', () => {
     sinon.assert.notCalled(mqttHandler.subscribe);
   });
 
+  it('should not subscribe to a state topic with a wildcard inside a level', () => {
+    // "+" is a wildcard only when it takes a whole level
+    ['foo+bar', 'sensor/foo+/state'].forEach((stateTopic) => {
+      mqttHandler.haStateBindings = {};
+      mqttHandler.listenToHomeAssistantDeviceStateIfNeeded({
+        external_id: 'homeassistant:my-device',
+        params: [
+          {
+            name: 'ha_discovery_config:sensor:temperature',
+            value: JSON.stringify({ state_topic: stateTopic, device_class: 'temperature' }),
+          },
+        ],
+        features: [{ external_id: 'homeassistant:my-device:sensor:temperature' }],
+      });
+      expect(mqttHandler.haStateBindings).to.deep.equal({});
+    });
+    sinon.assert.notCalled(mqttHandler.subscribe);
+  });
+
+  it('should ignore a non-string state topic without throwing', () => {
+    // A discovery payload can hold anything in "state_topic". Throwing here would abort
+    // the device walk done at init, and the MQTT service would never connect
+    [{}, true, 1, ['a/b']].forEach((stateTopic) => {
+      mqttHandler.haStateBindings = {};
+      mqttHandler.listenToHomeAssistantDeviceStateIfNeeded({
+        external_id: 'homeassistant:my-device',
+        params: [
+          {
+            name: 'ha_discovery_config:sensor:temperature',
+            value: JSON.stringify({ state_topic: stateTopic, device_class: 'temperature' }),
+          },
+        ],
+        features: [{ external_id: 'homeassistant:my-device:sensor:temperature' }],
+      });
+      expect(mqttHandler.haStateBindings).to.deep.equal({});
+    });
+    sinon.assert.notCalled(mqttHandler.subscribe);
+
+    // A device handled after the invalid one still gets its subscription
+    mqttHandler.listenToHomeAssistantDeviceStateIfNeeded({
+      external_id: 'homeassistant:my-other-device',
+      params: [
+        {
+          name: 'ha_discovery_config:sensor:temperature',
+          value: JSON.stringify({ state_topic: 'my-other-device/temperature', device_class: 'temperature' }),
+        },
+      ],
+      features: [{ external_id: 'homeassistant:my-other-device:sensor:temperature' }],
+    });
+    expect(mqttHandler.haStateBindings['my-other-device/temperature']).to.have.lengthOf(1);
+    sinon.assert.calledWith(mqttHandler.subscribe, 'my-other-device/temperature');
+  });
+
   it('should listen to the state topic of a sensor', () => {
     const device = {
       external_id: 'homeassistant:my-device',

--- a/server/test/services/mqtt/lib/homeAssistant/listenToHomeAssistantDevice.test.js
+++ b/server/test/services/mqtt/lib/homeAssistant/listenToHomeAssistantDevice.test.js
@@ -84,8 +84,8 @@ describe('mqttHandler.listenToHomeAssistantDeviceStateIfNeeded', () => {
   });
 
   it('should not subscribe to a state topic with a wildcard inside a level', () => {
-    // "+" is a wildcard only when it takes a whole level
-    ['foo+bar', 'sensor/foo+/state'].forEach((stateTopic) => {
+    // "+" is a wildcard only when it takes a whole level, and "#" is refused wherever it appears
+    ['foo+bar', 'sensor/foo+/state', 'foo#bar'].forEach((stateTopic) => {
       mqttHandler.haStateBindings = {};
       mqttHandler.listenToHomeAssistantDeviceStateIfNeeded({
         external_id: 'homeassistant:my-device',

--- a/server/test/services/mqtt/lib/homeAssistant/listenToHomeAssistantDevice.test.js
+++ b/server/test/services/mqtt/lib/homeAssistant/listenToHomeAssistantDevice.test.js
@@ -63,6 +63,26 @@ describe('mqttHandler.listenToHomeAssistantDeviceStateIfNeeded', () => {
     sinon.assert.calledWith(mqttHandler.subscribe, '+/+/BTtoMQTT/A4C138800021');
   });
 
+  it('should not subscribe to a state topic matching too many topics', () => {
+    // A discovery payload is untrusted input: "#" and filters without a concrete
+    // level would subscribe Gladys to traffic unrelated to the device
+    ['#', 'sensor/#', '+', '+/+'].forEach((stateTopic) => {
+      mqttHandler.haStateBindings = {};
+      mqttHandler.listenToHomeAssistantDeviceStateIfNeeded({
+        external_id: 'homeassistant:my-device',
+        params: [
+          {
+            name: 'ha_discovery_config:sensor:temperature',
+            value: JSON.stringify({ state_topic: stateTopic, device_class: 'temperature' }),
+          },
+        ],
+        features: [{ external_id: 'homeassistant:my-device:sensor:temperature' }],
+      });
+      expect(mqttHandler.haStateBindings).to.deep.equal({});
+    });
+    sinon.assert.notCalled(mqttHandler.subscribe);
+  });
+
   it('should listen to the state topic of a sensor', () => {
     const device = {
       external_id: 'homeassistant:my-device',

--- a/server/test/services/mqtt/lib/mqttTopicMatches.test.js
+++ b/server/test/services/mqtt/lib/mqttTopicMatches.test.js
@@ -1,0 +1,50 @@
+const { expect } = require('chai');
+
+const { mqttTopicMatches } = require('../../../../services/mqtt/lib/mqttTopicMatches');
+
+describe('mqttTopicMatches', () => {
+  it('should match an exact topic', () => {
+    expect(mqttTopicMatches('my-device/state', 'my-device/state')).to.equal(true);
+    expect(mqttTopicMatches('my-device/state', 'my-device/other')).to.equal(false);
+  });
+
+  it('should not match a topic with a different number of levels', () => {
+    expect(mqttTopicMatches('my-device/state', 'my-device/state/extra')).to.equal(false);
+    expect(mqttTopicMatches('my-device/state/extra', 'my-device/state')).to.equal(false);
+  });
+
+  it('should match a single "+" wildcard level', () => {
+    expect(mqttTopicMatches('home/+/temperature', 'home/livingroom/temperature')).to.equal(true);
+    expect(mqttTopicMatches('home/+/temperature', 'home/livingroom/kitchen/temperature')).to.equal(false);
+    expect(mqttTopicMatches('home/+/temperature', 'home/livingroom/humidity')).to.equal(false);
+  });
+
+  it('should match several "+" wildcard levels', () => {
+    expect(mqttTopicMatches('+/+/BTtoMQTT/A4C138800021', 'blegateway/office/BTtoMQTT/A4C138800021')).to.equal(true);
+    expect(mqttTopicMatches('+/+/BTtoMQTT/A4C138800021', 'blegateway/BTtoMQTT/A4C138800021')).to.equal(false);
+    expect(mqttTopicMatches('+/+/BTtoMQTT/A4C138800021', 'blegateway/office/BTtoMQTT/FFFFFFFFFFFF')).to.equal(false);
+  });
+
+  it('should not match a "+" wildcard when the level is missing', () => {
+    expect(mqttTopicMatches('home/+', 'home')).to.equal(false);
+  });
+
+  it('should match a trailing "#" wildcard', () => {
+    expect(mqttTopicMatches('homeassistant/#', 'homeassistant/sensor/my-device/config')).to.equal(true);
+    expect(mqttTopicMatches('homeassistant/#', 'homeassistant')).to.equal(true);
+    expect(mqttTopicMatches('homeassistant/#', 'other/sensor/config')).to.equal(false);
+  });
+
+  it('should match everything with a lone "#"', () => {
+    expect(mqttTopicMatches('#', 'any/topic/here')).to.equal(true);
+  });
+
+  it('should not match a "#" wildcard that is not the last level', () => {
+    expect(mqttTopicMatches('home/#/temperature', 'home/livingroom/temperature')).to.equal(false);
+  });
+
+  it('should not interpret regex special characters in topics', () => {
+    expect(mqttTopicMatches('my.device/state', 'myxdevice/state')).to.equal(false);
+    expect(mqttTopicMatches('my.device/state', 'my.device/state')).to.equal(true);
+  });
+});


### PR DESCRIPTION
### Description

Gladys was ignoring Home Assistant MQTT discovery state topics containing wildcards (`MQTT Home Assistant: ignoring state topic +/+/BTtoMQTT/A4C138800021, wildcards are not allowed`), which broke compatibility with Theengs gateways. Theengs advertises wildcard state topics such as `+/+/BTtoMQTT/<id>` so that several gateways can publish the state of the same BLE sensor.

Wildcards are valid MQTT in a subscription filter, so they are now supported in state topics:

- **`listenToHomeAssistantDevice`**: wildcard state topics are subscribed as-is instead of being ignored with a warning.
- **`handleHomeAssistantStateMessage`**: bindings are stored by state topic, which can now be a wildcard filter, so incoming messages (which arrive on a concrete topic) are matched against binding topics with a new spec-compliant matcher, `mqttTopicMatches` (`+` matches exactly one level, `#` matches any number of remaining levels as the last level).
- **`handleNewMessage`**: the `topicBinds` dispatch uses the same matcher. The previous regex-based matching only replaced the *first* occurrence of `+`/`#` (`String.replace` with a string pattern), so a filter with several wildcards like Theengs' would never have been dispatched. The new matcher also stops interpreting regex special characters in topics and no longer does unanchored substring matching.

Command topics still reject wildcards in `setValueHomeAssistant`, since publishing to a wildcard topic is invalid MQTT.

Tests added for the matcher itself, the wildcard subscribe path, the wildcard state-message path (including non-matching sensors), and multi-wildcard dispatch in `handleNewMessage`.

### Checklist

- [x] Tests pass: full MQTT service suite passes locally (248 tests), changed lines covered by new tests; no UI change
- [x] Linter and prettier pass on the changed server files (`npm run eslint`)
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R47ZGWPHMWrWuy4ECA5oBs

---
_Generated by [Claude Code](https://claude.ai/code/session_01R47ZGWPHMWrWuy4ECA5oBs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Home Assistant MQTT state bindings now support valid wildcard topic filters, including shared gateway topics.
  - MQTT topics support reliable exact, single-level (`+`), and multi-level (`#`) matching.

- **Bug Fixes**
  - Corrected message routing for subscriptions containing multiple wildcards.
  - Improved handling of wildcard Home Assistant state topics and discovery validation.
  - Prevented overly broad, malformed, or invalid wildcard filters from being accepted.
  - Ensured messages are delivered only to matching topic subscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->