### PR TITLE
fix(homekit): two Gladys categories can share one HomeKit service

### DIFF
--- a/server/services/homekit/lib/buildAccessory.js
+++ b/server/services/homekit/lib/buildAccessory.js
@@ -1,5 +1,6 @@
 const { mappings, mergedServiceCategories } = require('./deviceMappings');
 const { indexFeatureService } = require('./featureServices');
+const { sanitizeName } = require('./sanitizeName');
 
 /**
  * @description Move the features of categories HomeKit models as a single service into their host
@@ -68,7 +69,28 @@ function buildAccessory(device) {
 
   const categories = mergeCategories(featuresByCategory);
 
-  const accessory = new this.hap.Accessory(device.name.substring(0, 64), device.id);
+  const accessory = new this.hap.Accessory(sanitizeName(device.name), device.id);
+
+  // Two Gladys categories can land on the same HomeKit service: a siren and a switch are both a
+  // `Switch`, a curtain and a shutter both a `WindowCovering`. HAP refuses two services of one type
+  // on an accessory unless each carries a subtype, so what has to be counted here is the HomeKit
+  // service, not the Gladys category — counting categories is how a device carrying both used to
+  // throw and take the whole bridge down with it.
+  //
+  // When a service type is shared, *neither* category keeps the bare service, and the subtype is the
+  // category name rather than a position. Both points are about what HAP persists: the subtype takes
+  // part in the service identifiers of a paired bridge, so handing the bare identity to one of the
+  // two would silently give it whatever the other used to be — a switch that became a siren would
+  // keep its tile in the Home app and set off the alarm when pressed. Letting both identities change
+  // instead costs the user a service to re-add, which is at least visible.
+  const categoriesPerService = new Map();
+
+  Object.keys(categories).forEach((category) => {
+    const { service: serviceName } = mappings[category];
+
+    categoriesPerService.set(serviceName, (categoriesPerService.get(serviceName) || 0) + 1);
+  });
+
   Object.keys(categories).forEach((category) => {
     const serviceConfigs = [];
     // Features dropped by the read-only twin merge below, per service config. They build no
@@ -114,12 +136,18 @@ function buildAccessory(device) {
     });
 
     serviceConfigs.forEach((config, i) => {
-      const service = this.buildService(
-        device,
-        config,
-        mappings[category],
-        serviceConfigs.length > 1 ? `${category} ${i + 1}` : undefined,
-      );
+      const { service: serviceName } = mappings[category];
+      // A category giving several services numbers them as it always has; that subtype already
+      // carries the category name, so it cannot collide with another category's.
+      let subtype;
+
+      if (serviceConfigs.length > 1) {
+        subtype = `${category} ${i + 1}`;
+      } else if (categoriesPerService.get(serviceName) > 1) {
+        subtype = category;
+      }
+
+      const service = this.buildService(device, config, mappings[category], subtype);
       // Which features went into which service is only known here. sendState reads it back to
       // update the service the feature belongs to instead of the first one of its type.
       indexFeatureService(accessory, service, [...config, ...(droppedTwins.get(config) || [])]);

--- a/server/services/homekit/lib/buildAlarmAccessory.js
+++ b/server/services/homekit/lib/buildAlarmAccessory.js
@@ -1,6 +1,7 @@
 const { ALARM_MODES } = require('../../../utils/constants');
 const { ConflictError } = require('../../../utils/coreErrors');
 const logger = require('../../../utils/logger');
+const { sanitizeName } = require('./sanitizeName');
 
 // Values of the HomeKit SecuritySystemCurrentState characteristic. The target one uses the same
 // values without ALARM_TRIGGERED: HomeKit lets an alarm report that it went off, not be asked to.
@@ -42,8 +43,9 @@ function buildAlarmAccessory(house) {
 
   // The alarm is not a device: it lives on the house, so this accessory is built from a house
   // rather than from `buildAccessory`, and its UUID is the house id.
-  const accessory = new this.hap.Accessory(house.name.substring(0, 64), house.id);
-  const service = new Service.SecuritySystem(house.name.substring(0, 64));
+  const houseName = sanitizeName(house.name);
+  const accessory = new this.hap.Accessory(houseName, house.id);
+  const service = new Service.SecuritySystem(houseName);
 
   const readState = async () => {
     const { alarm_mode: alarmMode } = await this.gladys.house.getBySelector(house.selector);

--- a/server/services/homekit/lib/buildService.js
+++ b/server/services/homekit/lib/buildService.js
@@ -25,6 +25,7 @@ const {
   LOW_BATTERY_THRESHOLD,
 } = require('./deviceMappings');
 const { buildThermostatService } = require('./buildThermostatService');
+const { sanitizeName } = require('./sanitizeName');
 
 const sleep = promisify(setTimeout);
 
@@ -41,10 +42,10 @@ const sleep = promisify(setTimeout);
 function buildService(device, features, categoryMapping, subtype) {
   const { Characteristic, CharacteristicEventTypes, Perms, Service } = this.hap;
 
-  const service = new Service[categoryMapping.service](
-    (subtype ? features[0].name : device.name).substring(0, 64),
-    subtype,
-  );
+  // A service sharing its accessory with another one of the same type is named after the feature it
+  // was built from, since the device name would read the same on both.
+  const serviceName = subtype ? features[0].name : device.name;
+  const service = new Service[categoryMapping.service](sanitizeName(serviceName || device.name), subtype);
 
   // A thermostat is driven by features of several Gladys categories at once, so its characteristics
   // cannot be wired one feature at a time like the others.

--- a/server/services/homekit/lib/createBridge.js
+++ b/server/services/homekit/lib/createBridge.js
@@ -1,6 +1,11 @@
 const uuid = require('uuid');
 const { EVENTS } = require('../../../utils/constants');
 const { eventFunctionWrapper } = require('../../../utils/functionsWrapper');
+const logger = require('../../../utils/logger');
+
+// What HAP accepts on a bridge, `MAX_ACCESSORIES` in its own Accessory.js. Going over it throws, so
+// the bound is enforced here rather than discovered at publish time.
+const MAX_BRIDGED_ACCESSORIES = 149;
 
 /**
  * @description Create HomeKit bridge.
@@ -33,8 +38,19 @@ async function createBridge() {
   }
 
   const exposedDevices = await this.getExposedDevices();
+  // One accessory that cannot be built must not cost the user every other one: a bridge that fails
+  // to publish leaves the whole Home app empty, with nothing on screen saying which device is at
+  // fault. The device is dropped and named in the log instead.
   const accessories = exposedDevices
-    .map((device) => this.buildAccessory(device))
+    .map((device) => {
+      try {
+        return this.buildAccessory(device);
+      } catch (e) {
+        logger.error(`HomeKit: device ${device.selector} could not be exposed: ${e.message}`);
+
+        return null;
+      }
+    })
     .filter((accessory) => accessory !== null);
 
   // The alarm is not a device: it lives on the house, so one accessory per house is built here
@@ -42,22 +58,49 @@ async function createBridge() {
   // named after its own. They go through the same exposure setting as the devices, so someone who
   // does not use the Gladys alarm can leave it out.
   const exposedAlarms = await this.getExposedAlarms();
+  const alarmAccessories = [];
   this.alarmAccessories = new Map();
   exposedAlarms.forEach(({ house }) => {
-    const alarmAccessory = this.buildAlarmAccessory(house);
-    this.alarmAccessories.set(house.selector, alarmAccessory);
-    accessories.push(alarmAccessory);
+    try {
+      const alarmAccessory = this.buildAlarmAccessory(house);
+      this.alarmAccessories.set(house.selector, alarmAccessory);
+      alarmAccessories.push(alarmAccessory);
+    } catch (e) {
+      logger.error(`HomeKit: alarm of house ${house.selector} could not be exposed: ${e.message}`);
+    }
   });
+
+  // HomeKit takes 149 accessories on a bridge and HAP throws on the 150th, which would leave a
+  // growing instance with no bridge at all rather than with too many accessories. The extra devices
+  // are left out instead, and the log says where to choose which ones are kept. Alarms are counted
+  // first: there are one or two of them, and a house alarm is not what someone wants dropped.
+  const roomForDevices = Math.max(0, MAX_BRIDGED_ACCESSORIES - alarmAccessories.length);
+  // Sliced once more at the end rather than trusting the reservation above: a house count of its own
+  // over the limit is absurd, but a guard whose whole purpose is that the bridge always publishes
+  // may not have a case where it throws anyway.
+  const bridgedAccessories = [...accessories.slice(0, roomForDevices), ...alarmAccessories].slice(
+    0,
+    MAX_BRIDGED_ACCESSORIES,
+  );
+  const leftOut = accessories.length + alarmAccessories.length - bridgedAccessories.length;
+
+  if (leftOut > 0) {
+    logger.warn(
+      `HomeKit: ${accessories.length + alarmAccessories.length} accessories to expose, HomeKit allows ` +
+        `${MAX_BRIDGED_ACCESSORIES} on a bridge. ${leftOut} are left out — choose the ones to expose in the ` +
+        `HomeKit settings.`,
+    );
+  }
 
   if (this.bridge) {
     await this.stopBridge();
   }
 
-  this.notifyCb = eventFunctionWrapper(this.notifyChange.bind(this, accessories));
+  this.notifyCb = eventFunctionWrapper(this.notifyChange.bind(this, bridgedAccessories));
   this.gladys.event.on(EVENTS.TRIGGERS.CHECK, this.notifyCb);
 
   const gladysBridge = new this.hap.Bridge('Gladys', bridgeUuid);
-  gladysBridge.addBridgedAccessories(accessories);
+  gladysBridge.addBridgedAccessories(bridgedAccessories);
 
   await gladysBridge.publish({
     username,

--- a/server/services/homekit/lib/createBridge.js
+++ b/server/services/homekit/lib/createBridge.js
@@ -41,30 +41,29 @@ async function createBridge() {
   // One accessory that cannot be built must not cost the user every other one: a bridge that fails
   // to publish leaves the whole Home app empty, with nothing on screen saying which device is at
   // fault. The device is dropped and named in the log instead.
-  const accessories = exposedDevices
+  // The device is kept next to the accessory it produced: a HAP accessory only carries a UUID, and
+  // the log below has to be able to name the devices it leaves out.
+  const builtDevices = exposedDevices
     .map((device) => {
       try {
-        return this.buildAccessory(device);
+        return { device, accessory: this.buildAccessory(device) };
       } catch (e) {
         logger.error(`HomeKit: device ${device.selector} could not be exposed: ${e.message}`);
 
-        return null;
+        return { device, accessory: null };
       }
     })
-    .filter((accessory) => accessory !== null);
+    .filter(({ accessory }) => accessory !== null);
 
   // The alarm is not a device: it lives on the house, so one accessory per house is built here
   // rather than from the device list. Several houses give several alarms in the Home app, each
   // named after its own. They go through the same exposure setting as the devices, so someone who
   // does not use the Gladys alarm can leave it out.
   const exposedAlarms = await this.getExposedAlarms();
-  const alarmAccessories = [];
-  this.alarmAccessories = new Map();
+  const builtAlarms = [];
   exposedAlarms.forEach(({ house }) => {
     try {
-      const alarmAccessory = this.buildAlarmAccessory(house);
-      this.alarmAccessories.set(house.selector, alarmAccessory);
-      alarmAccessories.push(alarmAccessory);
+      builtAlarms.push({ house, accessory: this.buildAlarmAccessory(house) });
     } catch (e) {
       logger.error(`HomeKit: alarm of house ${house.selector} could not be exposed: ${e.message}`);
     }
@@ -74,23 +73,31 @@ async function createBridge() {
   // growing instance with no bridge at all rather than with too many accessories. The extra devices
   // are left out instead, and the log says where to choose which ones are kept. Alarms are counted
   // first: there are one or two of them, and a house alarm is not what someone wants dropped.
-  const roomForDevices = Math.max(0, MAX_BRIDGED_ACCESSORIES - alarmAccessories.length);
+  const roomForDevices = Math.max(0, MAX_BRIDGED_ACCESSORIES - builtAlarms.length);
   // Sliced once more at the end rather than trusting the reservation above: a house count of its own
   // over the limit is absurd, but a guard whose whole purpose is that the bridge always publishes
   // may not have a case where it throws anyway.
-  const bridgedAccessories = [...accessories.slice(0, roomForDevices), ...alarmAccessories].slice(
-    0,
-    MAX_BRIDGED_ACCESSORIES,
-  );
-  const leftOut = accessories.length + alarmAccessories.length - bridgedAccessories.length;
+  const bridged = [...builtDevices.slice(0, roomForDevices), ...builtAlarms].slice(0, MAX_BRIDGED_ACCESSORIES);
+  const bridgedAccessories = bridged.map(({ accessory }) => accessory);
+  const leftOutDevices = builtDevices.slice(roomForDevices);
 
-  if (leftOut > 0) {
+  if (builtDevices.length + builtAlarms.length > bridgedAccessories.length) {
+    // Named, not just counted: `device.get` sorts by name, so the devices left out are the last ones
+    // alphabetically and nothing on screen says which tiles went missing.
+    const names = leftOutDevices.map(({ device }) => device.selector).join(', ');
+
     logger.warn(
-      `HomeKit: ${accessories.length + alarmAccessories.length} accessories to expose, HomeKit allows ` +
-        `${MAX_BRIDGED_ACCESSORIES} on a bridge. ${leftOut} are left out — choose the ones to expose in the ` +
-        `HomeKit settings.`,
+      `HomeKit: ${builtDevices.length + builtAlarms.length} accessories to expose, HomeKit allows ` +
+        `${MAX_BRIDGED_ACCESSORIES} on a bridge. Left out: ${names || 'house alarms'} — choose the ones to ` +
+        `expose in the HomeKit settings.`,
     );
   }
+
+  // Indexed after the capacity selection, so an alarm event never resolves an accessory the bridge
+  // does not carry.
+  this.alarmAccessories = new Map(
+    bridged.filter(({ house }) => house !== undefined).map(({ house, accessory }) => [house.selector, accessory]),
+  );
 
   if (this.bridge) {
     await this.stopBridge();

--- a/server/services/homekit/lib/sanitizeName.js
+++ b/server/services/homekit/lib/sanitizeName.js
@@ -1,0 +1,47 @@
+// Apple's naming rules, as hap-nodejs enforces them: a name has to start and end with a letter or a
+// number, and may only carry letters, numbers, spaces, apostrophes, dots, commas and dashes in
+// between. Gladys lets people name a device anything, and integrations bring their own conventions:
+// `Detecteur_Cave` from Zigbee2mqtt, `Prise n°1`, a trailing space left by a copy-paste. hap-nodejs
+// warns on each of them, once per accessory and once per service built from it, and Apple states
+// such a name "may prevent the accessory from being added in the Home App".
+//
+// Rewriting the name is safe for a paired home: it is only what HomeKit shows until the user renames
+// the accessory, and it takes no part in the identifiers HAP persists.
+//
+// Accented letters are fine — `\p{L}` covers them — so a French name loses nothing here.
+//
+// One case is deliberately left alone: hap-nodejs asks for a first *and* a last alphanumeric
+// character, so it warns on a single-letter name that Apple's own rule accepts. Padding someone's
+// device name to please a regex is worse than the warning it would silence.
+const FORBIDDEN_CHARACTERS = /[^\p{L}\p{N}’ '.,-]/gu;
+const LEADING_SEPARATORS = /^[^\p{L}\p{N}]+/u;
+const TRAILING_SEPARATORS = /[^\p{L}\p{N}’]+$/u;
+
+const MAX_LENGTH = 64;
+const FALLBACK_NAME = 'Gladys';
+
+/**
+ * @description Rewrite a Gladys name into one HomeKit accepts.
+ * @param {string} name - Name of the Gladys device, feature or house.
+ * @param {string} [fallback] - Name to use when nothing usable is left.
+ * @returns {string} Name HomeKit accepts.
+ * @example
+ * sanitizeName('Detecteur_Cave'); // 'Detecteur Cave'
+ */
+function sanitizeName(name, fallback = FALLBACK_NAME) {
+  const sanitized = String(name || '')
+    .replace(FORBIDDEN_CHARACTERS, ' ')
+    .replace(/ +/g, ' ')
+    .replace(LEADING_SEPARATORS, '')
+    .replace(TRAILING_SEPARATORS, '')
+    // Truncating can uncover a separator that was in the middle a character ago, so the tail is
+    // trimmed again rather than before.
+    .substring(0, MAX_LENGTH)
+    .replace(TRAILING_SEPARATORS, '');
+
+  return sanitized || fallback;
+}
+
+module.exports = {
+  sanitizeName,
+};

