### PR TITLE
Scene editor: portal the date/time picker popup and restyle it

### DIFF
--- a/front/src/routes/scene/edit-scene/actions/CheckTime.jsx
+++ b/front/src/routes/scene/edit-scene/actions/CheckTime.jsx
@@ -7,6 +7,7 @@ import { Text, Localizer } from 'preact-i18n';
 import get from 'get-value';
 
 import 'react-datepicker/dist/react-datepicker.css';
+import datePickerStyle from '../datePicker.css';
 import style from './CheckTime.css';
 
 import fr from 'date-fns/locale/fr';
@@ -63,6 +64,8 @@ class CheckTime extends Component {
                 <DatePicker
                   selected={after}
                   className="form-control"
+                  popperClassName={datePickerStyle.datePickerPopper}
+                  portalId="scene-editor-datepicker"
                   clearButtonClassName={style.clearButtonCustom}
                   locale={localeSet}
                   onChange={this.handleBeforeAfterChange}
@@ -86,6 +89,8 @@ class CheckTime extends Component {
                 <DatePicker
                   selected={before}
                   className="form-control"
+                  popperClassName={datePickerStyle.datePickerPopper}
+                  portalId="scene-editor-datepicker"
                   clearButtonClassName={style.clearButtonCustom}
                   locale={localeSet}
                   onChange={this.handleBeforeTimeChange}

--- a/front/src/routes/scene/edit-scene/datePicker.css
+++ b/front/src/routes/scene/edit-scene/datePicker.css
@@ -1,0 +1,145 @@
+/* Date and time pickers of the scene editor (scheduled trigger, "check the
+   time" step). Two things are handled here:
+
+   - the popup is rendered on <body> through a portal, because the editor's
+     glass cards carry a backdrop filter: every card is its own stacking
+     context, so a popup opened inside one is painted UNDER the following
+     cards whatever z-index it gets from the inside;
+   - react-datepicker's stock look (grey header, hard 1px borders, square
+     corners, wide list rows) is replaced by the theme's soft card grammar.
+     The popup lives outside .glass-theme, hence the var() fallbacks.
+
+   Light colors only: dark mode comes from the app-wide inversion filter. */
+
+.datePickerPopper {
+  /* above the editor's sticky footer (.fixed-bottom, z-index 1030) */
+  z-index: 1050;
+}
+
+.datePickerPopper :global(.react-datepicker) {
+  font-family: inherit;
+  font-size: 0.875rem;
+  color: var(--gl-ink, #1c2334);
+  background-color: #fff;
+  border: none;
+  border-radius: 14px;
+  box-shadow: 0 12px 40px rgba(44, 62, 118, 0.18), 0 2px 8px rgba(44, 62, 118, 0.08);
+  overflow: hidden;
+}
+
+/* the stock triangle is drawn with the 1px border this card no longer has */
+.datePickerPopper :global(.react-datepicker__triangle) {
+  display: none;
+}
+
+.datePickerPopper :global(.react-datepicker__header) {
+  background-color: #fff;
+  border-bottom: 1px solid rgba(28, 35, 52, 0.08);
+  padding: 0.6rem 0.5rem 0.4rem;
+}
+
+.datePickerPopper :global(.react-datepicker-time__header),
+.datePickerPopper :global(.react-datepicker__current-month) {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--gl-muted, #7c8396);
+}
+
+/* ---- time list ---- */
+
+.datePickerPopper :global(.react-datepicker__time-container),
+.datePickerPopper :global(.react-datepicker__time-container .react-datepicker__time .react-datepicker__time-box) {
+  width: 6.5rem;
+  border-left: none;
+}
+
+.datePickerPopper
+  :global(.react-datepicker__time-container .react-datepicker__time .react-datepicker__time-box ul.react-datepicker__time-list) {
+  box-sizing: border-box;
+  padding: 0.25rem;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.datePickerPopper
+  :global(.react-datepicker__time-container
+    .react-datepicker__time
+    .react-datepicker__time-box
+    ul.react-datepicker__time-list
+    li.react-datepicker__time-list-item) {
+  height: auto;
+  padding: 0.375rem 0.5rem;
+  border-radius: 8px;
+  font-weight: 500;
+}
+
+.datePickerPopper
+  :global(.react-datepicker__time-container
+    .react-datepicker__time
+    .react-datepicker__time-box
+    ul.react-datepicker__time-list
+    li.react-datepicker__time-list-item:hover) {
+  background-color: rgba(28, 35, 52, 0.06);
+}
+
+.datePickerPopper
+  :global(.react-datepicker__time-container
+    .react-datepicker__time
+    .react-datepicker__time-box
+    ul.react-datepicker__time-list
+    li.react-datepicker__time-list-item--selected),
+.datePickerPopper
+  :global(.react-datepicker__time-container
+    .react-datepicker__time
+    .react-datepicker__time-box
+    ul.react-datepicker__time-list
+    li.react-datepicker__time-list-item--selected:hover) {
+  background-color: var(--gl-accent, #3d6df0);
+  color: #fff;
+  font-weight: 600;
+}
+
+/* ---- month grid (the "custom time" date field) ---- */
+
+.datePickerPopper :global(.react-datepicker__day-name),
+.datePickerPopper :global(.react-datepicker__day) {
+  width: 2rem;
+  line-height: 2rem;
+  margin: 0.125rem;
+  border-radius: 10px;
+  color: var(--gl-ink, #1c2334);
+}
+
+.datePickerPopper :global(.react-datepicker__day-name) {
+  font-weight: 600;
+  color: var(--gl-muted, #7c8396);
+}
+
+.datePickerPopper :global(.react-datepicker__day:hover) {
+  border-radius: 10px;
+  background-color: rgba(28, 35, 52, 0.06);
+}
+
+.datePickerPopper :global(.react-datepicker__day--outside-month),
+.datePickerPopper :global(.react-datepicker__day--disabled) {
+  color: var(--gl-muted, #7c8396);
+}
+
+.datePickerPopper :global(.react-datepicker__day--selected),
+.datePickerPopper :global(.react-datepicker__day--keyboard-selected),
+.datePickerPopper :global(.react-datepicker__day--selected:hover),
+.datePickerPopper :global(.react-datepicker__day--keyboard-selected:hover) {
+  background-color: var(--gl-accent, #3d6df0);
+  color: #fff;
+  font-weight: 600;
+}
+
+.datePickerPopper :global(.react-datepicker__navigation--previous) {
+  border-right-color: var(--gl-muted, #7c8396);
+}
+
+.datePickerPopper :global(.react-datepicker__navigation--next) {
+  border-left-color: var(--gl-muted, #7c8396);
+}

--- a/front/src/routes/scene/edit-scene/style.css
+++ b/front/src/routes/scene/edit-scene/style.css
@@ -583,6 +583,14 @@
   box-shadow: 0 0 0 3px rgba(61, 109, 240, 0.15);
 }
 
+/* The date/time fields fill their column like every other field: react-datepicker
+   wraps its input in an inline-block that otherwise shrinks to the input's own
+   default size. The popup itself is styled in datePicker.css — it is portaled
+   onto <body>, out of this container's reach. */
+.pageContainer :global(.react-datepicker-wrapper) {
+  display: block;
+}
+
 /* react-select (devices, houses, users…) joins the same family */
 :global(.glass-theme) .pageContainer :global(.react-select__control) {
   border-radius: 12px;

--- a/front/src/routes/scene/edit-scene/triggers/ScheduledTrigger.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/ScheduledTrigger.jsx
@@ -9,6 +9,7 @@ import Select from 'react-select';
 import fr from 'date-fns/locale/fr';
 
 import 'react-datepicker/dist/react-datepicker.css';
+import datePickerStyle from '../datePicker.css';
 
 const DAYS_OF_THE_MONTH = new Array(31).fill(0, 0, 31).map((val, index) => index + 1);
 
@@ -128,6 +129,8 @@ class TurnOnLight extends Component {
                   <DatePicker
                     selected={date}
                     className="form-control"
+                    popperClassName={datePickerStyle.datePickerPopper}
+                    portalId="scene-editor-datepicker"
                     placeholderText={<Text id="editScene.triggersCard.scheduledTrigger.dateLabel" />}
                     locale={localeSet}
                     onChange={this.handleDateChange}
@@ -147,6 +150,8 @@ class TurnOnLight extends Component {
                   <DatePicker
                     selected={time}
                     className="form-control"
+                    popperClassName={datePickerStyle.datePickerPopper}
+                    portalId="scene-editor-datepicker"
                     locale={localeSet}
                     onChange={this.handleTimeChange}
                     placeholderText={<Text id="editScene.triggersCard.scheduledTrigger.timeCaption" />}
@@ -208,6 +213,8 @@ class TurnOnLight extends Component {
                   <DatePicker
                     selected={time}
                     className="form-control"
+                    popperClassName={datePickerStyle.datePickerPopper}
+                    portalId="scene-editor-datepicker"
                     locale={localeSet}
                     onChange={this.handleTimeChange}
                     placeholderText={<Text id="editScene.triggersCard.scheduledTrigger.timeCaption" />}
@@ -278,6 +285,8 @@ class TurnOnLight extends Component {
                   <DatePicker
                     selected={time}
                     className="form-control"
+                    popperClassName={datePickerStyle.datePickerPopper}
+                    portalId="scene-editor-datepicker"
                     locale={localeSet}
                     onChange={this.handleTimeChange}
                     placeholderText={<Text id="editScene.triggersCard.scheduledTrigger.timeCaption" />}
@@ -319,6 +328,8 @@ class TurnOnLight extends Component {
                   <DatePicker
                     selected={time}
                     className="form-control"
+                    popperClassName={datePickerStyle.datePickerPopper}
+                    portalId="scene-editor-datepicker"
                     locale={localeSet}
                     onChange={this.handleTimeChange}
                     placeholderText={<Text id="editScene.triggersCard.scheduledTrigger.timeCaption" />}


### PR DESCRIPTION
## Problem

In the scene editor, the **scheduled trigger**'s time picker opens *under* the following steps and keeps react-datepicker's stock look, which is out of place in the modernized editor (#2936).

## Two separate causes

**1. Stacking, not z-index.** The Horizon glass theme sets a `backdrop-filter` on `.glass-theme .card`, which makes every card its own stacking context. A popup opened inside the triggers card can therefore never paint above the cards that follow it in the DOM, whatever z-index it gets from the inside. The popup is now rendered on `<body>` through react-datepicker's `portalId` — the same approach `LightControlPanel.jsx` already uses for the same reason — with a z-index above the sticky footer.

**2. Stock styling.** The default popup (grey header, hard 1px borders, square corners, fat scrollbar) is replaced by the theme's soft card grammar in a shared `datePicker.css`: rounded card with a soft shadow, muted small-caps caption, rounded rows, accent-colored selection, thin scrollbar. The month grid of the "custom time" date field follows the same grammar. Light colors only — dark mode comes from the app-wide inversion filter.

**Bonus, same root area.** The field itself stayed narrower than its column: react-datepicker wraps its input in an `inline-block` wrapper that shrinks to the input's default size. It is now a block, like every other field of the editor.

## Scope

Applied to every picker of the editor: the five of `ScheduledTrigger.jsx` and the two of `CheckTime.jsx` (the "check the time" step), which had the exact same defect.

## Checks

- `prettier-check`, `eslint` (0 errors), `compare-translations`, `npm run build`: all pass
- Verified with Playwright on a real mount of the component: the popup is a direct child of `<body>`, positioned exactly under the field (same `left`, `top` = field bottom + 10px) on first open, and `elementFromPoint` inside the popup returns a time-list item — nothing covers it anymore.


<img width="497" height="447" alt="Capture d’écran 2026-08-22 à 11 11 34" src="https://github.com/user-attachments/assets/d1363242-4103-4735-a6f5-ce4bce0b001a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated scene editor date and time pickers with a polished themed appearance, including rounded panels, shadows, improved typography, and clearer selected and hover states.
  * Improved date-picker layout so fields use the available column width.
  * Ensured picker menus display above sticky interface elements and remain properly positioned in the scene editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->