### PR TITLE
Front: collapse the integrations disclaimer banner on mobile

### DIFF
--- a/front/src/routes/integration/IntegrationGatewayBanner.jsx
+++ b/front/src/routes/integration/IntegrationGatewayBanner.jsx
@@ -1,0 +1,55 @@
+import { Component } from 'preact';
+import { Text, MarkupText } from 'preact-i18n';
+import cx from 'classnames';
+import style from './style.css';
+
+const DESCRIPTION_ID = 'integration-gateway-banner-description';
+
+// The "Can't find your device?" banner is a one-off explanation: useful the
+// first times, pure noise afterwards — and on a phone its four lines of text
+// pushed the whole integration list below the fold (forum #10576).
+//
+// So on small screens it is reduced to its clickable title, the description
+// living in a Bootstrap `.collapse` opened by the toggle. On desktop the
+// banner keeps its current always-expanded look: `d-lg-block` (which is
+// `!important`) beats `.collapse:not(.show)`, and the chevron affordance is
+// hidden there, exactly like the collapsed header menu of the app.
+class IntegrationGatewayBanner extends Component {
+  toggle = e => {
+    e.preventDefault();
+    this.setState(prevState => ({ expanded: !prevState.expanded }));
+  };
+
+  render(props, { expanded }) {
+    return (
+      <div class="alert alert-info mb-4">
+        <h4 class="alert-title mb-0">
+          <span class="d-none d-lg-inline">
+            <Text id="integration.root.gatewayBanner.title" />
+          </span>
+          <a
+            href="#"
+            class={cx(
+              'd-lg-none',
+              'd-flex',
+              'align-items-center',
+              'justify-content-between',
+              style.gatewayBannerToggle
+            )}
+            onClick={this.toggle}
+            aria-expanded={expanded ? 'true' : 'false'}
+            aria-controls={DESCRIPTION_ID}
+          >
+            <Text id="integration.root.gatewayBanner.title" />
+            <i class={cx('fe', 'ml-2', expanded ? 'fe-chevron-up' : 'fe-chevron-down')} />
+          </a>
+        </h4>
+        <div id={DESCRIPTION_ID} class={cx('collapse', 'd-lg-block', 'mt-2', { show: expanded })}>
+          <MarkupText id="integration.root.gatewayBanner.description" />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default IntegrationGatewayBanner;

--- a/front/src/routes/integration/IntegrationGatewayBanner.jsx
+++ b/front/src/routes/integration/IntegrationGatewayBanner.jsx
@@ -15,8 +15,7 @@ const DESCRIPTION_ID = 'integration-gateway-banner-description';
 // `!important`) beats `.collapse:not(.show)`, and the chevron affordance is
 // hidden there, exactly like the collapsed header menu of the app.
 class IntegrationGatewayBanner extends Component {
-  toggle = e => {
-    e.preventDefault();
+  toggle = () => {
     this.setState(prevState => ({ expanded: !prevState.expanded }));
   };
 
@@ -27,8 +26,8 @@ class IntegrationGatewayBanner extends Component {
           <span class="d-none d-lg-inline">
             <Text id="integration.root.gatewayBanner.title" />
           </span>
-          <a
-            href="#"
+          <button
+            type="button"
             class={cx(
               'd-lg-none',
               'd-flex',
@@ -42,7 +41,7 @@ class IntegrationGatewayBanner extends Component {
           >
             <Text id="integration.root.gatewayBanner.title" />
             <i class={cx('fe', 'ml-2', expanded ? 'fe-chevron-up' : 'fe-chevron-down')} />
-          </a>
+          </button>
         </h4>
         <div id={DESCRIPTION_ID} class={cx('collapse', 'd-lg-block', 'mt-2', { show: expanded })}>
           <MarkupText id="integration.root.gatewayBanner.description" />

--- a/front/src/routes/integration/IntegrationPage.jsx
+++ b/front/src/routes/integration/IntegrationPage.jsx
@@ -2,6 +2,7 @@ import { Text, MarkupText } from 'preact-i18n';
 import IntegrationMenu, { IntegrationMenuMobile } from './IntegrationMenu';
 import IntegrationCategory, { IntegrationListItem } from './IntegrationCategory';
 import IntegrationFacets from './IntegrationFacets';
+import IntegrationGatewayBanner from './IntegrationGatewayBanner';
 import IntegrationPageHeader from './IntegrationPageHeader';
 import StoreRefreshFooter from './all/external-integration/store-refresh/StoreRefreshFooter';
 import style from './style.css';
@@ -57,12 +58,7 @@ const IntegrationPage = ({
               setTransportFacet={setTransportFacet}
               toggleGladysPlusFacet={toggleGladysPlusFacet}
             />
-            <div class="alert alert-info mb-4">
-              <h4 class="alert-title">
-                <Text id="integration.root.gatewayBanner.title" />
-              </h4>
-              <MarkupText id="integration.root.gatewayBanner.description" />
-            </div>
+            <IntegrationGatewayBanner />
             <div class="row">
               <div class={`col-lg-3 ${style.desktopMenuCol}`}>
                 <IntegrationMenu

--- a/front/src/routes/integration/style.css
+++ b/front/src/routes/integration/style.css
@@ -220,3 +220,12 @@
   color: #fff;
   font-size: 1.25rem;
 }
+
+/* The collapsed banner title must read as a heading, not as a link: only the
+   chevron signals that it opens. */
+.gatewayBannerToggle,
+.gatewayBannerToggle:hover,
+.gatewayBannerToggle:focus {
+  color: inherit;
+  text-decoration: none;
+}

--- a/front/src/routes/integration/style.css
+++ b/front/src/routes/integration/style.css
@@ -221,11 +221,17 @@
   font-size: 1.25rem;
 }
 
-/* The collapsed banner title must read as a heading, not as a link: only the
-   chevron signals that it opens. */
+/* The toggle is a native button for its keyboard semantics, but it must look
+   like the banner heading it replaces: only the chevron signals that it opens. */
 .gatewayBannerToggle,
 .gatewayBannerToggle:hover,
 .gatewayBannerToggle:focus {
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: none;
   color: inherit;
+  font: inherit;
+  text-align: left;
   text-decoration: none;
 }


### PR DESCRIPTION
Implements feature request: https://community.gladysassistant.com/t/integrations-diminuer-le-bandeau-bleu-sur-mobile/10576

### Description

On a phone, the blue "Can't find your device?" banner displayed above the integration catalog took four lines of text and pushed the integration list below the fold, as reported on the forum.

The banner is now extracted into a small `IntegrationGatewayBanner` component (`front/src/routes/integration/IntegrationGatewayBanner.jsx`):

- **On small screens** it is reduced to a single clickable line — the banner title with a chevron. Clicking it expands the description.
- **On desktop the banner is unchanged**: it stays fully expanded and the chevron affordance is hidden. I chose to keep desktop as-is because the banner costs very little vertical space there and it is the onboarding hint that explains what community/external integrations are — hiding it on a wide screen would only make it harder to discover. The forum request is specifically about mobile.

Implementation uses the Bootstrap/Tabler `.collapse` idiom already used by the app header (`front/src/components/header/index.jsx`): the description carries `collapse d-lg-block` plus `show` when expanded, so `d-lg-block` (which is `!important`) wins over `.collapse:not(.show)` from `lg` up. No new dependency, no new CSS beyond three lines making the collapsed title read as a heading rather than a link. `aria-expanded` / `aria-controls` are set on the toggle.

No new translation key was needed: the existing `integration.root.gatewayBanner.title` is the collapsed line, so `compare-translations` is unaffected.

This PR was produced by an automated run.

## Forum

Forum: https://community.gladysassistant.com/t/integrations-diminuer-le-bandeau-bleu-sur-mobile/10576

### Checklist

- [x] Tests pass: no server code changed, so `npm run coverage` is not impacted. Front checks run locally: `npm run prettier`, `npm run prettier-check`, `npm run eslint`, `npm run compare-translations`, `npm run build` all pass.
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change


---
_Generated by [Claude Code](https://claude.ai/code/session_01REGRUvErzpwtSrsi9gKh4J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an integration gateway banner with a localized title and description.
  * On smaller screens, the description can be expanded or collapsed by selecting the title.
  * The description remains expanded on larger screens.
* **Accessibility**
  * Added an accessible keyboard-operable toggle with visible focus states.
  * Improved responsive behavior while preserving clear heading and description presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->