### PR TITLE
Fix missing vertical spacing under the link dashboard widget

### DIFF
--- a/front/src/components/boxs/link/LinkBox.jsx
+++ b/front/src/components/boxs/link/LinkBox.jsx
@@ -20,15 +20,15 @@ const LinkBox = ({ box }) => {
   }
 
   return (
-    <a href={url} target="_blank" rel="noopener noreferrer" class={style.linkCard}>
-      <div class="card mb-0">
+    <div class="card">
+      <a href={url} target="_blank" rel="noopener noreferrer" class={style.linkCard}>
         <div class={style.linkContent}>
           <i class={`fe fe-${icon} ${style.linkIcon}`} />
           <span class={style.linkTitle}>{title || url}</span>
           <i class={`fe fe-external-link ${style.linkArrow}`} />
         </div>
-      </div>
-    </a>
+      </a>
+    </div>
   );
 };
 


### PR DESCRIPTION
Implements feature request: https://community.gladysassistant.com/t/probleme-daffichage-widget/10582

### Description

On the dashboard, the "link" widget had no vertical gap with the widget displayed below it, unlike every other box type.

Cause: in `front/src/components/boxs/link/LinkBox.jsx`, the box was rendered as an `<a>` wrapping `<div class="card mb-0">`. Every dashboard box gets its bottom spacing from the theme's `.card` rule (`margin-bottom: 1.5rem`), and the `mb-0` utility class explicitly removed it, so the link box ended up flush against the next one.

Fix: the `.card` is now the root element of the box, exactly like the other boxes (and like the empty-URL state of this same box, which was already correct), and the `<a>` wraps the content inside the card. The standard card spacing therefore applies in all dashboard layouts and on mobile, without any hard-coded one-off margin. The anchor still fills the whole card, so the entire card stays clickable, and the hover styles are unchanged. Dashboard edit mode is not affected: it renders `EditLinkBox` through `BaseEditBox`, which was not touched, so drag & drop and the edit affordances are untouched.

This PR was created by an automated Claude Code run.

## Forum

Forum: https://community.gladysassistant.com/t/probleme-daffichage-widget/10582

### Checklist

- [ ] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

Checks run locally in `front/`: `npm run prettier`, `npm run prettier-check`, `npm run eslint` (0 errors), `npm run compare-translations` (no errors), `npm run build` (success). No server file was modified, and the Cypress binary was not available in the environment used to prepare this change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXRz5JiaM9N42djviseBRu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made the entire link card clickable, improving navigation and interaction.
  * Simplified the card layout for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->