### PR TITLE
Message channel selector: only list configured messaging services

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -3132,7 +3132,7 @@
         "serviceExplanation": "Wähle den Nachrichtendienst, der diese Nachricht sendet. Standardmäßig wird die Nachricht an alle vom Benutzer konfigurierten Dienste gesendet.",
         "serviceUnavailable": "nicht verfügbar",
         "serviceIntegrationExternal": "externe Integration",
-        "serviceIntegrationInternal": "integrierte Integration",
+        "serviceIntegrationInternal": "native Integration",
         "textLabel": "Nachricht",
         "textPlaceholder": "Nachrichtentext",
         "explanationText": "Um eine Variable in den Text einzufügen, gib \"{{\" ein. Um einen Variablenwert festzulegen, musst du zuerst das Feld \"Eine Variable definieren\" oder \"Gerätewert abrufen\" verwenden."

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -3131,6 +3131,8 @@
         "allServicesLabel": "Alle konfigurierten Dienste",
         "serviceExplanation": "Wähle den Nachrichtendienst, der diese Nachricht sendet. Standardmäßig wird die Nachricht an alle vom Benutzer konfigurierten Dienste gesendet.",
         "serviceUnavailable": "nicht verfügbar",
+        "serviceIntegrationExternal": "externe Integration",
+        "serviceIntegrationInternal": "integrierte Integration",
         "textLabel": "Nachricht",
         "textPlaceholder": "Nachrichtentext",
         "explanationText": "Um eine Variable in den Text einzufügen, gib \"{{\" ein. Um einen Variablenwert festzulegen, musst du zuerst das Feld \"Eine Variable definieren\" oder \"Gerätewert abrufen\" verwenden."

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -3131,6 +3131,8 @@
         "allServicesLabel": "All configured services",
         "serviceExplanation": "Choose the messaging service which will send this message. By default, the message is sent to every service configured by the user.",
         "serviceUnavailable": "unavailable",
+        "serviceIntegrationExternal": "external integration",
+        "serviceIntegrationInternal": "built-in integration",
         "textLabel": "Message",
         "textPlaceholder": "Message text",
         "explanationText": "To inject a variable in the text, press '{{'. To set a variable value, you need to use a 'Set a variable' or 'Get device value' box before this one."

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -3131,6 +3131,8 @@
         "allServicesLabel": "Tous les services configurés",
         "serviceExplanation": "Choisissez le service de messagerie qui enverra ce message. Par défaut, le message est envoyé sur tous les services configurés par l'utilisateur.",
         "serviceUnavailable": "indisponible",
+        "serviceIntegrationExternal": "intégration externe",
+        "serviceIntegrationInternal": "intégration native",
         "textLabel": "Message",
         "textPlaceholder": "Texte du message",
         "explanationText": "Pour injecter une variable, tapez '{{'. Attention, vous devez avoir défini une variable auparavant dans une action 'Définir une variable' ou 'Récupérer le dernier état' placée avant ce bloc message."

--- a/front/src/routes/scene/edit-scene/actions/MessageServiceSelector.jsx
+++ b/front/src/routes/scene/edit-scene/actions/MessageServiceSelector.jsx
@@ -13,6 +13,9 @@ const ALL_SERVICES_VALUE = '__all__';
 // that failed to start is STOPPED
 const RUNNING_STATUS = 'RUNNING';
 
