### PR TITLE
Fix the flaky rtsp-camera tests: stop sharing one temp folder across mocha workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ jsdoc
 build
 static
 gladys-backups
+# test/setup-env.js derives a per-process copy (gladys-backups-<pid>) for
+# every mocha worker: the bare name above does not match those.
+gladys-backups-*
 qemu-*
 coverage
 persist

--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -151,6 +151,10 @@
             "message": "Test files must use a per-file sinon sandbox: require('sinon').createSandbox(). The shared singleton accumulates every fake of the whole suite and makes sinon.reset() slower for everyone."
           },
           {
+            "selector": "Property[key.name='tempFolder'][value.value='/tmp/gladys']",
+            "message": "Take the temp folder from the environment: tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys'. setup-env.js gives each mocha worker its own copy because system.init() empties that folder at every Gladys boot; hardcoding the shared one lets a worker running the system suite wipe the fixtures another worker is reading."
+          },
+          {
             "selector": "ForInStatement",
             "message": "for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array."
           },

--- a/server/test/lib/system/system.checkIfGladysUpgraded.test.js
+++ b/server/test/lib/system/system.checkIfGladysUpgraded.test.js
@@ -18,7 +18,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.checkIfGladysUpgraded', () => {

--- a/server/test/lib/system/system.connectToNetwork.test.js
+++ b/server/test/lib/system/system.connectToNetwork.test.js
@@ -26,7 +26,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.connectToNetwork', () => {

--- a/server/test/lib/system/system.createContainer.test.js
+++ b/server/test/lib/system/system.createContainer.test.js
@@ -26,7 +26,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.createContainer', () => {

--- a/server/test/lib/system/system.createNetwork.test.js
+++ b/server/test/lib/system/system.createNetwork.test.js
@@ -25,7 +25,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.createNetwork', () => {

--- a/server/test/lib/system/system.detectHardwareClasses.test.js
+++ b/server/test/lib/system/system.detectHardwareClasses.test.js
@@ -27,7 +27,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.detectHardwareClasses', () => {

--- a/server/test/lib/system/system.exec.test.js
+++ b/server/test/lib/system/system.exec.test.js
@@ -25,7 +25,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.exec', () => {

--- a/server/test/lib/system/system.getContainerLogs.test.js
+++ b/server/test/lib/system/system.getContainerLogs.test.js
@@ -26,7 +26,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.getContainerLogs', () => {

--- a/server/test/lib/system/system.getContainerMounts.test.js
+++ b/server/test/lib/system/system.getContainerMounts.test.js
@@ -25,7 +25,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.getContainerMounts', () => {

--- a/server/test/lib/system/system.getContainers.test.js
+++ b/server/test/lib/system/system.getContainers.test.js
@@ -25,7 +25,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.getContainers', () => {

--- a/server/test/lib/system/system.getDiskSpace.test.js
+++ b/server/test/lib/system/system.getDiskSpace.test.js
@@ -36,7 +36,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.getDiskSpace', () => {

--- a/server/test/lib/system/system.getGladysBasePath.test.js
+++ b/server/test/lib/system/system.getGladysBasePath.test.js
@@ -25,7 +25,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.getGladysBasePath', () => {

--- a/server/test/lib/system/system.getGladysContainerId.test.js
+++ b/server/test/lib/system/system.getGladysContainerId.test.js
@@ -21,7 +21,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.getGladysContainerId', () => {

--- a/server/test/lib/system/system.getGladysImage.test.js
+++ b/server/test/lib/system/system.getGladysImage.test.js
@@ -26,7 +26,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.parseImageReference', () => {

