### PR TITLE
feat(chat): sell Gladys Plus in the chat empty state

### DIFF
--- a/front/src/components/gateway/GladysPlusUpsellCard.jsx
+++ b/front/src/components/gateway/GladysPlusUpsellCard.jsx
@@ -96,11 +96,16 @@ const GladysPlusUpsellCard = ({
             )}
             <div class="d-flex flex-wrap">
               {isUpgrade ? (
-                <a href={primaryHref} class="btn btn-success mb-2">
+                <a href={primaryHref} class={`btn btn-success mb-2 ${style.upsellCta}`}>
                   <Text id={primaryTextId} />
                 </a>
               ) : (
-                <a href={primaryHref} target="_blank" rel="noopener noreferrer" class="btn btn-success mb-2">
+                <a
+                  href={primaryHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class={`btn btn-success mb-2 ${style.upsellCta}`}
+                >
                   <Text id={primaryTextId} /> <i class="fe fe-external-link ml-1" />
                 </a>
               )}

--- a/front/src/components/gateway/style.css
+++ b/front/src/components/gateway/style.css
@@ -47,3 +47,85 @@
 .upsellCompact a {
   text-decoration: none;
 }
+
+/* ==================================================================
+   "Horizon" glass variant — the upsell also shows up on glass-themed
+   pages (chat empty state, dashboard widgets), where the flat Tabler
+   card and its solid blue rail read as a foreign object. Composes on
+   the global .glass-theme class like the other component variants,
+   and is authored light only: dark mode derives from the global
+   inversion filter (style/dark-mode.css).
+   The second selector is the same rule one class heavier, so the
+   panel keeps its own surface over the theme's nested-card rule
+   (.glass-theme .card .card) whatever the bundle order.
+   ================================================================== */
+:global(.glass-theme) .upsellCard:global(.card),
+:global(.glass-theme .card) .upsellCard:global(.card) {
+  border: 1px solid var(--gl-border);
+  border-radius: var(--gl-radius-md);
+  background: var(--gl-card-bg);
+  backdrop-filter: blur(22px) saturate(1.5);
+  -webkit-backdrop-filter: blur(22px) saturate(1.5);
+  box-shadow: var(--gl-shadow-soft);
+}
+
+/* dark-mode.css repaints glass cards with a solid !important background:
+   restore the panel surface with the same weight so the inversion filter
+   derives its dark counterpart, like the theme does for its own cards */
+:global(.dark-mode .glass-theme .card) .upsellCard:global(.card) {
+  background-color: var(--gl-card-bg) !important;
+}
+
+:global(.glass-theme) .upsellCard h3 {
+  font-size: 1.0625rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--gl-ink);
+}
+
+/* Hanging indent: the check keeps its own column so a wrapping feature
+   stays aligned on the text, not under the icon. Tabler's .text-success
+   is !important, hence the counter-weight on the tint. */
+:global(.glass-theme) .upsellFeatureList li {
+  display: flex;
+  align-items: flex-start;
+}
+
+:global(.glass-theme) .upsellFeatureList li :global(.fe-check) {
+  flex: none;
+  margin-top: 0.2rem;
+  color: var(--gl-success-ink) !important;
+}
+
+/* Stacked layout: the badge leads the panel like the title, not centered */
+@media (max-width: 767.98px) {
+  :global(.glass-theme) .upsellIconWrapper {
+    justify-content: flex-start;
+  }
+}
+
+/* The CTA joins the theme's pill family, in the Gladys Plus accent so it
+   stays the loudest thing on the panel. It carries .btn to outrank the
+   pages that repaint .btn-success with their own pill (settings), so the
+   upsell keeps one CTA identity wherever it appears. */
+:global(.glass-theme) .upsellCta:global(.btn) {
+  background-color: var(--gl-accent);
+  border: none;
+  border-radius: 999px;
+  padding: 0.45rem 1.15rem;
+  font-weight: 600;
+  color: #fff;
+  box-shadow: 0 6px 18px rgba(61, 109, 240, 0.26);
+}
+
+:global(.glass-theme) .upsellCta:global(.btn):hover,
+:global(.glass-theme) .upsellCta:global(.btn):focus {
+  background-color: #3462e0;
+  color: #fff;
+}
+
+/* dark-mode.css double-inverts .btn-success to preserve its green; under
+   glass the pill must invert with the theme like every other surface */
+:global(.dark-mode .glass-theme) .upsellCta:global(.btn) {
+  filter: none;
+}

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -4325,6 +4325,14 @@
       "feature2": "Proaktive KI in Szenen: führt regelmäßig Smart-Home-Abfragen aus (Kennzeichen lesen, CO₂-Wert prüfen, eine Kamera überwachen…)",
       "feature3": "Open-Weight-KI-Modelle · keine weiterverkauften Daten"
     },
