### PR TITLE
Gladys Plus: show trial countdown in sidebar with add-payment-method link

### DIFF
--- a/front/src/actions/main.js
+++ b/front/src/actions/main.js
@@ -6,6 +6,11 @@ import { route } from 'preact-router';
 import get from 'get-value';
 import { isUrlInArray } from '../utils/url';
 
+const ONE_DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
+// Self-hosted gateways without Stripe get a ~100-year "trial": past this
+// horizon a countdown is meaningless, so the indicator stays hidden.
+const MAX_TRIAL_DAYS_DISPLAYED = 92;
+
 const OPEN_PAGES = [
   '/signup',
   '/signup/create-account-gladys-gateway',
@@ -90,6 +95,8 @@ function createActions(store) {
             store.setState({
               gatewayAccountExpired: true
             });
+          } else if (gatewayUser.status === 'trialing') {
+            await actions.refreshGatewayTrialState(state, gatewayUser);
           }
         }
       } catch (e) {
@@ -112,6 +119,34 @@ function createActions(store) {
           console.error(e);
         }
       }
+    },
+    async refreshGatewayTrialState(state, gatewayUser) {
+      // The gateway API adds a 24-hour grace period to current_period_end:
+      // subtract it back so the countdown matches the real end of the trial.
+      const trialEnd = new Date(gatewayUser.current_period_end).getTime() - ONE_DAY_IN_MILLISECONDS;
+      const daysLeft = Math.max(0, Math.ceil((trialEnd - Date.now()) / ONE_DAY_IN_MILLISECONDS));
+      if (daysLeft > MAX_TRIAL_DAYS_DISPLAYED) {
+        return;
+      }
+      // The "add a payment method" call-to-action must not show up when the
+      // card check fails: better no reminder than a wrong one.
+      let hasPaymentMethod = true;
+      let stripePortalKey = null;
+      try {
+        const [card, setupState] = await Promise.all([
+          state.session.gatewayClient.getCard(),
+          state.session.gatewayClient.getSetupState()
+        ]);
+        hasPaymentMethod = card !== null;
+        stripePortalKey = setupState.stripe_portal_key || null;
+      } catch (e) {
+        console.error(e);
+      }
+      store.setState({
+        gatewayTrialDaysLeft: daysLeft,
+        gatewayTrialHasPaymentMethod: hasPaymentMethod,
+        gatewayTrialStripePortalKey: stripePortalKey
+      });
     },
     async logout(state, e) {
       e.preventDefault();

--- a/front/src/actions/main.js
+++ b/front/src/actions/main.js
@@ -10,6 +10,11 @@ const ONE_DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
 // Self-hosted gateways without Stripe get a ~100-year "trial": past this
 // horizon a countdown is meaningless, so the indicator stays hidden.
 const MAX_TRIAL_DAYS_DISPLAYED = 92;
+// Every focus-triggered refresh costs the gateway two Stripe calls: a user
+// hopping between tabs must not pay for them over and over.
+const GATEWAY_TRIAL_REFRESH_INTERVAL_MS = 30 * 1000;
+
+let lastGatewayTrialRefresh = 0;
 
 const OPEN_PAGES = [
   '/signup',
@@ -95,7 +100,7 @@ function createActions(store) {
             store.setState({
               gatewayAccountExpired: true
             });
-          } else if (gatewayUser.status === 'trialing') {
+          } else {
             await actions.refreshGatewayTrialState(state, gatewayUser);
           }
         }
@@ -120,12 +125,43 @@ function createActions(store) {
         }
       }
     },
