### PR TITLE
Scenes: don't force a space after a variable inserted in a text

### DIFF
--- a/front/src/components/scene/TextWithVariablesInjected.jsx
+++ b/front/src/components/scene/TextWithVariablesInjected.jsx
@@ -9,6 +9,8 @@ import { isVariableAvailableAtThisPath, convertPathToText } from '../../routes/s
 
 const OPENING_VARIABLE = '{{';
 const CLOSING_VARIABLE = '}}';
+const ZERO_WIDTH_SPACE = '\u200B';
+const NON_BREAKING_SPACE = '\u00A0';
 
 class TextWithVariablesInjected extends Component {
   setRef = dom => (this.tagifyInputRef = dom);
@@ -29,7 +31,14 @@ class TextWithVariablesInjected extends Component {
         maxItems: 200
       },
       whitelist: this.state.variableWhileList,
-      mixTagsInterpolator: [OPENING_VARIABLE, CLOSING_VARIABLE]
+      mixTagsInterpolator: [OPENING_VARIABLE, CLOSING_VARIABLE],
+      mixMode: {
+        // By default, Tagify inserts a non-breaking space after each variable, and this space
+        // ends up in the saved text (breaking JSON/MQTT payloads). We insert a zero-width space
+        // instead: the caret stays right after the variable so the user can keep typing
+        // (with or without a space), but nothing visible is added to the text.
+        insertAfterTag: ZERO_WIDTH_SPACE
+      }
     });
     const text = this.props.text || '';
     this.tagify.loadOriginalValues(text);
@@ -97,6 +106,12 @@ class TextWithVariablesInjected extends Component {
   };
   parseText = async textContent => {
     let text = textContent ? textContent : '';
+    // The zero-width spaces used to place the caret after a variable are not part of the text
+    // and non-breaking spaces (inserted by older versions of Gladys, or by the browser in
+    // contenteditable elements) are replaced by regular spaces, otherwise the text sent
+    // (MQTT payload, HTTP body, ...) would be invalid.
+    text = text.replaceAll(ZERO_WIDTH_SPACE, '');
+    text = text.replaceAll(NON_BREAKING_SPACE, ' ');
     const variableWhileListSorted = this.state.variableWhileList.sort((a, b) => b.id.length - a.id.length);
     variableWhileListSorted.forEach(variable => {
       text = text.replaceAll(variable.text, `${OPENING_VARIABLE}${variable.id}${CLOSING_VARIABLE}`);


### PR DESCRIPTION
Implements feature request: https://community.gladysassistant.com/t/scenes-supprimer-lespace-insere-automatiquement-apres-lappel-dune-variable/10683

### Description

When a variable is inserted in a scene action text (`TextWithVariablesInjected`, used by the MQTT, Zigbee2mqtt, notification, SMS, HTTP request, set variable, delay, condition… actions), Tagify appends a non-breaking space right after the injected tag. That space ends up in the text saved in the scene, so a payload typed as `{"state":"ON","brightness":{{1.0.last_value}}}` is actually stored as `{"state":"ON","brightness":{{1.0.last_value}} }`, and Zigbee2mqtt rejects it with `z2m: Invalid message 'undefined', skipping...`. Users currently have to delete that space by hand after every variable insertion.

**What changed** (a single file, `front/src/components/scene/TextWithVariablesInjected.jsx`):

1. `mixMode.insertAfterTag` is set to a zero-width space (``) instead of Tagify's default non-breaking space (` `, see `DEFAULTS.mixMode` in Tagify 4.5.0).
2. `parseText` strips zero-width spaces, and normalizes any remaining non-breaking space into a regular space, before the text is handed back to the action.

**Why a zero-width space rather than removing the inserted node entirely (`insertAfterTag: ''`)?** In Tagify 4.5.0, a variable picked in the dropdown goes through `prefixedTextToTag`, which ends with `var elm = this.insertAfterTag(tagElm) || tagElm; this.placeCaretAfterNode(elm)`. `placeCaretAfterNode` does `range.setStartBefore(node.nextSibling || node)`, so it relies on a real text node existing after the tag to anchor the caret — with an empty `insertAfterTag` the caret can land *before* the tag whenever that sibling is missing (for instance when the tag is appended instead of replacing typed text). Keeping a zero-width text node preserves exactly today's DOM shape and caret behaviour (Tagify itself uses `` as a caret anchor in `fixFirefoxLastTagNoCaret`), it is simply invisible and stripped when the text is read back. The result: typing right after a variable produces no space, and typing a space produces exactly one regular space — so `Il fait {{temp}} degrés` is still perfectly typeable.

The non-breaking space normalization also repairs scenes saved with previous versions of Gladys (the injected NBSP becomes a regular space, which keeps a JSON payload valid) and the non-breaking spaces browsers insert into `contenteditable` elements, without gluing words together (deliberately never deleting a space the user may have wanted).

This PR was produced by an automated run.

## Forum

Forum: https://community.gladysassistant.com/t/scenes-supprimer-lespace-insere-automatiquement-apres-lappel-dune-variable/10683

### Checklist

- [ ] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

Notes on the checklist: no server code is touched, so `server` tests are unaffected; `npm run eslint` in `front` reports 0 errors (only pre-existing warnings) and `prettier --check` passes on the changed file. Cypress was not run in this environment (the Cypress binary could not be downloaded), and the caret behaviour was reviewed against the Tagify 4.5.0 sources rather than verified in a real browser, so a quick manual check in the scene editor is welcome. The text normalization was verified with a standalone simulation of `parseText` covering: variable followed by nothing, variable followed by a typed space, and legacy texts containing the previously injected non-breaking space.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf5kSG9xiBoF41gdY8N1gJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of spaces around injected variables.
  * Prevented invisible spacing characters from appearing in displayed or saved text.
  * Preserved regular spaces when converting and persisting variable content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->