+    "chat": {
+      "title": "Chatte mit deinem Zuhause dank Gladys-Plus-KI",
+      "description": "Gladys Plus schaltet den Chat frei: Stelle Fragen in natürlicher Sprache, steuere deine Geräte und erfahre, was bei dir zu Hause los ist. Open-Weight-KI-Modelle, in Frankreich gehostet.",
+      "feature1": "„Mach das Licht im Wohnzimmer aus“, „Ist das Garagentor zu?“ – einfach eine Nachricht senden",
+      "feature2": "Frag, was deine Kameras sehen: Die KI analysiert das Bild und antwortet dir",
+      "feature3": "Erhalte eine Übersicht deines Zuhauses: Temperaturen, Verbrauch, eingeschaltete Geräte",
+      "feature4": "Open-Weight-KI-Modelle · keine weiterverkauften Daten"
+    },
     "enedis": {
       "title": "Verfolge deinen Stromverbrauch mit Enedis",
       "description": "Gladys Plus enthält die offizielle Enedis-Integration, um deinen Stromverbrauch abzurufen, in Dashboards anzuzeigen und Szenen darauf basierend auszulösen.",
@@ -5849,7 +5857,6 @@
   },
   "chat": {
     "emptyStateMessage": "Schick mir eine Nachricht!",
-    "emptyStateMessageNoPlus": "Der Gladys-Chat nutzt Gladys-Plus-KI. Verbinde deine Instanz mit Gladys Plus, um mit deinem Zuhause zu chatten.",
     "messagePlaceholder": "Tippe deine Nachricht …",
     "sendingInProgress": "Senden …",
     "typingInProgress": "Tippt …",
@@ -5864,18 +5871,6 @@
       "label": "KI-Modell",
       "auto": "Auto",
       "priceLegend": "€ günstig · €€ mittel · €€€ premium"
-    },
-    "sidebar": {
-      "title": "Wie funktioniert der Chat?",
-      "intro": "Der Gladys-Chat nutzt die Gladys-Plus-Künstliche Intelligenz, damit du natürlich mit deinem vernetzten Zuhause kommunizieren kannst.",
-      "plusNotConfigured": "Verbinde Gladys Plus, um den KI-Chat zu nutzen.",
-      "plusActive": "Gladys-Plus-KI ist in diesem Chat aktiv.",
-      "upsellTitle": "Erweiterte KI freischalten",
-      "upsellCompactDescription": "Gladys Plus gibt dir Zugang zu Open-Weight-KI-Modellen in diesem Chat: offene Fragen, Kameranalyse und mehr.",
-      "upsellDescription": "Chatte natürlich mit deinem vernetzten Zuhause dank Gladys-Plus-Künstlicher Intelligenz.",
-      "upsellFeature1": "Stelle deinem Zuhause offene Fragen",
-      "upsellFeature2": "Analysiere, was deine Kameras sehen",
-      "upsellFeature3": "Open-Weight-KI-Modelle in Frankreich gehostet"
     }
   },
   "history": {

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -4329,8 +4329,8 @@
       "title": "Chatte mit deinem Zuhause dank Gladys-Plus-KI",
       "description": "Gladys Plus schaltet den Chat frei: Stelle Fragen in natürlicher Sprache, steuere deine Geräte und erfahre, was bei dir zu Hause los ist. Open-Weight-KI-Modelle, in Frankreich gehostet.",
       "feature1": "„Mach das Licht im Wohnzimmer aus“, „Ist das Garagentor zu?“ – einfach eine Nachricht senden",
-      "feature2": "Frag, was deine Kameras sehen: Die KI analysiert das Bild und antwortet dir",
-      "feature3": "Erhalte eine Übersicht deines Zuhauses: Temperaturen, Verbrauch, eingeschaltete Geräte",
+      "feature2": "In deinen Szenen analysiert die KI, was deine Kameras sehen, und antwortet dir",
+      "feature3": "Erhalte eine wöchentliche Übersicht deines Zuhauses: Temperaturen, Verbrauch, eingeschaltete Geräte",
       "feature4": "Open-Weight-KI-Modelle · keine weiterverkauften Daten"
     },
     "enedis": {

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -4329,8 +4329,8 @@
       "title": "Chat with your home using Gladys Plus AI",
       "description": "Gladys Plus unlocks the chat: ask questions in plain language, control your devices and know what is happening at home. Open-weight AI models hosted in France.",
       "feature1": "\"Turn off the living room light\", \"Is the garage door closed?\" — just send a message",
-      "feature2": "Ask what your cameras see: the AI analyses the image and answers you",
-      "feature3": "Get a summary of your home: temperatures, consumption, devices left on",
+      "feature2": "In your scenes, the AI analyses what your cameras see and answers you",
+      "feature3": "Get a weekly summary of your home: temperatures, consumption, devices left on",
       "feature4": "Open-weight AI models · no data resold"
     },
     "enedis": {

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -4325,6 +4325,14 @@
       "feature2": "Proactive AI in scenes: run home automation questions on a schedule (read a licence plate, check CO₂ levels, monitor a camera…)",
       "feature3": "Open-weight AI models · no data resold"
     },
