### PR TITLE
Back-port the routine's "do not watch the PR" rule into the versioned prompt

### DIFF
--- a/.github/CLAUDE_AUTOFIX.md
+++ b/.github/CLAUDE_AUTOFIX.md
@@ -257,6 +257,14 @@ in sync. **A new `mode` cannot work until the prompt on the routine's page has
 been updated** — the workflows only send the payload, the prompt is what knows
 what to do with it.
 
+**Before copying, diff the two — the routine's page is what actually runs.**
+Editing the prompt directly in the web UI is easy and leaves no trace in git,
+so the live routine can hold instructions this file has never seen (that is how
+`Do not watch the PR you fix` came to exist only on the routine's page). Copying
+this file over a drifted routine silently deletes those edits. Read the stored
+prompt first, back-port anything missing here, and only then push the merged
+version.
+
 **The prompt must stay backward compatible with the payload already in
 production**, because the two are deployed separately and never atomically: the
 prompt lives in a web UI, the payload in a workflow file. That is why a payload

--- a/.github/CLAUDE_AUTOFIX_ROUTINE_PROMPT.md
+++ b/.github/CLAUDE_AUTOFIX_ROUTINE_PROMPT.md
@@ -30,6 +30,7 @@ Common rules, both modes:
 - Never force-push, never rewrite existing history on <branch>, never create another branch, never open or merge a pull request (the PR already exists), and never change repository settings, secrets or labels.
 - Never print, echo or copy a secret, token or credential anywhere, including in a commit, a comment or a log.
 - Work only inside the checked-out repository, on <branch>, for pull request <number>.
+- Do not watch the PR you fix: do not subscribe to its activity and do not keep monitoring it after your reply. Post your answer and end the run. Follow-ups are the next cron run's job, or a new "/claude" command.
 
 === MODE "scheduled" ===
 


### PR DESCRIPTION
### Description

Follow-up to #2932, found while diagnosing why a `/claude` command on #2910 did nothing.

The live routine's stored prompt ends with a line that **has never existed in `.github/CLAUDE_AUTOFIX_ROUTINE_PROMPT.md`**, on any revision:

```text
Do not watch the PR you fix
```

It was added directly in the claude.ai web UI, which leaves no trace in git. The setup instructions in `CLAUDE_AUTOFIX.md` tell you to copy the versioned file onto the routine's page — doing that today would have **silently deleted that instruction**, and fired sessions would have started subscribing to the activity of every PR they touch.

This PR back-ports it as a *common* rule, so it now also binds the on-demand mode (a `/claude` session should answer and stop, not start watching either), and documents the hazard that caused it: the routine's page is what actually runs, so the two must be diffed before pushing this file over it.

No workflow behaviour changes — this touches only the versioned prompt and its documentation.

### Why this matters now

#2932 is merged, so `claude-on-demand-autofix.yml` is live and firing correctly. But the routine's stored prompt is still the scheduled-only version, so an on-demand payload fails its validation and the session stops without doing anything. That is the documented pending step, not a defect — the prompt still has to be copied to the routine's page for `/claude` to work. This PR makes that copy safe to perform.

## Forum

<!-- Not a forum feature request: this is repository automation. -->

### Checklist

- [x] Tests pass — no application code and no workflow logic is touched (one Markdown line in the versioned prompt, plus documentation), so the server/front suites, Cypress and the gate harness are all unaffected.
- [x] Linter and prettier pass on both front and server — unchanged by this PR. `.github/*.md` is outside prettier's configured scope.
- [x] No undocumented breaking change — the added rule matches what the live routine has been doing all along; this only makes git agree with production.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1EYXKSQN8zZWrcTuCyduQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automation guidance to keep web-based edits aligned with version-controlled content.
  - Updated automated workflow behavior to conclude immediately after responding, reducing unnecessary follow-up activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->