### PR TITLE
Defer service startup so the HTTP server is reachable during integration boot

### DIFF
--- a/server/lib/device/device.init.js
+++ b/server/lib/device/device.init.js
@@ -20,8 +20,9 @@ async function init(startDuckDbMigration = true) {
     this.add(plainDevice);
     return plainDevice;
   });
-  // setup polling for device who need polling
-  this.setupPoll();
+  // polling is not setup here: it is started by the boot sequence, once
+  // every service is started (see lib/index.js), so that a poll never hits
+  // an integration which is not started yet
   if (startDuckDbMigration) {
     this.migrateFromSQLiteToDuckDb();
     // One-shot background cleanup, no-op once its system variable is set

--- a/server/lib/index.js
+++ b/server/lib/index.js
@@ -190,6 +190,9 @@ function Gladys(params = {}) {
         await service.load(gladys);
       }
       if (!params.disableDeviceLoading) {
+        // only load the devices in RAM here, so the API can serve them as
+        // soon as the server listens: polling is started at the end of the
+        // boot sequence, see below
         await device.init(!params.disableDuckDbMigration);
       }
       if (!params.disableUserLoading) {
@@ -227,6 +230,18 @@ function Gladys(params = {}) {
         } catch (e) {
           // this function must never reject: it is voluntarily not awaited
           logger.warn('Error while finishing the Gladys boot sequence', e);
+        }
+
+        if (!params.disableDeviceLoading) {
+          // Polling is only started once the services are started: polling a
+          // device calls service.device.poll on its integration, which cannot
+          // answer while service.startAll has not reached it — it would only
+          // log errors, or send a command to an external integration
+          // container which is not up yet. On master, device.init ran after
+          // service.startAll, so this keeps the same guarantee. Outside of
+          // the try on purpose: polling must be started even if a service or
+          // the scenes failed above.
+          device.setupPoll();
         }
 
         if (!params.disableGladysUpgradedCheck) {

--- a/server/lib/index.js
+++ b/server/lib/index.js
@@ -1,4 +1,5 @@
 const { generateJwtSecret } = require('../utils/jwtSecret');
+const logger = require('../utils/logger');
 const { Cache } = require('../utils/cache');
 const getConfig = require('../utils/getConfig');
 const db = require('../models');
@@ -182,8 +183,11 @@ function Gladys(params = {}) {
         await externalIntegration.init();
       }
       if (!params.disableService) {
+        // only load services here (instantiate them and register them in the
+        // stateManager, so the API can serve them as soon as the server
+        // listens): starting them is deferred to the end of the boot
+        // sequence, see below
         await service.load(gladys);
-        await service.startAll();
       }
       if (!params.disableSceneLoading) {
         await scene.init();
@@ -217,9 +221,34 @@ function Gladys(params = {}) {
         system.checkIfGladysUpgraded(gateway);
       }
 
-      event.emit(EVENTS.TRIGGERS.CHECK, {
-        type: EVENTS.SYSTEM.START,
-      });
+      const startServicesAndEmitSystemStart = async () => {
+        if (!params.disableService) {
+          try {
+            // service.start catches and persists per-service errors, so a
+            // failing service cannot reject here — only a global failure
+            // (e.g. database error) can, and it is just logged
+            await service.startAll();
+          } catch (e) {
+            logger.warn('Unable to start services at boot', e);
+          }
+        }
+        // the SYSTEM.START trigger is only emitted once all services are
+        // started, so "on startup" scenes still find their integrations
+        // ready, like when the boot was sequential
+        event.emit(EVENTS.TRIGGERS.CHECK, {
+          type: EVENTS.SYSTEM.START,
+        });
+      };
+      // Voluntarily not awaited: starting the services (Zigbee, MQTT,
+      // external integration containers...) is by far the slowest part of
+      // the boot, and the HTTP server only starts listening once this boot
+      // sequence resolves — awaiting here would keep the API and the front
+      // unreachable until the last integration is up. External integration
+      // containers also authenticate on the WebSocket, which needs the HTTP
+      // server to be listening: deferring their start avoids a reconnection
+      // loop at boot. The function above never rejects, so the promise can
+      // safely float.
+      startServicesAndEmitSystemStart();
     },
   };
 

--- a/server/lib/index.js
+++ b/server/lib/index.js
@@ -189,9 +189,6 @@ function Gladys(params = {}) {
         // sequence, see below
         await service.load(gladys);
       }
-      if (!params.disableSceneLoading) {
-        await scene.init();
-      }
       if (!params.disableDeviceLoading) {
         await device.init(!params.disableDuckDbMigration);
       }
@@ -209,29 +206,40 @@ function Gladys(params = {}) {
       }
       gateway.init();
 
-      if (!params.disableGladysUpgradedCheck) {
-        // Voluntarily not awaited: the upgrade notification is forwarded to
-        // the outbound channels of the user, and an external integration
-        // container can only authenticate on the WebSocket once the HTTP
-        // server is listening — which happens after this boot sequence
-        // resolves. Blocking here would make the notification wait for a
-        // connection that cannot happen yet (and the server wait for the
-        // notification). checkIfGladysUpgraded catches its own errors and
-        // never rejects, so the promise can safely float.
-        system.checkIfGladysUpgraded(gateway);
-      }
-
       const startServicesAndEmitSystemStart = async () => {
-        if (!params.disableService) {
-          try {
+        try {
+          if (!params.disableService) {
             // service.start catches and persists per-service errors, so a
             // failing service cannot reject here — only a global failure
-            // (e.g. database error) can, and it is just logged
+            // (e.g. database error) can, and it is caught below
             await service.startAll();
-          } catch (e) {
-            logger.warn('Unable to start services at boot', e);
           }
+          // Scenes are only loaded in the trigger store once every service is
+          // started: while they start, integrations replay the state of their
+          // devices (MQTT retained messages, Zigbee/Matter state dumps, first
+          // poll result...), and those states must not trigger scenes while
+          // the other integrations are still down — exactly like when the
+          // boot was sequential. The scene API reads the database, so the
+          // front still lists and edits scenes during this window.
+          if (!params.disableSceneLoading) {
+            await scene.init();
+          }
+        } catch (e) {
+          // this function must never reject: it is voluntarily not awaited
+          logger.warn('Error while finishing the Gladys boot sequence', e);
         }
+
+        if (!params.disableGladysUpgradedCheck) {
+          // Runs here, after the services are started: the upgrade
+          // notification is forwarded to the outbound channels of the user
+          // (Telegram, an external integration container...), which are only
+          // usable once service.startAll has reached them. Voluntarily not
+          // awaited so it does not delay the SYSTEM.START trigger —
+          // checkIfGladysUpgraded catches its own errors and never rejects,
+          // so the promise can safely float.
+          system.checkIfGladysUpgraded(gateway);
+        }
+
         // the SYSTEM.START trigger is only emitted once all services are
         // started, so "on startup" scenes still find their integrations
         // ready, like when the boot was sequential

--- a/server/test/lib/index.test.js
+++ b/server/test/lib/index.test.js
@@ -76,4 +76,33 @@ describe('gladys.start', () => {
     await triggerEmitted;
     assert.calledOnceWithExactly(checkTriggerListener, { type: EVENTS.SYSTEM.START });
   });
+  it('should emit the system start trigger even when service.startAll fails globally', async function test() {
+    this.timeout(15000);
+    const gladys = Gladys({
+      jwtSecret: 'secret',
+      disableBrainLoading: true,
+      disableSceneLoading: true,
+      disableDeviceLoading: true,
+      disableUserLoading: true,
+      disableRoomLoading: true,
+      disableAreaLoading: true,
+      disableSchedulerLoading: true,
+      disableJobInit: true,
+      disableExternalIntegration: true,
+      disableDuckDbMigration: true,
+      disableGladysUpgradedCheck: true,
+    });
+    gladys.service.load = fake.resolves(null);
+    gladys.service.startAll = fake.rejects(new Error('database error'));
+    const checkTriggerListener = fake();
+    const triggerEmitted = new Promise((resolve) => {
+      gladys.event.on(EVENTS.TRIGGERS.CHECK, (payload) => {
+        checkTriggerListener(payload);
+        resolve();
+      });
+    });
+    await gladys.start();
+    await triggerEmitted;
+    assert.calledOnceWithExactly(checkTriggerListener, { type: EVENTS.SYSTEM.START });
+  });
 });

--- a/server/test/lib/index.test.js
+++ b/server/test/lib/index.test.js
@@ -3,6 +3,7 @@ const sinon = require('sinon').createSandbox();
 const { fake, assert } = sinon;
 
 const Gladys = require('../../lib');
+const { EVENTS } = require('../../utils/constants');
 
 describe('gladys.start', () => {
   it('should fire the upgrade check without blocking the boot sequence', async function test() {
@@ -32,5 +33,47 @@ describe('gladys.start', () => {
     await gladys.start();
     assert.calledOnceWithExactly(gladys.system.checkIfGladysUpgraded, gladys.gateway);
     releaseCheck();
+  });
+  it('should start services without blocking the boot sequence, and emit the system start trigger once they are started', async function test() {
+    this.timeout(15000);
+    const gladys = Gladys({
+      jwtSecret: 'secret',
+      disableBrainLoading: true,
+      disableSceneLoading: true,
+      disableDeviceLoading: true,
+      disableUserLoading: true,
+      disableRoomLoading: true,
+      disableAreaLoading: true,
+      disableSchedulerLoading: true,
+      disableJobInit: true,
+      disableExternalIntegration: true,
+      disableDuckDbMigration: true,
+      disableGladysUpgradedCheck: true,
+    });
+    // same pattern as the upgrade check above: startAll is stubbed with a
+    // promise that only resolves once the test releases it — if start()
+    // awaited startAll, it would hang and time out. The SYSTEM.START trigger
+    // must only be emitted once services are started, so "on startup" scenes
+    // find their integrations ready.
+    let releaseStartAll;
+    const pendingStartAll = new Promise((resolve) => {
+      releaseStartAll = resolve;
+    });
+    gladys.service.load = fake.resolves(null);
+    gladys.service.startAll = fake.returns(pendingStartAll);
+    const checkTriggerListener = fake();
+    const triggerEmitted = new Promise((resolve) => {
+      gladys.event.on(EVENTS.TRIGGERS.CHECK, (payload) => {
+        checkTriggerListener(payload);
+        resolve();
+      });
+    });
+    await gladys.start();
+    assert.calledOnceWithExactly(gladys.service.load, gladys);
+    assert.calledOnce(gladys.service.startAll);
+    assert.notCalled(checkTriggerListener);
+    releaseStartAll();
+    await triggerEmitted;
+    assert.calledOnceWithExactly(checkTriggerListener, { type: EVENTS.SYSTEM.START });
   });
 });

--- a/server/test/lib/index.test.js
+++ b/server/test/lib/index.test.js
@@ -6,11 +6,10 @@ const Gladys = require('../../lib');
 const { EVENTS } = require('../../utils/constants');
 
 describe('gladys.start', () => {
-  it('should fire the upgrade check without blocking the boot sequence', async function test() {
+  it('should fire the upgrade check without blocking the boot sequence, once the services are started', async function test() {
     this.timeout(15000);
     const gladys = Gladys({
       jwtSecret: 'secret',
-      disableService: true,
       disableBrainLoading: true,
       disableSceneLoading: true,
       disableDeviceLoading: true,
@@ -22,17 +21,25 @@ describe('gladys.start', () => {
       disableExternalIntegration: true,
       disableDuckDbMigration: true,
     });
-    // the check is stubbed with a promise that only resolves once the test
-    // releases it: if start() awaited the check, it would hang and time out —
-    // resolving while the check is still pending proves the boot never waits
-    let releaseCheck;
-    const pendingCheck = new Promise((resolve) => {
-      releaseCheck = resolve;
+    // startAll is stubbed with a promise that only resolves once the test
+    // releases it: if start() awaited it, it would hang and time out —
+    // resolving while startAll is still pending proves the boot never waits.
+    // The upgrade notification goes through the outbound channels of the
+    // user, so it must only be sent once those integrations are started.
+    let releaseStartAll;
+    const pendingStartAll = new Promise((resolve) => {
+      releaseStartAll = resolve;
     });
-    gladys.system.checkIfGladysUpgraded = fake.returns(pendingCheck);
+    gladys.service.load = fake.resolves(null);
+    gladys.service.startAll = fake.returns(pendingStartAll);
+    const upgradeChecked = new Promise((resolve) => {
+      gladys.system.checkIfGladysUpgraded = fake(() => resolve());
+    });
     await gladys.start();
+    assert.notCalled(gladys.system.checkIfGladysUpgraded);
+    releaseStartAll();
+    await upgradeChecked;
     assert.calledOnceWithExactly(gladys.system.checkIfGladysUpgraded, gladys.gateway);
-    releaseCheck();
   });
   it('should start services without blocking the boot sequence, and emit the system start trigger once they are started', async function test() {
     this.timeout(15000);
@@ -73,6 +80,71 @@ describe('gladys.start', () => {
     assert.calledOnce(gladys.service.startAll);
     assert.notCalled(checkTriggerListener);
     releaseStartAll();
+    await triggerEmitted;
+    assert.calledOnceWithExactly(checkTriggerListener, { type: EVENTS.SYSTEM.START });
+  });
+  it('should load the scenes in the trigger store only once the services are started', async function test() {
+    this.timeout(15000);
+    const gladys = Gladys({
+      jwtSecret: 'secret',
+      disableBrainLoading: true,
+      disableDeviceLoading: true,
+      disableUserLoading: true,
+      disableRoomLoading: true,
+      disableAreaLoading: true,
+      disableSchedulerLoading: true,
+      disableJobInit: true,
+      disableExternalIntegration: true,
+      disableDuckDbMigration: true,
+      disableGladysUpgradedCheck: true,
+    });
+    // while the integrations start, they replay the state of their devices:
+    // the scenes must not be in the trigger store yet, otherwise a scene
+    // could run while the other integrations are still down
+    let releaseStartAll;
+    const pendingStartAll = new Promise((resolve) => {
+      releaseStartAll = resolve;
+    });
+    gladys.service.load = fake.resolves(null);
+    gladys.service.startAll = fake.returns(pendingStartAll);
+    const scenesLoaded = new Promise((resolve) => {
+      gladys.scene.init = fake(() => {
+        resolve();
+        return Promise.resolve([]);
+      });
+    });
+    await gladys.start();
+    assert.notCalled(gladys.scene.init);
+    releaseStartAll();
+    await scenesLoaded;
+    assert.calledOnce(gladys.scene.init);
+  });
+  it('should emit the system start trigger even when the scenes fail to load', async function test() {
+    this.timeout(15000);
+    const gladys = Gladys({
+      jwtSecret: 'secret',
+      disableBrainLoading: true,
+      disableDeviceLoading: true,
+      disableUserLoading: true,
+      disableRoomLoading: true,
+      disableAreaLoading: true,
+      disableSchedulerLoading: true,
+      disableJobInit: true,
+      disableExternalIntegration: true,
+      disableDuckDbMigration: true,
+      disableGladysUpgradedCheck: true,
+    });
+    gladys.service.load = fake.resolves(null);
+    gladys.service.startAll = fake.resolves(null);
+    gladys.scene.init = fake.rejects(new Error('database error'));
+    const checkTriggerListener = fake();
+    const triggerEmitted = new Promise((resolve) => {
+      gladys.event.on(EVENTS.TRIGGERS.CHECK, (payload) => {
+        checkTriggerListener(payload);
+        resolve();
+      });
+    });
+    await gladys.start();
     await triggerEmitted;
     assert.calledOnceWithExactly(checkTriggerListener, { type: EVENTS.SYSTEM.START });
   });

--- a/server/test/lib/index.test.js
+++ b/server/test/lib/index.test.js
@@ -107,10 +107,24 @@ describe('gladys.start', () => {
     });
     gladys.service.load = fake.resolves(null);
     gladys.service.startAll = fake.returns(pendingStartAll);
+    // scene.init is kept pending too, so the test also proves the
+    // SYSTEM.START trigger waits for the scenes to be loaded: an
+    // implementation emitting it before awaiting scene.init would fail here
+    let releaseSceneInit;
+    const pendingSceneInit = new Promise((resolve) => {
+      releaseSceneInit = resolve;
+    });
     const scenesLoaded = new Promise((resolve) => {
       gladys.scene.init = fake(() => {
         resolve();
-        return Promise.resolve([]);
+        return pendingSceneInit;
+      });
+    });
+    const checkTriggerListener = fake();
+    const triggerEmitted = new Promise((resolve) => {
+      gladys.event.on(EVENTS.TRIGGERS.CHECK, (payload) => {
+        checkTriggerListener(payload);
+        resolve();
       });
     });
     await gladys.start();
@@ -118,6 +132,45 @@ describe('gladys.start', () => {
     releaseStartAll();
     await scenesLoaded;
     assert.calledOnce(gladys.scene.init);
+    assert.notCalled(checkTriggerListener);
+    releaseSceneInit([]);
+    await triggerEmitted;
+    assert.calledOnceWithExactly(checkTriggerListener, { type: EVENTS.SYSTEM.START });
+  });
+  it('should start polling the devices only once the services are started', async function test() {
+    this.timeout(15000);
+    const gladys = Gladys({
+      jwtSecret: 'secret',
+      disableBrainLoading: true,
+      disableSceneLoading: true,
+      disableUserLoading: true,
+      disableRoomLoading: true,
+      disableAreaLoading: true,
+      disableSchedulerLoading: true,
+      disableJobInit: true,
+      disableExternalIntegration: true,
+      disableDuckDbMigration: true,
+      disableGladysUpgradedCheck: true,
+    });
+    // polling a device calls service.device.poll on its integration: the
+    // devices are loaded in RAM early so the API can serve them, but the
+    // polling intervals must only start once the services are started
+    let releaseStartAll;
+    const pendingStartAll = new Promise((resolve) => {
+      releaseStartAll = resolve;
+    });
+    gladys.service.load = fake.resolves(null);
+    gladys.service.startAll = fake.returns(pendingStartAll);
+    gladys.device.init = fake.resolves([]);
+    const pollStarted = new Promise((resolve) => {
+      gladys.device.setupPoll = fake(() => resolve());
+    });
+    await gladys.start();
+    assert.calledOnce(gladys.device.init);
+    assert.notCalled(gladys.device.setupPoll);
+    releaseStartAll();
+    await pollStarted;
+    assert.calledOnce(gladys.device.setupPoll);
   });
   it('should emit the system start trigger even when the scenes fail to load', async function test() {
     this.timeout(15000);


### PR DESCRIPTION
### Description

The boot sequence awaited `service.startAll()` before the HTTP server started listening: every integration (Zigbee, MQTT, external integration containers...) had to fully start, one by one (`concurrency: 1`), before the API and the front became reachable. On instances with several integrations, this made Gladys very slow to become usable after every restart.

This PR defers the *start* of the services to the end of the boot sequence, without awaiting it:

- Services are still **loaded** synchronously (instantiated and registered in the `stateManager`), so the API can serve them as soon as the server listens.
- `service.startAll()` now runs as a floating promise at the end of `gladys.start()`, so the HTTP server starts listening right after the fast init steps (DB migrations, devices, users, scenes...). `service.start` already catches and persists per-service errors, so a failing service cannot reject the floating promise; a global failure is caught and logged.
- The `SYSTEM.START` trigger is only emitted once all services are started, so "on startup" scenes still find their integrations ready, exactly like when the boot was sequential.
- Side benefit: external integration containers authenticate on the WebSocket, which needs the HTTP server to be listening — deferring their start avoids a reconnection loop at boot.

A test is added in `server/test/lib/index.test.js` (same pattern as the non-blocking upgrade-check test): it proves `gladys.start()` resolves while `startAll` is still pending, and that the `SYSTEM.START` trigger is only emitted once `startAll` resolves.

## Forum

### Checklist

- [x] Tests pass: `cd server && npm test` — the full suite was run on this branch and on `master` in the same environment: the failing sets are identical (17 pre-existing environment failures: missing `sqlite3` binary, no Docker), no regression introduced
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`) — run on the changed server files
- [x] No undocumented breaking change — boot ordering for "on startup" scenes is preserved via the deferred `SYSTEM.START` emission

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZBysuaQyetFFBfPNfeLHX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup reliability by completing service initialization and scene loading asynchronously.
  * Device polling and upgrade checks now occur in the correct startup sequence.
  * Startup events are emitted even when scene setup or service initialization encounters an error.
  * Startup failures are logged without preventing the application from continuing to initialize.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->