### PR TITLE
Display integration names on the services settings page

### DIFF
--- a/front/src/routes/devices/index.js
+++ b/front/src/routes/devices/index.js
@@ -3,8 +3,9 @@ import { connect } from 'unistore/preact';
 import get from 'get-value';
 
 import withIntlAsProp from '../../utils/withIntlAsProp';
+import disambiguateIntegrationNames from '../../utils/integrationNames';
 import DevicesPage from './DevicesPage';
-import { getDeviceIntegration, disambiguateIntegrationNames } from './integrationLinks';
+import { getDeviceIntegration } from './integrationLinks';
 
 class Devices extends Component {
   // The endpoint returns the whole list: load it once, then search, order

--- a/front/src/routes/devices/integrationLinks.js
+++ b/front/src/routes/devices/integrationLinks.js
@@ -36,7 +36,7 @@ const DEVICE_EDIT_LINKS = {
  * - name: raw name to display when there is no translation
  * - external: true for a community integration (own group in the filter)
  * - discriminant: technical identity, displayed only when two integrations
- *   share the same name (see disambiguateIntegrationNames)
+ *   share the same name (see utils/integrationNames)
  * - url: integration page listing the devices
  * - deviceUrl: most specific page for this device in its integration
  */
@@ -78,40 +78,4 @@ export function getDeviceIntegration(device) {
     url,
     deviceUrl: buildDeviceLink ? buildDeviceLink(device.selector) : url
   };
-}
-
-/**
- * Two community integrations can display the same name (two repositories
- * publishing a manifest with the same name, or two dev installs of the same
- * integration): those are the only ones that carry their technical identity
- * next to their name, so the common case stays readable. Built-in integrations
- * have unique names, and are told apart from community ones by their own group
- * in the filter and by the "community" tag in the list.
- * @param {Array} integrations - Integrations of the listed devices, with duplicates.
- * @returns {Map} Name to display, by integration slug.
- */
-export function disambiguateIntegrationNames(integrations) {
-  // names are compared lowercased: two manifests differing only by case read
-  // as the same name in the list
-  const slugsByName = new Map();
-  integrations.forEach(integration => {
-    if (integration && integration.external) {
-      const key = integration.name.toLowerCase();
-      const slugs = slugsByName.get(key) || new Set();
-      slugs.add(integration.slug);
-      slugsByName.set(key, slugs);
-    }
-  });
-  const nameBySlug = new Map();
-  integrations.forEach(integration => {
-    if (!integration || nameBySlug.has(integration.slug)) {
-      return;
-    }
-    const isDuplicated = integration.external && slugsByName.get(integration.name.toLowerCase()).size > 1;
-    nameBySlug.set(
-      integration.slug,
-      isDuplicated ? `${integration.name} (${integration.discriminant})` : integration.name
-    );
-  });
-  return nameBySlug;
 }

--- a/front/src/routes/settings/settings-service/ServiceItem.jsx
+++ b/front/src/routes/settings/settings-service/ServiceItem.jsx
@@ -1,11 +1,10 @@
 import { Component } from 'preact';
 import { Text, Localizer } from 'preact-i18n';
 import { Link } from 'preact-router';
-import get from 'get-value';
 
 import { RequestStatus } from '../../../utils/consts';
 import { SERVICE_STATUS } from '../../../../../server/utils/constants';
-import { integrations } from '../../../config/integrations';
+import style from './style.css';
 
 const STARTED_STATUS = [SERVICE_STATUS.RUNNING];
 const HIDDEN_ACTION_STATUS = [SERVICE_STATUS.UNKNOWN, SERVICE_STATUS.DISABLED];
@@ -31,24 +30,25 @@ class ServiceItem extends Component {
     }
   };
 
