### PR TITLE
Dashboard: move a widget from one dashboard to another

### DIFF
--- a/front/src/components/boxs/baseEditBox.jsx
+++ b/front/src/components/boxs/baseEditBox.jsx
@@ -1,8 +1,10 @@
-import { Text } from 'preact-i18n';
+import { Text, Localizer } from 'preact-i18n';
 import { useRef, useState } from 'preact/hooks';
 import { useDrag, useDrop } from 'react-dnd';
 import cx from 'classnames';
 import get from 'get-value';
+
+import { wrapEmojisJSX } from '../../utils/emojiWrapper';
 
 const DASHBOARD_EDIT_BOX_TYPE = 'DASHBOARD_EDIT_BOX';
 
@@ -97,9 +99,27 @@ const BaseEditBox = ({ children, ...props }) => {
           </a>
           {displayMoveToDashboard && (
             <div class="dropdown">
-              <a onClick={toggleMoveToDashboard} class="card-options-remove">
-                <i class="fe fe-corner-up-right mr-2" />
-              </a>
+              <Localizer>
+                <button
+                  type="button"
+                  onClick={toggleMoveToDashboard}
+                  class="card-options-remove"
+                  aria-label={<Text id="dashboard.moveBoxToDashboard.title" />}
+                  // .card-options only styles anchors, so a native button needs the same look
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    marginLeft: '0.5rem',
+                    minWidth: '1rem',
+                    fontSize: '1rem',
+                    color: '#9aa0ac',
+                    cursor: 'pointer'
+                  }}
+                >
+                  <i style={{ verticalAlign: 'middle' }} class="fe fe-corner-up-right mr-2" />
+                </button>
+              </Localizer>
               <div
                 class={cx('dropdown-menu', 'dropdown-menu-right', {
                   show: moveToDashboardOpened
@@ -109,9 +129,14 @@ const BaseEditBox = ({ children, ...props }) => {
                   <Text id="dashboard.moveBoxToDashboard.title" />
                 </span>
                 {otherDashboards.map(dashboard => (
-                  <a class="dropdown-item" onClick={() => moveBoxToDashboard(dashboard.selector)}>
-                    {dashboard.name}
-                  </a>
+                  <button
+                    key={dashboard.selector}
+                    type="button"
+                    class="dropdown-item"
+                    onClick={() => moveBoxToDashboard(dashboard.selector)}
+                  >
+                    {wrapEmojisJSX(dashboard.name)}
+                  </button>
                 ))}
               </div>
             </div>

--- a/front/src/components/boxs/baseEditBox.jsx
+++ b/front/src/components/boxs/baseEditBox.jsx
@@ -52,6 +52,7 @@ const BaseEditBox = ({ children, ...props }) => {
     setMoveToDashboardOpened(false);
     props.moveBoxToDashboard(x, y, dashboardSelector);
   };
+  const moveToDashboardMenuId = `move-box-to-dashboard-menu-${x}-${y}`;
   if (props.isMobileReordering) {
     return (
       <div
@@ -105,6 +106,9 @@ const BaseEditBox = ({ children, ...props }) => {
                   onClick={toggleMoveToDashboard}
                   class="card-options-remove"
                   aria-label={<Text id="dashboard.moveBoxToDashboard.title" />}
+                  aria-haspopup="true"
+                  aria-expanded={moveToDashboardOpened ? 'true' : 'false'}
+                  aria-controls={moveToDashboardMenuId}
                   // .card-options only styles anchors, so a native button needs the same look
                   style={{
                     background: 'none',
@@ -121,6 +125,7 @@ const BaseEditBox = ({ children, ...props }) => {
                 </button>
               </Localizer>
               <div
+                id={moveToDashboardMenuId}
                 class={cx('dropdown-menu', 'dropdown-menu-right', {
                   show: moveToDashboardOpened
                 })}

--- a/front/src/components/boxs/baseEditBox.jsx
+++ b/front/src/components/boxs/baseEditBox.jsx
@@ -1,12 +1,15 @@
 import { Text } from 'preact-i18n';
-import { useRef } from 'preact/hooks';
+import { useRef, useState } from 'preact/hooks';
 import { useDrag, useDrop } from 'react-dnd';
+import cx from 'classnames';
+import get from 'get-value';
 
 const DASHBOARD_EDIT_BOX_TYPE = 'DASHBOARD_EDIT_BOX';
 
 const BaseEditBox = ({ children, ...props }) => {
   const { x, y } = props;
   const ref = useRef(null);
+  const [moveToDashboardOpened, setMoveToDashboardOpened] = useState(false);
   const [{ isDragging }, drag, preview] = useDrag(() => ({
     type: DASHBOARD_EDIT_BOX_TYPE,
     item: () => {
@@ -31,6 +34,21 @@ const BaseEditBox = ({ children, ...props }) => {
   preview(drop(ref));
   const removeBox = () => {
     props.removeBox(x, y);
+  };
+  const currentDashboardSelector = get(props, 'homeDashboard.selector');
+  const otherDashboards = (props.dashboards || []).filter(dashboard => dashboard.selector !== currentDashboardSelector);
+  // A box can only be moved to another dashboard if it's configured, and if another dashboard exists
+  const displayMoveToDashboard =
+    !props.isMobileReordering &&
+    typeof props.moveBoxToDashboard === 'function' &&
+    get(props, 'box.type') !== undefined &&
+    otherDashboards.length > 0;
+  const toggleMoveToDashboard = () => {
+    setMoveToDashboardOpened(!moveToDashboardOpened);
+  };
+  const moveBoxToDashboard = dashboardSelector => {
+    setMoveToDashboardOpened(false);
+    props.moveBoxToDashboard(x, y, dashboardSelector);
   };
   if (props.isMobileReordering) {
     return (
@@ -77,6 +95,27 @@ const BaseEditBox = ({ children, ...props }) => {
           <a class="card-options-remove">
             <i ref={drag} style={{ cursor: 'move' }} class="fe fe-move mr-2 d-none d-lg-inline" />
           </a>
+          {displayMoveToDashboard && (
+            <div class="dropdown">
+              <a onClick={toggleMoveToDashboard} class="card-options-remove">
+                <i class="fe fe-corner-up-right mr-2" />
+              </a>
+              <div
+                class={cx('dropdown-menu', 'dropdown-menu-right', {
+                  show: moveToDashboardOpened
+                })}
+              >
+                <span class="dropdown-header">
+                  <Text id="dashboard.moveBoxToDashboard.title" />
+                </span>
+                {otherDashboards.map(dashboard => (
+                  <a class="dropdown-item" onClick={() => moveBoxToDashboard(dashboard.selector)}>
+                    {dashboard.name}
+                  </a>
+                ))}
+              </div>
+            </div>
+          )}
           {!props.isMobileReordering && (
             <a onClick={removeBox} class="card-options-remove">
               <i class="fe fe-x" />

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -321,6 +321,10 @@
     "editDashboardBoxNotEmpty": "Sie können diese Spalte nicht löschen, da sie Widgets enthält.",
     "editDashboardMyDashboards": "Meine Dashboards",
     "editDashboardExplanation": "Jedes Dashboard hat 3 Spalten, die du nach Belieben füllen kannst. Klicke auf \"+\", um ein neues Widget hinzuzufügen. Du kannst dieses Widget bewegen, indem du es greifst und verschiebst.",
+    "moveBoxToDashboard": {
+      "title": "In ein anderes Dashboard verschieben",
+      "pendingMoves": "Widgets, die in ein anderes Dashboard verschoben wurden, werden am Ende der ersten Spalte dieses Dashboards hinzugefügt, sobald du dieses Dashboard speicherst."
+    },
     "reorderDashboardButton": "Dashboards neu anordnen",
     "stopReorderingDashboardButton": "Anordnen der Dashboards beenden",
     "addBoxButton": "Hinzufügen",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -321,6 +321,10 @@
     "editDashboardBoxNotEmpty": "You cannot delete this column as it contains widgets.",
     "editDashboardMyDashboards": "My dashboards",
     "editDashboardExplanation": "Each dashboard has 3 columns, which you can fill in according to your preferences. Click on the + button to add a new widget. You can move this widget by grabbing it and moving it around.",
+    "moveBoxToDashboard": {
+      "title": "Move to another dashboard",
+      "pendingMoves": "Widgets moved to another dashboard will be added at the end of the first column of that dashboard when you save this dashboard."
+    },
     "reorderDashboardButton": "Re-order dashboards",
     "stopReorderingDashboardButton": "Stop re-ordering dashboards",
     "addBoxButton": "Add",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -321,6 +321,10 @@
     "editDashboardBoxNotEmpty": "Vous ne pouvez pas supprimer cette colonne car elle contient des widgets.",
     "editDashboardMyDashboards": "Mes tableaux de bord",
     "editDashboardExplanation": "Chaque tableau de bord comporte 3 colonnes, que vous pouvez remplir selon vos préférences. Cliquez sur le bouton + pour ajouter un nouveau widget. Vous pouvez déplacer ce widget en l'attrapant et en le déplaçant.",
+    "moveBoxToDashboard": {
+      "title": "Déplacer vers un autre tableau de bord",
+      "pendingMoves": "Les widgets déplacés vers un autre tableau de bord seront ajoutés à la fin de la première colonne de ce tableau de bord lors de l'enregistrement de ce tableau de bord."
+    },
     "reorderDashboardButton": "Re-ordonner",
     "stopReorderingDashboardButton": "Arrêter de réordonner",
     "addBoxButton": "Ajouter",

--- a/front/src/routes/dashboard/edit-dashboard/EditBoxColumns.jsx
+++ b/front/src/routes/dashboard/edit-dashboard/EditBoxColumns.jsx
@@ -39,6 +39,11 @@ const EditBoxColumns = ({ children, ...props }) => (
         <Text id="newDashboard.unknownError" />
       </div>
     )}
+    {props.boxesToMove && props.boxesToMove.length > 0 && (
+      <div class="alert alert-info">
+        <Text id="dashboard.moveBoxToDashboard.pendingMoves" />
+      </div>
+    )}
     <div class="row align-items-end">
       <div class="col-md-4">
         <div class="form-group">

--- a/front/src/routes/dashboard/edit-dashboard/EditDashboard.jsx
+++ b/front/src/routes/dashboard/edit-dashboard/EditDashboard.jsx
@@ -59,6 +59,8 @@ const EditDashboard = ({ children, ...props }) => (
                           homeDashboard={props.currentDashboard}
                           updateNewSelectedBox={props.updateNewSelectedBox}
                           removeBox={props.removeBox}
+                          moveBoxToDashboard={props.moveBoxToDashboard}
+                          boxesToMove={props.boxesToMove}
                           updateBoxConfig={props.updateBoxConfig}
                           showReorderDashboard={props.showReorderDashboard}
                           toggleReorderDashboard={props.toggleReorderDashboard}

--- a/front/src/routes/dashboard/edit-dashboard/index.js
+++ b/front/src/routes/dashboard/edit-dashboard/index.js
@@ -130,6 +130,64 @@ class EditDashboard extends Component {
     this.setState(newState);
   };
 
+  moveBoxToDashboard = async (x, y, dashboardSelector) => {
+    const box = get(this.state, `currentDashboard.boxes.${x}.${y}`);
+    // We don't move a box which is not configured yet
+    if (!box || box.type === undefined) {
+      return;
+    }
+    // The box is removed from the current dashboard, and saved in a list of boxes
+    // to move when the user will save the dashboard.
+    const newState = update(this.state, {
+      currentDashboard: {
+        boxes: {
+          [x]: {
+            $splice: [[y, 1]]
+          }
+        }
+      },
+      boxesToMove: {
+        $push: [{ dashboardSelector, box }]
+      }
+    });
+    await this.setState({ ...newState, boxNotEmptyError: false });
+  };
+
+  moveBoxesToOtherDashboards = async () => {
+    const { boxesToMove } = this.state;
+    if (boxesToMove.length === 0) {
+      return;
+    }
+    // Boxes are grouped by destination dashboard, so each dashboard is updated only once
+    const boxesByDashboard = {};
+    boxesToMove.forEach(boxToMove => {
+      boxesByDashboard[boxToMove.dashboardSelector] = (boxesByDashboard[boxToMove.dashboardSelector] || []).concat([
+        boxToMove.box
+      ]);
+    });
+    await Promise.all(
+      Object.keys(boxesByDashboard).map(async dashboardSelector => {
+        const dashboard = await this.props.httpClient.get(`/api/v1/dashboard/${dashboardSelector}`);
+        const columns = dashboard.boxes && dashboard.boxes.length > 0 ? dashboard.boxes : [[]];
+        // Boxes are added at the end of the first column of the destination dashboard
+        const newColumns = update(columns, {
+          0: {
+            $push: boxesByDashboard[dashboardSelector]
+          }
+        });
+        await this.props.httpClient.patch(`/api/v1/dashboard/${dashboardSelector}`, {
+          ...dashboard,
+          boxes: newColumns
+        });
+        // Boxes are removed from the pending list as soon as they are saved,
+        // so they are not moved twice if the user retries after an error.
+        this.setState(prevState => ({
+          boxesToMove: prevState.boxesToMove.filter(boxToMove => boxToMove.dashboardSelector !== dashboardSelector)
+        }));
+      })
+    );
+  };
+
   removeBox = async (x, y) => {
     const newState = update(this.state, {
       currentDashboard: {
@@ -241,6 +299,10 @@ class EditDashboard extends Component {
       // We purge all empty boxes
       await this.removeEmptyBoxes();
 
+      // Boxes moved to another dashboard are saved in those dashboards first,
+      // so a box is never lost if this dashboard fails to save.
+      await this.moveBoxesToOtherDashboards();
+
       const { currentDashboard: selectedDashboard, dashboards } = this.state;
       const { selector } = selectedDashboard;
 
@@ -264,6 +326,8 @@ class EditDashboard extends Component {
       route(`/dashboard/${currentDashboard.selector}`);
     } catch (e) {
       console.error(e);
+      // The save failed, we stop the loader so the user can fix the error and retry
+      this.setState({ loading: false });
       if (e.response && e.response.status === 422) {
         this.setState({
           dashboardValidationError: true
@@ -372,7 +436,8 @@ class EditDashboard extends Component {
       askDeleteDashboard: false,
       boxNotEmptyError: false,
       columnBoxNotEmptyError: null,
-      isMobileReordering: false
+      isMobileReordering: false,
+      boxesToMove: []
     };
   }
 
@@ -399,7 +464,8 @@ class EditDashboard extends Component {
       boxNotEmptyError,
       columnBoxNotEmptyError,
       savingNewDashboardList,
-      isMobileReordering
+      isMobileReordering,
+      boxesToMove
     }
   ) {
     return (
@@ -421,6 +487,8 @@ class EditDashboard extends Component {
         addBox={this.addBox}
         addBoxAtPosition={this.addBoxAtPosition}
         removeBox={this.removeBox}
+        moveBoxToDashboard={this.moveBoxToDashboard}
+        boxesToMove={boxesToMove}
         updateNewSelectedBox={this.updateNewSelectedBox}
         saveDashboard={this.saveDashboard}
         updateBoxConfig={this.updateBoxConfig}

--- a/front/src/routes/dashboard/edit-dashboard/index.js
+++ b/front/src/routes/dashboard/edit-dashboard/index.js
@@ -62,6 +62,9 @@ class EditDashboard extends Component {
   };
 
   init = async () => {
+    // Pending moves belong to the dashboard being edited: switching to another
+    // dashboard discards them, like the other unsaved edits.
+    await this.setState({ boxesToMove: [] });
     await this.getDashboards();
     if (this.state.currentDashboardSelector) {
       await this.getCurrentDashboard();


### PR DESCRIPTION
Implements feature request: https://community.gladysassistant.com/t/tableaux-de-bord-deplacer-des-blocs-entre-les-tableaux/10551

### Description

In dashboard edit mode, each configured widget now has a "Move to another dashboard" action in its header, next to the drag handle and the delete button. Clicking it opens a dropdown listing the other dashboards; picking one removes the widget from the current dashboard and schedules it to be added at the end of the first column of the target dashboard.

How it fits the existing edit/save flow:

- Nothing is persisted until the user clicks "Save": pending moves are kept in the edit page state, exactly like the other edits (name, visibility, box order). Cancelling the edit discards them.
- On save, the target dashboards are updated first through the existing `PATCH /api/v1/dashboard/:selector` API (one request per target dashboard, widgets grouped), then the current dashboard is saved without the moved widgets — so a widget can never be lost if one of the requests fails.
- Widgets already written to their target dashboard are removed from the pending list right away, so retrying a failed save does not move them twice.
- An info message is shown in the editor while moves are pending, explaining that they will be applied on save.
- The action is hidden for widgets that are not configured yet, while re-ordering on mobile, and when the user has only one dashboard.

This is a front-only change: no new endpoint and no server change, only the existing dashboard read/update API. Translations were added for `en`, `fr` and `de`.

Side fix: the loader was never stopped when saving a dashboard failed, which left the editor stuck behind the dimmer. It is now stopped so the user can fix the error and retry.

This pull request was produced by an automated run.

## Forum

Forum: https://community.gladysassistant.com/t/tableaux-de-bord-deplacer-des-blocs-entre-les-tableaux/10551

### Checklist

- [x] Tests pass: no server file changed, so `server` tests are untouched; front checks (`prettier-check`, `eslint`, `compare-translations`, `build`) pass locally
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change


---
_Generated by [Claude Code](https://claude.ai/code/session_01REGRUvErzpwtSrsi9gKh4J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to move eligible dashboard widgets to another dashboard while editing.
  * Added destination selection and confirmation messaging for pending widget moves.
  * Added an informational notice when widget moves are waiting to be saved.
  * Added German, English, and French translations for the dashboard-move experience.

* **Bug Fixes**
  * Dashboard saving now exits its loading state after a failure, allowing users to retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->