### PR TITLE
Zigbee2mqtt: map the Heiman HS2WD-E siren exposes to Gladys features

### DIFF
--- a/server/services/zigbee2mqtt/exposes/compositeType.js
+++ b/server/services/zigbee2mqtt/exposes/compositeType.js
@@ -1,14 +1,77 @@
 const { intToRgb, xyToInt } = require('../../../utils/colors');
 const { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } = require('../../../utils/constants');
 
-module.exports = {
-  type: 'composite',
-  writeValue: (expose, value) => {
+// Zigbee "warning" composite modes starting the siren, ordered by preference.
+// The Zigbee cluster defines them all, but each device only exposes a subset of them.
+const WARNING_START_MODES = ['emergency', 'burglar', 'fire', 'police_panic', 'emergency_panic', 'fire_panic'];
+// Zigbee "warning" composite modes stopping the siren, ordered by preference.
+const WARNING_STOP_MODES = ['stop'];
+// Duration sent when the siren is started. The siren stops by itself after this delay, or
+// earlier if the device "max_duration" attribute (exposed as its own Gladys feature) is lower.
+const WARNING_DURATION_IN_SECONDS = 600;
+
+/**
+ * @description Look for a sub-feature of a composite "expose".
+ * @param {object} expose - Zigbee composite "expose".
+ * @param {string} name - Sub-feature name.
+ * @returns {object} The matching sub-feature, or undefined.
+ * @example findSubFeature({ features: [{ name: 'mode' }] }, 'mode');
+ */
+function findSubFeature(expose, name) {
+  const { features = [] } = expose;
+  return features.find((feature) => feature.name === name);
+}
+
+/**
+ * @description Select the Zigbee "warning" mode to send, according to what the device supports.
+ * @param {object} expose - Zigbee composite "expose".
+ * @param {Array} candidates - Accepted modes, ordered by preference.
+ * @returns {string} The Zigbee mode to send.
+ * @example pickWarningMode({ features: [] }, ['emergency']);
+ */
+function pickWarningMode(expose, candidates) {
+  const { values = [] } = findSubFeature(expose, 'mode') || {};
+  // Modes not exposed by the device are ignored, the first candidate is the Zigbee default one.
+  return candidates.find((mode) => values.includes(mode)) || candidates[0];
+}
+
+const WRITE_VALUE_HANDLERS = {
+  color_xy: (expose, value) => {
     const [r, g, b] = intToRgb(parseInt(value, 10));
     return { rgb: `${r},${g},${b}` };
   },
+  // Siren "warning" command, e.g. Heiman HS2WD-E
+  // https://www.zigbee2mqtt.io/devices/HS2WD-E.html
+  warning: (expose, value) => {
+    const start = `${value}` === '1';
+    const warning = { mode: pickWarningMode(expose, start ? WARNING_START_MODES : WARNING_STOP_MODES) };
+
+    if (findSubFeature(expose, 'strobe')) {
+      warning.strobe = start;
+    }
+    if (findSubFeature(expose, 'duration')) {
+      warning.duration = start ? WARNING_DURATION_IN_SECONDS : 0;
+    }
+
+    return warning;
+  },
+};
+
+const READ_VALUE_HANDLERS = {
+  color_xy: (expose, value) => xyToInt(value.x, value.y),
+};
+
+module.exports = {
+  type: 'composite',
+  writeValue: (expose, value) => {
+    const { name } = expose || {};
+    const handler = WRITE_VALUE_HANDLERS[name];
+    return handler ? handler(expose, value) : undefined;
+  },
   readValue: (expose, value) => {
-    return xyToInt(value.x, value.y);
+    const { name } = expose || {};
+    const handler = READ_VALUE_HANDLERS[name];
+    return handler ? handler(expose, value) : undefined;
   },
   names: {
     color_xy: {
@@ -19,6 +82,14 @@ module.exports = {
         read_only: false,
         min: 0,
         max: 16777215,
+      },
+    },
+    warning: {
+      feature: {
+        category: DEVICE_FEATURE_CATEGORIES.SIREN,
+        type: DEVICE_FEATURE_TYPES.SIREN.BINARY,
+        min: 0,
+        max: 1,
       },
     },
   },

--- a/server/services/zigbee2mqtt/exposes/compositeType.js
+++ b/server/services/zigbee2mqtt/exposes/compositeType.js
@@ -6,9 +6,10 @@ const { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_TYPES } = require('../../../ut
 const WARNING_START_MODES = ['emergency', 'burglar', 'fire', 'police_panic', 'emergency_panic', 'fire_panic'];
 // Zigbee "warning" composite modes stopping the siren, ordered by preference.
 const WARNING_STOP_MODES = ['stop'];
-// Duration sent when the siren is started. The siren stops by itself after this delay, or
+// Duration sent when the siren is started and the device does not declare a maximum for the
+// "duration" sub-feature of its warning command. The siren stops by itself after this delay, or
 // earlier if the device "max_duration" attribute (exposed as its own Gladys feature) is lower.
-const WARNING_DURATION_IN_SECONDS = 600;
+const DEFAULT_WARNING_DURATION_IN_SECONDS = 600;
 
 /**
  * @description Look for a sub-feature of a composite "expose".
@@ -49,8 +50,12 @@ const WRITE_VALUE_HANDLERS = {
     if (findSubFeature(expose, 'strobe')) {
       warning.strobe = start;
     }
-    if (findSubFeature(expose, 'duration')) {
-      warning.duration = start ? WARNING_DURATION_IN_SECONDS : 0;
+    const durationSubFeature = findSubFeature(expose, 'duration');
+    if (durationSubFeature) {
+      // Ask for the longest alarm the device accepts: it stops by itself when its "max_duration"
+      // attribute is reached, and is stopped early by the "off" command.
+      const { value_max: valueMax } = durationSubFeature;
+      warning.duration = start ? valueMax ?? DEFAULT_WARNING_DURATION_IN_SECONDS : 0;
     }
 
     return warning;

--- a/server/services/zigbee2mqtt/exposes/numericType.js
+++ b/server/services/zigbee2mqtt/exposes/numericType.js
@@ -24,6 +24,15 @@ module.exports = {
         unit: DEVICE_FEATURE_UNITS.SECONDS,
       },
     },
+    // Maximum duration of a siren alarm, e.g. Heiman HS2WD-E
+    // https://www.zigbee2mqtt.io/devices/HS2WD-E.html
+    max_duration: {
+      feature: {
+        category: DEVICE_FEATURE_CATEGORIES.DURATION,
+        type: DEVICE_FEATURE_TYPES.DURATION.DECIMAL,
+        unit: DEVICE_FEATURE_UNITS.SECONDS,
+      },
+    },
     battery: {
       feature: {
         category: DEVICE_FEATURE_CATEGORIES.BATTERY,

--- a/server/services/zigbee2mqtt/utils/features/mapExpose.js
+++ b/server/services/zigbee2mqtt/utils/features/mapExpose.js
@@ -19,6 +19,13 @@ function mapExpose(deviceName, expose, parentType = undefined) {
     matchingFeatures.push(feature);
   });
 
+  // A "composite" expose mapped to a Gladys feature owns its sub-features: they are only parts
+  // of the payload of a single command (e.g. the siren "warning" command) and can't be set on
+  // their own, so they must not become standalone Gladys features.
+  if (type === 'composite' && builtFeatures.length > 0) {
+    return matchingFeatures;
+  }
+
   // Map exposed sub-features recursivly
   features.flatMap((f) => mapExpose(deviceName, f, parentType || type)).forEach((f) => matchingFeatures.push(f));
 

--- a/server/test/services/zigbee2mqtt/exposes/compositeType.test.js
+++ b/server/test/services/zigbee2mqtt/exposes/compositeType.test.js
@@ -3,13 +3,35 @@ const { assert } = require('chai');
 const compositeType = require('../../../../services/zigbee2mqtt/exposes/compositeType');
 
 describe('zigbee2mqtt compositeType', () => {
+  const colorExpose = { name: 'color_xy', property: 'color', type: 'composite' };
+
   it('should write color 16711680', () => {
-    const result = compositeType.writeValue(null, 16711680);
+    const result = compositeType.writeValue(colorExpose, 16711680);
     assert.deepEqual(result, { rgb: '255,0,0' });
   });
 
   it('should read color 16711680', () => {
-    const result = compositeType.readValue(null, { x: 0.701, y: 0.299 });
+    const result = compositeType.readValue(colorExpose, { x: 0.701, y: 0.299 });
     assert.equal(result, 16711680);
+  });
+
+  it('should not write value of an unhandled composite', () => {
+    const result = compositeType.writeValue({ name: 'unknown_composite' }, 1);
+    assert.equal(result, undefined);
+  });
+
+  it('should not read value of an unhandled composite', () => {
+    const result = compositeType.readValue({ name: 'unknown_composite' }, 1);
+    assert.equal(result, undefined);
+  });
+
+  it('should not write value without expose', () => {
+    const result = compositeType.writeValue(undefined, 1);
+    assert.equal(result, undefined);
+  });
+
+  it('should not read value without expose', () => {
+    const result = compositeType.readValue(undefined, 1);
+    assert.equal(result, undefined);
   });
 });

--- a/server/test/services/zigbee2mqtt/exposes/numericType.test.js
+++ b/server/test/services/zigbee2mqtt/exposes/numericType.test.js
@@ -67,4 +67,14 @@ describe('zigbee2mqtt numericType', () => {
       });
     });
   });
+
+  describe('Siren features', () => {
+    it('should configure max_duration feature', () => {
+      assert.deepEqual(numericType.names.max_duration.feature, {
+        category: DEVICE_FEATURE_CATEGORIES.DURATION,
+        type: DEVICE_FEATURE_TYPES.DURATION.DECIMAL,
+        unit: DEVICE_FEATURE_UNITS.SECONDS,
+      });
+    });
+  });
 });

--- a/server/test/services/zigbee2mqtt/exposes/sirenWarningCompositeType.test.js
+++ b/server/test/services/zigbee2mqtt/exposes/sirenWarningCompositeType.test.js
@@ -59,6 +59,20 @@ describe('zigbee2mqtt siren warning compositeType', () => {
     assert.deepEqual(result, { mode: 'stop', strobe: false, duration: 0 });
   });
 
+  it('should use the duration maximum declared by the device', () => {
+    // A device declaring a maximum for the warning duration is asked for that maximum, instead of
+    // the default one.
+    const expose = {
+      ...warningExpose,
+      features: warningExpose.features.map((feature) =>
+        feature.name === 'duration' ? { ...feature, value_min: 0, value_max: 1800 } : feature,
+      ),
+    };
+
+    assert.deepEqual(compositeType.writeValue(expose, 1), { mode: 'emergency', strobe: true, duration: 1800 });
+    assert.deepEqual(compositeType.writeValue(expose, 0), { mode: 'stop', strobe: false, duration: 0 });
+  });
+
   it('should keep the device supported modes only', () => {
     // A device not exposing the "emergency" mode falls back to another supported one
     const expose = {

--- a/server/test/services/zigbee2mqtt/exposes/sirenWarningCompositeType.test.js
+++ b/server/test/services/zigbee2mqtt/exposes/sirenWarningCompositeType.test.js
@@ -1,0 +1,120 @@
+const { assert } = require('chai');
+
+const compositeType = require('../../../../services/zigbee2mqtt/exposes/compositeType');
+const { buildFeatures } = require('../../../../services/zigbee2mqtt/utils/features/buildFeatures');
+const { mapExpose } = require('../../../../services/zigbee2mqtt/utils/features/mapExpose');
+
+describe('zigbee2mqtt siren warning compositeType', () => {
+  // Heiman HS2WD-E indoor siren
+  // https://www.zigbee2mqtt.io/devices/HS2WD-E.html
+  const warningExpose = {
+    name: 'warning',
+    property: 'warning',
+    label: 'Warning',
+    type: 'composite',
+    access: 2,
+    features: [
+      {
+        name: 'strobe',
+        property: 'strobe',
+        type: 'binary',
+        access: 2,
+        value_on: true,
+        value_off: false,
+      },
+      {
+        name: 'strobe_duty_cycle',
+        property: 'strobe_duty_cycle',
+        type: 'numeric',
+        access: 2,
+        value_min: 0,
+        value_max: 10,
+      },
+      {
+        name: 'duration',
+        property: 'duration',
+        type: 'numeric',
+        access: 2,
+        unit: 's',
+      },
+      {
+        name: 'mode',
+        property: 'mode',
+        type: 'enum',
+        access: 2,
+        values: ['stop', 'emergency'],
+      },
+    ],
+  };
+
+  it('should start the siren', () => {
+    const result = compositeType.writeValue(warningExpose, 1);
+
+    assert.deepEqual(result, { mode: 'emergency', strobe: true, duration: 600 });
+  });
+
+  it('should stop the siren', () => {
+    const result = compositeType.writeValue(warningExpose, 0);
+
+    assert.deepEqual(result, { mode: 'stop', strobe: false, duration: 0 });
+  });
+
+  it('should keep the device supported modes only', () => {
+    // A device not exposing the "emergency" mode falls back to another supported one
+    const expose = {
+      ...warningExpose,
+      features: [{ name: 'mode', property: 'mode', type: 'enum', access: 2, values: ['stop', 'burglar'] }],
+    };
+
+    assert.deepEqual(compositeType.writeValue(expose, 1), { mode: 'burglar' });
+    assert.deepEqual(compositeType.writeValue(expose, 0), { mode: 'stop' });
+  });
+
+  it('should fallback on the Zigbee default mode when no mode is exposed', () => {
+    const expose = { name: 'warning', property: 'warning', type: 'composite', access: 2 };
+
+    assert.deepEqual(compositeType.writeValue(expose, 1), { mode: 'emergency' });
+    assert.deepEqual(compositeType.writeValue(expose, 0), { mode: 'stop' });
+  });
+
+  it('should ignore unknown exposed modes', () => {
+    const expose = {
+      ...warningExpose,
+      features: [{ name: 'mode', property: 'mode', type: 'enum', access: 2, values: ['unknown_mode'] }],
+    };
+
+    assert.deepEqual(compositeType.writeValue(expose, 1), { mode: 'emergency' });
+  });
+
+  it('should not read the write-only warning command', () => {
+    const result = compositeType.readValue(warningExpose, { mode: 'stop' });
+
+    assert.equal(result, undefined);
+  });
+
+  it('should build the warning feature as a writable siren', () => {
+    const [feature] = buildFeatures('heiman-indoor-siren', warningExpose);
+
+    assert.deepEqual(feature, {
+      read_only: false,
+      has_feedback: false,
+      min: 0,
+      max: 1,
+      category: 'siren',
+      type: 'binary',
+      unit: null,
+      name: 'Warning',
+      external_id: 'zigbee2mqtt:heiman-indoor-siren:siren:binary:warning',
+      selector: 'zigbee2mqtt-heiman-indoor-siren-siren-binary-warning',
+    });
+  });
+
+  it('should not expose the warning sub-features as standalone features', () => {
+    const features = mapExpose('heiman-indoor-siren', warningExpose);
+
+    assert.deepEqual(
+      features.map((feature) => feature.external_id),
+      ['zigbee2mqtt:heiman-indoor-siren:siren:binary:warning'],
+    );
+  });
+});

--- a/server/test/services/zigbee2mqtt/lib/payloads/event_device_result.json
+++ b/server/test/services/zigbee2mqtt/lib/payloads/event_device_result.json
@@ -306,5 +306,51 @@
     ],
     "should_poll": false,
     "service_id": "f87b7af2-ca8e-44fc-b754-444354b42fee"
+  },
+  {
+    "name": "heiman-indoor-siren",
+    "model": "HS2WD-E",
+    "ieee_address": "0x00124b0023a1b2c4",
+    "external_id": "zigbee2mqtt:heiman-indoor-siren",
+    "features": [
+      {
+        "read_only": true,
+        "has_feedback": false,
+        "min": 0,
+        "max": 100,
+        "category": "battery",
+        "type": "integer",
+        "unit": "percent",
+        "name": "Battery",
+        "external_id": "zigbee2mqtt:heiman-indoor-siren:battery:integer:battery",
+        "selector": "zigbee2mqtt-heiman-indoor-siren-battery-integer-battery"
+      },
+      {
+        "read_only": false,
+        "has_feedback": true,
+        "min": 0,
+        "max": 600,
+        "category": "duration",
+        "type": "decimal",
+        "unit": "seconds",
+        "name": "Max duration",
+        "external_id": "zigbee2mqtt:heiman-indoor-siren:duration:decimal:max_duration",
+        "selector": "zigbee2mqtt-heiman-indoor-siren-duration-decimal-max-duration"
+      },
+      {
+        "read_only": false,
+        "has_feedback": false,
+        "min": 0,
+        "max": 1,
+        "category": "siren",
+        "type": "binary",
+        "unit": null,
+        "name": "Warning",
+        "external_id": "zigbee2mqtt:heiman-indoor-siren:siren:binary:warning",
+        "selector": "zigbee2mqtt-heiman-indoor-siren-siren-binary-warning"
+      }
+    ],
+    "should_poll": false,
+    "service_id": "f87b7af2-ca8e-44fc-b754-444354b42fee"
   }
 ]

--- a/server/test/services/zigbee2mqtt/lib/payloads/mqtt_devices_get.json
+++ b/server/test/services/zigbee2mqtt/lib/payloads/mqtt_devices_get.json
@@ -382,5 +382,83 @@
     "interviewing": false,
     "supported": true,
     "type": "Router"
+  },
+  {
+    "definition": {
+      "description": "Smart siren",
+      "exposes": [
+        {
+          "access": 1,
+          "description": "Remaining battery in %, can take up to 24 hours before reported",
+          "name": "battery",
+          "property": "battery",
+          "type": "numeric",
+          "unit": "%",
+          "value_max": 100,
+          "value_min": 0
+        },
+        {
+          "access": 7,
+          "description": "Max duration of Siren",
+          "name": "max_duration",
+          "property": "max_duration",
+          "type": "numeric",
+          "unit": "s",
+          "value_max": 600,
+          "value_min": 0
+        },
+        {
+          "access": 2,
+          "features": [
+            {
+              "access": 2,
+              "description": "Turn on/off the strobe (light) during warning",
+              "name": "strobe",
+              "property": "strobe",
+              "type": "binary",
+              "value_off": false,
+              "value_on": true
+            },
+            {
+              "access": 2,
+              "description": "Length of the flash cycle",
+              "name": "strobe_duty_cycle",
+              "property": "strobe_duty_cycle",
+              "type": "numeric",
+              "value_max": 10,
+              "value_min": 0
+            },
+            {
+              "access": 2,
+              "description": "Duration in seconds of the alarm",
+              "name": "duration",
+              "property": "duration",
+              "type": "numeric",
+              "unit": "s"
+            },
+            {
+              "access": 2,
+              "description": "Mode of the warning (sound effect)",
+              "name": "mode",
+              "property": "mode",
+              "type": "enum",
+              "values": ["stop", "emergency"]
+            }
+          ],
+          "name": "warning",
+          "property": "warning",
+          "type": "composite"
+        }
+      ],
+      "model": "HS2WD-E",
+      "supports_ota": false,
+      "vendor": "Heiman"
+    },
+    "friendly_name": "heiman-indoor-siren",
+    "ieee_address": "0x00124b0023a1b2c4",
+    "interview_completed": true,
+    "interviewing": false,
+    "supported": true,
+    "type": "EndDevice"
   }
 ]

--- a/server/test/services/zigbee2mqtt/lib/setValue.test.js
+++ b/server/test/services/zigbee2mqtt/lib/setValue.test.js
@@ -52,6 +52,16 @@ const featureStopAlarm = {
   type: 'push',
 };
 
+const featureSirenWarning = {
+  external_id: 'zigbee2mqtt:heiman-indoor-siren:siren:binary:warning',
+  type: 'binary',
+};
+
+const featureSirenMaxDuration = {
+  external_id: 'zigbee2mqtt:heiman-indoor-siren:duration:decimal:max_duration',
+  type: 'decimal',
+};
+
 describe('zigbee2mqtt setValue', () => {
   // PREPARE
   let zigbee2MqttManager;
@@ -158,6 +168,33 @@ describe('zigbee2mqtt setValue', () => {
       mqttClient.publish,
       'zigbee2mqtt/bosch-outdoor-siren/set',
       JSON.stringify({ stop_alarm: 'stop' }),
+    );
+  });
+
+  it('start Heiman siren warning', async () => {
+    await zigbee2MqttManager.setValue(null, featureSirenWarning, 1);
+    assert.calledOnceWithExactly(
+      mqttClient.publish,
+      'zigbee2mqtt/heiman-indoor-siren/set',
+      JSON.stringify({ warning: { mode: 'emergency', strobe: true, duration: 600 } }),
+    );
+  });
+
+  it('stop Heiman siren warning', async () => {
+    await zigbee2MqttManager.setValue(null, featureSirenWarning, 0);
+    assert.calledOnceWithExactly(
+      mqttClient.publish,
+      'zigbee2mqtt/heiman-indoor-siren/set',
+      JSON.stringify({ warning: { mode: 'stop', strobe: false, duration: 0 } }),
+    );
+  });
+
+  it('set Heiman siren max_duration', async () => {
+    await zigbee2MqttManager.setValue(null, featureSirenMaxDuration, 120);
+    assert.calledOnceWithExactly(
+      mqttClient.publish,
+      'zigbee2mqtt/heiman-indoor-siren/set',
+      JSON.stringify({ max_duration: 120 }),
     );
   });
 });

--- a/server/test/services/zigbee2mqtt/utils/payloads/HS2WD-E.json
+++ b/server/test/services/zigbee2mqtt/utils/payloads/HS2WD-E.json
@@ -1,0 +1,143 @@
+{
+  "name": "HS2WD-E device",
+  "mqttDevice": {
+    "definition": {
+      "description": "Smart siren",
+      "exposes": [
+        {
+          "name": "battery",
+          "label": "Battery",
+          "access": 1,
+          "type": "numeric",
+          "property": "battery",
+          "description": "Remaining battery in %, can take up to 24 hours before reported",
+          "category": "diagnostic",
+          "unit": "%",
+          "value_max": 100,
+          "value_min": 0
+        },
+        {
+          "name": "max_duration",
+          "label": "Max duration",
+          "access": 7,
+          "type": "numeric",
+          "property": "max_duration",
+          "description": "Max duration of Siren",
+          "category": "config",
+          "unit": "s",
+          "value_max": 600,
+          "value_min": 0
+        },
+        {
+          "name": "warning",
+          "label": "Warning",
+          "access": 2,
+          "type": "composite",
+          "property": "warning",
+          "features": [
+            {
+              "name": "strobe",
+              "label": "Strobe",
+              "access": 2,
+              "type": "binary",
+              "property": "strobe",
+              "description": "Turn on/off the strobe (light) during warning",
+              "value_on": true,
+              "value_off": false
+            },
+            {
+              "name": "strobe_duty_cycle",
+              "label": "Strobe duty cycle",
+              "access": 2,
+              "type": "numeric",
+              "property": "strobe_duty_cycle",
+              "description": "Length of the flash cycle",
+              "value_max": 10,
+              "value_min": 0
+            },
+            {
+              "name": "duration",
+              "label": "Duration",
+              "access": 2,
+              "type": "numeric",
+              "property": "duration",
+              "description": "Duration in seconds of the alarm",
+              "unit": "s"
+            },
+            {
+              "name": "mode",
+              "label": "Mode",
+              "access": 2,
+              "type": "enum",
+              "property": "mode",
+              "description": "Mode of the warning (sound effect)",
+              "values": ["stop", "emergency"]
+            }
+          ]
+        }
+      ],
+      "model": "HS2WD-E",
+      "options": [],
+      "supports_ota": false,
+      "vendor": "Heiman"
+    },
+    "friendly_name": "HS2WD-E device"
+  },
+  "gladysDevice": {
+    "name": "HS2WD-E device",
+    "model": "HS2WD-E",
+    "external_id": "zigbee2mqtt:HS2WD-E device",
+    "features": [
+      {
+        "read_only": true,
+        "has_feedback": false,
+        "min": 0,
+        "max": 100,
+        "category": "battery",
+        "type": "integer",
+        "unit": "percent",
+        "name": "Battery",
+        "external_id": "zigbee2mqtt:HS2WD-E device:battery:integer:battery",
+        "selector": "zigbee2mqtt-hs2wd-e-device-battery-integer-battery"
+      },
+      {
+        "read_only": false,
+        "has_feedback": true,
+        "min": 0,
+        "max": 600,
+        "category": "duration",
+        "type": "decimal",
+        "unit": "seconds",
+        "name": "Max duration",
+        "external_id": "zigbee2mqtt:HS2WD-E device:duration:decimal:max_duration",
+        "selector": "zigbee2mqtt-hs2wd-e-device-duration-decimal-max-duration"
+      },
+      {
+        "read_only": false,
+        "has_feedback": false,
+        "min": 0,
+        "max": 1,
+        "category": "siren",
+        "type": "binary",
+        "unit": null,
+        "name": "Warning",
+        "external_id": "zigbee2mqtt:HS2WD-E device:siren:binary:warning",
+        "selector": "zigbee2mqtt-hs2wd-e-device-siren-binary-warning"
+      }
+    ],
+    "should_poll": false,
+    "service_id": "a4c859f0-32d2-46b7-8f5a-3285960f498a"
+  },
+  "values": [
+    {
+      "internal": 92,
+      "external": 92,
+      "property": "battery"
+    },
+    {
+      "internal": 240,
+      "external": 240,
+      "property": "max_duration"
+    }
+  ]
+}

--- a/server/test/services/zigbee2mqtt/utils/payloads/index.js
+++ b/server/test/services/zigbee2mqtt/utils/payloads/index.js
@@ -3,5 +3,6 @@ const ZSSZKTHL = require('./ZSS-ZK-THL.json');
 const SNZB01M = require('./SNZB-01M.json');
 const TS0601GarageDoorOpener = require('./TS0601_garage_door_opener.json');
 const SWV = require('./SWV.json');
+const HS2WDE = require('./HS2WD-E.json');
 
-module.exports = [CCT5015, ZSSZKTHL, SNZB01M, TS0601GarageDoorOpener, SWV];
+module.exports = [CCT5015, ZSSZKTHL, SNZB01M, TS0601GarageDoorOpener, SWV, HS2WDE];


### PR DESCRIPTION
Implements feature request: https://community.gladysassistant.com/t/mapping-zigbee2mqtt-gladys-pour-la-sirene-heiman-hs2wd-e/10651

### Description

The Heiman HS2WD-E indoor siren is discovered by Gladys through Zigbee2mqtt, but only its `battery` expose was mapped to a Gladys device feature. The siren itself could not be triggered, stopped or configured from a scene without publishing raw MQTT payloads.

This PR maps the two remaining exposes of the device ([Zigbee2mqtt page](https://www.zigbee2mqtt.io/devices/HS2WD-E.html)):

| Zigbee2mqtt expose | Gladys category | Gladys type |
|---|---|---|
| `battery` (numeric, 0-100 %) | `battery` | `integer` (already mapped) |
| `max_duration` (numeric, 0-600 s, read/write) | `duration` | `decimal` (unit: seconds) |
| `warning` (composite, write-only) | `siren` | `binary` |

**No new device feature category, type or unit was added** — `docs/specs/device-feature-categories.md` asks to reuse the existing taxonomy first, and `siren`/`binary` plus `duration`/`decimal` (already used by the `duration` numeric expose) cover both capabilities. As a consequence there is no i18n or frontend change: both types are already registered in the frontend (`DeviceRow.jsx`, `SupportedFeatureTypes.jsx`, icons).

#### Siren `warning` command

`warning` is a write-only Zigbee composite: the siren is driven by publishing `{"warning": {"mode": …, "strobe": …, "duration": …}}`. It is now exposed as a writable siren feature:

- turning it **on** publishes an alarm mode with the strobe enabled and a duration of 600 s — the device stops by itself after that delay, or earlier if its own `max_duration` attribute (now configurable from Gladys) is lower;
- turning it **off** publishes the `stop` mode.

The mode actually sent is picked from the modes the device declares in its expose, from a preference list of the Zigbee warning modes (`emergency`, `burglar`, `fire`, …) for the "on" side and `stop` for the "off" side. The HS2WD-E only declares `stop` and `emergency`, but other sirens declare a different subset: modes a device does not declare are ignored rather than sent, and if none of the candidates match, the Zigbee default mode is used. Only the sub-features the device declares (`strobe`, `duration`) are added to the payload.

#### Composite expose mapping, generalised

`compositeType.js` previously assumed every composite expose was a `color_xy` light color. It now resolves write/read handlers per expose name, keeping the existing color behaviour untouched and adding the `warning` handler.

`mapExpose` also no longer maps the sub-features of a composite that is itself mapped to a Gladys feature: they are only parts of the payload of a single command and cannot be set on their own. Without this, the `duration` sub-feature of `warning` was mapped as a standalone, non-working duration feature (it would publish `{"duration": …}` at the root of the payload, which the device ignores).

### Forum

Forum: https://community.gladysassistant.com/t/mapping-zigbee2mqtt-gladys-pour-la-sirene-heiman-hs2wd-e/10651

### Tests

- `server/test/services/zigbee2mqtt/exposes/sirenWarningCompositeType.test.js` (new): start/stop payloads, device-specific mode subsets, unknown modes ignored, missing `mode` sub-feature, built Gladys feature, sub-features not exposed standalone.
- `server/test/services/zigbee2mqtt/exposes/compositeType.test.js`: per-name handler dispatch (color, unknown composite, missing expose).
- `server/test/services/zigbee2mqtt/exposes/numericType.test.js`: `max_duration` feature definition.
- `server/test/services/zigbee2mqtt/lib/setValue.test.js`: end-to-end MQTT payloads published for the siren (start, stop, `max_duration`), against a real HS2WD-E definition added to the discovered-devices fixture.
- `server/test/services/zigbee2mqtt/utils/payloads/HS2WD-E.json` (new): full real-device decoding fixture, so the whole `definition` → Gladys device conversion is asserted.

Local results: `npm run prettier-check`, `npm run eslint` (0 errors) and `npm run coverage` all pass on `server/`, with 100 % line and branch coverage on `compositeType.js`, `numericType.js` and `mapExpose.js`. `front/` is untouched.

This PR was opened by an automated Claude Code run. Testing on the real device is very welcome, since the siren behaviour could only be verified against the Zigbee2mqtt converter definitions here.

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change


---
_Generated by [Claude Code](https://claude.ai/code/session_01SfenWHvJmw3ffPA92yAend)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Heiman HS2WD-E indoor sirens.
  * Sirens can be started and stopped with supported alarm modes, strobe settings, and durations.
  * Added configurable maximum alarm duration in seconds.
  * Improved handling of siren controls so only relevant features are exposed.

* **Bug Fixes**
  * Prevented composite control sub-features from appearing as separate device features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->