### PR TITLE
Scene widget: allow ordering the scenes list

### DIFF
--- a/front/src/components/boxs/scene/EditSceneBox.jsx
+++ b/front/src/components/boxs/scene/EditSceneBox.jsx
@@ -1,10 +1,12 @@
 import { Component } from 'preact';
 import { Localizer, Text } from 'preact-i18n';
+import update from 'immutability-helper';
 import BaseEditBox from '../baseEditBox';
 import withIntlAsProp from '../../../utils/withIntlAsProp';
 import { connect } from 'unistore/preact';
 import Select from 'react-select';
 import { RequestStatus } from '../../../utils/consts';
+import { SceneListWithDragAndDrop } from '../../drag-and-drop/SceneListWithDragAndDrop';
 
 class EditSceneBox extends Component {
   updateScenes = selectedSceneOptions => {
@@ -19,6 +21,33 @@ class EditSceneBox extends Component {
   updateName = e => {
     this.props.updateBoxConfig(this.props.x, this.props.y, {
       name: e.target.value
+    });
+  };
+
+  updateCustomOrder = e => {
+    const customOrder = e.target.checked;
+    const newBoxConfig = {
+      scene_custom_order: customOrder
+    };
+    if (customOrder) {
+      // The currently displayed (alphabetical) order becomes
+      // the starting point of the custom order.
+      newBoxConfig.scenes = (this.state.selectedSceneOptions || []).map(option => option.value);
+    }
+    this.props.updateBoxConfig(this.props.x, this.props.y, newBoxConfig);
+  };
+
+  moveScene = (currentIndex, newIndex) => {
+    const scenes = (this.state.selectedSceneOptions || []).map(option => option.value);
+    const movedScene = scenes[currentIndex];
+    const scenesWithoutMovedScene = update(scenes, {
+      $splice: [[currentIndex, 1]]
+    });
+    const newScenes = update(scenesWithoutMovedScene, {
+      $splice: [[newIndex, 0, movedScene]]
+    });
+    this.props.updateBoxConfig(this.props.x, this.props.y, {
+      scenes: newScenes
     });
   };
 
@@ -54,11 +83,22 @@ class EditSceneBox extends Component {
   refreshSelectedOptions = async props => {
     const selectedSceneOptions = [];
     if (this.state.sceneOptions) {
-      this.state.sceneOptions.forEach(sceneOption => {
-        if (props.box.scenes && props.box.scenes.indexOf(sceneOption.value) !== -1) {
-          selectedSceneOptions.push(sceneOption);
-        }
-      });
+      if (props.box.scene_custom_order && props.box.scenes) {
+        // The scenes are displayed in the order chosen by the user
+        props.box.scenes.forEach(sceneSelector => {
+          const sceneOption = this.state.sceneOptions.find(option => option.value === sceneSelector);
+          if (sceneOption) {
+            selectedSceneOptions.push(sceneOption);
+          }
+        });
+      } else {
+        // By default, the scenes are displayed in alphabetical order
+        this.state.sceneOptions.forEach(sceneOption => {
+          if (props.box.scenes && props.box.scenes.indexOf(sceneOption.value) !== -1) {
+            selectedSceneOptions.push(sceneOption);
+          }
+        });
+      }
     }
     await this.setState({ selectedSceneOptions });
   };
@@ -68,14 +108,17 @@ class EditSceneBox extends Component {
   };
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.box && nextProps.box.scenes) {
-      if (!this.props.box || !this.props.box.scenes || nextProps.box.scenes !== this.props.box.scenes) {
+    const currentBox = this.props.box || {};
+    const nextBox = nextProps.box || {};
+    if (nextBox.scenes) {
+      if (nextBox.scenes !== currentBox.scenes || nextBox.scene_custom_order !== currentBox.scene_custom_order) {
         this.refreshSelectedOptions(nextProps);
       }
     }
   }
   render(props, { status, selectedSceneOptions, sceneOptions }) {
     const loading = status === RequestStatus.Getting && !status;
+    const displayScenesOrder = props.box.scene_custom_order && selectedSceneOptions && selectedSceneOptions.length > 0;
     return (
       <BaseEditBox {...props} titleKey="dashboard.boxTitle.scene">
         <div class={loading ? 'dimmer active' : 'dimmer'}>
@@ -110,6 +153,33 @@ class EditSceneBox extends Component {
                   className="react-select-container"
                   classNamePrefix="react-select"
                 />
+              </div>
+            )}
+            {sceneOptions && (
+              <div class="form-group">
+                <label class="custom-switch">
+                  <input
+                    type="checkbox"
+                    class="custom-switch-input"
+                    checked={props.box.scene_custom_order}
+                    onChange={this.updateCustomOrder}
+                  />
+                  <span class="custom-switch-indicator" />
+                  <span class="custom-switch-description">
+                    <Text id="dashboard.boxes.scene.customOrderLabel" />
+                  </span>
+                </label>
+                <small class="form-text text-muted">
+                  <Text id="dashboard.boxes.scene.customOrderDescription" />
+                </small>
+              </div>
+            )}
+            {displayScenesOrder && (
+              <div class="form-group">
+                <label>
+                  <Text id="dashboard.boxes.scene.orderSceneLabel" />
+                </label>
+                <SceneListWithDragAndDrop selectedSceneOptions={selectedSceneOptions} moveScene={this.moveScene} />
               </div>
             )}
           </div>

--- a/front/src/components/boxs/scene/SceneBox.jsx
+++ b/front/src/components/boxs/scene/SceneBox.jsx
@@ -111,9 +111,25 @@ class SceneBoxComponent extends Component {
     }
   }
 
+  // The API returns the scenes sorted alphabetically.
+  // If the user chose a custom order in the widget configuration,
+  // the scenes are displayed in the order of the box configuration.
+  getOrderedScenes = scenes => {
+    const { box } = this.props;
+    if (!scenes || !box.scene_custom_order || !box.scenes) {
+      return scenes;
+    }
+    const getScenePosition = selector => {
+      const position = box.scenes.indexOf(selector);
+      return position === -1 ? box.scenes.length : position;
+    };
+    return [...scenes].sort((a, b) => getScenePosition(a.selector) - getScenePosition(b.selector));
+  };
+
   render(props, { scenes, status, runningScenes, now }) {
     const boxTitle = props.box.name;
     const loading = status === RequestStatus.Getting && !status;
+    const orderedScenes = this.getOrderedScenes(scenes);
 
     return (
       <div class="card">
@@ -132,8 +148,8 @@ class SceneBoxComponent extends Component {
             <div class="table-responsive">
               <table className="table card-table table-vcenter">
                 <tbody>
-                  {scenes &&
-                    scenes.map(scene => (
+                  {orderedScenes &&
+                    orderedScenes.map(scene => (
                       <SceneRow
                         key={scene.selector}
                         boxStatus={status}

--- a/front/src/components/drag-and-drop/SceneListWithDragAndDrop.jsx
+++ b/front/src/components/drag-and-drop/SceneListWithDragAndDrop.jsx
@@ -10,15 +10,20 @@ const SCENE_TYPE = 'SCENE_TYPE';
 // We do not recommend using them in other places in Gladys front
 const SceneRow = ({ selectedSceneOption, moveScene, index }) => {
   const ref = useRef(null);
-  const [{ isDragging }, drag, preview] = useDrag(() => ({
-    type: SCENE_TYPE,
-    item: () => {
-      return { index };
-    },
-    collect: monitor => ({
-      isDragging: !!monitor.isDragging()
-    })
-  }));
+  const [{ isDragging }, drag, preview] = useDrag(
+    () => ({
+      type: SCENE_TYPE,
+      item: () => {
+        return { index };
+      },
+      collect: monitor => ({
+        isDragging: !!monitor.isDragging()
+      })
+    }),
+    // the rows have a stable key, so a row keeps its instance when the order changes:
+    // the drag spec must be re-created when the index of the row changes
+    [index]
+  );
   const [{ isActive }, drop] = useDrop({
     accept: SCENE_TYPE,
     collect: monitor => ({
@@ -61,7 +66,12 @@ const { backend: dragAndDropBackend, options: dragAndDropBackendOptions } = getD
 const SceneListWithDragAndDrop = ({ selectedSceneOptions, moveScene }) => (
   <DndProvider backend={dragAndDropBackend} options={dragAndDropBackendOptions}>
     {selectedSceneOptions.map((selectedSceneOption, index) => (
-      <SceneRow selectedSceneOption={selectedSceneOption} index={index} moveScene={moveScene} />
+      <SceneRow
+        key={selectedSceneOption.value}
+        selectedSceneOption={selectedSceneOption}
+        index={index}
+        moveScene={moveScene}
+      />
     ))}
   </DndProvider>
 );

--- a/front/src/components/drag-and-drop/SceneListWithDragAndDrop.jsx
+++ b/front/src/components/drag-and-drop/SceneListWithDragAndDrop.jsx
@@ -1,0 +1,69 @@
+import { DndProvider, useDrag, useDrop } from 'react-dnd';
+import { useRef } from 'preact/hooks';
+import cx from 'classnames';
+import style from './style.css';
+import { getDragAndDropBackend } from '../../utils/dragAndDropBackend';
+
+const SCENE_TYPE = 'SCENE_TYPE';
+
+// We use Preact Hooks here because the library react-dnd needs that
+// We do not recommend using them in other places in Gladys front
+const SceneRow = ({ selectedSceneOption, moveScene, index }) => {
+  const ref = useRef(null);
+  const [{ isDragging }, drag, preview] = useDrag(() => ({
+    type: SCENE_TYPE,
+    item: () => {
+      return { index };
+    },
+    collect: monitor => ({
+      isDragging: !!monitor.isDragging()
+    })
+  }));
+  const [{ isActive }, drop] = useDrop({
+    accept: SCENE_TYPE,
+    collect: monitor => ({
+      isActive: monitor.canDrop() && monitor.isOver()
+    }),
+    drop(item) {
+      if (!ref.current) {
+        return;
+      }
+      moveScene(item.index, index);
+    }
+  });
+  preview(drop(ref));
+
+  return (
+    <div class="mb-1">
+      <div
+        class={cx('input-group', style.sceneListDragAndDrop, {
+          [style.sceneListDragAndDropDragging]: isDragging
+        })}
+        ref={ref}
+      >
+        <div class="input-group-prepend" ref={drag}>
+          <span class="input-group-text fe fe-list" />
+        </div>
+        <div
+          class={cx('form-control', style.sceneListDragAndDropLabel, {
+            [style.sceneListDragAndDropActive]: isActive
+          })}
+        >
+          {selectedSceneOption.label}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const { backend: dragAndDropBackend, options: dragAndDropBackendOptions } = getDragAndDropBackend();
+
+const SceneListWithDragAndDrop = ({ selectedSceneOptions, moveScene }) => (
+  <DndProvider backend={dragAndDropBackend} options={dragAndDropBackendOptions}>
+    {selectedSceneOptions.map((selectedSceneOption, index) => (
+      <SceneRow selectedSceneOption={selectedSceneOption} index={index} moveScene={moveScene} />
+    ))}
+  </DndProvider>
+);
+
+export { SceneListWithDragAndDrop };

--- a/front/src/components/drag-and-drop/style.css
+++ b/front/src/components/drag-and-drop/style.css
@@ -47,3 +47,23 @@
 .deviceListRemoveButton {
   z-index: 0;
 }
+
+.sceneListDragAndDrop {
+  cursor: pointer;
+  user-select: none;
+}
+
+.sceneListDragAndDropDragging {
+  opacity: 0.5;
+}
+
+.sceneListDragAndDropActive {
+  background-color: #ecf0f1;
+}
+
+.sceneListDragAndDropLabel {
+  height: auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -610,7 +610,10 @@
       "scene": {
         "editNameLabel": "Widget-Name (optional)",
         "editNamePlaceholder": "Name auf dem Dashboard angezeigt",
-        "editSceneLabel": "Wähle die Szene aus, die hier angezeigt werden soll."
+        "editSceneLabel": "Wähle die Szene aus, die hier angezeigt werden soll.",
+        "customOrderLabel": "Benutzerdefinierte Reihenfolge",
+        "customOrderDescription": "Szenen werden standardmäßig in alphabetischer Reihenfolge angezeigt. Aktiviere diese Option, um sie nach deinen Wünschen zu sortieren.",
+        "orderSceneLabel": "Ziehe die Szenen per Drag & Drop, um ihre Reihenfolge zu ändern"
       },
       "link": {
         "editTitleLabel": "Titel",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -629,7 +629,10 @@
       "scene": {
         "editNameLabel": "Widget Name (optional)",
         "editNamePlaceholder": "Name displayed on the dashboard",
-        "editSceneLabel": "Select the scene you want to display here."
+        "editSceneLabel": "Select the scene you want to display here.",
+        "customOrderLabel": "Custom order",
+        "customOrderDescription": "By default, scenes are displayed in alphabetical order. Enable this option to sort them the way you want.",
+        "orderSceneLabel": "Drag and drop the scenes to change their order"
       },
       "link": {
         "editTitleLabel": "Title",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -595,7 +595,10 @@
       "scene": {
         "editNameLabel": "Nom du widget (optionnel)",
         "editNamePlaceholder": "Nom affiché sur le tableau de bord",
-        "editSceneLabel": "Sélectionnez la scène que vous souhaitez afficher ici."
+        "editSceneLabel": "Sélectionnez la scène que vous souhaitez afficher ici.",
+        "customOrderLabel": "Ordre personnalisé",
+        "customOrderDescription": "Par défaut, les scènes sont affichées par ordre alphabétique. Activez cette option pour les trier comme vous le souhaitez.",
+        "orderSceneLabel": "Glissez-déposez les scènes pour modifier leur ordre"
       },
       "link": {
         "editTitleLabel": "Titre",

--- a/server/models/dashboard.js
+++ b/server/models/dashboard.js
@@ -34,6 +34,9 @@ const boxesSchema = Joi.array().items(
       camera_latency: Joi.string(),
       camera_live_auto_start: Joi.boolean(),
       scenes: Joi.array().items(Joi.string()),
+      // scene box: when true, the scenes are displayed in the order of the "scenes" array
+      // instead of the default alphabetical order
+      scene_custom_order: Joi.boolean(),
       humidity_use_custom_value: Joi.boolean(),
       humidity_min: Joi.number(),
       humidity_max: Joi.number(),

--- a/server/test/lib/dashboard/dashboard.create.test.js
+++ b/server/test/lib/dashboard/dashboard.create.test.js
@@ -23,6 +23,28 @@ describe('dashboard.create', () => {
     // selector should be the slug of the name + a dash + 4 random characters
     expect(newDashboard.selector).to.match(/^my-new-dashboard-[a-z0-9]{4}$/);
   });
+  it('should create a dashboard with a scene box with a custom scene order', async () => {
+    const newDashboard = await dashboard.create('0cd30aef-9c4e-4a23-88e3-3547971296e5', {
+      name: 'My dashboard with a scene box',
+      type: DASHBOARD_TYPE.MAIN,
+      position: 0,
+      visibility: DASHBOARD_VISIBILITY.PRIVATE,
+      boxes: [
+        [
+          {
+            type: DASHBOARD_BOX_TYPE.SCENE,
+            scenes: ['my-second-scene', 'my-first-scene'],
+            scene_custom_order: true,
+          },
+        ],
+      ],
+    });
+    expect(newDashboard.boxes[0][0]).to.deep.equal({
+      type: DASHBOARD_BOX_TYPE.SCENE,
+      scenes: ['my-second-scene', 'my-first-scene'],
+      scene_custom_order: true,
+    });
+  });
   it('should create a dashboard with the selector given', async () => {
     const newDashboard = await dashboard.create('0cd30aef-9c4e-4a23-88e3-3547971296e5', {
       name: 'My dashboard with a custom selector',


### PR DESCRIPTION
Implements feature request: https://community.gladysassistant.com/t/widget-scene-pouvoir-trier-la-liste/10063

### Description

Scenes in the dashboard "Scenes" widget were always displayed in alphabetical order, so the only way to change the display order was to rename the scenes.

This PR adds a **Custom order** option in the scene widget configuration:

- when the option is disabled (default, and the case of all existing widgets), nothing changes: the scenes are still displayed in alphabetical order;
- when the option is enabled, the selected scenes can be reordered with drag & drop in the widget edit mode, and the dashboard displays them in that order.

Implementation details:

- `front/src/components/drag-and-drop/SceneListWithDragAndDrop.jsx` (new): reorderable list of the selected scenes, built with `react-dnd` following the exact same pattern as `DeviceListWithDragAndDrop` used by the devices widget (so it also works on touch devices).
- `front/src/components/boxs/scene/EditSceneBox.jsx`: new `scene_custom_order` switch, the drag & drop list, and the selected options are now kept in the configured order when the custom order is enabled. When the switch is turned on, the current alphabetical order is used as the starting point of the custom order.
- `front/src/components/boxs/scene/SceneBox.jsx`: the scenes returned by the API (sorted alphabetically) are re-ordered following the `scenes` array of the box configuration when `scene_custom_order` is `true`.
- `server/models/dashboard.js`: the box configuration schema is strict, so the new `scene_custom_order` boolean key had to be allowed. A test covering a scene box with a custom order was added to `server/test/lib/dashboard/dashboard.create.test.js`.
- Translations added in `en.json`, `fr.json` and `de.json`.

This pull request was created by an automated Claude Code run.

## Forum

Forum: https://community.gladysassistant.com/t/widget-scene-pouvoir-trier-la-liste/10063

### Checklist

- [ ] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

Checks run locally: front `prettier`/`prettier-check`, `eslint`, `compare-translations` and `build` all pass; server `prettier`/`prettier-check` and `eslint` pass, and the dashboard test suites (`test/lib/dashboard` and `test/controllers/dashboard`, 63 tests) pass. `npm run coverage` and Cypress were not run locally (the Cypress binary is not available in this environment), so the first checklist item is left for CI to confirm.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional custom ordering for scenes in dashboard widgets.
  * Users can enable custom ordering, initialize it from the current list, and reorder scenes via drag and drop.
  * Saved scene orders are preserved when custom ordering is enabled; alphabetical ordering remains the default.
* **Localization**
  * Added custom-ordering labels and instructions in English, German, and French.
* **Bug Fixes**
  * Scene selections now refresh when the scene list or custom-ordering setting changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->