--- a/server/services/homekit/lib/sanitizeName.js
+++ b/server/services/homekit/lib/sanitizeName.js
@@ -23,12 +23,11 @@ const FALLBACK_NAME = 'Gladys';
 /**
  * @description Rewrite a Gladys name into one HomeKit accepts.
  * @param {string} name - Name of the Gladys device, feature or house.
- * @param {string} [fallback] - Name to use when nothing usable is left.
  * @returns {string} Name HomeKit accepts.
  * @example
  * sanitizeName('Detecteur_Cave'); // 'Detecteur Cave'
  */
-function sanitizeName(name, fallback = FALLBACK_NAME) {
+function sanitizeName(name) {
   const sanitized = String(name || '')
     .replace(FORBIDDEN_CHARACTERS, ' ')
     .replace(/ +/g, ' ')
@@ -39,7 +38,7 @@ function sanitizeName(name, fallback = FALLBACK_NAME) {
     .substring(0, MAX_LENGTH)
     .replace(TRAILING_SEPARATORS, '');
 
-  return sanitized || fallback;
+  return sanitized || FALLBACK_NAME;
 }
 
 module.exports = {

--- a/server/test/services/homekit/index.test.js
+++ b/server/test/services/homekit/index.test.js
@@ -4,7 +4,8 @@ const sinon = require('sinon').createSandbox();
 const { stub } = sinon;
 
 const HomeKitService = require('../../../services/homekit/index');
-const { DEVICE_FEATURE_CATEGORIES } = require('../../../utils/constants');
+const logger = require('../../../utils/logger');
+const { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } = require('../../../utils/constants');
 
 describe('HomeKitService', () => {
   let gladys;
@@ -70,6 +71,52 @@ describe('HomeKitService', () => {
     expect(setValue.args[1][1]).to.match(/^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$/);
     expect(setValue.args[2][1]).to.match(/^\d{3}-\d{2}-\d{3}$/);
     expect(setValue.args[3][1]).to.match(/^X-HM:\/\/[0-9A-Z]+$/);
+  });
+
+  // This one runs against the real HAP library on purpose. Every other HomeKit test stubs it, and a
+  // stub happily accepts two services of one type on an accessory where HAP throws — which is how a
+  // detector carrying its own siren came to take the whole bridge down in 4.86.
+  it('should start service with a device whose features share one HomeKit service', async () => {
+    gladys.system.isDocker = stub().resolves(false);
+    gladys.variable.setValue = stub().resolves({});
+    gladys.device.get = stub().resolves([
+      {
+        id: '5b2b0ea1-5a25-4b6a-9a4c-1a6ba0f4b9c1',
+        name: 'Detecteur_Cave',
+        selector: 'detecteur-cave',
+        features: [
+          {
+            selector: 'detecteur-cave-relais',
+            name: 'Relais',
+            category: DEVICE_FEATURE_CATEGORIES.SWITCH,
+            type: DEVICE_FEATURE_TYPES.SWITCH.BINARY,
+            last_value: 0,
+          },
+          {
+            selector: 'detecteur-cave-sirene',
+            name: 'Sirène',
+            category: DEVICE_FEATURE_CATEGORIES.SIREN,
+            type: DEVICE_FEATURE_TYPES.SIREN.BINARY,
+            last_value: 0,
+          },
+        ],
+      },
+    ]);
+
+    // createBridge drops a device it cannot build rather than failing the whole bridge, so a
+    // published bridge is not proof on its own: what is asserted is that nothing was dropped.
+    const loggerError = stub(logger, 'error');
+
+    try {
+      await homekitService.start();
+
+      expect(loggerError.callCount).to.equal(0);
+    } finally {
+      loggerError.restore();
+    }
+
+    expect(gladys.variable.setValue.callCount).to.equal(4);
+    expect(gladys.variable.setValue.args[3][1]).to.match(/^X-HM:\/\/[0-9A-Z]+$/);
   });
 
   it('should stop service', async () => {

--- a/server/test/services/homekit/lib/buildAccessory.test.js
+++ b/server/test/services/homekit/lib/buildAccessory.test.js
@@ -475,4 +475,120 @@ describe('Build accessory', () => {
     expect(homekitHandler.buildService.callCount).to.equal(1);
     expect(homekitHandler.buildService.args[0][2].service).to.equal('TemperatureSensor');
   });
+
+  it('should give a subtype to every Gladys category landing on one HomeKit service', async () => {
+    homekitHandler.buildService = sinon.stub().returns('builded-service');
+    const addService = sinon.stub();
+    homekitHandler.hap = {
+      Accessory: sinon.stub().returns({ addService, services: ['service1', 'service2'] }),
+    };
+
+    // a Zigbee2mqtt detector carrying its own siren: two Gladys categories, one HomeKit Switch
+    const device = {
+      id: 'c22a4d4b-e261-4b22-a2be-309baf12c3ca',
+      name: 'Detecteur cave',
+      features: [
+        { selector: 'relais', name: 'Relais', category: 'switch', type: 'binary' },
+        { selector: 'sirene', name: 'Sirène', category: 'siren', type: 'binary' },
+      ],
+    };
+
+    await homekitHandler.buildAccessory(device);
+
+    expect(homekitHandler.buildService.callCount).to.equal(2);
+    // both are a Switch, so HAP needs to tell them apart — and neither keeps the bare service, which
+    // would otherwise hand one of them the identity the other had before
+    expect(homekitHandler.buildService.args[0][2].service).to.equal('Switch');
+    expect(homekitHandler.buildService.args[1][2].service).to.equal('Switch');
+    expect(homekitHandler.buildService.args[0][3]).to.equal('switch');
+    expect(homekitHandler.buildService.args[1][3]).to.equal('siren');
+  });
+
+  it('should give each category the same subtype whatever order the features come in', async () => {
+    homekitHandler.buildService = sinon.stub().returns('builded-service');
+    const addService = sinon.stub();
+    homekitHandler.hap = {
+      Accessory: sinon.stub().returns({ addService, services: ['service1', 'service2'] }),
+    };
+
+    // the same device, its features read the other way round: the subtype takes part in the
+    // identifiers HAP persists, so it may not depend on the order features happen to arrive in
+    const device = {
+      id: 'c22a4d4b-e261-4b22-a2be-309baf12c3ca',
+      name: 'Detecteur cave',
+      features: [
+        { selector: 'sirene', name: 'Sirène', category: 'siren', type: 'binary' },
+        { selector: 'relais', name: 'Relais', category: 'switch', type: 'binary' },
+      ],
+    };
+
+    await homekitHandler.buildAccessory(device);
+
+    expect(homekitHandler.buildService.args[0][3]).to.equal('siren');
+    expect(homekitHandler.buildService.args[1][3]).to.equal('switch');
+  });
+
+  it('should leave the bare service to a category that shares it with nobody', async () => {
+    homekitHandler.buildService = sinon.stub().returns('builded-service');
+    const addService = sinon.stub();
+    homekitHandler.hap = {
+      Accessory: sinon.stub().returns({ addService, services: ['service1', 'service2'] }),
+    };
+
+    // no siren here, so the switch keeps the subtype it has always had and a paired home does not
+    // see its service change identity
+    const device = {
+      id: 'c22a4d4b-e261-4b22-a2be-309baf12c3ca',
+      name: 'Prise salon',
+      features: [
+        { selector: 'relais', name: 'Relais', category: 'switch', type: 'binary' },
+        { selector: 'temperature', name: 'Température', category: 'temperature-sensor', type: 'decimal' },
+      ],
+    };
+
+    await homekitHandler.buildAccessory(device);
+
+    expect(homekitHandler.buildService.args[0][3]).to.equal(undefined);
+    expect(homekitHandler.buildService.args[1][3]).to.equal(undefined);
+  });
+
+  it('should still number several services built from a single category', async () => {
+    homekitHandler.buildService = sinon.stub().returns('builded-service');
+    const addService = sinon.stub();
+    homekitHandler.hap = {
+      Accessory: sinon.stub().returns({ addService, services: ['service1', 'service2'] }),
+    };
+
+    const device = {
+      id: 'c22a4d4b-e261-4b22-a2be-309baf12c3ca',
+      name: 'Volets salon',
+      features: [
+        { selector: 'volet-1', name: 'Volet 1', category: 'shutter', type: 'position' },
+        { selector: 'volet-2', name: 'Volet 2', category: 'shutter', type: 'position' },
+      ],
+    };
+
+    await homekitHandler.buildAccessory(device);
+
+    expect(homekitHandler.buildService.args[0][3]).to.equal('shutter 1');
+    expect(homekitHandler.buildService.args[1][3]).to.equal('shutter 2');
+  });
+
+  it('should name the accessory with a name HomeKit accepts', async () => {
+    homekitHandler.buildService = sinon.stub().returns('builded-service');
+    const addService = sinon.stub();
+    homekitHandler.hap = {
+      Accessory: sinon.stub().returns({ addService, services: ['service1', 'service2'] }),
+    };
+
+    const device = {
+      id: 'c22a4d4b-e261-4b22-a2be-309baf12c3ca',
+      name: 'Detecteur_Cave ',
+      features: [{ selector: 'sirene', name: 'Sirène', category: 'siren', type: 'binary' }],
+    };
+
+    await homekitHandler.buildAccessory(device);
+
+    expect(homekitHandler.hap.Accessory.args[0][0]).to.equal('Detecteur Cave');
+  });
 });

--- a/server/test/services/homekit/lib/buildAlarmAccessory.test.js
+++ b/server/test/services/homekit/lib/buildAlarmAccessory.test.js
@@ -194,4 +194,13 @@ describe('Build alarm accessory', () => {
     expect(current).to.equal(failure);
     expect(target).to.equal(failure);
   });
+  it('should name the accessory and its service with a name HomeKit accepts', () => {
+    const { hap } = buildAlarmHapStub();
+    const homekitHandler = { hap, gladys: { house: { getBySelector: stub().resolves({}) } }, buildAlarmAccessory };
+
+    homekitHandler.buildAlarmAccessory({ ...HOUSE, name: 'Maison_Principale ' });
+
+    expect(hap.Accessory.args[0][0]).to.equal('Maison Principale');
+    expect(hap.Service.SecuritySystem.args[0][0]).to.equal('Maison Principale');
+  });
 });

--- a/server/test/services/homekit/lib/buildService.test.js
+++ b/server/test/services/homekit/lib/buildService.test.js
@@ -3061,4 +3061,52 @@ describe('Build service', () => {
       device_feature: features[0].selector,
     });
   });
+  it('should name a service HomeKit accepts, after its feature when it carries a subtype', async () => {
+    const Switch = stub().returns({ getCharacteristic: stub().returns({ on: stub(), props: { perms: [] } }) });
+
+    homekitHandler.hap = {
+      Characteristic: { On: 'ON' },
+      CharacteristicEventTypes: stub(),
+      Perms: { PAIRED_READ: 'PAIRED_READ', PAIRED_WRITE: 'PAIRED_WRITE' },
+      Service: { Switch },
+    };
+    const device = { name: 'Detecteur_Cave', selector: 'detecteur-cave' };
+    const features = [
+      {
+        name: 'Sirene_1 ',
+        selector: 'sirene',
+        category: DEVICE_FEATURE_CATEGORIES.SIREN,
+        type: DEVICE_FEATURE_TYPES.SIREN.BINARY,
+      },
+    ];
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.SIREN], 'siren');
+
+    expect(Switch.args[0][0]).to.equal('Sirene 1');
+    expect(Switch.args[0][1]).to.equal('siren');
+  });
+
+  it('should fall back on the device name when the feature carrying the subtype has none', async () => {
+    const Switch = stub().returns({ getCharacteristic: stub().returns({ on: stub(), props: { perms: [] } }) });
+
+    homekitHandler.hap = {
+      Characteristic: { On: 'ON' },
+      CharacteristicEventTypes: stub(),
+      Perms: { PAIRED_READ: 'PAIRED_READ', PAIRED_WRITE: 'PAIRED_WRITE' },
+      Service: { Switch },
+    };
+    const device = { name: 'Detecteur_Cave', selector: 'detecteur-cave' };
+    const features = [
+      {
+        name: '',
+        selector: 'sirene',
+        category: DEVICE_FEATURE_CATEGORIES.SIREN,
+        type: DEVICE_FEATURE_TYPES.SIREN.BINARY,
+      },
+    ];
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.SIREN], 'siren');
+
+    expect(Switch.args[0][0]).to.equal('Detecteur Cave');
+  });
 });

