### PR TITLE
feat(dashboard): sections with weighted column widths (normal / wide)

### DIFF
--- a/docs/specs/dashboard-flexible-layout-and-widgets.md
+++ b/docs/specs/dashboard-flexible-layout-and-widgets.md
@@ -45,13 +45,17 @@ Decided with the maintainer in forum topic 10553: instead of a per-row column co
 
 - **No SQL migration**: the column stays JSON. Legacy values are normalized in a `beforeValidate` hook (`server/utils/dashboardSections.js`), so validation only ever sees the section shape and any save — even one that doesn't touch `boxes` — lazily migrates the row.
 - **Lazy, lossless migration**: on read, a legacy value (array of arrays) is normalized to a single section `[{ columns: legacyValue }]`; on the first save, the new shape is written. `dashboard.getBySelector` returns the normalized shape so the frontend only ever sees sections.
-- **Editor implementation note**: the editor keeps working on a *flat* list of columns plus a `sectionSizes` array (`front/src/utils/dashboardSections.js`), so drag & drop coordinates stay global and none of the box-level editing code changed; sections are reassembled on save.
+- **Optional per-column widths**: a section may carry a `widths` array — **one small integer weight per column, `1` = normal, `2` = wide** — so a `2 | 1` section puts a large house view on the left with a stack of tiles on the right. Weights are shares, not pixels: a column renders at `weight / totalWeight` of the section width. **Absent `widths` means an equal split**, which is the shape every dashboard had before, so there is again **no SQL migration** and existing rows are untouched.
+- **One canonical form**: the same `beforeValidate` hook aligns `widths` to the columns — it pads a missing or malformed weight with the default and truncates the extras a deleted column leaves behind — and **drops the field entirely when every column has the default weight**, so an equal-width section has exactly one representation whatever the client sent. Joi then validates what survives: integers `1..2`, at most `MAX_COLUMNS_PER_SECTION` entries. An out-of-range weight on a real column is rejected (422), not silently clamped.
+- **Editor implementation note**: the editor keeps working on a *flat* list of columns plus a `sectionSizes` array (`front/src/utils/dashboardSections.js`), so drag & drop coordinates stay global and none of the box-level editing code changed; sections are reassembled on save. **Column widths flatten and rebuild alongside `sectionSizes`**, as a `columnWidths` array holding one weight per *global* column index (`flattenSections`/`buildSections`), so they follow every structural operation — add/delete a column, add/move a section — without a second coordinate system. The front-end clamps to the two supported weights on both the flatten and the rebuild path, so malformed stored data degrades to an equal split instead of a `NaN%` width.
 - Column count per section: **1 to 6** (raised from 4 together with the per-dashboard width setting, section G — 6 columns only make sense on a wide dashboard). 5 columns don't divide the 12-column grid, so that case uses a dedicated 20% class (`BoxColumns.jsx`); beyond 6, dense rows of small items remain the job of the chips bar (section B), not of many narrow columns.
 - A section carries no name or title in phase 1 (`{ columns }` only); an optional `name` field may be added later without migration.
 
 ### A.3 Editor UX
 
 The edit mode keeps the current interaction model, per section: an "Add a section" button appends a one-column section, a per-section **+** button adds a column (up to 6) and a per-column trash removes an empty one (removing the last column removes the section); drag & drop moves boxes within and across sections/columns (the existing drag & drop and drop-zone components are reused per section). There is no separate column-count picker.
+
+**Column width toggle (implemented):** the column header carries a second control next to the trash — a two-state button that switches that column between **normal** and **wide** (the `1`/`2` weights of A.2). It is shown **only when the section has more than one column** (a width means nothing next to no neighbour), it exposes its state to assistive tech (`aria-pressed`, localized `aria-label`), and it sits in the same coarse-pointer touch-target floor as the rest of the editor chrome. The editor canvas previews the result live with `flex-grow`, so the proportion is visible before saving. This is still not a picker: two clicks, two values, no free ratio.
 
 **Editor polish (implemented):** the editor lives on the same Horizon glass surface as the dashboard (section frames as quiet glass panels, frosted drop zones), and the widget-type picker is a **searchable tile grid** (icon + localized name per type, accent-insensitive search) instead of a raw `<select>` — picking a widget is see-and-tap, like the icon picker.
 
@@ -93,7 +97,7 @@ Sections of different heights create blank space below short columns. Resolution
 
 ### A.5 Mobile
 
-On small screens sections keep today's behavior: columns collapse to a single column, sections stack in order. Nothing to configure.
+On small screens sections keep today's behavior: columns collapse to a single column, sections stack in order. Nothing to configure. **Weighted columns are no exception**: below the desktop breakpoint (992px) a `2 | 1` section stacks full-width exactly like a grid section — the percentage shares only apply above it, so a wide column never becomes a cramped one on a phone.
 
 ## B. New box type: `chips`
 
@@ -269,7 +273,8 @@ Each phase is a separate PR (or PR series) that updates this spec in the same di
 
 ## Out of scope
 
