### PR TITLE
fix: do not overwrite feature last_value when a device is saved (#2930)

### DIFF
--- a/server/lib/device/device.create.js
+++ b/server/lib/device/device.create.js
@@ -37,6 +37,23 @@ const getDeviceInDb = async (device) => {
   return deviceByExternalId;
 };
 
+// Those columns hold the current STATE of a feature, not its definition: they are
+// written by device.saveState / device.saveStringState and by the aggregation jobs.
+// A caller saving a device sends back the features it read earlier (the MQTT device
+// page posts the whole device just to append one feature), so letting them through
+// rolled every existing feature back to the value the client had in hand — null for
+// a feature that had not received anything yet when the page was loaded. They are
+// only accepted when the feature is created, so an integration can declare a first
+// value along with a brand new feature (lan-manager does it for presence).
+const DEVICE_FEATURE_STATE_COLUMNS = [
+  'last_value',
+  'last_value_string',
+  'last_value_changed',
+  'last_hourly_aggregate',
+  'last_daily_aggregate',
+  'last_monthly_aggregate',
+];
+
 const matchFeatureInList = (existingFeature, features) => {
   // We are matching on both external_id and id, so we can match a device that changed external_id but kept the same id
   return features.find(
@@ -197,6 +214,9 @@ async function create(device) {
           const keepHistoryBeforeUpdate = deviceFeature.keep_history;
           const featureToUpdate = { ...feature };
           delete featureToUpdate.selector;
+          DEVICE_FEATURE_STATE_COLUMNS.forEach((column) => {
+            delete featureToUpdate[column];
+          });
           await deviceFeature.update(featureToUpdate, { transaction });
           if (keepHistoryBeforeUpdate !== false && deviceFeature.keep_history === false) {
             deviceFeaturesIdsToPurge.push(deviceFeature.id);

--- a/server/test/lib/device/device.create.test.js
+++ b/server/test/lib/device/device.create.test.js
@@ -375,6 +375,21 @@ describe('Device', () => {
     const stateManager = new StateManager(event);
     const serviceManager = new ServiceManager({}, stateManager);
     const device = new Device(event, {}, stateManager, serviceManager, {}, {}, job, brain);
+    // Every state column gets a distinct persisted value, so an overwrite of any one of
+    // them fails here instead of silently passing on a column that is null on both sides.
+    const persistedLastValueChanged = new Date('2019-02-12T07:49:07.556Z');
+    const persistedHourlyAggregate = new Date('2020-03-01T10:00:00.000Z');
+    const persistedDailyAggregate = new Date('2020-03-01T00:00:00.000Z');
+    const persistedMonthlyAggregate = new Date('2020-03-01T00:00:00.000Z');
+    await db.DeviceFeature.update(
+      {
+        last_value_string: 'persisted-string',
+        last_hourly_aggregate: persistedHourlyAggregate,
+        last_daily_aggregate: persistedDailyAggregate,
+        last_monthly_aggregate: persistedMonthlyAggregate,
+      },
+      { where: { id: 'ce9dc798-b09f-4e51-8c16-311cdebf97cd' } },
+    );
     // The MQTT device page posts the whole device back just to append one feature, and the
     // existing features it carries hold whatever the page had in hand when it was loaded:
     // stale, or null for a feature that had not received any value yet.
@@ -394,8 +409,11 @@ describe('Device', () => {
           min: 0,
           max: 100,
           last_value: null,
-          last_value_string: null,
+          last_value_string: 'stale-string',
           last_value_changed: null,
+          last_hourly_aggregate: new Date('2019-01-01T00:00:00.000Z'),
+          last_daily_aggregate: new Date('2019-01-01T00:00:00.000Z'),
+          last_monthly_aggregate: new Date('2019-01-01T00:00:00.000Z'),
         },
         {
           name: 'Brand new feature',
@@ -414,7 +432,11 @@ describe('Device', () => {
 
     const existingFeature = newDevice.features.find((feature) => feature.external_id === 'hue:brightness:1');
     expect(existingFeature).to.have.property('last_value', 20);
-    expect(existingFeature.last_value_changed).to.not.equal(null);
+    expect(existingFeature).to.have.property('last_value_string', 'persisted-string');
+    expect(existingFeature.last_value_changed).to.deep.equal(persistedLastValueChanged);
+    expect(existingFeature.last_hourly_aggregate).to.deep.equal(persistedHourlyAggregate);
+    expect(existingFeature.last_daily_aggregate).to.deep.equal(persistedDailyAggregate);
+    expect(existingFeature.last_monthly_aggregate).to.deep.equal(persistedMonthlyAggregate);
 
     const createdFeature = newDevice.features.find((feature) => feature.external_id === 'hue:brand-new-feature:1');
     expect(createdFeature).to.have.property('last_value', 1);

--- a/server/test/lib/device/device.create.test.js
+++ b/server/test/lib/device/device.create.test.js
@@ -248,7 +248,9 @@ describe('Device', () => {
         last_daily_aggregate: null,
         last_hourly_aggregate: null,
         last_monthly_aggregate: null,
-        last_value_changed: null,
+        // The current state of a feature is not part of what a device save writes:
+        // the seeded last_value_changed survives the update.
+        last_value_changed: new Date('2019-02-12T07:49:07.556Z'),
         last_value_string: null,
         unit: null,
         supported_options: [],
@@ -358,7 +360,9 @@ describe('Device', () => {
         last_daily_aggregate: null,
         last_hourly_aggregate: null,
         last_monthly_aggregate: null,
-        last_value_changed: null,
+        // The current state of a feature is not part of what a device save writes:
+        // the seeded last_value_changed survives the update.
+        last_value_changed: new Date('2019-02-12T07:49:07.556Z'),
         last_value_string: null,
         unit: null,
         supported_options: [],
@@ -366,6 +370,54 @@ describe('Device', () => {
         updated_at: newDevice.features[0] && newDevice.features[0].updated_at,
       },
     ]);
+  });
+  it('should keep the last value of existing features when a new feature is added', async () => {
+    const stateManager = new StateManager(event);
+    const serviceManager = new ServiceManager({}, stateManager);
+    const device = new Device(event, {}, stateManager, serviceManager, {}, {}, job, brain);
+    // The MQTT device page posts the whole device back just to append one feature, and the
+    // existing features it carries hold whatever the page had in hand when it was loaded:
+    // stale, or null for a feature that had not received any value yet.
+    const newDevice = await device.create({
+      name: 'Test device',
+      external_id: 'test-device-external',
+      service_id: 'a810b8db-6d04-4697-bed3-c4b72c996279',
+      features: [
+        {
+          id: 'ce9dc798-b09f-4e51-8c16-311cdebf97cd',
+          name: 'Test device feature 2',
+          external_id: 'hue:brightness:1',
+          category: 'light',
+          type: 'brightness',
+          read_only: false,
+          has_feedback: false,
+          min: 0,
+          max: 100,
+          last_value: null,
+          last_value_string: null,
+          last_value_changed: null,
+        },
+        {
+          name: 'Brand new feature',
+          external_id: 'hue:brand-new-feature:1',
+          category: 'light',
+          type: 'binary',
+          read_only: false,
+          has_feedback: false,
+          min: 0,
+          max: 1,
+          // A first value declared along with a brand new feature is still accepted
+          last_value: 1,
+        },
+      ],
+    });
+
+    const existingFeature = newDevice.features.find((feature) => feature.external_id === 'hue:brightness:1');
+    expect(existingFeature).to.have.property('last_value', 20);
+    expect(existingFeature.last_value_changed).to.not.equal(null);
+
+    const createdFeature = newDevice.features.find((feature) => feature.external_id === 'hue:brand-new-feature:1');
+    expect(createdFeature).to.have.property('last_value', 1);
   });
   it('should update device which already exist with a new poll frequency', async () => {
     const stateManager = new StateManager(event);


### PR DESCRIPTION
> ⚠️ This pull request was produced by an automated routine and has **not been reviewed by a human**. Please review it carefully before merging.

Fixes #2930

### Description

**What changed and why**

`last_value`, `last_value_string`, `last_value_changed` and the three aggregate bookmarks (`last_hourly_aggregate`, `last_daily_aggregate`, `last_monthly_aggregate`) hold the *current state* of a device feature. They are written by `device.saveState` / `device.saveStringState` and by the aggregation jobs — they are not part of a feature's definition.

`server/lib/device/device.create.js` passed the caller's feature payload straight to `deviceFeature.update()`, so those columns were writable through a plain device save.

The MQTT device page does exactly that: it loads the device with `GET /api/v1/device/:selector`, appends one feature, and posts the **whole** device back to `POST /api/v1/device`. Its snapshot of the existing features is stale, because `device.add()` replaces `device.features` with a fresh array of objects while the `deviceFeature` state store keeps the previous objects — after a device has been saved once, `device.saveState` only mutates the store copy, and the device object served by `getBySelector` stops being refreshed. Posting that snapshot back rolled every previously existing feature to the value the page had in hand, i.e. `null` for any feature that had received nothing yet when the page was loaded. That is the "adding a new feature erases the last_value of previously existing features" reported in #2930.

The fix strips those state columns from the payload **on the update path only**. They are still accepted when a feature is *created*, so an integration can declare a first value along with a brand new feature — `lan-manager` does it for its presence feature (`last_value: 1`).

Two existing assertions in `device.create.test.js` encoded the old behaviour (`last_value_changed` becoming `null` after a save that posted `null`) and were updated to the seeded date, plus a new dedicated test.

**What was verified locally**

- `server/test/lib/device/device.create.test.js` — 34 passing, 0 failing (includes the new test `should keep the last value of existing features when a new feature is added`).
- `test/lib/device/**`, `test/controllers/device/*`, `test/services/lan-manager/**` — 397 passing, 0 failing.
- Full server suite (`mocha --parallel --recursive "./test/**/*.test.js"`) — exit code 0.
- `cd server && npm run eslint` — 0 errors (29 pre-existing warnings elsewhere in the tree, none in the touched files).
- `cd server && npm run prettier-check` — all files formatted.
- No front-end file was touched, so the front lint/build/Cypress jobs were not run locally.

**What a human must check before merge**

- That no integration relies on `device.create` to update the current value of an **existing** feature. A grep over `server/services/` found only `lan-manager` writing `last_value` into a feature payload, and it only does so for freshly discovered devices, which still works — but the check is worth repeating.
- The underlying RAM staleness is **not** fixed here: after a device is saved, `stateManager.get('device', selector).features[i]` and `stateManager.get('deviceFeature', selector)` are different objects (`device.add` + `Store.setState` use `Object.assign`), so `GET /api/v1/device/:selector` keeps serving the value frozen at the last save. The data loss is fixed server-side, but the MQTT device page will still *display* a stale last value until the process restarts. Worth deciding whether `device.add` should be fixed in a follow-up.
- Whether the aggregate bookmarks should also be protected on the create path (they are currently accepted there, like `last_value`).

### Checklist

- [x] Tests pass: `cd server && npm test` (full suite, exit 0). Cypress not run (no UI change).
- [x] Linter and prettier pass on the server (`npm run eslint`, `npm run prettier-check`)
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7wr1RZjtQw6E1qbKsm52a)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing device feature state when updating devices.
  * Prevented updates from unintentionally overwriting stored feature values and change timestamps.
  * New features can still be created with an initial value while existing feature data remains intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->