--- a/server/test/services/homekit/lib/createBridge.test.js
+++ b/server/test/services/homekit/lib/createBridge.test.js
@@ -3,6 +3,7 @@ const sinon = require('sinon').createSandbox();
 
 const { stub } = sinon;
 const { createBridge } = require('../../../../services/homekit/lib/createBridge');
+const logger = require('../../../../utils/logger');
 const { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } = require('../../../../utils/constants');
 
 const LAMP = {
@@ -120,13 +121,25 @@ describe('Create bridge', () => {
       }),
     });
 
-    await homekitHandler.createBridge();
+    const loggerWarn = stub(logger, 'warn');
+
+    try {
+      await homekitHandler.createBridge();
+    } finally {
+      loggerWarn.restore();
+    }
 
     // 149 is what HAP takes, and the house alarm is one of them rather than the one left out
     const bridged = homekitHandler.addBridgedAccessories.args[0][0];
     expect(bridged.length).to.equal(149);
     expect(bridged[bridged.length - 1]).to.eql({ UUID: 'e1b0a9cf-3f6f-4f2e-9f6b-2c0a7f4a1d55' });
+    expect(homekitHandler.alarmAccessories.get('maison')).to.eql({ UUID: 'e1b0a9cf-3f6f-4f2e-9f6b-2c0a7f4a1d55' });
     expect(homekitHandler.publish.callCount).to.equal(1);
