### PR TITLE
Matter: support door locks on the DoorLock cluster

### DIFF
--- a/server/services/matter/lib/matter.listenToStateChange.js
+++ b/server/services/matter/lib/matter.listenToStateChange.js
@@ -24,11 +24,13 @@ const {
   RvcRunMode,
   RvcCleanMode,
   PowerSource,
+  DoorLock,
   // eslint-disable-next-line import/no-unresolved
 } = require('@matter/main/clusters');
 
 const logger = require('../../../utils/logger');
 const { matterFanModeToGladys, matterAttributeToNumber } = require('../utils/fanMatterMapping');
+const { matterLockStateToGladys, matterLockStateToGladysBinary } = require('../utils/doorLockMatterMapping');
 const { matterSystemModeToGladysAcMode } = require('../utils/thermostatMatterMapping');
 const { hsbToRgb, rgbToInt } = require('../../../utils/colors');
 const { EVENTS, STATE, BUTTON_STATUS } = require('../../../utils/constants');
@@ -640,6 +642,29 @@ async function listenToStateChange(nodeId, devicePath, device) {
         device_feature_external_id: cleanModeExternalId,
         state: gladysMode,
       });
+    });
+  }
+
+  const doorLock = device.getClusterClientById(DoorLock.Complete.id);
+  if (doorLock && !this.stateChangeListeners.has(doorLock)) {
+    logger.debug(`Matter: Adding state change listener for DoorLock cluster ${doorLock.name}`);
+    this.stateChangeListeners.add(doorLock);
+    const doorLockExternalId = `matter:${nodeId}:${devicePath}:${DoorLock.Complete.id}`;
+    // Subscribe to the lock state attribute changes
+    doorLock.addLockStateAttributeListener((value) => {
+      logger.debug(`Matter: DoorLock lockState attribute changed to ${value}`);
+      this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
+        device_feature_external_id: `${doorLockExternalId}:state`,
+        state: matterLockStateToGladys(value),
+      });
+      const binaryState = matterLockStateToGladysBinary(value);
+      // A transient/unknown lock state has no binary equivalent, so we keep the last known one
+      if (binaryState !== null) {
+        this.gladys.event.emit(EVENTS.DEVICE.NEW_STATE, {
+          device_feature_external_id: `${doorLockExternalId}:lock`,
+          state: binaryState,
+        });
+      }
     });
   }
 

--- a/server/services/matter/lib/matter.readInitialDeviceStates.js
+++ b/server/services/matter/lib/matter.readInitialDeviceStates.js
@@ -23,11 +23,13 @@ const {
   RvcRunMode,
   RvcCleanMode,
   PowerSource,
+  DoorLock,
   // eslint-disable-next-line import/no-unresolved
 } = require('@matter/main/clusters');
 
 const logger = require('../../../utils/logger');
 const { matterFanModeToGladys, matterAttributeToNumber } = require('../utils/fanMatterMapping');
+const { matterLockStateToGladys, matterLockStateToGladysBinary } = require('../utils/doorLockMatterMapping');
 const { matterSystemModeToGladysAcMode } = require('../utils/thermostatMatterMapping');
 const { hsbToRgb, rgbToInt } = require('../../../utils/colors');
 const { EVENTS, STATE } = require('../../../utils/constants');
@@ -350,6 +352,17 @@ async function readInitialDeviceStates(nodeId, devicePath, device) {
         cleanModeExternalId,
         convertMatterCleanModeToGladys(value, this.supportedModesMap.get(cleanModeExternalId)),
       );
+    }
+  }
+
+  const doorLock = device.getClusterClientById(DoorLock.Complete.id);
+  if (doorLock) {
+    const value = await safeReadAttribute(() => doorLock.getLockStateAttribute());
+    if (value !== undefined) {
+      const doorLockExternalId = `matter:${nodeId}:${devicePath}:${DoorLock.Complete.id}`;
+      emitState(`${doorLockExternalId}:state`, matterLockStateToGladys(value));
+      // A transient/unknown lock state resolves to null and is skipped by emitState
+      emitState(`${doorLockExternalId}:lock`, matterLockStateToGladysBinary(value));
     }
   }
 

