### PR TITLE
fix: HomeKit cannot turn on an AC whose integration declares no supported option (#2938)

### DIFF
--- a/server/services/homekit/lib/buildThermostatService.js
+++ b/server/services/homekit/lib/buildThermostatService.js
@@ -82,7 +82,12 @@ function listSupportedModes(modeFeature, modeToHeatingCoolingState) {
   // a Matter cooling-only air conditioner reports cool, dry and fan — 1, 3 and 4 — so walking
   // min..max would offer HomeKit a heat mode the device cannot honour, and SET would write it.
   // min/max are only a fallback for integrations that declare no options.
-  if (modeFeature.supported_options) {
+  //
+  // The length matters: a device loaded from the database always carries the association, so a
+  // feature with no declared option arrives as an empty array rather than undefined. Treating that
+  // as a declaration of "no mode at all" left an air conditioner with an on/off command — MELCloud,
+  // among others — with Off as its only valid HomeKit state, so the Home app could not turn it on.
+  if (modeFeature.supported_options && modeFeature.supported_options.length > 0) {
     return modeFeature.supported_options.map(({ value }) => value);
   }
   return Object.keys(modeToHeatingCoolingState)

--- a/server/test/services/homekit/lib/buildService.test.js
+++ b/server/test/services/homekit/lib/buildService.test.js
@@ -2266,6 +2266,71 @@ describe('Build service', () => {
     expect(homekitHandler.gladys.event.emit.args[2][1].value).to.equal(AC_MODE.COOLING);
   });
 
+  it('should still offer the on states when the device declares an empty options list', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-power').returns({ last_value: 0 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-mode').returns({ last_value: AC_MODE.AUTO });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-temp').returns({ last_value: 21 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildThermostatHapStub();
+    homekitHandler.hap = hap;
+
+    // an air conditioner whose integration declares no supported option: loaded from the database
+    // the feature carries an empty list, not a missing one, and the modes must still be deduced
+    // from the min/max range — otherwise off is the only state HomeKit is given and the Home app
+    // cannot turn the device back on
+    const device = { name: 'Clim', selector: 'clim' };
+    const features = [
+      {
+        name: 'Marche',
+        selector: 'clim-power',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.BINARY,
+        min: 0,
+        max: 1,
+        supported_options: [],
+      },
+      {
+        name: 'Mode',
+        selector: 'clim-mode',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
+        min: AC_MODE.AUTO,
+        max: AC_MODE.COOLING,
+        supported_options: [],
+      },
+      {
+        name: 'Consigne',
+        selector: 'clim-temp',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE,
+        unit: DEVICE_FEATURE_UNITS.CELSIUS,
+        min: 16,
+        max: 31,
+        supported_options: [],
+      },
+    ];
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
+
+    // off, cool and auto, instead of off alone
+    expect(characteristics.TargetHeatingCoolingState.setProps.args[0][0]).to.eql({ validValues: [0, 2, 3] });
+
+    const cb = stub();
+    await characteristics.TargetHeatingCoolingState.handlers.set(2, cb);
+
+    expect(homekitHandler.gladys.event.emit.args[0][1].device_feature).to.equal('clim-power');
+    expect(homekitHandler.gladys.event.emit.args[0][1].value).to.equal(1);
+    expect(homekitHandler.gladys.event.emit.args[1][1].device_feature).to.equal('clim-mode');
+    expect(homekitHandler.gladys.event.emit.args[1][1].value).to.equal(AC_MODE.COOLING);
+
+    await characteristics.TargetHeatingCoolingState.handlers.set(0, cb);
+
+    expect(homekitHandler.gladys.event.emit.args[2][1].device_feature).to.equal('clim-power');
+    expect(homekitHandler.gladys.event.emit.args[2][1].value).to.equal(0);
+  });
+
   it('should build thermostat service from a setpoint and a temperature sensor', async () => {
     homekitHandler.gladys.stateManager.get = stub();
     homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'chauffage-setpoint').returns({ last_value: 21 });

--- a/server/test/services/homekit/lib/buildThermostatService.test.js
+++ b/server/test/services/homekit/lib/buildThermostatService.test.js
@@ -92,6 +92,25 @@ describe('Thermostat valid target states', () => {
     expect(buildValidTargetStates({ modeFeature: { min: 2, max: 2 } })).to.eql([1]);
   });
 
+  it('should fall back on the min/max range when the options list is empty', () => {
+    // a feature loaded from the database always carries the association, so an integration that
+    // declares no option arrives with an empty array and not with no array at all. Reading that as
+    // "no mode at all" left an air conditioner with an on/off command offering off and nothing
+    // else, and the Home app could not turn it back on
+    expect(buildValidTargetStates({ modeFeature: { min: 0, max: 4, supported_options: [] } })).to.eql([1, 2, 3]);
+    expect(
+      buildValidTargetStates({
+        powerFeature: POWER,
+        modeFeature: { min: AC_MODE.AUTO, max: AC_MODE.COOLING, supported_options: [] },
+      }),
+    ).to.eql([0, 2, 3]);
+    expect(
+      buildValidTargetStates({
+        thermostatModeFeature: { min: THERMOSTAT_MODE.OFF, max: THERMOSTAT_MODE.HEATING, supported_options: [] },
+      }),
+    ).to.eql([0, 1]);
+  });
+
   it('should offer off only when the device has an on/off command', () => {
     expect(
       buildValidTargetStates({


### PR DESCRIPTION
> **This pull request was produced by an automated routine and has NOT been reviewed by a human.** Please review it carefully before merging.

Fixes #2938

### Description

**(a) What changed and why**

`buildValidTargetStates` builds the list of `TargetHeatingCoolingState` values HomeKit is allowed to set, and it asks `listSupportedModes` which Gladys modes the device declares. That helper preferred `supported_options` and only fell back on the feature `min`/`max` range when no options were declared:

```js
if (modeFeature.supported_options) {
  return modeFeature.supported_options.map(({ value }) => value);
}
```

A device feature loaded from the database always carries its `supported_options` association (`getStandardDeviceIncludes` includes it, and `device.get` is what the bridge reads), so an integration that declares no option arrives with an **empty array**, not with no array at all. `[]` is truthy, so the fallback never ran and the helper answered "this device supports no mode at all".

For an air conditioner exposing an on/off command plus a mode — MELCloud is exactly this shape: `air-conditioning:binary` + `air-conditioning:mode` + `air-conditioning:target-temperature`, none of them declaring supported options — the valid target states then collapsed to `[OFF]` alone. HomeKit was told the only state the accessory accepts is *Off*, which is why the Home app showed the AC permanently "Éteint" with no way to turn it on. The same empty list also made `writeMode` refuse to write any mode.

The fix is one condition: the options list is only authoritative when it actually contains something, otherwise the existing `min`/`max` fallback applies as it was meant to. It is confined to `server/services/homekit/lib/buildThermostatService.js`; no integration and no other service is touched.

**(b) What I verified locally**

- `mocha ./test/services/homekit/**/*.test.js` — **178 passing, 0 failing**.
- Reverting only the source change (keeping the new tests) makes **2 tests fail**, so the tests do cover the fixed line.
- `eslint` on the three touched files — clean.
- `prettier --check` on the three touched files — clean.
- Two tests added:
  - `buildThermostatService.test.js` — `buildValidTargetStates` falls back on `min`/`max` when `supported_options` is `[]`, for an AC mode and for a thermostat mode.
  - `buildService.test.js` — a MELCloud-shaped accessory (power + mode + setpoint, every feature carrying `supported_options: []`) is offered `validValues: [0, 2, 3]` instead of `[0]`, and `SET(COOL)` emits power `1` + mode `COOLING` while `SET(OFF)` emits power `0`.

**(c) What a human must check before merging**

- **Verification on real hardware was not possible here.** The fix should be confirmed against a real MELCloud AC paired through the HomeKit bridge: the accessory must offer Off / Cool / Auto and actually switch on and off from the Home app and from Siri. The bridge may need to be reset (or the accessory re-paired) for iOS to pick up the new `validValues`.
- **A separate MELCloud bug is *not* fixed here and will still limit the modes offered.** `server/services/melcloud/lib/device/air-to-air.device.js` declares the mode feature as `min: 0, max: 1`, while it maps `AC_MODE.HEATING` (2), `AC_MODE.DRYING` (3) and `AC_MODE.FAN` (4) as well. With the range fallback, HomeKit will therefore only be offered Off / Cool / Auto — *heat will still be missing*. Widening that to `max: 4` looked like a separate issue (and would not migrate features already stored in existing installs), so it was deliberately left out of this focused fix. Worth deciding whether to open a follow-up.
- Confirm the reporter's accessory really is a MELCloud device and not another integration, since the analysis is based on reading the code rather than on reproducing with the device.

## Forum

<!-- no forum topic -->

### Checklist

- [x] Tests pass: HomeKit service suite run locally (178 passing); the changed line is covered by the two new tests. The full `npm run coverage` / Cypress run was not executed.
- [x] Linter and prettier pass on the touched server files
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7wr1RZjtQw6E1qbKsm52a)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HomeKit thermostat and air conditioner mode detection when supported mode options are empty.
  * Correctly exposes available off, cooling, and automatic states using configured mode ranges.
  * Ensures enabling cooling sends the required power and mode commands, while disabling sends a power-off command.
* **Tests**
  * Added regression coverage for air conditioner and thermostat mode handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->