### PR TITLE
Enedis: support the new DataConnect 2026 consent callback (autorisation_id)

### DIFF
--- a/front/src/routes/integration/all/enedis-gateway/Welcome.jsx
+++ b/front/src/routes/integration/all/enedis-gateway/Welcome.jsx
@@ -134,6 +134,12 @@ class EnedisWelcomePageComponent extends Component {
       await this.setState({ errored: true });
       return;
     }
+    if (this.props.autorisation_id && !this.props.state) {
+      // The state is required on the new Enedis DataConnect callback,
+      // a missing state means the callback is malformed
+      await this.setState({ errored: true });
+      return;
+    }
     if (this.props.code || this.props.autorisation_id) {
       try {
         await this.setState({ errored: false });
@@ -142,9 +148,7 @@ class EnedisWelcomePageComponent extends Component {
           // New Enedis DataConnect flow (2026): Enedis returns an autorisation_id
           // that the Gladys Gateway exchanges for the usage points ids (PRM)
           finalizeBody.autorisation_id = this.props.autorisation_id;
-          if (this.props.state) {
-            finalizeBody.state = this.props.state;
-          }
+          finalizeBody.state = this.props.state;
         } else {
           // Legacy Enedis DataConnect flow: Enedis returns an OAuth code
           // and the usage points ids are passed in the redirect URL

--- a/front/src/routes/integration/all/enedis-gateway/Welcome.jsx
+++ b/front/src/routes/integration/all/enedis-gateway/Welcome.jsx
@@ -129,12 +129,27 @@ class EnedisWelcomePageComponent extends Component {
     await this.props.httpClient.post('/api/v1/service/enedis/sync');
   };
   detectCode = async () => {
-    if (this.props.code) {
+    if (this.props.error) {
+      // Enedis redirects with an error query param when the consent was not granted
+      await this.setState({ errored: true });
+      return;
+    }
+    if (this.props.code || this.props.autorisation_id) {
       try {
         await this.setState({ errored: false });
-        const finalizeBody = {
-          code: this.props.code
-        };
+        const finalizeBody = {};
+        if (this.props.autorisation_id) {
+          // New Enedis DataConnect flow (2026): Enedis returns an autorisation_id
+          // that the Gladys Gateway exchanges for the usage points ids (PRM)
+          finalizeBody.autorisation_id = this.props.autorisation_id;
+          if (this.props.state) {
+            finalizeBody.state = this.props.state;
+          }
+        } else {
+          // Legacy Enedis DataConnect flow: Enedis returns an OAuth code
+          // and the usage points ids are passed in the redirect URL
+          finalizeBody.code = this.props.code;
+        }
         if (config.enedisForceUsagePoints) {
           finalizeBody.usage_points_id = config.enedisForceUsagePoints.split(',');
         }


### PR DESCRIPTION
### Description

Enedis is replacing the DataConnect APIs in September 2026 ([documentation](https://datahub-enedis.fr/services-api/data-connect/documentation/), [migration guide PDF](https://datahub-enedis.fr/wp-content/uploads/2026_Guide-des-evolutions-DataConnect.pdf)). What changes for third parties:

- **New consent URL** (`https://mon-compte-particulier.enedis.fr/dataconnect/v2/oauth2/authorize?client_id=…&state=…&duration=…&response_type=code`).
- **New callback contract**: the redirect URL no longer contains the OAuth `code` and the `usage_point_id`. On success it contains `autorisation_id` + `state` (`<redirect_url>?autorisation_id=…&state=…`), on failure `error` + `error_description`. The `autorisation_id` must then be exchanged for the usage point id (PRM) with the new *Services souscrits* API (`POST /subscribed_services/v1`).
- **New data APIs**: *Mesures V1* (`/mesure_synchrone_auto/v1/metering_data/daily_consumption`, `/consumption_load_curve`, …) replaces *Metering Data v5*, and *Synthèse contractuelle V1* (`GET /synth_contrat_auto/v1/{usage_point_id}`) replaces *Customers UPC v5* for the last activation date.

In Gladys, all Enedis API calls go through the Gladys Gateway, so the bulk of the migration (token, subscribed services exchange, Mesures V1 endpoints) lives in the `gladys-gateway` backend — see the companion patch. This PR covers the Gladys side of the contract:

- `detectCode` in the Enedis welcome page now handles the new callback: when `autorisation_id` is present in the redirect query params, it is forwarded (with `state`) to the Gateway `POST /enedis/finalize` endpoint, which exchanges it for the usage points ids. The rest of the flow (device creation, `ENEDIS_USAGE_POINTS_ID` variable, refresh) is unchanged since the Gateway keeps returning `usage_points_id`.
- The legacy flow (`code` + optional `usage_point_id` in the URL) is kept for backward compatibility until the Enedis switch-over day, so this can be merged and deployed ahead of the bascule.
- When Enedis redirects with an `error` query param (consent denied/failed in the new flow), the page now shows the existing error message instead of doing nothing.

No server-side change is needed in this repo: the Gateway API contract consumed by `server/services/enedis` (`/enedis/metering_data/*` returning `{value, created_at}`) is unchanged.

### Checklist

- [x] Tests pass: front `npm run eslint` (0 errors), `npm run prettier-check`, `npm run compare-translations` and `npm run build` all pass; no server change so `npm run coverage` is unaffected; no Cypress spec covers this page
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change (legacy consent flow still supported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bb74c9p3VRZVRtqa4YZvLc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bb74c9p3VRZVRtqa4YZvLc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Enedis connection handling when consent is denied or an error occurs.
  * Added support for the new authorization identifier while preserving compatibility with the existing OAuth code flow.
  * Prevented further processing when consent errors are detected.
  * Ensured authorization callbacks include the required state information before completing the connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->