### PR TITLE
Fix scene last execution timestamp

### DIFF
--- a/server/lib/scene/scene.execute.js
+++ b/server/lib/scene/scene.execute.js
@@ -1,4 +1,5 @@
 const uuid = require('uuid');
+const db = require('../../models');
 const executeActionsFactory = require('./scene.executeActions');
 const actionsFunc = require('./scene.actions');
 const logger = require('../../utils/logger');
@@ -36,6 +37,12 @@ function execute(sceneSelector, scope = {}) {
         icon: scene.icon,
         startedAt: new Date(),
       };
+      try {
+        await db.Scene.update({ last_executed: runningScene.startedAt }, { where: { selector: sceneSelector } });
+        scene.last_executed = runningScene.startedAt;
+      } catch (e) {
+        logger.warn(e);
+      }
       // Controller used to abort this execution (e.g. a manual "stop").
       // The signal is passed through the scope so abortable actions (like
       // the "delay" action) can react to it. The scope is not copied: callers

--- a/server/test/lib/scene/scene.execute.test.js
+++ b/server/test/lib/scene/scene.execute.test.js
@@ -2,6 +2,7 @@
 const { assert, fake, createSandbox, match } = require('sinon');
 const EventEmitter = require('events');
 const { expect } = require('chai');
+const db = require('../../../models');
 const { ACTIONS, EVENTS, WEBSOCKET_MESSAGE_TYPES } = require('../../../utils/constants');
 const SceneManager = require('../../../lib/scene');
 const StateManager = require('../../../lib/state');
@@ -19,6 +20,7 @@ describe('scene.execute', () => {
     brain.addNamedEntity = fake.returns(null);
     brain.removeNamedEntity = fake.returns(null);
     device.setValue = fake.resolves(null);
+    sandbox.stub(db.Scene, 'update').resolves([1]);
     stateManager = new StateManager(event);
     sceneManager = new SceneManager(stateManager, event, device, {}, {}, {}, {}, {}, {}, {}, brain);
   });
@@ -46,6 +48,41 @@ describe('scene.execute', () => {
       sceneManager.queue.start(() => {
         try {
           assert.calledOnce(device.setValue);
+          assert.calledOnceWithExactly(
+            db.Scene.update,
+            { last_executed: sceneManager.scenes['my-scene'].last_executed },
+            { where: { selector: 'my-scene' } },
+          );
+          expect(sceneManager.scenes['my-scene'].last_executed).to.be.an.instanceOf(Date);
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  });
+  it('should execute the scene when updating last_executed fails', async () => {
+    db.Scene.update.rejects(new Error('Database unavailable'));
+    const scene = {
+      selector: 'my-scene',
+      triggers: [],
+      actions: [
+        [
+          {
+            type: ACTIONS.LIGHT.TURN_ON,
+            devices: ['light-1'],
+          },
+        ],
+      ],
+    };
+    await sceneManager.addScene(scene);
+    sceneManager.execute('my-scene');
+
+    return new Promise((resolve, reject) => {
+      sceneManager.queue.start(() => {
+        try {
+          assert.calledOnce(device.setValue);
+          expect(sceneManager.scenes['my-scene'].last_executed).to.equal(undefined);
           resolve();
         } catch (e) {
           reject(e);


### PR DESCRIPTION
### Description

Persist the `last_executed` timestamp when a scene starts executing.

The field already exists in the scene model and is returned by the scene API, but it was never updated, so it remained `null` even for frequently executed scenes.

This change:
- stores the execution start time in the database;
- keeps the in-memory scene value synchronized;
- does not prevent the scene from running if the metadata update fails;
- adds tests for both the successful update and the database-error fallback.

### Checklist

- [x] Prettier passes on the changed files
- [x] ESLint passes on the changed files
- [x] Tests added for all new branches
- [ ] Full local test suite (blocked in the sandbox by Matter calling `uv_uptime`, which returns `EPERM`; CI will run the suite in the supported environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scene executions now record the time they were last run.
  * The latest execution time is reflected immediately in the scene.

* **Bug Fixes**
  * Scene execution continues normally even if saving the execution timestamp fails.
  * Improved resilience prevents database update issues from interrupting device actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->