-- Per-box user-facing sizing controls (S/M/L pickers): sections + `canStretch` + compact widgets cover the target layouts without adding a sizing concept for users to manage.
+- Per-box user-facing sizing controls (S/M/L pickers): sections + `canStretch` + compact widgets cover the target layouts without adding a sizing concept for users to manage. **Per-column** widths are a different thing and are *in scope* (A.2/A.3): they are a two-value toggle on a column the user already created, not a size property to manage on every widget.
+- Free column ratios and drag-to-resize handles: a discrete `1|2` weight is one tap and always renders sensibly at every dashboard width, while a free ratio is a value to tune, to get wrong on another screen size, and to drag precisely — on a wall tablet, with a finger. The two weights cover the layout people actually ask for (a big view next to a stack of tiles); a third weight can be added later without a migration if real-world feedback asks for it.
 - Interactive chips (tap-to-act) and chip-level scene triggers: display-only in phase 2.
 - AI-assisted pin placement (vision model guessing coordinates on the illustration): manual drag placement is reliable and takes seconds; may be revisited later.
 - Floor-plan editors, 3D rendering, or camera-based live overlays.

--- a/front/cypress/e2e/routes/dashboard/Dashboard.cy.js
+++ b/front/cypress/e2e/routes/dashboard/Dashboard.cy.js
@@ -43,6 +43,17 @@ describe('Dashboard', () => {
       cy.url().should('eq', `${Cypress.config().baseUrl}/dashboard/${dashboardSelector}/edit`);
     });
   });