+// SERVICE_TYPES.EXTERNAL server side
+const EXTERNAL_SERVICE_TYPE = 'external';
+
 /**
  * A core service has no manifest, so the server falls back to its technical
  * name ("nextcloud-talk"). The human readable name lives in the front i18n
@@ -29,29 +32,56 @@ const toI18nKey = name => name.replace(/-([a-z])/g, (match, letter) => letter.to
  * in the editor shows "All configured services" without being rewritten.
  */
 class MessageServiceSelector extends Component {
-  buildLabel = service => {
+  buildName = service => {
     // an external integration ships its own name in its manifest; a core
     // service is translated from the front dictionary, falling back to the
     // technical name when no translation exists
     const translated = get(this.props.intl.dictionary, `integration.${toI18nKey(service.name)}.title`);
-    const name = service.manifest_name || translated || service.name;
-    if (service.status === RUNNING_STATUS) {
-      return name;
+    return service.manifest_name || translated || service.name;
+  };
+  buildLabel = (service, suffixes = []) => {
+    const parts = [...suffixes];
+    if (service.status !== RUNNING_STATUS) {
+      // a stopped or degraded channel stays selectable — a scene can legitimately
+      // target a service that is temporarily down — but the user must see it
+      parts.push(
+        get(this.props.intl.dictionary, 'editScene.actionsCard.messageSend.serviceUnavailable', {
+          default: 'unavailable'
+        })
+      );
     }
-    // a stopped or degraded channel stays selectable — a scene can legitimately
-    // target a service that is temporarily down — but the user must see it
-    const unavailable = get(this.props.intl.dictionary, 'editScene.actionsCard.messageSend.serviceUnavailable', {
-      default: 'unavailable'
-    });
-    return `${name} (${unavailable})`;
+    const name = this.buildName(service);
+    return parts.length === 0 ? name : `${name} (${parts.join(', ')})`;
   };
   getOptions = async () => {
     try {
       const services = await this.props.httpClient.get('/api/v1/service/message');
-      const serviceOptions = services.map(service => ({
-        label: this.buildLabel(service),
-        value: service.name
-      }));
+      // a core service and an external integration can display the exact same
+      // name (a native Telegram alongside a Telegram integration from the
+      // store): tell them apart, but only when the ambiguity is real
+      const countByName = {};
+      services.forEach(service => {
+        const name = this.buildName(service);
+        countByName[name] = (countByName[name] || 0) + 1;
+      });
+      const serviceOptions = services.map(service => {
+        const ambiguous = countByName[this.buildName(service)] > 1;
+        const suffixes = ambiguous
+          ? [
+              get(
+                this.props.intl.dictionary,
+                service.type === EXTERNAL_SERVICE_TYPE
+                  ? 'editScene.actionsCard.messageSend.serviceIntegrationExternal'
+                  : 'editScene.actionsCard.messageSend.serviceIntegrationInternal',
+                { default: service.type === EXTERNAL_SERVICE_TYPE ? 'external integration' : 'built-in integration' }
+              )
+            ]
+          : [];
+        return {
+          label: this.buildLabel(service, suffixes),
+          value: service.name
+        };
+      });
       this.setState({ serviceOptions });
     } catch (e) {
       console.error(e);

--- a/server/api/controllers/service.controller.js
+++ b/server/api/controllers/service.controller.js
@@ -119,6 +119,7 @@ module.exports = function ServiceController(gladys) {
    *   "name":"telegram",
    *   "selector":"telegram",
    *   "status":"RUNNING",
+   *   "type":"internal",
    *   "manifest_name":null
    *  }
    * ]

--- a/server/lib/service/service.getMessageServices.js
+++ b/server/lib/service/service.getMessageServices.js
@@ -1,4 +1,7 @@
+const Promise = require('bluebird');
+const logger = require('../../utils/logger');
 const db = require('../../models');
+const { SERVICE_TYPES } = require('../../utils/constants');
 
 /**
  * @public
@@ -6,8 +9,18 @@ const db = require('../../models');
  * the core services exposing `message.sendToUser` (telegram, nextcloud-talk,
  * callmebot…) and the external integrations of type "communication" (the Free
  * Mobile SMS family). This feeds the channel selector of the "send message"
- * scene action, so a service flagged in database but not currently loaded in
- * the stateManager is filtered out: it could not deliver anything.
+ * scene action, so only channels the user can actually use are returned:
+ * - a service flagged in database but not currently loaded in the
+ *   stateManager is filtered out: it could not deliver anything;
+ * - a core service loaded but not configured is filtered out too. A service
+ *   that failed to start with a ServiceNotConfiguredError stays RUNNING and
+ *   keeps its `message.sendToUser` method, so the presence of the method is
+ *   not a proof of configuration: the `isUsed()` hook is, like in getUsage().
+ *   A core messaging service without that hook is kept, as there is nothing
+ *   to check it against.
+ *
+ * An installed external integration is always configured by definition (the
+ * user installed it), and it is proxied, so it exposes no `isUsed()` hook.
  * @returns {Promise} Resolve with the list of messaging services.
  * @example
  * const channels = await service.getMessageServices();
@@ -24,27 +37,45 @@ async function getMessageServices() {
       },
     ],
   });
-  return servicesInDb
-    .map((serviceInDb) => {
-      const plainService = serviceInDb.get({ plain: true });
-      const loadedService = this.getService(plainService.name);
-      const canSendToUser = Boolean(
-        loadedService && loadedService.message && typeof loadedService.message.sendToUser === 'function',
-      );
-      return { plainService, canSendToUser };
-    })
-    .filter(({ canSendToUser }) => canSendToUser)
-    .map(({ plainService }) => ({
+
+  const services = await Promise.mapSeries(servicesInDb, async (serviceInDb) => {
+    const plainService = serviceInDb.get({ plain: true });
+    const loadedService = this.getService(plainService.name);
+    const canSendToUser = Boolean(
+      loadedService && loadedService.message && typeof loadedService.message.sendToUser === 'function',
+    );
+    if (!canSendToUser) {
+      return null;
+    }
+    if (plainService.type !== SERVICE_TYPES.EXTERNAL && typeof loadedService.isUsed === 'function') {
+      try {
+        const isUsed = await loadedService.isUsed();
+        if (!isUsed) {
+          return null;
+        }
+      } catch (e) {
+        logger.warn(`Unable to know if messaging service ${plainService.name} is used`, e);
+        return null;
+      }
+    }
+    return {
       id: plainService.id,
       name: plainService.name,
       selector: plainService.selector,
       status: plainService.status,
+      // internal / external: a core service and an external integration can
+      // carry the very same name (a native Telegram and a Telegram
+      // integration from the store), so the front needs to tell them apart
+      type: plainService.type,
       // an external integration carries its human readable name in its
       // manifest. A core service has none: the front translates its
       // technical name through the integration.* i18n dictionary, so send
       // the manifest name on its own and let the front fall back to `name`.
       manifest_name: (plainService.manifest && plainService.manifest.name) || null,
-    }));
+    };
+  });
+
+  return services.filter((service) => service !== null);
 }
 
 module.exports = {

--- a/server/services/telegram/index.js
+++ b/server/services/telegram/index.js
@@ -35,9 +35,22 @@ module.exports = function TelegramService(gladys, serviceId) {
     await messageHandler.disconnect();
   }
 
+  /**
+   * @public
+   * @description This function returns if the Telegram service is used.
+   * @returns {Promise<boolean>} Returns true if a Telegram API token is configured.
+   * @example
+   * const used = await gladys.services.telegram.isUsed();
+   */
+  async function isUsed() {
+    const token = await gladys.variable.getValue('TELEGRAM_API_KEY', serviceId);
+    return Boolean(token);
+  }
+
   return Object.freeze({
     start,
     stop,
+    isUsed,
     message: messageHandler,
     controllers: TelegramControllers(messageHandler),
   });

--- a/server/test/lib/service/service.test.js
+++ b/server/test/lib/service/service.test.js
@@ -52,6 +52,11 @@ const gladys = {
 describe('service', () => {
   const stateManager = new StateManager();
   const service = new Service(services, stateManager);
+  afterEach(() => {
+    // the database is reset by the global beforeEach, the stateManager is not:
+    // drop the fixtures a test may have registered, even when it failed
+    stateManager.setState('service', 'external-message-service', null);
+  });
   it('should start a service', async () => {
     await service.load(gladys);
     await service.start('example');
@@ -75,6 +80,9 @@ describe('service', () => {
     expect(messagingService).to.not.equal(undefined);
     expect(messagingService).to.have.property('name', 'test-service');
     expect(messagingService).to.have.property('status');
+    // the selector suffixes a channel with its origin when two of them display
+    // the same name, so `type` is part of the contract
+    expect(messagingService).to.have.property('type', SERVICE_TYPES.INTERNAL);
     // a core service has no manifest: the front translates its technical name
     expect(messagingService).to.have.property('manifest_name', null);
     // `label` would only ever repeat manifest_name or name: the front derives it
@@ -103,7 +111,7 @@ describe('service', () => {
     // an installed external integration is configured by definition, and it is
     // proxied: it must never be filtered out on an isUsed() hook, even when a
     // proxy object happens to expose one that throws
-    const externalServiceInDb = await db.Service.create({
+    await db.Service.create({
       name: 'external-message-service',
       selector: 'external-message-service',
       version: '0.1.0',
@@ -111,15 +119,17 @@ describe('service', () => {
       type: SERVICE_TYPES.EXTERNAL,
       manifest: { name: 'External Messenger' },
     });
-    const externalService = {
+    // the global beforeEach resets the database between tests, but not the
+    // stateManager: the afterEach below takes that entry back out even when
+    // an assertion throws
+    stateManager.setState('service', 'external-message-service', {
       isUsed: async () => {
         throw new Error('an external integration exposes no usable isUsed hook');
       },
       message: {
         sendToUser: async () => Promise.resolve(),
       },
-    };
-    stateManager.setState('service', 'external-message-service', externalService);
+    });
 
     const messageServices = await service.getMessageServices();
     const external = messageServices.find((s) => s.name === 'external-message-service');
@@ -131,15 +141,12 @@ describe('service', () => {
     // a core service carries the other side of that contract
     const coreService = messageServices.find((s) => s.name === 'test-service');
     expect(coreService).to.have.property('type', SERVICE_TYPES.INTERNAL);
-
-    stateManager.setState('service', 'external-message-service', null);
-    await externalServiceInDb.destroy();
   });
   it('should not return a messaging service that is not loaded in the stateManager', async () => {
     await service.load(gladys);
     // flagged in database by a previous run, but the service is gone from the
     // instance: it could not deliver anything
-    const orphanServiceInDb = await db.Service.create({
+    await db.Service.create({
       name: 'orphan-message-service',
       selector: 'orphan-message-service',
       version: '0.1.0',
@@ -148,8 +155,6 @@ describe('service', () => {
 
     const messageServices = await service.getMessageServices();
     expect(messageServices.map((s) => s.name)).to.not.include('orphan-message-service');
-
-    await orphanServiceInDb.destroy();
   });
   it('should return service by name', async () => {
     const testService = await service.getByName('test-service');

--- a/server/test/lib/service/service.test.js
+++ b/server/test/lib/service/service.test.js
@@ -15,6 +15,32 @@ const services = {
       sendToUser: async () => Promise.resolve(),
     },
   }),
+  // a core messaging service that is loaded but not configured: it keeps its
+  // sendToUser method (start() only threw a ServiceNotConfiguredError, which
+  // leaves the service RUNNING), so only isUsed() tells it apart
+  'not-configured-service': () => ({
+    start: async () => Promise.resolve(),
+    isUsed: async () => false,
+    message: {
+      sendToUser: async () => Promise.resolve(),
+    },
+  }),
+  'configured-service': () => ({
+    start: async () => Promise.resolve(),
+    isUsed: async () => true,
+    message: {
+      sendToUser: async () => Promise.resolve(),
+    },
+  }),
+  'broken-service': () => ({
+    start: async () => Promise.resolve(),
+    isUsed: async () => {
+      throw new Error('boom');
+    },
+    message: {
+      sendToUser: async () => Promise.resolve(),
+    },
+  }),
 };
 
 const gladys = {
@@ -53,6 +79,22 @@ describe('service', () => {
     expect(messagingService).to.not.have.property('label');
     // "example" has no message interface: it could not deliver anything
     expect(messageServices.map((s) => s.name)).to.not.include('example');
+  });
+  it('should not return a core messaging service that is not configured', async () => {
+    await service.load(gladys);
+    const messageServices = await service.getMessageServices();
+    const names = messageServices.map((s) => s.name);
+    // the selector must only offer channels the user configured: an unused
+    // core service would silently drop the message
+    expect(names).to.not.include('not-configured-service');
+    expect(names).to.include('configured-service');
+    // no isUsed hook: nothing to check the service against, so it is kept
+    expect(names).to.include('test-service');
+  });
+  it('should not return a core messaging service whose isUsed hook fails', async () => {
+    await service.load(gladys);
+    const messageServices = await service.getMessageServices();
+    expect(messageServices.map((s) => s.name)).to.not.include('broken-service');
   });
   it('should return service by name', async () => {
     const testService = await service.getByName('test-service');

--- a/server/test/lib/service/service.test.js
+++ b/server/test/lib/service/service.test.js
@@ -1,7 +1,9 @@
 const { expect, assert } = require('chai');
 
+const db = require('../../../models');
 const Service = require('../../../lib/service');
 const StateManager = require('../../../lib/state');
+const { SERVICE_TYPES } = require('../../../utils/constants');
 
 const services = {
   example: () => ({
@@ -95,6 +97,59 @@ describe('service', () => {
     await service.load(gladys);
     const messageServices = await service.getMessageServices();
     expect(messageServices.map((s) => s.name)).to.not.include('broken-service');
+  });
+  it('should return an external messaging integration even when its isUsed hook fails', async () => {
+    await service.load(gladys);
+    // an installed external integration is configured by definition, and it is
+    // proxied: it must never be filtered out on an isUsed() hook, even when a
+    // proxy object happens to expose one that throws
+    const externalServiceInDb = await db.Service.create({
+      name: 'external-message-service',
+      selector: 'external-message-service',
+      version: '0.1.0',
+      has_message_feature: true,
+      type: SERVICE_TYPES.EXTERNAL,
+      manifest: { name: 'External Messenger' },
+    });
+    const externalService = {
+      isUsed: async () => {
+        throw new Error('an external integration exposes no usable isUsed hook');
+      },
+      message: {
+        sendToUser: async () => Promise.resolve(),
+      },
+    };
+    stateManager.setState('service', 'external-message-service', externalService);
+
+    const messageServices = await service.getMessageServices();
+    const external = messageServices.find((s) => s.name === 'external-message-service');
+    expect(external).to.not.equal(undefined);
+    // the front tells a native channel from an external one on `type`, and
+    // displays the manifest name of an external integration
+    expect(external).to.have.property('type', SERVICE_TYPES.EXTERNAL);
+    expect(external).to.have.property('manifest_name', 'External Messenger');
+    // a core service carries the other side of that contract
+    const coreService = messageServices.find((s) => s.name === 'test-service');
+    expect(coreService).to.have.property('type', SERVICE_TYPES.INTERNAL);
+
+    stateManager.setState('service', 'external-message-service', null);
+    await externalServiceInDb.destroy();
+  });
+  it('should not return a messaging service that is not loaded in the stateManager', async () => {
+    await service.load(gladys);
+    // flagged in database by a previous run, but the service is gone from the
+    // instance: it could not deliver anything
+    const orphanServiceInDb = await db.Service.create({
+      name: 'orphan-message-service',
+      selector: 'orphan-message-service',
+      version: '0.1.0',
+      has_message_feature: true,
+    });
+
+    const messageServices = await service.getMessageServices();
+    expect(messageServices.map((s) => s.name)).to.not.include('orphan-message-service');
+
+    await orphanServiceInDb.destroy();
   });
   it('should return service by name', async () => {
     const testService = await service.getByName('test-service');

--- a/server/test/services/telegram/index.test.js
+++ b/server/test/services/telegram/index.test.js
@@ -1,8 +1,16 @@
+const { expect } = require('chai');
+
 const TelegramService = require('../../../services/telegram');
 
 const gladys = {
   variable: {
     getValue: () => Promise.resolve('TELEGRAM_API_KEY'),
+  },
+};
+
+const gladysNotConfigured = {
+  variable: {
+    getValue: () => Promise.resolve(null),
   },
 };
 
@@ -13,5 +21,15 @@ describe('telegram', () => {
   });
   it('should stop service', async () => {
     await telegramService.stop();
+  });
+  it('should be used when an API token is configured', async () => {
+    expect(await telegramService.isUsed()).to.equal(true);
+  });
+  it('should not be used when no API token is configured', async () => {
+    // the service stays loaded and RUNNING when start() throws a
+    // ServiceNotConfiguredError, so isUsed() is what tells the message
+    // channel selector that Telegram must not be offered
+    const notConfigured = TelegramService(gladysNotConfigured, 'f87b7af2-ca8e-44fc-b754-444354b42fee');
+    expect(await notConfigured.isUsed()).to.equal(false);
   });
 });


### PR DESCRIPTION
### Description

The "send message" scene action offered CallMeBot, Telegram and Nextcloud Talk even when the user had never configured them, and showed a duplicate Telegram entry next to the external Telegram integration.

getMessageServices() only checked that a service was loaded and exposed message.sendToUser. That proves nothing about configuration: a core service whose start() throws a ServiceNotConfiguredError stays RUNNING, stays in the stateManager and keeps its sendToUser method.

Filter on the isUsed() hook instead, the convention getUsage() already relies on. External integrations are kept as-is (installed means configured, and a proxied service exposes no hook), and a core service without the hook is kept too, as there is nothing to check it against.

Telegram had no isUsed() hook: add one, based on TELEGRAM_API_KEY, exactly like start() does. CallMeBot and Nextcloud Talk already had theirs.

Also disambiguate the selector labels: a native service and an external integration can display the very same name, so append "built-in integration" / "external integration" when two channels would otherwise be identical.

<img width="594" height="248" alt="image" src="https://github.com/user-attachments/assets/08a7fbd6-921b-407c-858b-c1d5b60d6b87" />


## Forum

Reported at https://community.gladysassistant.com/t/choix-canal-communication/10549

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message service selectors now distinguish external integrations from built-in services, including when names overlap.
  * Unavailable services are clearly indicated while remaining selectable where applicable.
  * Added German, English, and French translations for service type labels.

* **Bug Fixes**
  * Service discovery now excludes unconfigured or invalid built-in messaging services while retaining valid integrations.
  * Telegram availability now reflects whether an API token is configured.

* **Documentation**
  * Updated API examples to include service type information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->