### PR TITLE
Scene editor: stop truncating the scene name on mobile

### DIFF
--- a/front/src/routes/scene/edit-scene/EditScenePage.jsx
+++ b/front/src/routes/scene/edit-scene/EditScenePage.jsx
@@ -36,7 +36,7 @@ const EditScenePage = ({ children, ...props }) => {
           <div class={cx('container', style.pageContainer)}>
             <div class="mb-4">
               <div class="row justify-content-between">
-                <div class="col-7 col-md-8">
+                <div class={cx('col', style.pageTitleColumn)}>
                   <h1 class={cx('page-title', style.pageTitle)}>
                     <Localizer>
                       <button
@@ -55,7 +55,7 @@ const EditScenePage = ({ children, ...props }) => {
                     <span class={style.sceneName}>{props.scene.name}</span>
 
                     {/* The active flag is patched on its own: keep it from racing a full save */}
-                    <label className="custom-switch m-0 ml-4">
+                    <label className="custom-switch m-0 ml-3 ml-md-4">
                       <input
                         type="checkbox"
                         name="active"
@@ -70,7 +70,7 @@ const EditScenePage = ({ children, ...props }) => {
                   </h1>
                 </div>
 
-                <div class="col-5 col-md-4">
+                <div class="col-auto">
                   <div class="text-right">
                     <Localizer>
                       <button

--- a/front/src/routes/scene/edit-scene/style.css
+++ b/front/src/routes/scene/edit-scene/style.css
@@ -29,6 +29,13 @@
   padding-bottom: 6rem;
 }
 
+/* The title column shrinks with the scene name: without min-width, the flex
+   item refuses to go below the intrinsic width of the name and the ellipsis
+   never kicks in */
+.pageTitleColumn {
+  min-width: 0;
+}
+
 .pageTitle {
   display: flex;
   align-items: center;
@@ -62,6 +69,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  min-width: 0;
 }
 
 /* On small screens the header action buttons are icon-only: make them compact


### PR DESCRIPTION
## Problem

In the scene editor on mobile, the scene name is cut down to a couple of characters (`Te…`), even for short names.

The header locked the title into a fixed `col-7` / `col-5` grid. On mobile the settings button is icon-only (~32px wide) but its column still took 42% of the width, while the title column had to fit the back button, the icon tile, the name **and** the active switch in the remaining 58%. On a 375px screen that left roughly 45px for the name.

## Fix

`front/src/routes/scene/edit-scene/`:

- the title column becomes a fluid `col` and the settings column a `col-auto`, so the button takes only the width it needs (icon on mobile, icon + label on desktop) and the name gets all the remaining space;
- `min-width: 0` on the new `.pageTitleColumn` and on `.sceneName` — a flex item otherwise refuses to shrink below its intrinsic width and the ellipsis never kicks in;
- the active switch margin drops from `ml-4` to `ml-3` under 768px only.

On a 375px screen the name now has ~165px instead of ~45px. Desktop is unchanged apart from long names, which get more room than before.

## Checks

- `npm run prettier-check`, `npm run eslint` (0 error) and `npm run build` pass in `front/`.
- No `data-cy` selector changed, so the scene Cypress spec is untouched.

<img width="498" height="310" alt="Capture d’écran 2026-08-22 à 11 29 40" src="https://github.com/user-attachments/assets/210e6800-52f3-4c1a-85f4-09214386ea78" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the scene editor header layout across screen sizes.
  * Scene names now truncate cleanly when space is limited.
  * Adjusted spacing and sizing for the active toggle and settings actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->