### PR TITLE
Fix the flaky Device.migrate tests: raise the mocha timeout on the suite

### DIFF
--- a/server/test/lib/device/device.migrate.test.js
+++ b/server/test/lib/device/device.migrate.test.js
@@ -41,7 +41,10 @@ const countDuckDbStates = async (featureId) => {
   return Number(count);
 };
 
-describe('Device.migrate', () => {
+describe('Device.migrate', function Describe() {
+  // Every DuckDB-backed suite in this folder raises the mocha timeout: the slicing
+  // tests below drive dozens of write statements and do not fit in the 2s default.
+  this.timeout(15000);
   let deviceManager;
   let sceneManagerFake;
   let destinationService;


### PR DESCRIPTION
### Description

The `Server test` job fails intermittently on unrelated pull requests with two failures, always the same two:

```
1) Device.migrate
     should move the whole history in slices, with one cutoff per feature:
   Error: Timeout of 2000ms exceeded.

2) Device.migrate
     should cap each statement when every state shares the same timestamp:
   Error: Timeout of 2000ms exceeded.
```

Seen on #2943, which only touches four front CSS/JSX files, while `master` was green on the exact same commit the branch had just been updated with.

**Cause:** `server/test/lib/device/device.migrate.test.js` runs on mocha's 2000 ms default. There is no `--timeout` in the `test` script of `server/package.json`, and this suite is the only DuckDB-backed one in `test/lib/device` that does not raise the timeout itself:

| Suite | timeout |
|---|---|
| `device.getDeviceFeatureStates.test.js` | 15 000 ms |
| `device.getDeviceFeaturesAggregates.test.js` | 15 000 ms |
| `device.getDeviceFeaturesAggregatesMulti.test.js` | 15 000 ms |
| `device.getDeviceStatesHistory.test.js` | 15 000 ms |
| `device.purgeOrphanedDuckDbStates.test.js` | 10 000 ms |
| `device.purgeStatesByFeatureId.test.js` | 5 000 ms |
| **`device.migrate.test.js`** | **none — 2 000 ms default** |

The two tests that fail are precisely the two heaviest of the file. The first sets `DUCKDB_STATES_MIGRATE_STATES_PER_SLICE = 1` to force one slice per state, so the migration does about 18 UPDATE/DELETE round trips; the second caps statements at 3 affected rows over 31 states, so both the capped UPDATE and the capped DELETE have to repeat several times. Run locally on an idle machine they take 461 ms and 234 ms — the two slowest of the suite, the next one being 255 ms. `npm test` runs mocha with `--parallel`, so on a two-core CI runner several workers contend for CPU and for the DuckDB file, and a 4x slowdown is enough to cross 2 s.

**Fix:** raise the timeout of the suite to 15 s, matching the other DuckDB suites of the same folder. This only changes how long mocha is willing to wait; no test logic, no production code, and nothing that could hide a real regression — a genuine hang still fails the job.

Note that `device.destroy`, `device.destroyStatesFrom`, `device.migrateFromSQLiteToDuckDb`, `device.purgeStates`, `device.saveHistoricalState` and `device.saveMultipleHistoricalStates` also touch DuckDB without a timeout of their own. None of them has been observed flaking, so they are left alone here rather than widening this fix.

## Forum

<!-- Not applicable: CI-only fix, no user-facing change. -->

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

Ran locally in `server/`: the full `device.migrate.test.js` suite passes (19 passing), `npx eslint` and `npx prettier --check` are clean on the changed file. No production file is touched, so there is no changed line for Codecov to cover, and the UI is untouched so Cypress is unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XiuPN5xDvCTKbZo7DnnJD9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the migration test timeout to accommodate longer-running database operations.
  * Added documentation explaining the extended test duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->