### PR TITLE
Show the remaining SQLite aggregates in the DuckDB migration card

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -3974,6 +3974,7 @@
     "duckDbMigrationProgressTitle": "Migrationsfortschritt",
     "duckDbMigrationMigrationDone": "Migration abgeschlossen:",
     "duckDbNumberOfStatesinSQlite": "Anzahl der Zustände in SQLite",
+    "duckDbNumberOfAggregatesinSQlite": "Anzahl der Aggregate in SQLite",
     "duckDbNumberOfStatesinDuckDb": "Anzahl der Zustände in DuckDB",
     "restartMigrationTitle": "Migration neu starten",
     "confirm": "Bestätigen",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -3974,6 +3974,7 @@
     "duckDbMigrationProgressTitle": "Migration Progress",
     "duckDbMigrationMigrationDone": "Migration completed:",
     "duckDbNumberOfStatesinSQlite": "Number of states in SQLite",
+    "duckDbNumberOfAggregatesinSQlite": "Number of aggregates in SQLite",
     "duckDbNumberOfStatesinDuckDb": "Number of states in DuckDB",
     "restartMigrationTitle": "Restart Migration",
     "confirm": "Confirm",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -3974,6 +3974,7 @@
     "duckDbMigrationProgressTitle": "Avancement de la migration",
     "duckDbMigrationMigrationDone": "Migration effectuée :",
     "duckDbNumberOfStatesinSQlite": "Nombre d'états dans SQLite",
+    "duckDbNumberOfAggregatesinSQlite": "Nombre d'agrégats dans SQLite",
     "duckDbNumberOfStatesinDuckDb": "Nombre d'états dans DuckDB",
     "restartMigrationTitle": "Relancer la migration",
     "confirm": "Confirmer",

