### PR TITLE
Light panel: survive a cancelled touch on the color wheel

### DIFF
--- a/front/src/components/boxs/device-in-room/device-features/light/LightColorWheel.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/light/LightColorWheel.jsx
@@ -102,6 +102,8 @@ class LightColorWheel extends Component {
     this.userIsInteracting = false;
     if (this.interactionCancelled) {
       this.interactionCancelled = false;
+      // The handle may have been dragged further before the interaction was torn down.
+      this.restoreColorFromProps();
       return;
     }
     this.props.onChange(hexToInt(color.hexString));
@@ -113,13 +115,29 @@ class LightColorWheel extends Component {
     }
     this.userIsInteracting = false;
     this.interactionCancelled = true;
+    this.detachIroDocumentListeners();
     // Prop sync was suppressed during the drag: put the wheel back on the color the lamp has.
-    const { value } = this.props;
-    if (Number.isFinite(value)) {
-      this.colorPicker.color.hexString = `#${intToHex(value)}`;
-    }
+    this.restoreColorFromProps();
     if (this.props.onCancel) {
       this.props.onCancel();
+    }
+  };
+
+  // iro attaches mousemove/touchmove/mouseup/touchend on `document` when a drag starts and only
+  // detaches them from its own mouseup/touchend branch — a branch that also `preventDefault()`s
+  // every event it sees. Leaving them attached after a cancelled touch would swallow the next tap
+  // anywhere on the page (its click is never synthesized) and let a stray touchmove keep moving the
+  // handle. Ending the interaction the way iro expects is what detaches them; its End branch emits
+  // `input:end` without reading the coordinates, so a bare synthetic mouseup is enough, and the
+  // `input:end` it triggers is swallowed by the cancelled flag set just above.
+  detachIroDocumentListeners = () => {
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: false, cancelable: true }));
+  };
+
+  restoreColorFromProps = () => {
+    const { value } = this.props;
+    if (this.colorPicker && Number.isFinite(value)) {
+      this.colorPicker.color.hexString = `#${intToHex(value)}`;
     }
   };
 

--- a/front/src/components/boxs/device-in-room/device-features/light/LightColorWheel.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/light/LightColorWheel.jsx
@@ -20,6 +20,12 @@ const MAX_WHEEL_SHARE_OF_VIEWPORT_HEIGHT = 0.32;
  * writing the color there would send one order per move (~5/s through a debounce) to a lamp whose
  * color writes are expensive (xy conversion, Zigbee/Hue queues). `onChange` fires when the finger
  * leaves the wheel, and is the only one that reaches the device.
