### PR TITLE
Sort a house's rooms alphabetically when expanding them

### DIFF
--- a/server/lib/house/house.get.js
+++ b/server/lib/house/house.get.js
@@ -28,6 +28,10 @@ async function get(options) {
       model: db.Room,
       as: 'rooms',
     });
+    // Rooms come back in creation order otherwise, which is the order the user happened
+    // to add them in and not an order anyone can scan in a dropdown. Sorting them by name
+    // here fixes every room list at once, as they all read this route.
+    queryParams.order.push([{ model: db.Room, as: 'rooms' }, 'name', 'ASC']);
   }
   if (optionsWithDefault.search) {
     queryParams.where = Sequelize.where(Sequelize.fn('lower', Sequelize.col('t_house.name')), {

--- a/server/test/lib/house/house.test.js
+++ b/server/test/lib/house/house.test.js
@@ -17,6 +17,8 @@ const event = {
   emit: fake.returns(null),
 };
 
+const HOUSE_ID = 'a741dfa6-24de-4b46-afc7-370772f068d5';
+
 describe('House', () => {
   afterEach(() => {
     sinon.reset();
@@ -130,6 +132,16 @@ describe('House', () => {
           .to.have.property('rooms')
           .and.to.be.instanceOf(Array);
       });
+    });
+    it('should get rooms sorted by name, not in creation order', async () => {
+      // Created in an order that is neither alphabetical nor its reverse, so a house
+      // returning them untouched cannot pass by chance.
+      await db.Room.create({ name: 'Kitchen', selector: 'kitchen', house_id: HOUSE_ID });
+      await db.Room.create({ name: 'Attic', selector: 'attic', house_id: HOUSE_ID });
+      await db.Room.create({ name: 'Bedroom', selector: 'bedroom', house_id: HOUSE_ID });
+      const houses = await house.get({ expand: ['rooms'] });
+      const testHouse = houses.find((oneHouse) => oneHouse.id === HOUSE_ID);
+      expect(testHouse.rooms.map((room) => room.name)).to.deep.equal(['Attic', 'Bedroom', 'Kitchen', 'Test room']);
     });
   });
 


### PR DESCRIPTION
### Description

The `rooms` include in house.get had no `order`, so rooms came back in insertion order — the order the user happened to create them in, which is not an order anyone can scan in a dropdown.

Every room list in the front reads GET /api/v1/house?expand=rooms, so ordering the include by name fixes them all at once: the device edit form, every integration's device and discovery page, and the room selector. Three front files had each grown their own copy of a sort helper to work around this locally; those are now redundant.

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

<!--
More details in the contribution guide: .github/CONTRIBUTING.md
Testing in real life with real devices is always appreciated. An AMD64 preview
Docker image is built automatically for non-draft PRs; for ARM64, comment
/build-arm64 on the PR.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded house details now list rooms alphabetically by name for more consistent results.

* **Tests**
  * Added coverage to verify room sorting when house details are expanded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->