--- a/front/src/routes/settings/settings-system/SettingsSystemDuckDbMigration.jsx
+++ b/front/src/routes/settings/settings-system/SettingsSystemDuckDbMigration.jsx
@@ -24,6 +24,9 @@ class SettingsSystemDuckDbMigration extends Component {
       migrationState.sqlite_db_device_state_count = new Intl.NumberFormat(this.props.user.language).format(
         migrationState.sqlite_db_device_state_count
       );
+      migrationState.sqlite_db_device_state_aggregate_count = new Intl.NumberFormat(this.props.user.language).format(
+        migrationState.sqlite_db_device_state_aggregate_count
+      );
       migrationState.duck_db_device_count = new Intl.NumberFormat(this.props.user.language).format(
         migrationState.duck_db_device_count
       );
@@ -133,6 +136,12 @@ class SettingsSystemDuckDbMigration extends Component {
                       <Text id="systemSettings.duckDbNumberOfStatesinSQlite" />
                     </b>{' '}
                     : {migrationState.sqlite_db_device_state_count}
+                  </li>
+                  <li>
+                    <b>
+                      <Text id="systemSettings.duckDbNumberOfAggregatesinSQlite" />
+                    </b>{' '}
+                    : {migrationState.sqlite_db_device_state_aggregate_count}
                   </li>
                   <li>
                     <b>

--- a/server/lib/device/device.getDuckDbMigrationState.js
+++ b/server/lib/device/device.getDuckDbMigrationState.js
@@ -26,6 +26,10 @@ async function getDuckDbMigrationState() {
     is_duck_db_migrated: isDuckDbMigrated === 'true',
     duck_db_device_count: Number(duckDbDeviceStateCount),
     sqlite_db_device_state_count: sqliteDeviceStateCount,
+    // Served next to the states count: an install can have no state left and still carry
+    // millions of aggregates, and the card then announced "0 state in SQLite" while it was
+    // displayed precisely because of those aggregates.
+    sqlite_db_device_state_aggregate_count: sqliteDeviceStateAggregateCount,
     // Migrating/purging states is only useful while rows remain in the legacy SQLite tables.
     // Aggregates are counted too: the purge empties the states first, then the aggregates,
     // so a crash in between must not hide the card that is the only way to finish the purge.

--- a/server/test/lib/device/device.getDuckDbMigrationState.test.js
+++ b/server/test/lib/device/device.getDuckDbMigrationState.test.js
@@ -54,6 +54,7 @@ describe('Device.getDuckDbMigrationState', () => {
       .to.have.property('duck_db_device_count')
       .that.is.a('number');
     expect(migrationState).to.have.property('sqlite_db_device_state_count', 0);
+    expect(migrationState).to.have.property('sqlite_db_device_state_aggregate_count', 0);
     expect(migrationState).to.have.property('is_migration_needed', false);
   });
   it('should return migration done', async () => {
@@ -68,6 +69,7 @@ describe('Device.getDuckDbMigrationState', () => {
       .to.have.property('duck_db_device_count')
       .that.is.a('number');
     expect(migrationState).to.have.property('sqlite_db_device_state_count', 0);
+    expect(migrationState).to.have.property('sqlite_db_device_state_aggregate_count', 0);
     expect(migrationState).to.have.property('is_migration_needed', false);
   });
   it('should return that a migration is needed when states remain in SQLite', async () => {
@@ -80,6 +82,7 @@ describe('Device.getDuckDbMigrationState', () => {
     const migrationState = await device.getDuckDbMigrationState();
     expect(migrationState).to.have.property('is_duck_db_migrated', true);
     expect(migrationState).to.have.property('sqlite_db_device_state_count', 1);
+    expect(migrationState).to.have.property('sqlite_db_device_state_aggregate_count', 0);
     expect(migrationState).to.have.property('is_migration_needed', true);
   });
   it('should return that a migration is needed when only aggregates remain in SQLite', async () => {
@@ -92,6 +95,7 @@ describe('Device.getDuckDbMigrationState', () => {
     const migrationState = await device.getDuckDbMigrationState();
     expect(migrationState).to.have.property('is_duck_db_migrated', true);
     expect(migrationState).to.have.property('sqlite_db_device_state_count', 0);
+    expect(migrationState).to.have.property('sqlite_db_device_state_aggregate_count', 1);
     expect(migrationState).to.have.property('is_migration_needed', true);
   });
 });


### PR DESCRIPTION
## What

The "Migration to DuckDB" card in Settings → System now displays **Number of aggregates in SQLite**, next to the states counts it already showed.

`getDuckDbMigrationState` already counted the aggregates — it needs them to decide whether the card is displayed at all — it simply did not serve the number to the frontend.

## Why

The card shows up as soon as legacy rows remain in **either** SQLite table (`t_device_feature_state` **or** `t_device_feature_state_aggregate`), but it only listed the states.

An install can have zero state left in SQLite and still carry millions of rows in `t_device_feature_state_aggregate`. The card then announced *"Number of states in SQLite: 0"* while it was displayed precisely because of those aggregates, and nothing pointed at the "Purge SQLite states" button right below it — which is the only way to get rid of them.

Those leftover aggregates are not harmless. `t_device_feature_state_aggregate` declares `ON DELETE CASCADE` on `device_feature_id`, and Sequelize turns SQLite foreign keys on for every connection, so destroying a device feature that still holds half a million aggregates deletes them **synchronously, inside the transaction**, with 4 indexes to maintain.

That is what freezes a Zigbee2mqtt device update: `device.create` destroys the features the integration no longer exposes, and the SQLite write lock is held long enough for the other writers to fail with `SQLITE_BUSY` / `SequelizeTimeoutError` and for the HTTP request to time out. Making the aggregates visible lets users purge them with the button that already exists.

## How to test

1. Insert rows in `t_device_feature_state_aggregate` while leaving `t_device_feature_state` empty.
2. Settings → System: the card now reads `Number of states in SQLite: 0` **and** `Number of aggregates in SQLite: N`.
3. Click "Purge SQLite states": the `device-state-purge-all-sqlite-states` job runs and the card disappears once both tables are empty.

## Notes

Out of scope here, worth a follow-up: `device.create` destroys obsolete features without the guard `device.destroy` already has (`MAX_NUMBER_OF_STATES_ALLOWED_TO_DELETE_DEVICE`), so the same freeze can still happen on a feature that has rows left in `t_device_feature_state`.


<img width="446" height="679" alt="gladys_aggregates_states" src="https://github.com/user-attachments/assets/9b9a6a80-d323-49cf-a492-7cdf05694dcf" />