-    async refreshGatewayTrialState(state, gatewayUser) {
-      // The gateway API adds a 24-hour grace period to current_period_end:
-      // subtract it back so the countdown matches the real end of the trial.
+    // Called at session check with the gateway user already in hand, and again
+    // with no argument when the tab regains focus: the user comes back from the
+    // Stripe portal, where they may just have entered the card this card asks
+    // for — or ended the trial altogether.
+    async refreshGatewayTrialState(state, gatewayUserFromSessionCheck) {
+      let gatewayUser = gatewayUserFromSessionCheck;
+      if (!gatewayUser) {
+        if (Date.now() - lastGatewayTrialRefresh < GATEWAY_TRIAL_REFRESH_INTERVAL_MS) {
+          return;
+        }
+        try {
+          gatewayUser = await state.session.getGatewayUser();
+        } catch (e) {
+          console.error(e);
+          return;
+        }
+      }
+      lastGatewayTrialRefresh = Date.now();
+      // The gateway API returns current_period_end padded with a 24-hour grace
+      // period (see getMySelf in the gateway: `current_period_end + interval
+      // '24 hour'`). The account indeed stays usable during that day — which is
+      // why the expiry check above compares against the padded value — but what
+      // this card counts down to is the end of the free trial, when the card on
+      // file gets charged, so the pad is taken back out here.
       const trialEnd = new Date(gatewayUser.current_period_end).getTime() - ONE_DAY_IN_MILLISECONDS;
-      const daysLeft = Math.max(0, Math.ceil((trialEnd - Date.now()) / ONE_DAY_IN_MILLISECONDS));
-      if (daysLeft > MAX_TRIAL_DAYS_DISPLAYED) {
+      // floor, not ceil: with 12 hours to go the trial ends today, it does not
+      // have "1 day left". Only a full remaining day counts as one.
+      const daysLeft = Math.max(0, Math.floor((trialEnd - Date.now()) / ONE_DAY_IN_MILLISECONDS));
+      // Billing belongs to the admin of the Gladys Plus account: the other
+      // members of the household get neither the countdown nor a one-click link
+      // into the Stripe portal of a subscription that is not theirs.
+      if (gatewayUser.status !== 'trialing' || gatewayUser.role !== 'admin' || daysLeft > MAX_TRIAL_DAYS_DISPLAYED) {
+        store.setState({
+          gatewayTrialDaysLeft: null,
+          gatewayTrialHasPaymentMethod: true,
+          gatewayTrialStripePortalKey: null
+        });
         return;
       }
       // The "add a payment method" call-to-action must not show up when the

--- a/front/src/components/app.jsx
+++ b/front/src/components/app.jsx
@@ -242,6 +242,7 @@ const AppRouter = connect(
       gatewayTrialDaysLeft={props.gatewayTrialDaysLeft}
       gatewayTrialHasPaymentMethod={props.gatewayTrialHasPaymentMethod}
       gatewayTrialStripePortalKey={props.gatewayTrialStripePortalKey}
+      refreshGatewayTrialState={props.refreshGatewayTrialState}
     />
     <Layout currentUrl={props.currentUrl}>
       <Router onChange={props.handleRoute}>

--- a/front/src/components/app.jsx
+++ b/front/src/components/app.jsx
@@ -216,7 +216,7 @@ const SafeAsyncRoute = props => (
 );
 
 const AppRouter = connect(
-  'currentUrl,user,profilePicture,showDropDown,showCollapsedMenu,fullScreen,externalIntegrationsToUpdate',
+  'currentUrl,user,profilePicture,showDropDown,showCollapsedMenu,fullScreen,externalIntegrationsToUpdate,session,gatewayTrialDaysLeft,gatewayTrialHasPaymentMethod,gatewayTrialStripePortalKey',
   actions
 )(props => (
   <div id="app">
@@ -238,6 +238,10 @@ const AppRouter = connect(
       toggleCollapsedMenu={props.toggleCollapsedMenu}
       showCollapsedMenu={props.showCollapsedMenu}
       logout={props.logout}
+      session={props.session}
+      gatewayTrialDaysLeft={props.gatewayTrialDaysLeft}
+      gatewayTrialHasPaymentMethod={props.gatewayTrialHasPaymentMethod}
+      gatewayTrialStripePortalKey={props.gatewayTrialStripePortalKey}
     />
     <Layout currentUrl={props.currentUrl}>
       <Router onChange={props.handleRoute}>

--- a/front/src/components/header/GatewayTrialIndicator.jsx
+++ b/front/src/components/header/GatewayTrialIndicator.jsx
@@ -1,44 +1,60 @@
+import { Component } from 'preact';
 import { Text } from 'preact-i18n';
 import cx from 'classnames';
 import style from './style.css';
 
 const WARNING_DAYS_THRESHOLD = 7;
 
-// Gladys Plus trial countdown, shown in the sidebar while the account is in
-// its trial period (gatewayTrialDaysLeft is only set in that case). When no
-// payment method is configured yet, a call-to-action opens the Stripe
-// customer portal so the user can add their card before the trial ends.
-const GatewayTrialIndicator = ({ daysLeft, hasPaymentMethod, stripePortalKey, session }) => {
-  if (!Number.isInteger(daysLeft)) {
-    return null;
-  }
-  const openStripePortal = e => {
-    e.preventDefault();
-    window.open(`${session.gladysGatewayApiUrl}/accounts/stripe_customer_portal/${stripePortalKey}`);
+// Gladys Plus trial countdown, displayed in the sidebar while the account is
+// in its trial period. When no payment method is configured yet, a
+// call-to-action opens the Stripe customer portal so the user can add their
+// card before the trial ends.
+// Only mounted when there is a trial to display (see the header): the
+// visibility listener below then lives exactly as long as that card does.
+class GatewayTrialIndicator extends Component {
+  // The Stripe portal opens in another tab: coming back is the moment the card
+  // may have just been added, and the moment this reminder must stop nagging.
+  handleVisibilityChange = () => {
+    if (!document.hidden) {
+      this.props.refreshGatewayTrialState();
+    }
   };
-  return (
-    <div
-      class={cx(style.trialCard, { [style.trialCardWarning]: daysLeft <= WARNING_DAYS_THRESHOLD })}
-      data-cy="gateway-trial-indicator"
-    >
-      <a href="/dashboard/settings/billing" class={style.trialDaysLeft}>
-        <i class={cx('fe fe-clock', style.trialIcon)} />
-        <span>
-          <Text id="header.trialDaysLeft" plural={daysLeft} fields={{ count: daysLeft }} />
-        </span>
-      </a>
-      {!hasPaymentMethod &&
-        (stripePortalKey ? (
-          <a href="#" onClick={openStripePortal} class={style.trialCta}>
-            <Text id="header.trialAddPaymentMethod" /> <i class="fe fe-external-link" />
-          </a>
-        ) : (
-          <a href="/dashboard/settings/billing" class={style.trialCta}>
-            <Text id="header.trialAddPaymentMethod" />
-          </a>
-        ))}
-    </div>
-  );
-};
+
+  componentDidMount() {
+    document.addEventListener('visibilitychange', this.handleVisibilityChange);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('visibilitychange', this.handleVisibilityChange);
+  }
+
+  render({ daysLeft, hasPaymentMethod, stripePortalKey, session }) {
+    const stripePortalUrl =
+      stripePortalKey && `${session.gladysGatewayApiUrl}/accounts/stripe_customer_portal/${stripePortalKey}`;
+    return (
+      <div
+        class={cx(style.trialCard, { [style.trialCardWarning]: daysLeft <= WARNING_DAYS_THRESHOLD })}
+        data-cy="gateway-trial-indicator"
+      >
+        <a href="/dashboard/settings/billing" class={style.trialDaysLeft}>
+          <i class={cx('fe fe-clock', style.trialIcon)} />
+          <span>
+            <Text id="header.trialDaysLeft" plural={daysLeft} fields={{ count: daysLeft }} />
+          </span>
+        </a>
+        {!hasPaymentMethod &&
+          (stripePortalUrl ? (
+            <a href={stripePortalUrl} target="_blank" rel="noopener noreferrer" class={style.trialCta}>
+              <Text id="header.trialAddPaymentMethod" /> <i class="fe fe-external-link" />
+            </a>
+          ) : (
+            <a href="/dashboard/settings/billing" class={style.trialCta}>
+              <Text id="header.trialAddPaymentMethod" />
+            </a>
+          ))}
+      </div>
+    );
+  }
+}
 
 export default GatewayTrialIndicator;

--- a/front/src/components/header/GatewayTrialIndicator.jsx
+++ b/front/src/components/header/GatewayTrialIndicator.jsx
@@ -1,0 +1,44 @@
+import { Text } from 'preact-i18n';
+import cx from 'classnames';
+import style from './style.css';
+
+const WARNING_DAYS_THRESHOLD = 7;
+
+// Gladys Plus trial countdown, shown in the sidebar while the account is in
+// its trial period (gatewayTrialDaysLeft is only set in that case). When no
+// payment method is configured yet, a call-to-action opens the Stripe
+// customer portal so the user can add their card before the trial ends.
+const GatewayTrialIndicator = ({ daysLeft, hasPaymentMethod, stripePortalKey, session }) => {
+  if (!Number.isInteger(daysLeft)) {
+    return null;
+  }
+  const openStripePortal = e => {
+    e.preventDefault();
+    window.open(`${session.gladysGatewayApiUrl}/accounts/stripe_customer_portal/${stripePortalKey}`);
+  };
+  return (
+    <div
+      class={cx(style.trialCard, { [style.trialCardWarning]: daysLeft <= WARNING_DAYS_THRESHOLD })}
+      data-cy="gateway-trial-indicator"
+    >
+      <a href="/dashboard/settings/billing" class={style.trialDaysLeft}>
+        <i class={cx('fe fe-clock', style.trialIcon)} />
+        <span>
+          <Text id="header.trialDaysLeft" plural={daysLeft} fields={{ count: daysLeft }} />
+        </span>
+      </a>
+      {!hasPaymentMethod &&
+        (stripePortalKey ? (
+          <a href="#" onClick={openStripePortal} class={style.trialCta}>
+            <Text id="header.trialAddPaymentMethod" /> <i class="fe fe-external-link" />
+          </a>
+        ) : (
+          <a href="/dashboard/settings/billing" class={style.trialCta}>
+            <Text id="header.trialAddPaymentMethod" />
+          </a>
+        ))}
+    </div>
+  );
+};
+
+export default GatewayTrialIndicator;

--- a/front/src/components/header/index.jsx
+++ b/front/src/components/header/index.jsx
@@ -6,6 +6,7 @@ import { Link } from 'preact-router/match';
 import { isUrlInArray } from '../../utils/url';
 import { USER_ROLE } from '../../../../server/utils/constants';
 import DarkModeToggle from '../darkmode/DarkModeToggle';
+import GatewayTrialIndicator from './GatewayTrialIndicator';
 import style from './style.css';
 
 const PAGES_WITHOUT_HEADER = [
@@ -230,6 +231,12 @@ class Header extends Component {
               </li>
             ))}
           </ul>
+          <GatewayTrialIndicator
+            daysLeft={props.gatewayTrialDaysLeft}
+            hasPaymentMethod={props.gatewayTrialHasPaymentMethod}
+            stripePortalKey={props.gatewayTrialStripePortalKey}
+            session={props.session}
+          />
           <div class={cx('dropdown', style.sidebarFooter, { show: props.showDropDown })} ref={this.dropdownRef}>
             <a onClick={props.toggleDropDown} class={style.profileButton} data-toggle="dropdown">
               <span class="avatar" style={`background-image: url(${props.profilePicture})`} />

--- a/front/src/components/header/index.jsx
+++ b/front/src/components/header/index.jsx
@@ -231,12 +231,15 @@ class Header extends Component {
               </li>
             ))}
           </ul>
-          <GatewayTrialIndicator
-            daysLeft={props.gatewayTrialDaysLeft}
-            hasPaymentMethod={props.gatewayTrialHasPaymentMethod}
-            stripePortalKey={props.gatewayTrialStripePortalKey}
-            session={props.session}
-          />
+          {Number.isInteger(props.gatewayTrialDaysLeft) && (
+            <GatewayTrialIndicator
+              daysLeft={props.gatewayTrialDaysLeft}
+              hasPaymentMethod={props.gatewayTrialHasPaymentMethod}
+              stripePortalKey={props.gatewayTrialStripePortalKey}
+              session={props.session}
+              refreshGatewayTrialState={props.refreshGatewayTrialState}
+            />
+          )}
           <div class={cx('dropdown', style.sidebarFooter, { show: props.showDropDown })} ref={this.dropdownRef}>
             <a onClick={props.toggleDropDown} class={style.profileButton} data-toggle="dropdown">
               <span class="avatar" style={`background-image: url(${props.profilePicture})`} />

--- a/front/src/components/header/style.css
+++ b/front/src/components/header/style.css
@@ -95,6 +95,55 @@
   margin-left: auto;
 }
 
+/* Gladys Plus trial countdown: a discreet card between the nav and the
+   footer, only rendered while the account is in its trial period */
+.trialCard {
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.65rem;
+  border-radius: 10px;
+  background-color: rgba(61, 109, 240, 0.09);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
+.trialCardWarning {
+  background-color: rgba(245, 166, 35, 0.16);
+}
+
+.trialDaysLeft {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.45rem;
+  color: #1c2334;
+}
+
+.trialDaysLeft:hover {
+  color: #1c2334;
+  text-decoration: none;
+}
+
+.trialIcon {
+  color: #3d6df0;
+  margin-top: 1px;
+}
+
+.trialCardWarning .trialIcon {
+  color: #c4762a;
+}
+
+.trialCta {
+  margin-left: 1.35rem;
+  font-weight: 600;
+  color: #3d6df0;
+}
+
+.trialCta:hover {
+  color: #3d6df0;
+}
+
 /* Footer: profile row opening a dropup menu, dark-mode toggle beside it */
 .sidebarFooter {
   position: relative;

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -6173,6 +6173,12 @@
     "scenes": "Szenen",
     "profile": "Profil",
     "settings": "Einstellungen",
+    "trialDaysLeft": {
+      "zero": "Gladys-Plus-Testphase endet heute",
+      "one": "Gladys-Plus-Testphase: noch 1 Tag",
+      "other": "Gladys-Plus-Testphase: noch {{count}} Tage"
+    },
+    "trialAddPaymentMethod": "Zahlungsmethode hinzufügen",
     "needHelp": "Hilfe benötigt",
     "signOut": "Abmelden"
   },

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -6173,6 +6173,12 @@
     "scenes": "Scenes",
     "profile": "Profile",
     "settings": "Settings",
+    "trialDaysLeft": {
+      "zero": "Gladys Plus trial ends today",
+      "one": "Gladys Plus trial: 1 day left",
+      "other": "Gladys Plus trial: {{count}} days left"
+    },
+    "trialAddPaymentMethod": "Add a payment method",
     "needHelp": "Need help",
     "signOut": "Sign Out"
   },

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -6173,6 +6173,12 @@
     "scenes": "Scènes",
     "profile": "Profil",
     "settings": "Paramètres",
+    "trialDaysLeft": {
+      "zero": "L'essai Gladys Plus se termine aujourd'hui",
+      "one": "Essai Gladys Plus : 1 jour restant",
+      "other": "Essai Gladys Plus : {{count}} jours restants"
+    },
+    "trialAddPaymentMethod": "Ajouter un moyen de paiement",
     "needHelp": "Besoin d'aide",
     "signOut": "Déconnexion"
   },


### PR DESCRIPTION
### Description

Improve the free → paid conversion of Gladys Plus trial users by showing a discreet reminder of the time left in the trial, with a direct link to add a payment method when none is configured.

**What it looks like** (gateway mode only): a small card between the navigation and the profile footer in the sidebar:

- "Essai Gladys Plus : X jours restants" — the whole line links to the billing settings tab.
- When the account has **no payment method configured** (`getCard()` returns `null`), an "Ajouter un moyen de paiement" call-to-action opens the Stripe customer portal in a new tab (same URL scheme as the billing tab), so the user can enter their card in one click.
- The card turns orange during the last 7 days of the trial; on the last day it reads "L'essai Gladys Plus se termine aujourd'hui".

**How it works**

- `checkSession` already fetches the gateway user (`/users/me`), which carries `status` and `current_period_end`. When `status === 'trialing'` and the account is not expired, a new `refreshGatewayTrialState` action computes the days left (subtracting the 24-hour grace period the gateway API adds to `current_period_end`) and fetches the card + `stripe_portal_key` in one round-trip pair.
- The countdown is hidden past 92 days so self-hosted gateways without Stripe (which get a ~100-year "trial") never see it.
- If the card check fails, the payment call-to-action is not shown (better no reminder than a wrong one); the countdown still displays.
- Nothing renders in local or demo mode: the state keys are only set in gateway mode.

Translations added for en/fr/de with proper zero/one/other plural forms.

**Known limitation**: the gateway's `GET /accounts/source` only looks at legacy Stripe `sources`. A trial user who adds a card through the newer customer portal (stored as a PaymentMethod) would still see the call-to-action. Fixing that belongs to the gladys-gateway backend; the link they get still lands on the portal where their card is visible, so the impact is limited.

## Forum

### Checklist

- [x] Tests pass: no server change, so no server coverage impact; front build passes (`vite build`)
- [x] Linter and prettier pass on both front and server (`npm run eslint`: 0 errors, `prettier --check` clean on changed files, `npm run compare-translations` clean)
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbgoUzARiW8tmdaeRvytHw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Gladys Plus trial countdown card in the sidebar.
  - Displays remaining trial days and highlights when seven days or fewer remain.
  - Provides quick access to billing settings and payment-method setup.
  - Trial and payment information refresh automatically when returning to the app.
  - Added English, French, and German translations for billing messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->