### PR TITLE
Scenes: restore the spacing between mobile scene rows

### DIFF
--- a/front/src/routes/scene/SceneCards.jsx
+++ b/front/src/routes/scene/SceneCards.jsx
@@ -1,9 +1,8 @@
 import SceneCard from './SceneCard';
-import style from './style.css';
 
 const SceneCards = ({ children, ...props }) => (
   <>
-    <div class={`d-block d-lg-none ${style.sceneMobileList}`}>
+    <div class="d-block d-lg-none">
       {/* Only visible on small screens */}
       {props.scenes.map((scene, index) => (
         <SceneCard {...props} scene={scene} index={index} showMobileView />

--- a/front/src/routes/scene/style.css
+++ b/front/src/routes/scene/style.css
@@ -63,19 +63,21 @@
   font-size: 1.35rem;
 }
 
-/* Horizon: on small screens each scene is its own translucent pill row */
-.sceneMobileList {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
+/* Horizon: on small screens each scene is its own translucent pill row.
+   The rows are spaced with a margin, not a flex `gap`: the list also carries
+   Bootstrap's `.d-block` (`display: block !important`), so a `display: flex`
+   here would never win and the gap would be dropped. */
 .sceneMobileRow {
   background-color: var(--gl-card-nested-bg, rgba(255, 255, 255, 0.4));
   border: 1px solid var(--gl-border, rgba(255, 255, 255, 0.85));
   border-radius: 16px;
   box-shadow: var(--gl-shadow-soft, 0 4px 16px rgba(44, 62, 118, 0.09));
   padding: 0.65rem 0.75rem;
+  margin-bottom: 10px;
+}
+
+.sceneMobileRow:last-child {
+  margin-bottom: 0;
 }
 
 /* Rows are links, but their text keeps the theme ink, not the link accent */


### PR DESCRIPTION
### Description

On small screens the scene list rows were stacked with no space between them.

The mobile list spaced its rows with `display: flex; flex-direction: column;
gap: 10px`, but the same element also carries Bootstrap's `.d-block`
(`display: block !important`). The flex display could therefore never win, and
`gap` has no effect on a block container — so the spacing was silently dropped.

Spacing now comes from a `margin-bottom` on `.sceneMobileRow` (with
`:last-child { margin-bottom: 0 }` so no dead space is added under the list),
which works on a block container. The now-unused `.sceneMobileList` class and
its JSX reference are removed. Desktop grid (`row row-cards`) is untouched.

### Checklist

- [X] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [X] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [X] No undocumented breaking change

<img width="573" height="875" alt="Capture d’écran 2026-08-22 à 10 54 57" src="https://github.com/user-attachments/assets/8d1453e6-c8ea-4961-a432-b657c5c844b9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing between scene rows on small-screen layouts.
  * Removed extra spacing after the final scene row.
  * Preserved the existing scene list appearance and behavior across larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->