+ *
+ * iro@5 does not listen to `touchcancel` (its document listeners are touchmove/touchend only), so
+ * a cancelled touch — browser scroll takeover, OS gesture — leaves it mid-drag until the next
+ * touchend anywhere on the page, whose `input:end` would commit the cancelled color. A window
+ * `touchcancel` listener marks the interaction as cancelled: the events iro keeps emitting for it
+ * are swallowed, nothing is written, and the wheel snaps back to the value of the lamp.
  */
 class LightColorWheel extends Component {
   containerRef = createRef();
@@ -29,6 +35,10 @@ class LightColorWheel extends Component {
   // While the finger is on the wheel, the value coming back from the parent state is our own echo:
   // writing it back into the picker would fight the drag.
   userIsInteracting = false;
+
+  // Set by a touchcancel during a drag: the interaction is dead, its remaining iro events must not
+  // preview nor commit anything.
+  interactionCancelled = false;
 
   componentDidMount() {
     const { value } = this.props;
@@ -44,6 +54,7 @@ class LightColorWheel extends Component {
     this.colorPicker.on('input:end', this.handleInputEnd);
 
     window.addEventListener('resize', this.handleResize);
+    window.addEventListener('touchcancel', this.handleTouchCancel);
   }
 
   componentDidUpdate(previousProps) {
@@ -55,6 +66,7 @@ class LightColorWheel extends Component {
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.handleResize);
+    window.removeEventListener('touchcancel', this.handleTouchCancel);
     this.colorPicker.off('input:start', this.handleInputStart);
     this.colorPicker.off('input:change', this.handleInputChange);
     this.colorPicker.off('input:end', this.handleInputEnd);
@@ -76,15 +88,39 @@ class LightColorWheel extends Component {
 
   handleInputStart = () => {
     this.userIsInteracting = true;
+    this.interactionCancelled = false;
   };
 
   handleInputChange = color => {
+    if (this.interactionCancelled) {
+      return;
+    }
     this.props.onPreview(hexToInt(color.hexString));
   };
 
   handleInputEnd = color => {
     this.userIsInteracting = false;
+    if (this.interactionCancelled) {
+      this.interactionCancelled = false;
+      return;
+    }
     this.props.onChange(hexToInt(color.hexString));
+  };
+
+  handleTouchCancel = () => {
+    if (!this.userIsInteracting) {
+      return;
+    }
+    this.userIsInteracting = false;
+    this.interactionCancelled = true;
+    // Prop sync was suppressed during the drag: put the wheel back on the color the lamp has.
+    const { value } = this.props;
+    if (Number.isFinite(value)) {
+      this.colorPicker.color.hexString = `#${intToHex(value)}`;
+    }
+    if (this.props.onCancel) {
+      this.props.onCancel();
+    }
   };
 
   render() {

--- a/front/src/components/boxs/device-in-room/device-features/light/LightControlPanel.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/light/LightControlPanel.jsx
@@ -102,6 +102,9 @@ class LightControlPanel extends Component {
   // The wheel paints the panel on every move but only writes to the lamp when the finger leaves it.
   previewColor = color => this.setState({ previewColor: color });
 
+  // A cancelled wheel touch writes nothing: the panel goes back to the color the lamp really has.
+  cancelColorPreview = () => this.setState({ previewColor: undefined });
+
   setColor = colorFeature => color => {
     this.setState({ previewColor: undefined });
     this.props.updateValue(colorFeature, color);
@@ -213,6 +216,7 @@ class LightControlPanel extends Component {
               value={colorFeature.last_value}
               onPreview={this.previewColor}
               onChange={this.setColor(colorFeature)}
+              onCancel={this.cancelColorPreview}
             />
             <div class={style.presets}>
               {COLOR_PRESETS.map(preset => (


### PR DESCRIPTION
### Description

Follow-up to #2975, addressing the one finding that arrived while it sat in the merge queue ([CodeRabbit's outside-diff comment](https://github.com/GladysAssistant/Gladys/pull/2975#pullrequestreview-3560528401), also listed as residual by cursor's approving review).

`@jaames/iro@5` does not listen to `touchcancel` — its document listeners are `touchmove`/`touchend` only. A cancelled touch on the color wheel (browser scroll takeover, OS gesture, palmed tablet) therefore left the picker mid-drag until the next `touchend` anywhere on the page, whose `input:end` **committed the cancelled color** to the lamp; meanwhile the wrapper's `userIsInteracting` flag stayed set and blocked prop sync into the wheel. The wiring predates #2975 (`ColorDeviceFeature` behaved the same), but the light panel makes the wheel a primary control, so it is handled at the wrapper boundary now:

- a `window` `touchcancel` listener marks the interaction as cancelled;
- the `input:change` / `input:end` events iro keeps emitting for that dead interaction are swallowed — no preview, no device write;
- the wheel snaps back to the value the lamp really has, and the panel drops its preview color (`onCancel`).

Verified with real touch events (CDP `Input.dispatchTouchEvent`): a drag on the wheel followed by `touchCancel` and then a stray touch elsewhere on the page sends **zero** device writes, and the wheel keeps working normally afterwards.

### Checklist

- [x] Tests pass: front-only change; no Cypress spec covers the color wheel. Verified with synthesized touch sequences as described above; `npm run coverage` untouched (no server change)
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier-check`), and `npm run build` passes
- [x] No undocumented breaking change


---
_Generated by [Claude Code](https://claude.ai/code/session_01PyJvDgCYYYWwX62BhpHXYe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color-wheel touch handling by safely cancelling interrupted gestures.
  * Prevented cancelled interactions from previewing or applying unintended light colors.
  * Restored the color wheel to the light’s current value after a cancelled touch interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->