+    "chat": {
+      "title": "Chat with your home using Gladys Plus AI",
+      "description": "Gladys Plus unlocks the chat: ask questions in plain language, control your devices and know what is happening at home. Open-weight AI models hosted in France.",
+      "feature1": "\"Turn off the living room light\", \"Is the garage door closed?\" — just send a message",
+      "feature2": "Ask what your cameras see: the AI analyses the image and answers you",
+      "feature3": "Get a summary of your home: temperatures, consumption, devices left on",
+      "feature4": "Open-weight AI models · no data resold"
+    },
     "enedis": {
       "title": "Track your electric consumption with Enedis",
       "description": "Gladys Plus includes the official Enedis integration to fetch your electric consumption, show it on your dashboards and trigger scenes based on it.",
@@ -5849,23 +5857,10 @@
   },
   "chat": {
     "emptyStateMessage": "Send me a message!",
-    "emptyStateMessageNoPlus": "Gladys chat uses Gladys Plus AI. Connect your instance to Gladys Plus to chat with your home.",
     "messagePlaceholder": "Type your message...",
     "sendingInProgress": "Sending...",
     "typingInProgress": "Typing...",
     "gladysAlt": "Gladys",
-    "sidebar": {
-      "title": "How does the chat work?",
-      "intro": "Gladys chat uses Gladys Plus artificial intelligence so you can communicate naturally with your connected home.",
-      "plusNotConfigured": "Connect Gladys Plus to use AI chat.",
-      "plusActive": "Gladys Plus AI is active in this chat.",
-      "upsellTitle": "Unlock advanced AI",
-      "upsellCompactDescription": "Gladys Plus gives you access to open-weight AI models in this chat: open questions, camera analysis, and more.",
-      "upsellDescription": "Chat naturally with your connected home using Gladys Plus artificial intelligence.",
-      "upsellFeature1": "Ask open-ended questions to your home",
-      "upsellFeature2": "Analyse what your cameras see",
-      "upsellFeature3": "Open-weight AI models · no data resold"
-    },
     "toolCall": {
       "statusUsed": "Used",
       "statusError": "Error",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -4325,6 +4325,14 @@
       "feature2": "IA proactive dans les scènes : exécute des questions domotiques à intervalle régulier (lire une plaque d'immatriculation, vérifier le niveau de CO₂, surveiller une caméra…)",
       "feature3": "Modèles IA open-weight hébergés en France · pas de données revendues"
     },
+    "chat": {
+      "title": "Discute avec ta maison grâce à l'IA Gladys Plus",
+      "description": "Gladys Plus débloque le chat : pose tes questions en langage naturel, pilote tes appareils et sache ce qui se passe chez toi. Modèles d'IA open-weight hébergés en France.",
+      "feature1": "« Éteins la lumière du salon », « Est-ce que le garage est fermé ? » : il suffit d'envoyer un message",
+      "feature2": "Demande ce que voient tes caméras : l'IA analyse l'image et te répond",
+      "feature3": "Obtiens un résumé de ta maison : températures, consommation, appareils restés allumés",
+      "feature4": "Modèles d'IA open-weight · aucune donnée revendue"
+    },
     "enedis": {
       "title": "Suis ta consommation électrique avec Enedis",
       "description": "Gladys Plus inclut l'intégration officielle Enedis pour récupérer ta consommation électrique, l'afficher sur tes dashboards et déclencher des scènes selon ta conso.",
@@ -5849,23 +5857,10 @@
   },
   "chat": {
     "emptyStateMessage": "Envoie-moi un message !",
-    "emptyStateMessageNoPlus": "Le chat Gladys utilise l'IA Gladys Plus. Connecte ton instance à Gladys Plus pour discuter avec ta maison.",
     "messagePlaceholder": "Ecrivez votre message...",
     "sendingInProgress": "Envoi en cours ...",
     "typingInProgress": "Ecrit...",
     "gladysAlt": "Gladys",
-    "sidebar": {
-      "title": "Comment fonctionne le chat ?",
-      "intro": "Le chat Gladys utilise l'intelligence artificielle Gladys Plus pour te permettre de communiquer naturellement avec ta maison connectée.",
-      "plusNotConfigured": "Connecte Gladys Plus pour utiliser le chat IA.",
-      "plusActive": "L'IA Gladys Plus est active dans ce chat.",
-      "upsellTitle": "Débloque l'IA avancée",
-      "upsellCompactDescription": "Gladys Plus donne accès à des modèles IA open-weight dans ce chat : questions ouvertes, analyse de caméras, et bien plus.",
-      "upsellDescription": "Discute naturellement avec ta maison connectée grâce à l'intelligence artificielle Gladys Plus.",
-      "upsellFeature1": "Pose des questions ouvertes à ta maison",
-      "upsellFeature2": "Analyse ce que voient tes caméras",
-      "upsellFeature3": "Modèles IA open-weight hébergés en France"
-    },
     "toolCall": {
       "statusUsed": "Utilisé",
       "statusError": "Erreur",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -4329,8 +4329,8 @@
       "title": "Discute avec ta maison grâce à l'IA Gladys Plus",
       "description": "Gladys Plus débloque le chat : pose tes questions en langage naturel, pilote tes appareils et sache ce qui se passe chez toi. Modèles d'IA open-weight hébergés en France.",
       "feature1": "« Éteins la lumière du salon », « Est-ce que le garage est fermé ? » : il suffit d'envoyer un message",
-      "feature2": "Demande ce que voient tes caméras : l'IA analyse l'image et te répond",
-      "feature3": "Obtiens un résumé de ta maison : températures, consommation, appareils restés allumés",
+      "feature2": "Dans tes scènes, l'IA analyse ce que voient tes caméras et te répond",
+      "feature3": "Obtiens un résumé hebdomadaire de ta maison : températures, consommation, appareils restés allumés",
       "feature4": "Modèles d'IA open-weight · aucune donnée revendue"
     },
     "enedis": {

--- a/front/src/routes/chat/EmptyChat.jsx
+++ b/front/src/routes/chat/EmptyChat.jsx
@@ -1,7 +1,16 @@
 import { Component } from 'preact';
 import { Text } from 'preact-i18n';
 import { connect } from 'unistore/preact';
+
+import GladysPlusUpsellCard from '../../components/gateway/GladysPlusUpsellCard';
 import style from './style.css';
+
+const CHAT_UPSELL_FEATURES = [
+  'gladysPlusUpsell.chat.feature1',
+  'gladysPlusUpsell.chat.feature2',
+  'gladysPlusUpsell.chat.feature3',
+  'gladysPlusUpsell.chat.feature4'
+];
 
 class EmptyChat extends Component {
   state = {
@@ -27,13 +36,29 @@ class EmptyChat extends Component {
   }
 
   render({}, { gladysPlusConfigured }) {
-    const messageKey = gladysPlusConfigured === false ? 'chat.emptyStateMessageNoPlus' : 'chat.emptyStateMessage';
+    // Without Gladys Plus the chat can't answer at all: instead of a dead end,
+    // show what the AI chat makes possible and how to unlock it.
+    if (gladysPlusConfigured === false) {
+      return (
+        <div class={style.emptyChatUpsellScroll}>
+          <div class={style.emptyChatUpsell}>
+            <GladysPlusUpsellCard
+              icon="fe-message-circle"
+              utmCampaign="chat_empty_state"
+              titleKey="gladysPlusUpsell.chat.title"
+              descriptionKey="gladysPlusUpsell.chat.description"
+              featureKeys={CHAT_UPSELL_FEATURES}
+            />
+          </div>
+        </div>
+      );
+    }
 
     return (
       <div class={style.emptyChatState}>
         <img src="/assets/images/undraw_typing.svg" class={style.emptyChatImage} />
         <p class={style.emptyChatText}>
-          <Text id={messageKey} />
+          <Text id="chat.emptyStateMessage" />
         </p>
       </div>
     );

--- a/front/src/routes/chat/style.css
+++ b/front/src/routes/chat/style.css
@@ -453,6 +453,21 @@
   margin: auto;
 }
 
+/* The Gladys Plus upsell is taller than the illustrated empty state: give it
+   its own scroll area so it stays fully readable on small screens. */
+.chatMessagesArea .emptyChatUpsellScroll {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  overflow-y: auto;
+  padding: 20px;
+}
+
+.emptyChatUpsell {
+  margin: auto;
+  width: min(100%, 620px);
+}
+
 /* Full-height page: the only chrome above is the 3.25rem fixed mobile top
    bar — on desktop the nav is the left sidebar, so the chat owns 100dvh.
    The page carries the Horizon glass scene (class from


### PR DESCRIPTION
### Description

The chat empty state for users without Gladys Plus only said: _"Le chat Gladys utilise l'IA Gladys Plus. Connecte ton instance à Gladys Plus pour discuter avec ta maison."_ — a dead end, with nothing about what the chat can actually do and no way to subscribe.

**1. Sell the chat instead of stating a requirement**

It now shows the standard `<GladysPlusUpsellCard />` used everywhere else for premium features (backups, Enedis, Alexa, Google Home, Ask AI, TTS, voice assistant):

- a title and description that sell the possibilities, with the "open-weight models hosted in France, no data resold" trust argument;
- four concrete feature bullets: natural language control with real example sentences, camera analysis inside scenes (where that need actually is), the weekly home summary, and the open-weight/no-data-resold line;
- the shared free-trial notice ("1 month free, no credit card");
- a "Start my free trial" CTA to the Gladys Plus page built with `buildGladysPlusUrl()`, so it carries the same UTM tracking as the other upsells: `utm_source=gladys_app`, `utm_medium=in_app`, `utm_campaign=chat_empty_state`, `utm_content=upsell_cta`, and the fr/en landing page depending on the user language.

The empty state for users who *do* have Gladys Plus is unchanged (illustration + "Send me a message!").

**2. Dress the upsell card in the Horizon glass theme**

The card is a flat Tabler card with a solid blue left rail, which read as a foreign object on the glass-themed pages it now appears on (chat, dashboard widgets, settings). A glass variant now lives next to the component in `components/gateway/style.css`, composing on the global `.glass-theme` class like the other component variants — authored light only, so dark mode derives from the global inversion filter:

- frosted panel on the theme surface, `--gl-radius-md` corners and soft shadow, no blue rail;
- tighter title, feature list with a hanging indent (a wrapping feature stays aligned on the text) and the theme's success tint on the checks;
- the badge leads the stacked layout on mobile instead of being centered;
- the CTA becomes an accent pill from the theme's button family, and inverts with the theme in dark mode instead of keeping its stock green. It carries `.btn` so it outranks the pages that repaint `.btn-success` with their own pill (settings) — the upsell keeps one CTA identity wherever it appears.

Cleanup included: `chat.emptyStateMessageNoPlus` is now unused and removed, and the dead `chat.sidebar.*` translations (leftovers from a chat sidebar that no longer exists, whose copy partly inspired the new keys) are removed too. New keys added under `gladysPlusUpsell.chat.*` in `en`, `fr` and `de`.

Files touched:
- `front/src/routes/chat/EmptyChat.jsx` — render the upsell card when the gateway is not configured
- `front/src/routes/chat/style.css` — own scroll area for the card so it stays readable on small screens
- `front/src/components/gateway/GladysPlusUpsellCard.jsx` + `style.css` — CTA class hook and the Horizon glass variant
- `front/src/config/i18n/{en,fr,de}.json` — new copy, removed dead keys

Checked in the browser (demo mode with the gateway forced to not-configured): chat empty state in French and English, on desktop, mobile and dark mode, plus Settings → Backups, which uses the same card.

## Forum

<!-- Not linked to a forum topic. -->

### Checklist

- [ ] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`: 0 errors, `npm run prettier-check`: clean, `npm run compare-translations`: no errors)
- [x] No undocumented breaking change

Front-only change, no server code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Gladys Plus upsell card to the chat when the gateway is not configured.
  - Highlighted AI chat capabilities, including natural-language control, scene-based camera analysis, weekly home summaries, and hosted models.
  - Added localized upsell content in English, French, and German.

- **Style**
  - Improved upsell card appearance with glass-theme styling, responsive layouts, and dark-mode support.
  - Made the chat upsell scrollable on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->