-  render({ service }, { changeStatus }) {
+  render({ service, integration }, { changeStatus }) {
     const started = STARTED_STATUS.includes(service.status);
     const displayAction = !HIDDEN_ACTION_STATUS.includes(service.status);
-    const integrationPage = integrations.find(
-      integration => get(integration, 'link', { default: integration.key }).toLowerCase() === service.selector
-    );
-    const integrationLink =
-      integrationPage &&
-      `/dashboard/integration/${integrationPage.type}/${(integrationPage.link || integrationPage.key).toLowerCase()}`;
-    const integrationKey = integrationPage && integrationPage.key;
 
     const changingStatus = changeStatus === RequestStatus.Getting;
 
     return (
       <tr>
         <td>
-          <div style="max-width: 400px; overflow: hidden">
-            <Text id={`integration.${integrationKey}.title`}>{service.name}</Text>
+          <div class={style.serviceName}>
+            {integration.i18nKey ? <Text id={integration.i18nKey}>{integration.name}</Text> : integration.name}
+            {integration.external && (
+              // same tag as in the integration catalog: the list mixes both
+              // families, and a community integration can be named like a
+              // built-in one
+              <span class="badge badge-secondary">
+                <Text id="integration.tags.external" />
+              </span>
+            )}
           </div>
           <div class="small text-muted">
             <Text id="servicesSettings.selector" fields={{ key: service.selector }} />
@@ -78,10 +78,10 @@ class ServiceItem extends Component {
           )}
         </td>
         <td>
-          {integrationPage && (
+          {integration.url && (
             <Localizer>
               <Link
-                href={integrationLink}
+                href={integration.url}
                 class="btn btn-outline-secondary border-0"
                 title={<Text id="servicesSettings.integrationLinkTitle" />}
               >

--- a/front/src/routes/settings/settings-service/ServiceItem.jsx
+++ b/front/src/routes/settings/settings-service/ServiceItem.jsx
@@ -40,12 +40,14 @@ class ServiceItem extends Component {
       <tr>
         <td>
           <div class={style.serviceName}>
-            {integration.i18nKey ? <Text id={integration.i18nKey}>{integration.name}</Text> : integration.name}
+            <span class={style.serviceNameLabel}>
+              {integration.i18nKey ? <Text id={integration.i18nKey}>{integration.name}</Text> : integration.name}
+            </span>
             {integration.external && (
               // same tag as in the integration catalog: the list mixes both
               // families, and a community integration can be named like a
               // built-in one
-              <span class="badge badge-secondary">
+              <span class={`badge badge-secondary ${style.serviceNameTag}`}>
                 <Text id="integration.tags.external" />
               </span>
             )}

--- a/front/src/routes/settings/settings-service/ServicesPage.jsx
+++ b/front/src/routes/settings/settings-service/ServicesPage.jsx
@@ -25,8 +25,13 @@ const ServicesPage = ({ services, integrations, actionOnService }) => (
             </thead>
             <tbody>
               {services &&
-                services.map(service => (
-                  <ServiceItem service={service} integrations={integrations} actionOnService={actionOnService} />
+                services.map(({ service, integration }) => (
+                  <ServiceItem
+                    service={service}
+                    integration={integration}
+                    integrations={integrations}
+                    actionOnService={actionOnService}
+                  />
                 ))}
             </tbody>
           </table>

--- a/front/src/routes/settings/settings-service/ServicesPage.jsx
+++ b/front/src/routes/settings/settings-service/ServicesPage.jsx
@@ -3,7 +3,7 @@ import { Text } from 'preact-i18n';
 import SettingsLayout from '../SettingsLayout';
 import ServiceItem from './ServiceItem';
 
-const ServicesPage = ({ services, integrations, actionOnService }) => (
+const ServicesPage = ({ services, actionOnService }) => (
   <SettingsLayout>
     <div class="card">
       <div>
@@ -27,9 +27,9 @@ const ServicesPage = ({ services, integrations, actionOnService }) => (
               {services &&
                 services.map(({ service, integration }) => (
                   <ServiceItem
+                    key={service.selector}
                     service={service}
                     integration={integration}
-                    integrations={integrations}
                     actionOnService={actionOnService}
                   />
                 ))}

--- a/front/src/routes/settings/settings-service/index.js
+++ b/front/src/routes/settings/settings-service/index.js
@@ -1,7 +1,12 @@
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
-import ServicesPage from './ServicesPage';
+import get from 'get-value';
 import update from 'immutability-helper';
+
+import withIntlAsProp from '../../../utils/withIntlAsProp';
+import disambiguateIntegrationNames from '../../../utils/integrationNames';
+import ServicesPage from './ServicesPage';
+import getServiceIntegration from './serviceIntegration';
 
 class SettingsServices extends Component {
   getServices = async (podId = null) => {
@@ -10,7 +15,6 @@ class SettingsServices extends Component {
         pod_id: podId
       };
       const services = await this.props.httpClient.get(`/api/v1/service`, query);
-      services.sort((s1, s2) => s1.name.localeCompare(s2.name));
       this.setState({
         services
       });
@@ -44,10 +48,31 @@ class SettingsServices extends Component {
   }
 
   render(props, { services }) {
+    const integrations = (services || []).map(service => getServiceIntegration(service));
+    // names are resolved on the whole list: whether an integration needs its
+    // technical identity displayed depends on the other integrations present
+    const nameBySlug = disambiguateIntegrationNames(integrations);
+    // sorted on the label the row actually displays: a built-in integration is
+    // listed under its translated title, which its service name does not always
+    // match (in French, the "rtsp-camera" service reads "Caméras"), and a
+    // community integration under its manifest name, not its docker image tag
+    const getDisplayedName = integration =>
+      (integration.i18nKey && get(props.intl.dictionary, integration.i18nKey)) || nameBySlug.get(integration.slug);
+    const servicesWithIntegration = (services || [])
+      .map((service, index) => ({
+        service,
+        integration: { ...integrations[index], name: nameBySlug.get(integrations[index].slug) }
+      }))
+      .sort((a, b) =>
+        getDisplayedName(a.integration).localeCompare(getDisplayedName(b.integration), undefined, {
+          sensitivity: 'base'
+        })
+      );
+
     return (
       <ServicesPage
         {...props}
-        services={services}
+        services={services && servicesWithIntegration}
         startService={this.startService}
         stopService={this.stopService}
         actionOnService={this.actionOnService}
@@ -56,4 +81,4 @@ class SettingsServices extends Component {
   }
 }
 
-export default connect('httpClient', {})(SettingsServices);
+export default withIntlAsProp(connect('httpClient', {})(SettingsServices));

--- a/front/src/routes/settings/settings-service/serviceIntegration.js
+++ b/front/src/routes/settings/settings-service/serviceIntegration.js
@@ -26,7 +26,10 @@ function getServiceIntegration(service) {
       // the store slug (owner/repo) reads better than the selector built from
       // it; dev installs have none, their selector is the only identity
       discriminant: service.store_slug || service.selector,
-      url: null
+      // all community integrations share the same parameterized page; the
+      // communication and weather ones redirect from there to their config
+      // screen, so this single URL is right for every type
+      url: `/dashboard/integration/device/external/${service.selector}`
     };
   }
   const integrationPage = integrations.find(

--- a/front/src/routes/settings/settings-service/serviceIntegration.js
+++ b/front/src/routes/settings/settings-service/serviceIntegration.js
@@ -1,0 +1,47 @@
+import get from 'get-value';
+
+import { integrations } from '../../../config/integrations';
+import { SERVICE_TYPES } from '../../../../../server/utils/constants';
+
+/**
+ * Returns how a service should be presented in the services list:
+ * - slug: identity of the service in the list (its selector, unique)
+ * - i18nKey: translation key of the integration name (built-in integrations)
+ * - name: raw name to display when there is no translation
+ * - external: true for a community integration
+ * - discriminant: technical identity, displayed only when two integrations
+ *   share the same name (see utils/integrationNames)
+ * - url: integration page of the service, when it has one
+ * @param {object} service - Service returned by the API.
+ * @returns {object} Display identity of the service.
+ */
+function getServiceIntegration(service) {
+  if (service.type === SERVICE_TYPES.EXTERNAL) {
+    // The service name is the technical selector (ext-<owner>-<repo>): display
+    // the manifest name, the same title as the integration card in the catalog
+    return {
+      slug: service.selector,
+      name: get(service, 'manifest.name') || service.name,
+      external: true,
+      // the store slug (owner/repo) reads better than the selector built from
+      // it; dev installs have none, their selector is the only identity
+      discriminant: service.store_slug || service.selector,
+      url: null
+    };
+  }
+  const integrationPage = integrations.find(
+    integration => get(integration, 'link', { default: integration.key }).toLowerCase() === service.selector
+  );
+  if (!integrationPage) {
+    // Service without a front-end page (usb, example...): no link
+    return { slug: service.selector, name: service.name, url: null };
+  }
+  return {
+    slug: service.selector,
+    i18nKey: `integration.${integrationPage.key}.title`,
+    name: service.name,
+    url: `/dashboard/integration/${integrationPage.type}/${(integrationPage.link || integrationPage.key).toLowerCase()}`
+  };
+}
+
+export default getServiceIntegration;

--- a/front/src/routes/settings/settings-service/style.css
+++ b/front/src/routes/settings/settings-service/style.css
@@ -3,5 +3,15 @@
   align-items: center;
   gap: 0.5rem;
   max-width: 400px;
+}
+
+.serviceNameLabel {
   overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* the community tag tells a community integration apart from a built-in one
+   with a similar name: a long name must be ellipsed, never the tag */
+.serviceNameTag {
+  flex-shrink: 0;
 }

--- a/front/src/routes/settings/settings-service/style.css
+++ b/front/src/routes/settings/settings-service/style.css
@@ -1,0 +1,7 @@
+.serviceName {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  max-width: 400px;
+  overflow: hidden;
+}

--- a/front/src/utils/integrationNames.js
+++ b/front/src/utils/integrationNames.js
@@ -1,0 +1,44 @@
+/**
+ * Two community integrations can display the same name (two repositories
+ * publishing a manifest with the same name, or two dev installs of the same
+ * integration): those are the only ones that carry their technical identity
+ * next to their name, so the common case stays readable. Built-in integrations
+ * have unique names, and are told apart from community ones by the "community"
+ * tag displayed next to them.
+ *
+ * Integrations are described by:
+ * - slug: identity of the integration, the key of the returned map
+ * - name: name to display, before disambiguation
+ * - external: true for a community integration
+ * - discriminant: technical identity, appended to the name when needed
+ *
+ * @param {Array} integrations - Listed integrations, duplicates allowed.
+ * @returns {Map} Name to display, by integration slug.
+ */
+function disambiguateIntegrationNames(integrations) {
+  // names are compared lowercased: two manifests differing only by case read
+  // as the same name in the list
+  const slugsByName = new Map();
+  integrations.forEach(integration => {
+    if (integration && integration.external) {
+      const key = integration.name.toLowerCase();
+      const slugs = slugsByName.get(key) || new Set();
+      slugs.add(integration.slug);
+      slugsByName.set(key, slugs);
+    }
+  });
+  const nameBySlug = new Map();
+  integrations.forEach(integration => {
+    if (!integration || nameBySlug.has(integration.slug)) {
+      return;
+    }
+    const isDuplicated = integration.external && slugsByName.get(integration.name.toLowerCase()).size > 1;
+    nameBySlug.set(
+      integration.slug,
+      isDuplicated ? `${integration.name} (${integration.discriminant})` : integration.name
+    );
+  });
+  return nameBySlug;
+}
+
+export default disambiguateIntegrationNames;


### PR DESCRIPTION
Implements feature request: https://community.gladysassistant.com/t/appareils-avoir-le-vrai-nom-des-integrations/10559

### Description

The devices part of this forum request was already shipped in #2886. This PR covers the remaining part reported in reply #3 and confirmed by the author: the same problem exists in **Settings → Services**, which still lists community integrations under their raw service name — the docker image based selector (`ext-callemand-gladys-melcould-home`) instead of their real name (`MELCloud Home`).

What changes on the services page:

- a community integration is listed under its manifest name, the same title as its card in the integration catalog, and still falls back to the raw service name when there is no manifest name;
- it carries the same `Community` tag as in the catalog, so it stays distinguishable from a built-in integration with a similar name;
- when two community integrations display the same name (two repositories publishing the same manifest name, or dev installs), each one carries its technical identity next to its name — exactly the rule introduced in #2886;
- the list is sorted on the label it actually displays: a built-in integration is now sorted under its translated title instead of its service name, and a community one under its real name instead of its `ext-…` selector.

The technical identity of every service stays visible: the `Internal name: …` line under the name is unchanged.

Implementation notes:

- the disambiguation helper written for the devices list is reused, not duplicated: `disambiguateIntegrationNames` moved from `front/src/routes/devices/integrationLinks.js` to `front/src/utils/integrationNames.js`, and both pages import it from there (the devices page behaviour is unchanged);
- the integration lookup that `ServiceItem` did inline moved to `front/src/routes/settings/settings-service/serviceIntegration.js`, which resolves the display identity of a service (name, translation key, community flag, integration link) the same way the devices page does;
- no server change, no new translation key: `integration.tags.external` already exists in every language file, and `GET /api/v1/service` already returns the service manifest.

This PR was created by an automated Claude Code run.

## Forum

Forum: https://community.gladysassistant.com/t/appareils-avoir-le-vrai-nom-des-integrations/10559

### Checklist

- [ ] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

Front only change: `npm run prettier-check`, `npm run eslint`, `npm run compare-translations` and `npm run build` all pass locally. No server file is touched, so the server suite and Codecov patch coverage are not impacted. Cypress was not run locally (binary unavailable in this environment); there is no E2E spec covering the services settings page, and CI runs it anyway.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved service display names, including clearer labels for integrations with duplicate names.
  * Services are now sorted by translated or manifest-provided names.
  * Added localized names, external-service indicators, and direct links to integration dashboards.
  * Improved handling of services without matching integration pages.
  * Updated service-name styling for better alignment, spacing, and long-name display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->