--- a/server/services/matter/lib/matter.setValue.js
+++ b/server/services/matter/lib/matter.setValue.js
@@ -8,9 +8,10 @@ const {
   RvcOperationalState,
   RvcRunMode,
   RvcCleanMode,
+  DoorLock,
   // eslint-disable-next-line import/no-unresolved
 } = require('@matter/main/clusters');
-const { DEVICE_FEATURE_TYPES, DEVICE_FEATURE_CATEGORIES, COVER_STATE } = require('../../../utils/constants');
+const { DEVICE_FEATURE_TYPES, DEVICE_FEATURE_CATEGORIES, COVER_STATE, LOCK } = require('../../../utils/constants');
 const { intToHsb } = require('../../../utils/colors');
 const logger = require('../../../utils/logger');
 const {
@@ -102,7 +103,11 @@ async function setValue(gladysDevice, gladysFeature, value) {
   }
 
   // Handle binary device
-  if (gladysFeature.type === DEVICE_FEATURE_TYPES.SWITCH.BINARY) {
+  // Locks share the same "binary" type, but they are controlled through the DoorLock cluster below
+  if (
+    gladysFeature.type === DEVICE_FEATURE_TYPES.SWITCH.BINARY &&
+    gladysFeature.category !== DEVICE_FEATURE_CATEGORIES.LOCK
+  ) {
     const onOff = targetDevice.getClusterClientById(OnOff.Complete.id);
 
     if (!onOff) {
@@ -135,6 +140,25 @@ async function setValue(gladysDevice, gladysFeature, value) {
       } else if (value === COVER_STATE.STOP) {
         await windowCovering.stopMotion();
       }
+    }
+  }
+
+  // Handle door locks
+  if (
+    gladysFeature.category === DEVICE_FEATURE_CATEGORIES.LOCK &&
+    gladysFeature.type === DEVICE_FEATURE_TYPES.LOCK.BINARY
+  ) {
+    const doorLock = targetDevice.getClusterClientById(DoorLock.Complete.id);
+    if (!doorLock) {
+      throw new Error('Device does not support DoorLock cluster');
+    }
+    const lockValue = Number(value);
+    if (lockValue === LOCK.ACTION.LOCK) {
+      await doorLock.lockDoor({});
+    } else if (lockValue === LOCK.ACTION.UNLOCK) {
+      await doorLock.unlockDoor({});
+    } else {
+      throw new Error(`Unsupported lock command value: ${value}. Only 0 (unlock) and 1 (lock) are supported.`);
     }
   }
 

--- a/server/services/matter/lib/matter.setValue.js
+++ b/server/services/matter/lib/matter.setValue.js
@@ -152,7 +152,10 @@ async function setValue(gladysDevice, gladysFeature, value) {
     if (!doorLock) {
       throw new Error('Device does not support DoorLock cluster');
     }
-    const lockValue = Number(value);
+    // Number(null), Number('') and Number(false) all return 0, which would unlock the door:
+    // only a real number or the exact "0"/"1" strings are accepted as a lock command
+    const isBinaryCommandString = typeof value === 'string' && /^[01]$/.test(value);
+    const lockValue = typeof value === 'number' || isBinaryCommandString ? Number(value) : Number.NaN;
     if (lockValue === LOCK.ACTION.LOCK) {
       await doorLock.lockDoor({});
     } else if (lockValue === LOCK.ACTION.UNLOCK) {

--- a/server/services/matter/utils/convertToGladysDevice.js
+++ b/server/services/matter/utils/convertToGladysDevice.js
@@ -25,6 +25,7 @@ const {
   RvcRunMode,
   RvcCleanMode,
   PowerSource,
+  DoorLock,
   // eslint-disable-next-line import/no-unresolved
 } = require('@matter/main/clusters');
 const Promise = require('bluebird');
@@ -32,6 +33,7 @@ const {
   DEVICE_FEATURE_CATEGORIES,
   DEVICE_FEATURE_TYPES,
   DEVICE_FEATURE_UNITS,
+  LOCK,
   FAN_MODE,
   FAN_AIRFLOW_DIRECTION,
   FAN_ROCK_SETTING,
@@ -640,6 +642,28 @@ async function convertToGladysDevice(serviceId, nodeId, device, nodeDetailDevice
           external_id: `matter:${nodeId}:${devicePath}:${clusterIndex}`,
           min: 0,
           max: 6,
+        });
+      } else if (clusterIndex === DoorLock.Complete.id) {
+        // The lock/unlock command feature, and the detailed lock state reported by the lock
+        gladysDevice.features.push({
+          name: `${clusterClient.name} - ${clusterClient.endpointId} (Lock)`,
+          category: DEVICE_FEATURE_CATEGORIES.LOCK,
+          type: DEVICE_FEATURE_TYPES.LOCK.BINARY,
+          read_only: false,
+          has_feedback: true,
+          external_id: `matter:${nodeId}:${devicePath}:${clusterIndex}:lock`,
+          min: LOCK.ACTION.UNLOCK,
+          max: LOCK.ACTION.LOCK,
+        });
+        gladysDevice.features.push({
+          name: `${clusterClient.name} - ${clusterClient.endpointId} (State)`,
+          category: DEVICE_FEATURE_CATEGORIES.LOCK,
+          type: DEVICE_FEATURE_TYPES.LOCK.STATE,
+          read_only: true,
+          has_feedback: true,
+          external_id: `matter:${nodeId}:${devicePath}:${clusterIndex}:state`,
+          min: LOCK.STATE.UNLOCKED,
+          max: LOCK.STATE.ERROR,
         });
       } else if (clusterIndex === PowerSource.Complete.id) {
         if (clusterClient.supportedFeatures && clusterClient.supportedFeatures.battery) {

--- a/server/services/matter/utils/doorLockMatterMapping.js
+++ b/server/services/matter/utils/doorLockMatterMapping.js
@@ -1,0 +1,53 @@
+const {
+  DoorLock,
+  // eslint-disable-next-line import/no-unresolved
+} = require('@matter/main/clusters');
+
+const { LOCK } = require('../../../utils/constants');
+
+/**
+ * @description Convert a Matter DoorLock lockState attribute to the Gladys lock state value.
+ * @param {number|null|undefined} matterLockState - The Matter DoorLock lockState attribute.
+ * @returns {number} The Gladys lock state (LOCK.STATE).
+ * @example
+ * const gladysState = matterLockStateToGladys(DoorLock.LockState.Locked);
+ */
+function matterLockStateToGladys(matterLockState) {
+  switch (matterLockState) {
+    case DoorLock.LockState.Locked:
+      return LOCK.STATE.LOCKED;
+    case DoorLock.LockState.Unlocked:
+    case DoorLock.LockState.Unlatched:
+      return LOCK.STATE.UNLOCKED;
+    case DoorLock.LockState.NotFullyLocked:
+      return LOCK.STATE.ACTIVITY;
+    default:
+      // A null lockState means the lock cannot report its current state
+      return LOCK.STATE.ERROR;
+  }
+}
+
+/**
+ * @description Convert a Matter DoorLock lockState attribute to the Gladys binary lock value.
+ * @param {number|null|undefined} matterLockState - The Matter DoorLock lockState attribute.
+ * @returns {number|null} 1 when locked, 0 when unlocked, null when the state is unknown.
+ * @example
+ * const gladysBinaryState = matterLockStateToGladysBinary(DoorLock.LockState.Unlocked);
+ */
+function matterLockStateToGladysBinary(matterLockState) {
+  switch (matterLockState) {
+    case DoorLock.LockState.Locked:
+      return LOCK.ACTION.LOCK;
+    case DoorLock.LockState.Unlocked:
+    case DoorLock.LockState.Unlatched:
+      return LOCK.ACTION.UNLOCK;
+    default:
+      // NotFullyLocked or an unknown state is not a stable binary value
+      return null;
+  }
+}
+
+module.exports = {
+  matterLockStateToGladys,
+  matterLockStateToGladysBinary,
+};

--- a/server/test/services/matter/lib/convertToGladysDevice.test.js
+++ b/server/test/services/matter/lib/convertToGladysDevice.test.js
@@ -10,6 +10,7 @@ const {
   PowerSource,
   Thermostat,
   CarbonDioxideConcentrationMeasurement,
+  DoorLock,
   // eslint-disable-next-line import/no-unresolved
 } = require('@matter/main/clusters');
 
@@ -17,7 +18,7 @@ const {
   convertToGladysDevice,
   matterExternalIdToSelector,
 } = require('../../../../services/matter/utils/convertToGladysDevice');
-const { AC_MODE } = require('../../../../utils/constants');
+const { AC_MODE, LOCK } = require('../../../../utils/constants');
 
 describe('Matter.convertToGladysDevice', () => {
   const serviceId = 'service-1';
@@ -545,5 +546,46 @@ describe('Matter.convertToGladysDevice', () => {
 
     const modeFeatures = gladysDevice.features.filter((feature) => feature.type === 'mode');
     expect(modeFeatures).to.have.lengthOf(0);
+  });
+
+  it('should create lock features for DoorLock cluster', async () => {
+    const clusterClient = {
+      id: DoorLock.Complete.id,
+      name: 'DoorLock',
+      endpointId: 1,
+    };
+
+    const device = {
+      name: 'Door Lock',
+      number: 1,
+      getAllClusterClients: () => [clusterClient],
+      getChildEndpoints: () => [],
+    };
+
+    const gladysDevice = await convertToGladysDevice(serviceId, nodeId, device, basicInformation, '1');
+
+    expect(gladysDevice.features).to.have.lengthOf(2);
+    expect(gladysDevice.features[0]).to.deep.equal({
+      name: 'DoorLock - 1 (Lock)',
+      selector: matterExternalIdToSelector('matter:12345:1:257:lock'),
+      category: 'lock',
+      type: 'binary',
+      read_only: false,
+      has_feedback: true,
+      external_id: 'matter:12345:1:257:lock',
+      min: LOCK.ACTION.UNLOCK,
+      max: LOCK.ACTION.LOCK,
+    });
+    expect(gladysDevice.features[1]).to.deep.equal({
+      name: 'DoorLock - 1 (State)',
+      selector: matterExternalIdToSelector('matter:12345:1:257:state'),
+      category: 'lock',
+      type: 'state',
+      read_only: true,
+      has_feedback: true,
+      external_id: 'matter:12345:1:257:state',
+      min: LOCK.STATE.UNLOCKED,
+      max: LOCK.STATE.ERROR,
+    });
   });
 });

--- a/server/test/services/matter/lib/listenToStateChange.test.js
+++ b/server/test/services/matter/lib/listenToStateChange.test.js
@@ -24,6 +24,7 @@ const {
   RvcRunMode,
   RvcCleanMode,
   PowerSource,
+  DoorLock,
   // eslint-disable-next-line import/no-unresolved
 } = require('@matter/main/clusters');
 
@@ -32,7 +33,7 @@ const { expect } = require('chai');
 
 const { fake, assert } = sinon;
 
-const { EVENTS, STATE, BUTTON_STATUS, FAN_MODE, AC_MODE } = require('../../../../utils/constants');
+const { EVENTS, STATE, BUTTON_STATUS, FAN_MODE, AC_MODE, LOCK } = require('../../../../utils/constants');
 
 const MatterHandler = require('../../../../services/matter/lib');
 
@@ -983,6 +984,65 @@ describe('Matter.listenToStateChange', () => {
     assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
       device_feature_external_id: 'matter:1234:2:85',
       state: 0,
+    });
+  });
+  it('should listen to state change (DoorLock locked)', async () => {
+    const clusterClient = {
+      id: DoorLock.Complete.id,
+      addLockStateAttributeListener: (callback) => {
+        callback(DoorLock.LockState.Locked);
+      },
+    };
+    const device = {
+      number: 1,
+      getClusterClientById: (id) => (id === clusterClient.id ? clusterClient : null),
+    };
+    await matterHandler.listenToStateChange(1234n, '1', device);
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'matter:1234:1:257:state',
+      state: LOCK.STATE.LOCKED,
+    });
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'matter:1234:1:257:lock',
+      state: LOCK.ACTION.LOCK,
+    });
+  });
+  it('should listen to state change (DoorLock unlocked)', async () => {
+    const clusterClient = {
+      id: DoorLock.Complete.id,
+      addLockStateAttributeListener: (callback) => {
+        callback(DoorLock.LockState.Unlocked);
+      },
+    };
+    const device = {
+      number: 1,
+      getClusterClientById: (id) => (id === clusterClient.id ? clusterClient : null),
+    };
+    await matterHandler.listenToStateChange(1234n, '1', device);
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'matter:1234:1:257:state',
+      state: LOCK.STATE.UNLOCKED,
+    });
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'matter:1234:1:257:lock',
+      state: LOCK.ACTION.UNLOCK,
+    });
+  });
+  it('should only emit the detailed state when the DoorLock state is not fully locked', async () => {
+    const clusterClient = {
+      id: DoorLock.Complete.id,
+      addLockStateAttributeListener: (callback) => {
+        callback(DoorLock.LockState.NotFullyLocked);
+      },
+    };
+    const device = {
+      number: 1,
+      getClusterClientById: (id) => (id === clusterClient.id ? clusterClient : null),
+    };
+    await matterHandler.listenToStateChange(1234n, '1', device);
+    assert.calledOnceWithExactly(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: 'matter:1234:1:257:state',
+      state: LOCK.STATE.ACTIVITY,
     });
   });
   it('should listen to state change (PowerSource battery)', async () => {

--- a/server/test/services/matter/lib/matter.readInitialDeviceStates.test.js
+++ b/server/test/services/matter/lib/matter.readInitialDeviceStates.test.js
@@ -28,11 +28,12 @@ const {
   RvcRunMode,
   RvcCleanMode,
   PowerSource,
+  DoorLock,
   // eslint-disable-next-line import/no-unresolved
 } = require('@matter/main/clusters');
 
 const MatterHandler = require('../../../../services/matter/lib');
-const { EVENTS, STATE, FAN_MODE, AC_MODE } = require('../../../../utils/constants');
+const { EVENTS, STATE, FAN_MODE, AC_MODE, LOCK } = require('../../../../utils/constants');
 
 describe('Matter.readInitialDeviceStates', () => {
   let matterHandler;
@@ -659,6 +660,55 @@ describe('Matter.readInitialDeviceStates', () => {
       device_feature_external_id: `matter:1234:1:${OccupancySensing.Complete.id}`,
       state: STATE.OFF,
     });
+  });
+
+  it('should read the initial DoorLock state', async () => {
+    const doorLock = {
+      getLockStateAttribute: fake.resolves(DoorLock.LockState.Locked),
+    };
+    const device = {
+      getClusterClientById: (id) => (id === DoorLock.Complete.id ? doorLock : null),
+    };
+
+    await matterHandler.readInitialDeviceStates(1234n, '1', device);
+
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: `matter:1234:1:${DoorLock.Complete.id}:state`,
+      state: LOCK.STATE.LOCKED,
+    });
+    assert.calledWith(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: `matter:1234:1:${DoorLock.Complete.id}:lock`,
+      state: LOCK.ACTION.LOCK,
+    });
+  });
+
+  it('should only emit the detailed DoorLock state when the lock is not fully locked', async () => {
+    const doorLock = {
+      getLockStateAttribute: fake.resolves(DoorLock.LockState.NotFullyLocked),
+    };
+    const device = {
+      getClusterClientById: (id) => (id === DoorLock.Complete.id ? doorLock : null),
+    };
+
+    await matterHandler.readInitialDeviceStates(1234n, '1', device);
+
+    assert.calledOnceWithExactly(gladys.event.emit, EVENTS.DEVICE.NEW_STATE, {
+      device_feature_external_id: `matter:1234:1:${DoorLock.Complete.id}:state`,
+      state: LOCK.STATE.ACTIVITY,
+    });
+  });
+
+  it('should skip the DoorLock state when the attribute is not readable', async () => {
+    const doorLock = {
+      getLockStateAttribute: fake.rejects(new Error('read failed')),
+    };
+    const device = {
+      getClusterClientById: (id) => (id === DoorLock.Complete.id ? doorLock : null),
+    };
+
+    await matterHandler.readInitialDeviceStates(1234n, '1', device);
+
+    assert.notCalled(gladys.event.emit);
   });
 
   it('should skip occupancy when attribute read returns null', async () => {

--- a/server/test/services/matter/lib/matter.setValue.test.js
+++ b/server/test/services/matter/lib/matter.setValue.test.js
@@ -1314,6 +1314,40 @@ describe('Matter.setValue', () => {
     await chaiAssert.isRejected(promise, 'Unsupported lock command value: 2');
   });
 
+  it('should lock a door lock with a string command value', async () => {
+    const clusterClients = new Map();
+    const doorLock = {
+      lockDoor: fake.resolves(null),
+      unlockDoor: fake.resolves(null),
+    };
+    clusterClients.set(DoorLock.Complete.id, doorLock);
+    matterHandler.nodesMap.set(12345n, buildLockNode(clusterClients));
+
+    await matterHandler.setValue(lockGladysDevice, lockGladysFeature, '1');
+
+    assert.calledOnceWithExactly(doorLock.lockDoor, {});
+    assert.notCalled(doorLock.unlockDoor);
+  });
+
+  [null, '', false, 'unlock'].forEach((invalidValue) => {
+    it(`should throw an error and send no command for the lock command value ${JSON.stringify(
+      invalidValue,
+    )}`, async () => {
+      const clusterClients = new Map();
+      const doorLock = {
+        lockDoor: fake.resolves(null),
+        unlockDoor: fake.resolves(null),
+      };
+      clusterClients.set(DoorLock.Complete.id, doorLock);
+      matterHandler.nodesMap.set(12345n, buildLockNode(clusterClients));
+
+      const promise = matterHandler.setValue(lockGladysDevice, lockGladysFeature, invalidValue);
+      await chaiAssert.isRejected(promise, 'Unsupported lock command value');
+      assert.notCalled(doorLock.lockDoor);
+      assert.notCalled(doorLock.unlockDoor);
+    });
+  });
+
   it('should throw an error when the DoorLock cluster is not available', async () => {
     const clusterClients = new Map();
     matterHandler.nodesMap.set(12345n, buildLockNode(clusterClients));

--- a/server/test/services/matter/lib/matter.setValue.test.js
+++ b/server/test/services/matter/lib/matter.setValue.test.js
@@ -4,7 +4,7 @@ const { assert: chaiAssert } = require('chai');
 const { fake, assert } = sinon;
 
 // eslint-disable-next-line import/no-unresolved
-const { FanControl } = require('@matter/main/clusters');
+const { FanControl, DoorLock } = require('@matter/main/clusters');
 
 const MatterHandler = require('../../../../services/matter/lib');
 const {
@@ -14,6 +14,7 @@ const {
   AC_MODE,
   FAN_MODE,
   FAN_AIRFLOW_DIRECTION,
+  LOCK,
 } = require('../../../../utils/constants');
 
 describe('Matter.setValue', () => {
@@ -1230,5 +1231,94 @@ describe('Matter.setValue', () => {
 
     const promise = matterHandler.setValue(gladysDevice, gladysFeature, value);
     await chaiAssert.isRejected(promise, 'Device does not support RvcCleanMode cluster');
+  });
+
+  const buildLockNode = (clusterClients) => ({
+    isConnected: true,
+    getDevices: fake.returns([
+      {
+        number: 1,
+        getClusterClientById: (id) => clusterClients.get(id),
+        getChildEndpoints: () => [],
+      },
+    ]),
+  });
+
+  const lockGladysDevice = { external_id: 'matter:12345:1' };
+  const lockGladysFeature = {
+    category: DEVICE_FEATURE_CATEGORIES.LOCK,
+    type: DEVICE_FEATURE_TYPES.LOCK.BINARY,
+  };
+
+  it('should lock a door lock', async () => {
+    const clusterClients = new Map();
+    const doorLock = {
+      lockDoor: fake.resolves(null),
+      unlockDoor: fake.resolves(null),
+    };
+    clusterClients.set(DoorLock.Complete.id, doorLock);
+    matterHandler.nodesMap.set(12345n, buildLockNode(clusterClients));
+
+    await matterHandler.setValue(lockGladysDevice, lockGladysFeature, LOCK.ACTION.LOCK);
+
+    assert.calledOnceWithExactly(doorLock.lockDoor, {});
+    assert.notCalled(doorLock.unlockDoor);
+  });
+
+  it('should unlock a door lock', async () => {
+    const clusterClients = new Map();
+    const doorLock = {
+      lockDoor: fake.resolves(null),
+      unlockDoor: fake.resolves(null),
+    };
+    clusterClients.set(DoorLock.Complete.id, doorLock);
+    matterHandler.nodesMap.set(12345n, buildLockNode(clusterClients));
+
+    await matterHandler.setValue(lockGladysDevice, lockGladysFeature, LOCK.ACTION.UNLOCK);
+
+    assert.calledOnceWithExactly(doorLock.unlockDoor, {});
+    assert.notCalled(doorLock.lockDoor);
+  });
+
+  it('should not send an OnOff command for a lock binary feature', async () => {
+    const clusterClients = new Map();
+    const onOff = {
+      on: fake.resolves(null),
+      off: fake.resolves(null),
+    };
+    const doorLock = {
+      lockDoor: fake.resolves(null),
+      unlockDoor: fake.resolves(null),
+    };
+    clusterClients.set(6, onOff);
+    clusterClients.set(DoorLock.Complete.id, doorLock);
+    matterHandler.nodesMap.set(12345n, buildLockNode(clusterClients));
+
+    await matterHandler.setValue(lockGladysDevice, lockGladysFeature, LOCK.ACTION.LOCK);
+
+    assert.notCalled(onOff.on);
+    assert.notCalled(onOff.off);
+    assert.calledOnce(doorLock.lockDoor);
+  });
+
+  it('should throw an error for an unsupported lock command value', async () => {
+    const clusterClients = new Map();
+    const doorLock = {
+      lockDoor: fake.resolves(null),
+      unlockDoor: fake.resolves(null),
+    };
+    clusterClients.set(DoorLock.Complete.id, doorLock);
+    matterHandler.nodesMap.set(12345n, buildLockNode(clusterClients));
+
+    const promise = matterHandler.setValue(lockGladysDevice, lockGladysFeature, 2);
+    await chaiAssert.isRejected(promise, 'Unsupported lock command value: 2');
+  });
+
+  it('should throw an error when the DoorLock cluster is not available', async () => {
+    const clusterClients = new Map();
+    matterHandler.nodesMap.set(12345n, buildLockNode(clusterClients));
+
+    const promise = matterHandler.setValue(lockGladysDevice, lockGladysFeature, LOCK.ACTION.LOCK);
+    await chaiAssert.isRejected(promise, 'Device does not support DoorLock cluster');
   });
 });

--- a/server/test/services/matter/utils/doorLockMatterMapping.test.js
+++ b/server/test/services/matter/utils/doorLockMatterMapping.test.js
@@ -1,0 +1,56 @@
+const { expect } = require('chai');
+
+const {
+  DoorLock,
+  // eslint-disable-next-line import/no-unresolved
+} = require('@matter/main/clusters');
+
+const {
+  matterLockStateToGladys,
+  matterLockStateToGladysBinary,
+} = require('../../../../services/matter/utils/doorLockMatterMapping');
+const { LOCK } = require('../../../../utils/constants');
+
+describe('Matter.doorLockMatterMapping', () => {
+  describe('matterLockStateToGladys', () => {
+    it('should convert Locked to the Gladys locked state', () => {
+      expect(matterLockStateToGladys(DoorLock.LockState.Locked)).to.eq(LOCK.STATE.LOCKED);
+    });
+
+    it('should convert Unlocked to the Gladys unlocked state', () => {
+      expect(matterLockStateToGladys(DoorLock.LockState.Unlocked)).to.eq(LOCK.STATE.UNLOCKED);
+    });
+
+    it('should convert Unlatched to the Gladys unlocked state', () => {
+      expect(matterLockStateToGladys(DoorLock.LockState.Unlatched)).to.eq(LOCK.STATE.UNLOCKED);
+    });
+
+    it('should convert NotFullyLocked to the Gladys activity state', () => {
+      expect(matterLockStateToGladys(DoorLock.LockState.NotFullyLocked)).to.eq(LOCK.STATE.ACTIVITY);
+    });
+
+    it('should convert an unknown lock state to the Gladys error state', () => {
+      expect(matterLockStateToGladys(null)).to.eq(LOCK.STATE.ERROR);
+      expect(matterLockStateToGladys(42)).to.eq(LOCK.STATE.ERROR);
+    });
+  });
+
+  describe('matterLockStateToGladysBinary', () => {
+    it('should convert Locked to 1', () => {
+      expect(matterLockStateToGladysBinary(DoorLock.LockState.Locked)).to.eq(LOCK.ACTION.LOCK);
+    });
+
+    it('should convert Unlocked to 0', () => {
+      expect(matterLockStateToGladysBinary(DoorLock.LockState.Unlocked)).to.eq(LOCK.ACTION.UNLOCK);
+    });
+
+    it('should convert Unlatched to 0', () => {
+      expect(matterLockStateToGladysBinary(DoorLock.LockState.Unlatched)).to.eq(LOCK.ACTION.UNLOCK);
+    });
+
+    it('should return null for a transient or unknown lock state', () => {
+      expect(matterLockStateToGladysBinary(DoorLock.LockState.NotFullyLocked)).to.eq(null);
+      expect(matterLockStateToGladysBinary(null)).to.eq(null);
+    });
+  });
+});


### PR DESCRIPTION
Implements feature request: https://community.gladysassistant.com/t/matter-serrures-et-detecteurs-de-fuites/10544

### Description

The forum topic asks for two things: Matter **door locks** (Nuki Smart Lock Ultra) and Matter **water leak detectors** (IKEA Klippbok).

**This PR only covers the door lock half.** The leak-detector half is already handled by the open PR #2892 ("Matter: handle water leak detectors (and contact/rain sensors) on the BooleanState cluster"), so it is deliberately out of scope here.

Until now the Matter integration ignored the `DoorLock` cluster (id `257`): a Matter lock was discovered with zero features and therefore never added to Gladys. This PR maps that cluster onto the **existing `lock` device feature category** — no new category or type is introduced, so `docs/specs/device-feature-categories.md` does not change (rule 4, "reuse before creating"): the same category/types are already used by the Nuki, MQTT/Home Assistant and HomeKit integrations, and the front (i18n, `SupportedFeatureTypes`, feature components) already supports them.

Two features are created per `DoorLock` endpoint:

| Feature | Category / type | Read-only | Behavior |
|---|---|---|---|
| `…:lock` | `lock` / `binary` | no | actionable: `1` sends the Matter `LockDoor` command, `0` sends `UnlockDoor`. Also reports the current locked/unlocked state. |
| `…:state` | `lock` / `state` | yes | detailed state: unlocked (0), locked (1), activity (2), error (3) |

`lockState` mapping (new `server/services/matter/utils/doorLockMatterMapping.js`):

- `Locked` → locked
- `Unlocked` and `Unlatched` → unlocked
- `NotFullyLocked` → activity
- unknown / unreadable (`null`) → error

A transient or unknown state has no meaningful binary equivalent, so in that case only the detailed state feature is updated and the binary feature keeps its last known value.

The state is emitted both from the attribute subscription (`matter.listenToStateChange.js`) and from the initial state read (`matter.readInitialDeviceStates.js`), consistent with the other supported clusters.

One existing line changed in `matter.setValue.js`: locks share the `binary` feature *type* with switches, so the `OnOff` branch is now scoped to non-`lock` features and a `lock` / `binary` feature is routed to the `DoorLock` cluster instead.

This PR was produced by an automated run; it has not been tested against physical hardware, so a real-world test with a Matter lock is very welcome.

## Forum

Forum: https://community.gladysassistant.com/t/matter-serrures-et-detecteurs-de-fuites/10544

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

Tests added for every new/changed line: the new mapping util (all `LockState` values, including the unknown/transient cases), the discovery of the two features, the subscription and initial-state emissions, and the `setValue` lock/unlock commands, the unsupported-value error, the missing-cluster error and the "a lock binary feature must not fall through to `OnOff`" case. No front change was needed (`npm run compare-translations` still passes).


---
_Generated by [Claude Code](https://claude.ai/code/session_01REGRUvErzpwtSrsi9gKh4J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Matter door lock support.
  - Door locks now display their current state and provide lock/unlock controls.
  - Lock and unlock commands are handled separately from switch controls.
  - Transient or unknown lock states preserve the last known action state.

- **Bug Fixes**
  - Improved handling of partially locked, unreadable, or unavailable lock states.

- **Tests**
  - Added comprehensive coverage for door lock discovery, state updates, initial readings, and commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->