+    // the devices left out are named, not just counted: a count alone does not say which tiles went
+    expect(loggerWarn.callCount).to.equal(1);
+    expect(loggerWarn.args[0][0]).to.contain('lampe-148');
+    expect(loggerWarn.args[0][0]).to.contain('lampe-199');
+    expect(loggerWarn.args[0][0]).to.not.contain('lampe-147,');
   });
 
   it('should expose the devices when the alarm of a house cannot be built', async () => {

--- a/server/test/services/homekit/lib/createBridge.test.js
+++ b/server/test/services/homekit/lib/createBridge.test.js
@@ -5,52 +5,67 @@ const { stub } = sinon;
 const { createBridge } = require('../../../../services/homekit/lib/createBridge');
 const { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } = require('../../../../utils/constants');
 
+const LAMP = {
+  id: '07f16117-8556-4b50-b9f0-e190d08f8d92',
+  name: 'Lampe bureau',
+  selector: 'lampe-bureau',
+  features: [{ category: DEVICE_FEATURE_CATEGORIES.LIGHT, type: DEVICE_FEATURE_TYPES.LIGHT.BINARY }],
+};
+
+const HOUSE_ALARM = {
+  name: 'Maison',
+  selector: 'house-alarm:maison',
+  house: { id: 'e1b0a9cf', name: 'Maison', selector: 'maison' },
+};
+
+/**
+ * @description Build a HomeKit handler whose bridge, accessories and Gladys calls are all stubbed.
+ * @param {object} [overrides] - Handler properties to replace.
+ * @returns {object} The handler, with `addBridgedAccessories` and `publish` readable on it.
+ * @example
+ * const handler = buildHandler({ buildAccessory: stub().throws(new Error('boom')) });
+ */
+function buildHandler(overrides = {}) {
+  const addBridgedAccessories = stub().returns();
+  const publish = stub().resolves();
+
+  return {
+    serviceId: '7056e3d4-31cc-4d2a-bbdd-128cd49755e6',
+    createBridge,
+    addBridgedAccessories,
+    publish,
+    buildAccessory: stub().returns({ UUID: '78a7b724-18e8-4c15-ab30-c8486c253f36' }),
+    buildAlarmAccessory: stub().returns({ UUID: 'e1b0a9cf-3f6f-4f2e-9f6b-2c0a7f4a1d55' }),
+    getExposedAlarms: stub().resolves([HOUSE_ALARM]),
+    getExposedDevices: stub().resolves([LAMP]),
+    gladys: {
+      variable: {
+        getValue: stub().resolves(null),
+        setValue: stub().resolves(),
+      },
+      event: {
+        on: stub().returns(),
+      },
+    },
+    newUsername: stub().resolves('C4:D0:AB:12:BC:51'),
+    newPinCode: stub().resolves('123-45-678'),
+    notifyChange: stub().returns(),
+    hap: {
+      Categories: { BRIDGE: 'BRIDGE' },
+      Bridge: stub().returns({
+        addBridgedAccessories,
+        publish,
+        setupURI: stub().returns(),
+      }),
+      MDNSAdvertiser: { BONJOUR: 'bonjour-hap' },
+    },
+    ...overrides,
+  };
+}
+
 describe('Create bridge', () => {
   it('should create a bridge', async () => {
-    const addBridgedAccessories = stub().returns();
-    const publish = stub().resolves();
-    const homekitHandler = {
-      serviceId: '7056e3d4-31cc-4d2a-bbdd-128cd49755e6',
-      createBridge,
-      buildAccessory: stub().returns({ UUID: '78a7b724-18e8-4c15-ab30-c8486c253f36' }),
-      buildAlarmAccessory: stub().returns({ UUID: 'e1b0a9cf-3f6f-4f2e-9f6b-2c0a7f4a1d55' }),
-      getExposedAlarms: stub().resolves([
-        {
-          name: 'Maison',
-          selector: 'house-alarm:maison',
-          house: { id: 'e1b0a9cf', name: 'Maison', selector: 'maison' },
-        },
-      ]),
-      getExposedDevices: stub().resolves([
-        {
-          id: '07f16117-8556-4b50-b9f0-e190d08f8d92',
-          name: 'Lampe bureau',
-          selector: 'lampe-bureau',
-          features: [{ category: DEVICE_FEATURE_CATEGORIES.LIGHT, type: DEVICE_FEATURE_TYPES.LIGHT.BINARY }],
-        },
-      ]),
-      gladys: {
-        variable: {
-          getValue: stub().resolves(null),
-          setValue: stub().resolves(),
-        },
-        event: {
-          on: stub().returns(),
-        },
-      },
-      newUsername: stub().resolves('C4:D0:AB:12:BC:51'),
-      newPinCode: stub().resolves('123-45-678'),
-      notifyChange: stub().returns(),
-      hap: {
-        Categories: { BRIDGE: 'BRIDGE' },
-        Bridge: stub().returns({
-          addBridgedAccessories,
-          publish,
-          setupURI: stub().returns(),
-        }),
-        MDNSAdvertiser: { BONJOUR: 'bonjour-hap' },
-      },
-    };
+    const homekitHandler = buildHandler();
 
     await homekitHandler.createBridge();
 
@@ -58,17 +73,73 @@ describe('Create bridge', () => {
     expect(homekitHandler.hap.Bridge.args[0][1]).not.equal(null);
     // the house alarm is exposed alongside the devices, and is indexed by selector so an alarm
     // event can find its accessory again
-    expect(addBridgedAccessories.args[0][0]).to.deep.members([
+    expect(homekitHandler.addBridgedAccessories.args[0][0]).to.deep.members([
       { UUID: '78a7b724-18e8-4c15-ab30-c8486c253f36' },
       { UUID: 'e1b0a9cf-3f6f-4f2e-9f6b-2c0a7f4a1d55' },
     ]);
     expect(homekitHandler.alarmAccessories.get('maison')).to.eql({ UUID: 'e1b0a9cf-3f6f-4f2e-9f6b-2c0a7f4a1d55' });
-    expect(publish.args[0][0]).to.eql({
+    expect(homekitHandler.publish.args[0][0]).to.eql({
       username: 'C4:D0:AB:12:BC:51',
       pincode: '123-45-678',
       port: '47129',
       category: 'BRIDGE',
       advertiser: 'bonjour-hap',
     });
+  });
+
+  it('should expose the other devices when one of them cannot be built', async () => {
+    const brokenDevice = { ...LAMP, id: '5b2b0ea1-5a25-4b6a-9a4c-1a6ba0f4b9c1', selector: 'detecteur-cave' };
+    const homekitHandler = buildHandler({
+      getExposedDevices: stub().resolves([brokenDevice, LAMP]),
+      buildAccessory: stub()
+        .onFirstCall()
+        .throws(new Error('Cannot add a Service with the same UUID'))
+        .onSecondCall()
+        .returns({ UUID: '78a7b724-18e8-4c15-ab30-c8486c253f36' }),
+    });
+
+    await homekitHandler.createBridge();
+
+    // the bridge is published all the same, with only the device that threw left out of it
+    expect(homekitHandler.addBridgedAccessories.args[0][0]).to.deep.members([
+      { UUID: '78a7b724-18e8-4c15-ab30-c8486c253f36' },
+      { UUID: 'e1b0a9cf-3f6f-4f2e-9f6b-2c0a7f4a1d55' },
+    ]);
+    expect(homekitHandler.publish.callCount).to.equal(1);
+  });
+
+  it('should keep the bridge under the HomeKit accessory limit', async () => {
+    const devices = Array.from({ length: 200 }, (unused, i) => ({ ...LAMP, selector: `lampe-${i}` }));
+    let built = 0;
+    const homekitHandler = buildHandler({
+      getExposedDevices: stub().resolves(devices),
+      buildAccessory: stub().callsFake(() => {
+        built += 1;
+
+        return { UUID: `device-${built}` };
+      }),
+    });
+
+    await homekitHandler.createBridge();
+
+    // 149 is what HAP takes, and the house alarm is one of them rather than the one left out
+    const bridged = homekitHandler.addBridgedAccessories.args[0][0];
+    expect(bridged.length).to.equal(149);
+    expect(bridged[bridged.length - 1]).to.eql({ UUID: 'e1b0a9cf-3f6f-4f2e-9f6b-2c0a7f4a1d55' });
+    expect(homekitHandler.publish.callCount).to.equal(1);
+  });
+
+  it('should expose the devices when the alarm of a house cannot be built', async () => {
+    const homekitHandler = buildHandler({
+      buildAlarmAccessory: stub().throws(new Error('boom')),
+    });
+
+    await homekitHandler.createBridge();
+
+    expect(homekitHandler.addBridgedAccessories.args[0][0]).to.deep.members([
+      { UUID: '78a7b724-18e8-4c15-ab30-c8486c253f36' },
+    ]);
+    expect(homekitHandler.alarmAccessories.get('maison')).to.equal(undefined);
+    expect(homekitHandler.publish.callCount).to.equal(1);
   });
 });

--- a/server/test/services/homekit/lib/sanitizeName.test.js
+++ b/server/test/services/homekit/lib/sanitizeName.test.js
@@ -43,10 +43,6 @@ describe('Sanitize name', () => {
     expect(sanitizeName(undefined)).to.equal('Gladys');
   });
 
-  it('should use the given fallback rather than the default one', () => {
-    expect(sanitizeName('()', 'Capteur')).to.equal('Capteur');
-  });
-
   it('should cut a name at 64 characters, without leaving a separator at the end', () => {
     // 63 letters then a space and a letter: truncating lands on the space, which may not end a name
     const longName = `${'a'.repeat(63)} b`;

--- a/server/test/services/homekit/lib/sanitizeName.test.js
+++ b/server/test/services/homekit/lib/sanitizeName.test.js
@@ -1,0 +1,58 @@
+const { expect } = require('chai');
+
+const { sanitizeName } = require('../../../../services/homekit/lib/sanitizeName');
+
+// The rule hap-nodejs applies, kept here so a test failure says which side moved.
+const HOMEKIT_NAME = /^[\p{L}\p{N}][\p{L}\p{N}’ '.,-]*[\p{L}\p{N}’]$/u;
+
+describe('Sanitize name', () => {
+  const cases = [
+    // what integrations and users really produce
+    ['Detecteur_Cave', 'Detecteur Cave'],
+    ['Prise n°1', 'Prise n 1'],
+    ['Salon ', 'Salon'],
+    [' Salon', 'Salon'],
+    ['Salon (bas)', 'Salon bas'],
+    ['Capteur — cave', 'Capteur cave'],
+    ['Chambre  des   parents', 'Chambre des parents'],
+    // a name that ends on a character allowed only in the middle
+    ['Salon.', 'Salon'],
+    ['Salon,', 'Salon'],
+    ['Salon-', 'Salon'],
+    // accented letters are letters: a French name goes through untouched
+    ['Détecteur Cave', 'Détecteur Cave'],
+    ["Chambre d'amis", "Chambre d'amis"],
+    ['Chambre d’amis', 'Chambre d’amis'],
+    ['Pièce n° 2, étage 1', 'Pièce n 2, étage 1'],
+    ['Chambre-1', 'Chambre-1'],
+  ];
+
+  cases.forEach(([given, expected]) => {
+    it(`should rewrite ${JSON.stringify(given)} as ${JSON.stringify(expected)}`, () => {
+      const sanitized = sanitizeName(given);
+
+      expect(sanitized).to.equal(expected);
+      expect(sanitized).to.match(HOMEKIT_NAME);
+    });
+  });
+
+  it('should fall back when nothing usable is left', () => {
+    expect(sanitizeName('__ ()')).to.equal('Gladys');
+    expect(sanitizeName('')).to.equal('Gladys');
+    expect(sanitizeName(null)).to.equal('Gladys');
+    expect(sanitizeName(undefined)).to.equal('Gladys');
+  });
+
+  it('should use the given fallback rather than the default one', () => {
+    expect(sanitizeName('()', 'Capteur')).to.equal('Capteur');
+  });
+
+  it('should cut a name at 64 characters, without leaving a separator at the end', () => {
+    // 63 letters then a space and a letter: truncating lands on the space, which may not end a name
+    const longName = `${'a'.repeat(63)} b`;
+    const sanitized = sanitizeName(longName);
+
+    expect(sanitized).to.equal('a'.repeat(63));
+    expect(sanitized).to.match(HOMEKIT_NAME);
+  });
+});


### PR DESCRIPTION
## What this fixes

Reported on the forum right after 4.86.1: [Apple HomeKit non fonctionnel depuis la dernière mise à jour](https://community.gladysassistant.com/t/apple-homekit-non-fonctionnel-depuis-la-derniere-mise-a-jour-4-86-1/10594). The Home app went empty, and the log showed:

```
Cannot add a Service with the same UUID '00000049-0000-1000-8000-0026BB765291'
as another Service in this Accessory without also defining a unique 'subtype' property.
```

`00000049` is the HAP `Switch` service. Two Gladys categories map to it — `switch` and `siren` — and `buildAccessory` numbered its services **per Gladys category**, so a device carrying both produced two `Switch` services with no subtype at all. HAP throws on that.

`shutter` and `curtain` both map to `WindowCovering` and had the same hole, since #2266.

## Why the whole bridge went down

`createBridge` built every accessory in a single `map`, so the throw rejected the whole promise: the bridge never published, and nothing on screen said which device was at fault. The reporter had to find and delete the device by trial and error.

That is fixed separately, and it is the half that matters most: any future accessory HAP refuses now costs its own device instead of the entire Home app.

## Changes

**Subtypes are counted per HomeKit service, not per Gladys category.** When a service type is shared, *neither* category keeps the bare service, and the subtype is the category name rather than a position.

Both points are about what HAP persists. `IdentifierCache` keys a service's IID on `accessoryUUID|serviceUUID|subtype`, so leaving the bare identity to one of the two would hand it whatever the other used to be: on a device that carried a switch before 4.86, the siren would inherit the switch's IID, and the tile the user presses to turn on a relay would set off the alarm instead. Letting both identities change costs a service to re-add, which is at least visible. A category that shares its service with nobody keeps exactly what it had.

**One device that cannot be built no longer costs the others.** It is dropped and named in the log. Same for the alarm of a house.

**The bridge stays under the HomeKit accessory limit.** HAP takes 149 accessories on a bridge and throws on the 150th, from `addBridgedAccessories` — outside the per-device guard, so an instance that simply grew past 149 exposable devices ended up with no bridge at all. More people are within reach of that limit since 4.86, because the bridge went from 12 mapped categories to 28 and devices that used to be skipped now count. The extra devices are left out with a log pointing at the exposure setting, and house alarms are counted first so an alarm is never the thing dropped.

**Names are sanitized.** hap-nodejs applies Apple's naming rules and warns once per accessory and once per service built from a name that breaks them — `Detecteur_Cave` from Zigbee2mqtt, `Prise n°1`, a trailing space left by a copy-paste — and Apple states such a name "may prevent the accessory from being added in the Home App". Several users reported the log flooding with those.

Accented letters were never the problem: `\p{L}` covers them, so `Détecteur Cave` goes through untouched. What gets replaced is underscores, parentheses, `°`, em dashes, and leading or trailing separators.

## Tests

| | |
|---|---|
| `sanitizeName.test.js` | new, table-driven, each case also checked against hap-nodejs' own regex |
| `buildAccessory.test.js` | the collision, its stability under a reversed feature order, a category that shares its service with nobody keeping the bare one, the unchanged numbering inside one category, the sanitized accessory name |
| `createBridge.test.js` | a device that throws is dropped and the bridge still publishes; same for a house alarm; 200 devices are cut down to 149 with the alarm kept |
| `index.test.js` | the end-to-end regression, run **against the real HAP library** |

That last one matters. Every other HomeKit test stubs HAP, and a stub happily accepts two services of one type on an accessory — which is exactly why the bug shipped. Verified both ways: the test fails on the code before this PR and passes after.

## Audit

The two collisions were found by grouping the mappings by HomeKit service and comparing that against `mergedServiceCategories`, rather than by looking at the reported device. Two audits were then run against the real HAP library, with this PR applied:

- **461 accessory builds** — every `(category, type)` pair on its own, every category with all its types at once, **every pair of categories on one device**, and one device carrying all 54 mapped features. No failure. Every characteristic the mappings declare also belongs to the service they declare it on.
- **1417 characteristic handlers fired** — every GET and every SET built by the mappings, over 13 values of `last_value` including `null`, `undefined`, a negative, and values past the feature bounds. No handler threw, none failed to call back, none called back twice, and every value returned passes hap-nodejs' own `validateUserInput`.

## Not fixed here

- A one-character device name still warns: hap-nodejs asks for a first *and* a last alphanumeric character, which is stricter than Apple's own rule. Padding someone's device name to please a regex seemed worse than the warning.
- The BONJOUR / AVAHI reports in the same thread are a separate, pre-existing subject (#2511), not a 4.86 regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved HomeKit name compatibility by normalizing names and enforcing length limits.
  * Added clearer service subtype naming when multiple categories share a service type.
  * HomeKit bridges now enforce the accessory limit while prioritizing alarms.
  * Failed accessory builds are skipped so bridge publication can continue.

* **Bug Fixes**
  * Prevented invalid names and individual accessory failures from blocking HomeKit setup.

* **Tests**
  * Added coverage for naming, subtype assignment, accessory limits, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->