--- a/server/test/lib/system/system.getGladysLogs.test.js
+++ b/server/test/lib/system/system.getGladysLogs.test.js
@@ -26,7 +26,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 /**

--- a/server/test/lib/system/system.getImageLabels.test.js
+++ b/server/test/lib/system/system.getImageLabels.test.js
@@ -25,7 +25,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.getImageLabels', () => {

--- a/server/test/lib/system/system.getImagePullTime.test.js
+++ b/server/test/lib/system/system.getImagePullTime.test.js
@@ -24,7 +24,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.getImagePullTime', () => {

--- a/server/test/lib/system/system.getInfos.test.js
+++ b/server/test/lib/system/system.getInfos.test.js
@@ -19,7 +19,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.getInfos', () => {

--- a/server/test/lib/system/system.getNetworkMode.test.js
+++ b/server/test/lib/system/system.getNetworkMode.test.js
@@ -28,7 +28,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.getNetworkMode', () => {

--- a/server/test/lib/system/system.hasCpuCfsSupport.test.js
+++ b/server/test/lib/system/system.hasCpuCfsSupport.test.js
@@ -25,7 +25,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.hasCpuCfsSupport', () => {

--- a/server/test/lib/system/system.imageExists.test.js
+++ b/server/test/lib/system/system.imageExists.test.js
@@ -25,7 +25,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.imageExists', () => {

--- a/server/test/lib/system/system.init.test.js
+++ b/server/test/lib/system/system.init.test.js
@@ -24,7 +24,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.init', () => {

--- a/server/test/lib/system/system.inspectContainer.test.js
+++ b/server/test/lib/system/system.inspectContainer.test.js
@@ -25,7 +25,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.inspectContainer', () => {

--- a/server/test/lib/system/system.inspectNetwork.test.js
+++ b/server/test/lib/system/system.inspectNetwork.test.js
@@ -25,7 +25,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.inspectNetwork', () => {

--- a/server/test/lib/system/system.installUpgrade.test.js
+++ b/server/test/lib/system/system.installUpgrade.test.js
@@ -27,7 +27,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 // the Dockerode mock is shared by every system test file: patch it through a

--- a/server/test/lib/system/system.isDocker.test.js
+++ b/server/test/lib/system/system.isDocker.test.js
@@ -34,7 +34,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.isDocker', () => {

--- a/server/test/lib/system/system.listImages.test.js
+++ b/server/test/lib/system/system.listImages.test.js
@@ -25,7 +25,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.listImages', () => {

--- a/server/test/lib/system/system.pull.test.js
+++ b/server/test/lib/system/system.pull.test.js
@@ -25,7 +25,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.pull', () => {

--- a/server/test/lib/system/system.removeContainer.test.js
+++ b/server/test/lib/system/system.removeContainer.test.js
@@ -25,7 +25,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.removeContainer', () => {

--- a/server/test/lib/system/system.removeImage.test.js
+++ b/server/test/lib/system/system.removeImage.test.js
@@ -25,7 +25,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 /**

--- a/server/test/lib/system/system.removeNetwork.test.js
+++ b/server/test/lib/system/system.removeNetwork.test.js
@@ -25,7 +25,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.removeNetwork', () => {

--- a/server/test/lib/system/system.restartContainer.test.js
+++ b/server/test/lib/system/system.restartContainer.test.js
@@ -25,7 +25,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.restartContainer', () => {

--- a/server/test/lib/system/system.setDuckDbTimezone.test.js
+++ b/server/test/lib/system/system.setDuckDbTimezone.test.js
@@ -34,7 +34,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.setDuckDbTimezone', () => {

--- a/server/test/lib/system/system.shutdown.test.js
+++ b/server/test/lib/system/system.shutdown.test.js
@@ -17,7 +17,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.shutdown', () => {

--- a/server/test/lib/system/system.stopContainer.test.js
+++ b/server/test/lib/system/system.stopContainer.test.js
@@ -26,7 +26,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.stopContainer', () => {

--- a/server/test/lib/system/system.updateContainer.test.js
+++ b/server/test/lib/system/system.updateContainer.test.js
@@ -25,7 +25,7 @@ const event = {
 const job = new Job(event);
 
 const config = {
-  tempFolder: '/tmp/gladys',
+  tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
 };
 
 describe('system.updateContainer', () => {

--- a/server/test/services/rtsp-camera/rstp.convertLocalStreamToGateway.test.js
+++ b/server/test/services/rtsp-camera/rstp.convertLocalStreamToGateway.test.js
@@ -24,7 +24,7 @@ const device = {
 
 const gladys = {
   config: {
-    tempFolder: '/tmp/gladys',
+    tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
   },
   device: {
     camera: {

--- a/server/test/services/rtsp-camera/rstpCamera.onNewCameraFile.test.js
+++ b/server/test/services/rtsp-camera/rstpCamera.onNewCameraFile.test.js
@@ -23,7 +23,7 @@ const device = {
 
 const gladys = {
   config: {
-    tempFolder: '/tmp/gladys',
+    tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
   },
   device: {
     camera: {

--- a/server/test/services/rtsp-camera/rtspCamera.sendCameraFileToGateway.test.js
+++ b/server/test/services/rtsp-camera/rtspCamera.sendCameraFileToGateway.test.js
@@ -7,7 +7,7 @@ const RtspCameraManager = require('../../../services/rtsp-camera/lib');
 
 const gladys = {
   config: {
-    tempFolder: '/tmp/gladys',
+    tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
   },
   gateway: {
     gladysGatewayClient: {

--- a/server/test/services/rtsp-camera/rtspCamera.streaming.test.js
+++ b/server/test/services/rtsp-camera/rtspCamera.streaming.test.js
@@ -26,7 +26,7 @@ const device = {
 
 const gladys = {
   config: {
-    tempFolder: '/tmp/gladys',
+    tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
   },
   gateway: {
     gladysGatewayClient: {
@@ -110,7 +110,7 @@ describe('Camera.streaming', () => {
   it('should not start streaming, camera is disabled', async () => {
     const disabledCameraGladys = {
       config: {
-        tempFolder: '/tmp/gladys',
+        tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
       },
       device: {
         getBySelector: fake.resolves({
@@ -185,7 +185,7 @@ describe('Camera.streaming', () => {
   it('should star with 90 rotation & stop streaming', async () => {
     const gladysDeviceWithRotation = {
       config: {
-        tempFolder: '/tmp/gladys',
+        tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
       },
       device: {
         getBySelector: fake.resolves({
@@ -220,7 +220,7 @@ describe('Camera.streaming', () => {
   it('should star with 180 rotation & stop streaming', async () => {
     const gladysDeviceWithRotation = {
       config: {
-        tempFolder: '/tmp/gladys',
+        tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
       },
       device: {
         getBySelector: fake.resolves({
@@ -255,7 +255,7 @@ describe('Camera.streaming', () => {
   it('should star with 270 rotation & stop streaming', async () => {
     const gladysDeviceWithRotation = {
       config: {
-        tempFolder: '/tmp/gladys',
+        tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
       },
       device: {
         getBySelector: fake.resolves({
@@ -290,7 +290,7 @@ describe('Camera.streaming', () => {
   it('should star with not rotation params & stop streaming after', async () => {
     const gladysDeviceWithRotation = {
       config: {
-        tempFolder: '/tmp/gladys',
+        tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
       },
       device: {
         getBySelector: fake.resolves({
@@ -338,7 +338,7 @@ describe('Camera.streaming', () => {
     };
     const gladysWithHlsCamera = {
       config: {
-        tempFolder: '/tmp/gladys',
+        tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
       },
       device: {
         getBySelector: fake.resolves({
@@ -518,7 +518,7 @@ describe('Camera.streaming', () => {
   it('should stop streaming, but kill + clean is not working', async () => {
     const gladysWithFailClean = {
       config: {
-        tempFolder: '/tmp/gladys',
+        tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
       },
       gateway: {
         gladysGatewayClient: {

--- a/server/test/services/rtsp-camera/rtspCamera.test.js
+++ b/server/test/services/rtsp-camera/rtspCamera.test.js
@@ -40,7 +40,7 @@ const deviceWithRtspImage = {
 
 const gladys = {
   config: {
-    tempFolder: '/tmp/gladys',
+    tempFolder: process.env.TEMP_FOLDER || '/tmp/gladys',
   },
   device: {
     camera: {

--- a/server/test/setup-env.js
+++ b/server/test/setup-env.js
@@ -81,6 +81,14 @@ if (!process.env.GLADYS_TEST_TEMP_FOLDER_ROOT) {
 }
 process.env.TEMP_FOLDER = `${process.env.GLADYS_TEST_TEMP_FOLDER_ROOT}-${process.pid}`;
 
+// A test that builds its own fake `gladys` object must take its tempFolder
+// from process.env.TEMP_FOLDER (`process.env.TEMP_FOLDER || '/tmp/gladys'`)
+// and never hardcode the shared folder: the isolation above only holds if
+// every worker stays inside its own copy. Hardcoding it made the whole suite
+// share one folder across workers, so the ~30 system tests calling init()
+// emptied it under the rtsp-camera tests, whose fixtures live there — the
+// `ENOENT ... /tmp/gladys/camera-<id>/index.m3u8` failures.
+
 process.on('exit', () => {
   // eslint-disable-next-line global-require
   const { unlinkSync, readdirSync, rmSync } = require('fs');


### PR DESCRIPTION
### Description

The rtsp-camera tests fail intermittently in CI with `ENOENT ... /tmp/gladys/camera-<id>/index.m3u8` — most recently three failures on #2946, where nothing in the diff went near the camera service.

**Root cause.** `test/setup-env.js` already gives every mocha worker its own temp folder, and its comment says why: *"system.init() empties the temp folder at every Gladys boot: give each worker its own copy"*. Forty test files bypassed that isolation by hardcoding the literal `/tmp/gladys` in the fake `gladys` config they build. The suite therefore shared one folder across workers, and the two sides collided:

- ~30 `test/lib/system/*` files call `system.init()`, which runs `fse.emptyDir(config.tempFolder)`;
- the rtsp-camera tests write their fixtures into that same folder in a `before` hook and read them back during the tests.

With `--parallel`, one worker emptied the folder while another was mid-test. Whether it blew up came down to scheduling, which is why it looked like an infra flake.

**Fix.** Take the folder from `process.env.TEMP_FOLDER`, which is what `test/services/rtsp-camera/controllers/rtspCamera.controller.test.js` already did — the remaining 40 files now follow the same pattern. The invariant is recorded next to the derivation it protects in `setup-env.js`, so the next fake `gladys` config doesn't silently reintroduce it.

No production file is touched.

**Second effect, worth noting.** Because ~30 tests called `emptyDir` on the literal path, running `npm test` wiped the real `/tmp/gladys` — the folder a locally running Gladys uses for camera streams. That stops too.

**One `.gitignore` line.** `setup-env.js` also derives a per-process `gladys-backups-<pid>` for each worker, but `.gitignore` only listed the bare `gladys-backups`, so every run leaves untracked folders a contributor can sweep into a commit. It caught me while preparing this PR. Adding `gladys-backups-*` closes it.

### Verification

Running the rtsp-camera and system suites together, `--parallel --jobs 4`:

| | runs | result |
|---|---|---|
| before | 6 | failed **every** run — 5, 7, 8, 9, 10 and 15 failures |
| after | 5 | passed every run — 285 passing, 0 failing |

The mechanism was also confirmed on its own: writing the camera fixture, then constructing a `System` with the hardcoded config and calling `init()`, deletes the fixture outright.

A sentinel file dropped in the real `/tmp/gladys` survives a run now, where it was deleted before.

### Checklist

- [x] Tests pass: full `npm test` green locally, plus the rtsp-camera + system suites across repeated `--parallel` runs
- [x] Linter and prettier pass on the server (`npx eslint`, `npx prettier --check` on the touched paths)
- [x] No undocumented breaking change

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test isolation by allowing temporary files to use a process-specific location.
  - Reduced conflicts and accidental fixture cleanup during concurrent test runs.
  - Applied isolated temporary directory configuration across system and camera-related scenarios.

- **Chores**
  - Updated ignore rules for process-specific backup directories.
  - Added guidance and linting checks to help maintain isolated temporary test environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->