+  it('Should widen a column', () => {
+    // a new dashboard starts with 3 columns: widen the first one
+    cy.get('[data-cy="toggle-column-width-0"]').click();
+    cy.intercept('PATCH', '**/api/v1/dashboard/*').as('saveDashboard');
+    cy.contains('.btn-outline-primary', 'dashboard.editDashboardSaveButton').click();
+    // the section is saved with one weight per column, wide first
+    cy.wait('@saveDashboard')
+      .its('request.body.boxes.0.widths')
+      .should('deep.equal', [2, 1, 1]);
+    cy.get('[data-cy="dashboard-saved-label"]').should('be.visible');
+  });
   it('Should delete dashboard', () => {
     cy.then(() => {
       cy.visit(`/dashboard/${dashboardSelector}`);

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -329,6 +329,8 @@
     "editorDashboardSettingsButton": "Dashboard-Einstellungen",
     "editorDashboardSettings": "Dashboard-Einstellungen",
     "editorMoveSectionUp": "Abschnitt nach oben verschieben",
+    "editorColumnWidthWide": "Spalte verbreitern (doppelte Breite)",
+    "editorColumnWidthNormal": "Zurück zur normalen Spaltenbreite",
     "editorMoveSectionDown": "Abschnitt nach unten verschieben",
     "editorNewWidget": "Neues Widget",
     "editorNewWidgetPlaceholder": "Wähle ein Widget im Panel",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -330,6 +330,8 @@
     "editorDashboardSettings": "Dashboard settings",
     "editorMoveSectionUp": "Move the section up",
     "editorMoveSectionDown": "Move the section down",
+    "editorColumnWidthWide": "Widen the column (double width)",
+    "editorColumnWidthNormal": "Back to normal column width",
     "editorNewWidget": "New widget",
     "editorNewWidgetPlaceholder": "Choose a widget in the panel",
     "reorderDashboardButton": "Re-order dashboards",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -330,6 +330,8 @@
     "editorDashboardSettings": "Réglages du tableau de bord",
     "editorMoveSectionUp": "Monter la section",
     "editorMoveSectionDown": "Descendre la section",
+    "editorColumnWidthWide": "Élargir la colonne (largeur double)",
+    "editorColumnWidthNormal": "Revenir à la largeur normale",
     "editorNewWidget": "Nouveau widget",
     "editorNewWidgetPlaceholder": "Choisissez un widget dans le panneau",
     "reorderDashboardButton": "Re-ordonner",

--- a/front/src/routes/dashboard/BoxColumns.jsx
+++ b/front/src/routes/dashboard/BoxColumns.jsx
@@ -1,7 +1,13 @@
 import Box from './Box';
 import cx from 'classnames';
 import style from './style.css';
-import { canBoxStretchAt, isTileStretchBox, isValueTileBox } from '../../utils/dashboardSections';
+import {
+  DEFAULT_COLUMN_WIDTH,
+  canBoxStretchAt,
+  getSectionWidths,
+  isTileStretchBox,
+  isValueTileBox
+} from '../../utils/dashboardSections';
 
 const BoxColumns = ({ children, ...props }) => {
   let columnOffset = 0;
@@ -16,6 +22,11 @@ const BoxColumns = ({ children, ...props }) => {
           const columnCount = Math.max(section.columns.length, 1);
           // 5 doesn't divide the 12-column grid: those columns get a 20% class instead
           const columnClass = columnCount === 5 ? style.colFifth : `col-lg-${12 / columnCount}`;
+          // per-column weights (e.g. 2|1): widths become percentage shares
+          // instead of grid classes, mobile stacking stays identical
+          const widths = getSectionWidths(section);
+          const isWeighted = widths.some(width => width !== DEFAULT_COLUMN_WIDTH);
+          const totalWeight = widths.reduce((sum, width) => sum + width, 0);
           return (
             <div
               key={`section-${sectionIndex}`}
@@ -26,10 +37,20 @@ const BoxColumns = ({ children, ...props }) => {
                 return (
                   <div
                     key={`column-${x}`}
-                    class={cx('d-flex flex-column', columnClass, style.removePadding, {
-                      [style.removePaddingFirstCol]: columnIndex === 0,
-                      [style.removePaddingLastCol]: columnIndex === section.columns.length - 1
-                    })}
+                    class={cx(
+                      'd-flex flex-column',
+                      isWeighted ? style.weightedColumn : columnClass,
+                      style.removePadding,
+                      {
+                        [style.removePaddingFirstCol]: columnIndex === 0,
+                        [style.removePaddingLastCol]: columnIndex === section.columns.length - 1
+                      }
+                    )}
+                    style={
+                      isWeighted
+                        ? `--column-width: ${((widths[columnIndex] / totalWeight) * 100).toFixed(4)}%`
+                        : undefined
+                    }
                   >
                     {column.map((box, y) =>
                       canBoxStretchAt(box, y === column.length - 1) ? (

--- a/front/src/routes/dashboard/edit-dashboard/EditBoxColumns.jsx
+++ b/front/src/routes/dashboard/edit-dashboard/EditBoxColumns.jsx
@@ -4,7 +4,12 @@ import cx from 'classnames';
 import EditableBoxPreview from './EditableBoxPreview';
 import EditPanel from './EditPanel';
 import EmptyColumnDropZone from './EmptyColumnDropZone';
-import { getSectionOffsets, MAX_COLUMNS_PER_SECTION } from '../../../utils/dashboardSections';
+import {
+  DEFAULT_COLUMN_WIDTH,
+  WIDE_COLUMN_WIDTH,
+  getSectionOffsets,
+  MAX_COLUMNS_PER_SECTION
+} from '../../../utils/dashboardSections';
 import style from './style.css';
 import stylePrimary from '../style.css';
 
@@ -91,16 +96,41 @@ const EditBoxColumns = ({ children, ...props }) => (
               <div class={cx('d-flex align-items-start', style.columnsCard)}>
                 {sectionColumns.map((column, columnIndex) => {
                   const x = sectionOffset + columnIndex;
+                  // the canvas previews the weights: a wide column grows double
+                  const columnWidth = (props.columnWidths && props.columnWidths[x]) || DEFAULT_COLUMN_WIDTH;
+                  const isWide = columnWidth === WIDE_COLUMN_WIDTH;
                   return (
                     <div
                       class={cx('d-flex flex-column', style.column, stylePrimary.removePadding, {
                         [stylePrimary.removePaddingFirstCol]: columnIndex === 0,
                         [stylePrimary.removePaddingLastCol]: columnIndex === sectionSize - 1
                       })}
+                      style={{ flexGrow: columnWidth }}
                     >
                       <div class={style.columnBoxHeader}>
                         <span class={style.columnLabel}>
                           <Text id="dashboard.boxes.column" fields={{ index: columnIndex + 1 }} />
+                          {/* a width only means something next to other columns */}
+                          {sectionSize > 1 && (
+                            <Localizer>
+                              <button
+                                class={cx('btn p-0 ml-2', style.btnLinkDelete, {
+                                  [style.btnColumnWidthActive]: isWide
+                                })}
+                                onClick={() => props.toggleColumnWidth(x)}
+                                data-cy={`toggle-column-width-${x}`}
+                                title={
+                                  <Text
+                                    id={
+                                      isWide ? 'dashboard.editorColumnWidthNormal' : 'dashboard.editorColumnWidthWide'
+                                    }
+                                  />
+                                }
+                              >
+                                <i class={cx('fe', isWide ? 'fe-minimize-2' : 'fe-maximize-2')} />
+                              </button>
+                            </Localizer>
+                          )}
                           {getTotalColumns(props) > 1 && (
                             <button
                               class={cx('btn p-0 ml-2', style.btnLinkDelete)}
@@ -155,6 +185,7 @@ const EditBoxColumns = ({ children, ...props }) => (
                       <button
                         class={cx('btn btn-outline-primary', style.btnAddColumn)}
                         onClick={() => props.addColumn(sectionIndex)}
+                        data-cy={`add-column-${sectionIndex}`}
                         data-title={<Text id="dashboard.editDashboardAddColumnButton" />}
                       >
                         <i class="fe fe-plus" />

--- a/front/src/routes/dashboard/edit-dashboard/EditBoxColumns.jsx
+++ b/front/src/routes/dashboard/edit-dashboard/EditBoxColumns.jsx
@@ -114,11 +114,20 @@ const EditBoxColumns = ({ children, ...props }) => (
                           {sectionSize > 1 && (
                             <Localizer>
                               <button
+                                type="button"
                                 class={cx('btn p-0 ml-2', style.btnLinkDelete, {
                                   [style.btnColumnWidthActive]: isWide
                                 })}
                                 onClick={() => props.toggleColumnWidth(x)}
                                 data-cy={`toggle-column-width-${x}`}
+                                aria-pressed={isWide}
+                                aria-label={
+                                  <Text
+                                    id={
+                                      isWide ? 'dashboard.editorColumnWidthNormal' : 'dashboard.editorColumnWidthWide'
+                                    }
+                                  />
+                                }
                                 title={
                                   <Text
                                     id={
@@ -127,7 +136,7 @@ const EditBoxColumns = ({ children, ...props }) => (
                                   />
                                 }
                               >
-                                <i class={cx('fe', isWide ? 'fe-minimize-2' : 'fe-maximize-2')} />
+                                <i class={cx('fe', isWide ? 'fe-minimize-2' : 'fe-maximize-2')} aria-hidden="true" />
                               </button>
                             </Localizer>
                           )}

--- a/front/src/routes/dashboard/edit-dashboard/index.js
+++ b/front/src/routes/dashboard/edit-dashboard/index.js
@@ -5,7 +5,9 @@ import update from 'immutability-helper';
 import EditDashboardPage from './EditDashboard';
 import get from 'get-value';
 import {
+  DEFAULT_COLUMN_WIDTH,
   MAX_COLUMNS_PER_SECTION,
+  WIDE_COLUMN_WIDTH,
   flattenSections,
   buildSections,
   getSectionOffsets,
@@ -57,11 +59,13 @@ class EditDashboard extends Component {
         `/api/v1/dashboard/${this.state.currentDashboardSelector}`
       );
       // The editor works on a flat list of columns so drag & drop coordinates
-      // stay global, the section sizes are kept aside and reassembled on save
-      const { columns, sectionSizes } = flattenSections(currentDashboard.boxes);
+      // stay global, the section sizes and column widths are kept aside and
+      // reassembled on save
+      const { columns, sectionSizes, columnWidths } = flattenSections(currentDashboard.boxes);
       this.setState({
         currentDashboard: { ...currentDashboard, boxes: columns },
         sectionSizes,
+        columnWidths,
         loading: false,
         hasUnsavedChanges: false
       });
@@ -319,12 +323,12 @@ class EditDashboard extends Component {
       // We purge all empty boxes
       await this.removeEmptyBoxes();
 
-      const { currentDashboard: selectedDashboard, dashboards, sectionSizes } = this.state;
+      const { currentDashboard: selectedDashboard, dashboards, sectionSizes, columnWidths } = this.state;
       const { selector } = selectedDashboard;
 
       const currentDashboard = await this.props.httpClient.patch(`/api/v1/dashboard/${selector}`, {
         ...selectedDashboard,
-        boxes: buildSections(selectedDashboard.boxes, sectionSizes)
+        boxes: buildSections(selectedDashboard.boxes, sectionSizes, columnWidths)
       });
 
       const currentDashboardIndex = dashboards.findIndex(d => d.selector === selector);
@@ -334,10 +338,13 @@ class EditDashboard extends Component {
         }
       });
 
-      const { columns, sectionSizes: newSectionSizes } = flattenSections(currentDashboard.boxes);
+      const { columns, sectionSizes: newSectionSizes, columnWidths: newColumnWidths } = flattenSections(
+        currentDashboard.boxes
+      );
       await this.setState({
         currentDashboard: { ...currentDashboard, boxes: columns },
         sectionSizes: newSectionSizes,
+        columnWidths: newColumnWidths,
         loading: false,
         dashboards: updatedDashboards,
         justSaved: true,
@@ -382,25 +389,42 @@ class EditDashboard extends Component {
         [sectionIndex]: {
           $set: sectionSizes[sectionIndex] + 1
         }
+      },
+      columnWidths: {
+        $splice: [[insertAt, 0, DEFAULT_COLUMN_WIDTH]]
       }
     });
     this.setState({ ...newState, boxNotEmptyError: false, hasUnsavedChanges: true });
   };
 
+  // A column is either normal (1) or wide (2): one toggle, no free resize
+  toggleColumnWidth = x => {
+    const isWide = this.state.columnWidths[x] === WIDE_COLUMN_WIDTH;
+    const newState = update(this.state, {
+      columnWidths: {
+        [x]: {
+          $set: isWide ? DEFAULT_COLUMN_WIDTH : WIDE_COLUMN_WIDTH
+        }
+      }
+    });
+    this.setState({ ...newState, hasUnsavedChanges: true });
+  };
+
   // Sections reorder with one-step arrows — dragging a whole section
   // across the canvas would be miserable, especially on mobile
   moveSection = (sectionIndex, direction) => {
-    const { sectionSizes, currentDashboard } = this.state;
+    const { sectionSizes, columnWidths, currentDashboard } = this.state;
     const target = sectionIndex + direction;
     if (target < 0 || target >= sectionSizes.length) {
       return;
     }
-    const sections = buildSections(currentDashboard.boxes, sectionSizes);
+    const sections = buildSections(currentDashboard.boxes, sectionSizes, columnWidths);
     [sections[sectionIndex], sections[target]] = [sections[target], sections[sectionIndex]];
-    const { columns, sectionSizes: newSectionSizes } = flattenSections(sections);
+    const { columns, sectionSizes: newSectionSizes, columnWidths: newColumnWidths } = flattenSections(sections);
     this.setState({
       currentDashboard: { ...currentDashboard, boxes: columns },
       sectionSizes: newSectionSizes,
+      columnWidths: newColumnWidths,
       boxNotEmptyError: false,
       // global column coordinates shifted: never point the panel at a stale box
       editingBoxPosition: null,
@@ -417,6 +441,9 @@ class EditDashboard extends Component {
       },
       sectionSizes: {
         $push: [1]
+      },
+      columnWidths: {
+        $push: [DEFAULT_COLUMN_WIDTH]
       }
     });
     this.setState({ ...newState, boxNotEmptyError: false, editingBoxPosition: null, hasUnsavedChanges: true });
@@ -441,7 +468,10 @@ class EditDashboard extends Component {
                 [sectionIndex]: {
                   $set: newSectionSize
                 }
-              }
+              },
+        columnWidths: {
+          $splice: [[x, 1]]
+        }
       });
       await this.setState({ ...newState, boxNotEmptyError: false, editingBoxPosition: null, hasUnsavedChanges: true });
     } else {
@@ -511,6 +541,7 @@ class EditDashboard extends Component {
     this.state = {
       dashboards: [],
       sectionSizes: [],
+      columnWidths: [],
       newSelectedBoxType: {},
       askDeleteDashboard: false,
       boxNotEmptyError: false,
@@ -544,6 +575,7 @@ class EditDashboard extends Component {
       dashboards,
       currentDashboard,
       sectionSizes,
+      columnWidths,
       loading,
       dashboardValidationError,
       dashboardAlreadyExistError,
@@ -608,6 +640,8 @@ class EditDashboard extends Component {
         addSection={this.addSection}
         moveSection={this.moveSection}
         sectionSizes={sectionSizes}
+        columnWidths={columnWidths}
+        toggleColumnWidth={this.toggleColumnWidth}
         deleteCurrentColumn={this.deleteCurrentColumn}
         boxNotEmptyError={boxNotEmptyError}
         columnBoxNotEmptyError={columnBoxNotEmptyError}

--- a/front/src/routes/dashboard/edit-dashboard/style.css
+++ b/front/src/routes/dashboard/edit-dashboard/style.css
@@ -461,6 +461,12 @@
   height: auto;
 }
 
+/* the width toggle shows its state: tinted primary while the column is wide */
+.btnColumnWidthActive,
+.btnColumnWidthActive:hover {
+  color: #467fcf;
+}
+
 .btnLinkDelete {
   text-decoration: none;
   border: none;

--- a/front/src/routes/dashboard/edit-dashboard/style.css
+++ b/front/src/routes/dashboard/edit-dashboard/style.css
@@ -467,6 +467,11 @@
   color: #467fcf;
 }
 
+:global(.glass-theme) .btnColumnWidthActive,
+:global(.glass-theme) .btnColumnWidthActive:hover {
+  color: var(--gl-accent);
+}
+
 .btnLinkDelete {
   text-decoration: none;
   border: none;
@@ -813,6 +818,29 @@
   .listDragHandle {
     padding: 0.5rem;
     margin: -0.5rem;
+  }
+
+  /* the column header controls (trash, width toggle) are real tap targets on
+     a wall tablet. Sized like .previewButton rather than padded: these
+     buttons carry Bootstrap's p-0, whose !important would win over padding.
+     The header already reserves 48px, so the row doesn't grow. */
+  .btnLinkDelete {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    vertical-align: middle;
+    width: 2.5rem;
+    height: 2.5rem;
+    font-size: 1rem;
+  }
+
+  /* columns shrink to nothing (flex-basis 0, min-width 0), so on a narrow
+     screen the grown buttons wrap under the label instead of overflowing */
+  .columnLabel {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
   }
 
   .editorTopBar :global(.btn),

--- a/front/src/routes/dashboard/style.css
+++ b/front/src/routes/dashboard/style.css
@@ -182,6 +182,23 @@
   }
 }
 
+/* A section with per-column weights (e.g. 2|1) shares its width in
+   percentages (--column-width, set inline) instead of grid classes.
+   Same stacking behavior as a col-lg-* below the breakpoint. */
+.weightedColumn {
+  position: relative;
+  width: 100%;
+  padding-right: 15px;
+  padding-left: 15px;
+}
+
+@media (min-width: 992px) {
+  .weightedColumn {
+    flex: 0 0 var(--column-width);
+    max-width: var(--column-width);
+  }
+}
+
 @media (min-width: 992px) {
   .removePaddingFirstCol {
     padding-left: 0;

--- a/front/src/utils/dashboardSections.js
+++ b/front/src/utils/dashboardSections.js
@@ -3,6 +3,18 @@ import { DASHBOARD_BOX_TYPE } from '../../../server/utils/constants';
 // Maximum number of columns a dashboard section can hold
 export const MAX_COLUMNS_PER_SECTION = 6;
 
+// A column width is a small integer weight, not a free ratio: the editor
+// only toggles a column between normal (1) and wide (2)
+export const DEFAULT_COLUMN_WIDTH = 1;
+export const WIDE_COLUMN_WIDTH = 2;
+
+// One weight per column, defaulting missing entries so callers can always
+// index it safely whatever the stored shape
+export const getSectionWidths = section =>
+  section.columns.map((column, i) =>
+    section.widths && typeof section.widths[i] === 'number' ? section.widths[i] : DEFAULT_COLUMN_WIDTH
+  );
+
 // Box types that absorb the remaining height of their column so sections
 // with columns of different heights don't leave blank space. This is a
 // per-type constant, not a user setting: charts are excluded for now
@@ -42,22 +54,31 @@ const VALUE_TILE_BOX_TYPES = [DASHBOARD_BOX_TYPE.TEMPERATURE_IN_ROOM, DASHBOARD_
 export const isValueTileBox = box => box && VALUE_TILE_BOX_TYPES.includes(box.type);
 
 // The editor works on a flat list of columns (so drag & drop coordinates stay
-// global) plus the number of columns of each section.
+// global) plus the number of columns of each section. Column widths flatten
+// the same way, into one weight per global column index.
 export const flattenSections = sections => {
   const columns = [];
   const sectionSizes = [];
+  const columnWidths = [];
   sections.forEach(section => {
     section.columns.forEach(column => columns.push(column));
     sectionSizes.push(section.columns.length);
+    columnWidths.push(...getSectionWidths(section));
   });
-  return { columns, sectionSizes };
+  return { columns, sectionSizes, columnWidths };
 };
 
-export const buildSections = (columns, sectionSizes) => {
+export const buildSections = (columns, sectionSizes, columnWidths = []) => {
   const sections = [];
   let offset = 0;
   sectionSizes.forEach(size => {
-    sections.push({ columns: columns.slice(offset, offset + size) });
+    const section = { columns: columns.slice(offset, offset + size) };
+    const widths = section.columns.map((column, i) => columnWidths[offset + i] || DEFAULT_COLUMN_WIDTH);
+    // all-default widths stay implicit, matching the server normalization
+    if (widths.some(width => width !== DEFAULT_COLUMN_WIDTH)) {
+      section.widths = widths;
+    }
+    sections.push(section);
     offset += size;
   });
   return sections;

--- a/front/src/utils/dashboardSections.js
+++ b/front/src/utils/dashboardSections.js
@@ -8,11 +8,17 @@ export const MAX_COLUMNS_PER_SECTION = 6;
 export const DEFAULT_COLUMN_WIDTH = 1;
 export const WIDE_COLUMN_WIDTH = 2;
 
+// Only the two supported weights survive: anything else (0, 3, NaN, a hole
+// left by a malformed value) falls back to normal, so the renderer never
+// divides by a zero total weight and never emits a NaN% share
+const normalizeColumnWidth = width =>
+  width === DEFAULT_COLUMN_WIDTH || width === WIDE_COLUMN_WIDTH ? width : DEFAULT_COLUMN_WIDTH;
+
 // One weight per column, defaulting missing entries so callers can always
 // index it safely whatever the stored shape
 export const getSectionWidths = section =>
   section.columns.map((column, i) =>
-    section.widths && typeof section.widths[i] === 'number' ? section.widths[i] : DEFAULT_COLUMN_WIDTH
+    normalizeColumnWidth(Array.isArray(section.widths) ? section.widths[i] : undefined)
   );
 
 // Box types that absorb the remaining height of their column so sections
@@ -73,7 +79,7 @@ export const buildSections = (columns, sectionSizes, columnWidths = []) => {
   let offset = 0;
   sectionSizes.forEach(size => {
     const section = { columns: columns.slice(offset, offset + size) };
-    const widths = section.columns.map((column, i) => columnWidths[offset + i] || DEFAULT_COLUMN_WIDTH);
+    const widths = section.columns.map((column, i) => normalizeColumnWidth(columnWidths[offset + i]));
     // all-default widths stay implicit, matching the server normalization
     if (widths.some(width => width !== DEFAULT_COLUMN_WIDTH)) {
       section.widths = widths;

--- a/server/models/dashboard.js
+++ b/server/models/dashboard.js
@@ -1,6 +1,6 @@
 const Joi = require('joi');
 const { addSelectorBeforeValidateHook } = require('../utils/addSelector');
-const { normalizeDashboardBoxes } = require('../utils/dashboardSections');
+const { normalizeDashboardBoxes, MAX_COLUMN_WIDTH } = require('../utils/dashboardSections');
 const {
   DASHBOARD_BOX_TYPE_LIST,
   DASHBOARD_TYPE_LIST,
@@ -142,12 +142,23 @@ const boxSchema = Joi.object().keys({
 // A dashboard is a stack of sections, each section holding its own columns
 // (1 to MAX_COLUMNS_PER_SECTION). Legacy column-based values are normalized
 // to this shape in a beforeValidate hook, so validation only sees sections.
+// widths holds one integer weight per column (1 = normal, 2 = wide); the
+// beforeValidate hook aligns it to the columns and drops it when every
+// column has the default weight, so it is optional here.
 const boxesSchema = Joi.array().items(
   Joi.object().keys({
     columns: Joi.array()
       .items(Joi.array().items(boxSchema))
       .max(MAX_COLUMNS_PER_SECTION)
       .required(),
+    widths: Joi.array()
+      .items(
+        Joi.number()
+          .integer()
+          .min(1)
+          .max(MAX_COLUMN_WIDTH),
+      )
+      .max(MAX_COLUMNS_PER_SECTION),
   }),
 );
 

--- a/server/test/lib/dashboard/dashboard.update.test.js
+++ b/server/test/lib/dashboard/dashboard.update.test.js
@@ -75,6 +75,36 @@ describe('dashboard.update', () => {
     expect(updatedDashboard.boxes[1].columns).to.have.lengthOf(4);
   });
 
+  it('should save per-column widths and drop all-default ones', async () => {
+    const updatedDashboard = await dashboard.update('0cd30aef-9c4e-4a23-88e3-3547971296e5', 'test-dashboard', {
+      boxes: [
+        {
+          columns: [[{ type: DASHBOARD_BOX_TYPE.CLOCK }], []],
+          widths: [2, 1],
+        },
+        {
+          columns: [[], [{ type: DASHBOARD_BOX_TYPE.USER_PRESENCE }]],
+          widths: [1, 1],
+        },
+      ],
+    });
+    expect(updatedDashboard.boxes[0].widths).to.deep.equal([2, 1]);
+    // all-default widths are normalized away
+    expect(updatedDashboard.boxes[1]).to.not.have.property('widths');
+  });
+
+  it('should reject a width above the maximum weight', async () => {
+    const promise = dashboard.update('0cd30aef-9c4e-4a23-88e3-3547971296e5', 'test-dashboard', {
+      boxes: [
+        {
+          columns: [[], []],
+          widths: [3, 1],
+        },
+      ],
+    });
+    await assert.isRejected(promise);
+  });
+
   it('should update the dashboard appearance', async () => {
     const updatedDashboard = await dashboard.update('0cd30aef-9c4e-4a23-88e3-3547971296e5', 'test-dashboard', {
       icon: 'home',

--- a/server/test/utils/dashboardSections.test.js
+++ b/server/test/utils/dashboardSections.test.js
@@ -21,4 +21,21 @@ describe('normalizeDashboardBoxes', () => {
     expect(normalizeDashboardBoxes('invalid')).to.equal('invalid');
     expect(normalizeDashboardBoxes(undefined)).to.equal(undefined);
   });
+  it('should keep a section with valid widths untouched', () => {
+    const sectionBoxes = [{ columns: [[], []], widths: [2, 1] }];
+    expect(normalizeDashboardBoxes(sectionBoxes)).to.equal(sectionBoxes);
+  });
+  it('should drop widths when every column has the default weight', () => {
+    expect(normalizeDashboardBoxes([{ columns: [[], []], widths: [1, 1] }])).to.deep.equal([{ columns: [[], []] }]);
+  });
+  it('should pad missing widths with the default weight', () => {
+    expect(normalizeDashboardBoxes([{ columns: [[], [], []], widths: [2] }])).to.deep.equal([
+      { columns: [[], [], []], widths: [2, 1, 1] },
+    ]);
+  });
+  it('should truncate extra widths left by a deleted column', () => {
+    expect(normalizeDashboardBoxes([{ columns: [[], []], widths: [2, 1, 2] }])).to.deep.equal([
+      { columns: [[], []], widths: [2, 1] },
+    ]);
+  });
 });

--- a/server/test/utils/dashboardSections.test.js
+++ b/server/test/utils/dashboardSections.test.js
@@ -38,4 +38,19 @@ describe('normalizeDashboardBoxes', () => {
       { columns: [[], []], widths: [2, 1] },
     ]);
   });
+  it('should pad a hole in the middle of widths, which keeps the same length', () => {
+    expect(normalizeDashboardBoxes([{ columns: [[], []], widths: [2, null] }])).to.deep.equal([
+      { columns: [[], []], widths: [2, 1] },
+    ]);
+    expect(normalizeDashboardBoxes([{ columns: [[], []], widths: [2, undefined] }])).to.deep.equal([
+      { columns: [[], []], widths: [2, 1] },
+    ]);
+    expect(normalizeDashboardBoxes([{ columns: [[], []], widths: [2, 'wide'] }])).to.deep.equal([
+      { columns: [[], []], widths: [2, 1] },
+    ]);
+  });
+  it('should keep a section with widths but non-array columns untouched', () => {
+    const sectionBoxes = [{ columns: 'invalid', widths: [2, 1] }];
+    expect(normalizeDashboardBoxes(sectionBoxes)).to.equal(sectionBoxes);
+  });
 });

--- a/server/utils/dashboardSections.js
+++ b/server/utils/dashboardSections.js
@@ -24,7 +24,11 @@ function normalizeSectionWidths(section) {
     const { widths: droppedWidths, ...rest } = section;
     return rest;
   }
-  if (aligned.length === widths.length) {
+  // keep the original reference only when nothing actually changed: a hole in
+  // the middle ([2, null]) keeps the length but still has to be padded, so
+  // comparing lengths alone would let a malformed value reach validation
+  const isUnchanged = aligned.length === widths.length && aligned.every((width, i) => width === widths[i]);
+  if (isUnchanged) {
     return section;
   }
   return { ...section, widths: aligned };

--- a/server/utils/dashboardSections.js
+++ b/server/utils/dashboardSections.js
@@ -1,9 +1,43 @@
+// A column width is a small integer weight (1 = normal, 2 = wide), not a
+// free ratio: the editor only toggles between these two values.
+const DEFAULT_COLUMN_WIDTH = 1;
+const MAX_COLUMN_WIDTH = 2;
+
+/**
+ * @description Normalize the optional widths array of a section.
+ * Widths are per-column integer weights; the canonical form has exactly one
+ * weight per column and is absent when every column has the default weight,
+ * so equal-width sections all share a single representation.
+ * @param {object} section - A section in the { columns, widths } shape.
+ * @returns {object} The section with widths aligned to columns, or unchanged.
+ * @example
+ * normalizeSectionWidths({ columns: [[], []], widths: [2] });
+ * // => { columns: [[], []], widths: [2, 1] }
+ */
+function normalizeSectionWidths(section) {
+  const { columns, widths } = section;
+  if (!Array.isArray(widths) || !Array.isArray(columns)) {
+    return section;
+  }
+  const aligned = columns.map((column, i) => (typeof widths[i] === 'number' ? widths[i] : DEFAULT_COLUMN_WIDTH));
+  if (aligned.every((width) => width === DEFAULT_COLUMN_WIDTH)) {
+    const { widths: droppedWidths, ...rest } = section;
+    return rest;
+  }
+  if (aligned.length === widths.length) {
+    return section;
+  }
+  return { ...section, widths: aligned };
+}
+
 /**
  * @description Normalize dashboard boxes to the section-based shape.
  * Dashboards historically stored an array of columns (each column being an
  * array of boxes). The current shape is an array of sections, each section
  * holding its own columns: [{ columns: [[box]] }]. A legacy value is wrapped
  * into a single section so existing dashboards keep working unchanged.
+ * A section may carry a widths array (one weight per column); it is aligned
+ * to the columns and dropped when every column has the default weight.
  * @param {Array} boxes - Dashboard boxes, in legacy or section shape.
  * @returns {Array} Boxes in section shape.
  * @example
@@ -18,9 +52,17 @@ function normalizeDashboardBoxes(boxes) {
   if (isLegacyShape) {
     return [{ columns: boxes }];
   }
-  return boxes;
+  const normalized = boxes.map((section) =>
+    section && typeof section === 'object' ? normalizeSectionWidths(section) : section,
+  );
+  // keep the original reference when nothing changed, so unchanged values
+  // stay strictly equal for callers (and Sequelize change detection)
+  const hasChanged = normalized.some((section, i) => section !== boxes[i]);
+  return hasChanged ? normalized : boxes;
 }
 
 module.exports = {
   normalizeDashboardBoxes,
+  DEFAULT_COLUMN_WIDTH,
+  MAX_COLUMN_WIDTH,
 };


### PR DESCRIPTION
### Description

A dashboard section can now share its width unevenly between its columns. Each column carries a small integer weight — 1 (normal) or 2 (wide) — toggled from the editor's column header, so a `2 | 1` section puts a large house view on the left with a stack of tiles on the right.

**Data model (server)**
- A section may carry an optional `widths` array (one weight per column), validated by Joi (integers 1–2, max 6 entries).
- The `beforeValidate` normalization aligns `widths` to the columns (pads missing weights, truncates extras left by a deleted column) and drops the field entirely when every column has the default weight, so equal-width sections keep a single canonical representation and existing dashboards are untouched.

**Rendering (front)**
- A weighted section renders its columns as percentage shares (`weight / totalWeight`, via a CSS variable) instead of the `col-lg-*` grid classes; equal-width sections keep the exact markup they had before.
- Below the desktop breakpoint nothing changes: weighted columns stack full-width exactly like grid columns.

**Editor**
- Column widths flatten alongside the flat column list (`flattenSections`/`buildSections`), so drag & drop coordinates stay global, and they follow every structural operation: add/delete column, add/move section.
- A new toggle in the column header (shown when the section has more than one column) switches a column between normal and wide; the editor canvas previews the proportion with `flex-grow`.
- New i18n keys in `en`, `fr` and `de`.

### Checklist

- [x] Tests pass: server unit tests for the normalization and Joi validation (`dashboardSections`, `dashboard.update` — 81 passing), and the Cypress dashboard spec extended with a "Should widen a column" test (4 passing locally)
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier-check`, `npm run compare-translations`)
- [x] No undocumented breaking change — `widths` is optional, absent means equal split, legacy shapes normalize exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CseeJreZSxqZaeyPUykrqU

---
_Generated by [Claude Code](https://claude.ai/code/session_01CseeJreZSxqZaeyPUykrqU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard editors can widen individual columns to double width or restore their standard width.
  * Column widths are preserved when dashboards are saved, reordered, or modified.
  * Responsive layouts automatically stack weighted columns on smaller screens.
  * Added English, French, and German translations for column-width controls.

* **Tests**
  * Added coverage for resizing columns, saving changes, persistence, normalization, and invalid width values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->