### PR TITLE
Free Mobile: flag the built-in integration as soon deprecated

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -1262,7 +1262,7 @@
       "description": "SMS von Gladys über Free Mobile senden.",
       "deprecatedWarning": {
         "title": "Integration bald veraltet",
-        "description": "Diese integrierte Integration wird in einer künftigen Gladys-Version entfernt. Sie wird durch die Community-Integration <b>Free Mobile SMS</b> ersetzt, die dieselben Funktionen bietet und weiterhin gepflegt wird. Installiere sie über den <a href=\"/dashboard/integration/notifications\">Integrationskatalog</a> und stelle anschließend deine SMS-Szenen darauf um."
+        "description": "Diese integrierte Integration wird in einer künftigen Gladys-Version entfernt. Sie wird durch die Community-Integration <b>Free Mobile SMS</b> ersetzt, die dieselben Funktionen bietet und weiterhin gepflegt wird. Installiere sie über den <a href=\"/dashboard/integration/notifications\">Integrationskatalog</a> und hinterlege anschließend deine Free-Mobile-Zugangsdaten in deinem Benutzerprofil. In deinen Szenen nutzt die Aktion <b>SMS senden</b> weiterhin diese integrierte Integration: Ersetze sie durch eine Aktion <b>Nachricht senden</b>, die den Kanal Free Mobile SMS anspricht."
       },
       "documentation": "Free Mobile Dokumentation",
       "introduction": "Dieses Plugin ermöglicht es Ihnen, SMS an Ihr Free-Handy über den Benachrichtigungsdienst von Free zu senden. Geben Sie Ihre Kundennummer und den Identifizierungsschlüssel unten ein, den Sie auf der <a href=\"https://mobile.free.fr\"> FreeMobile</a>-Website finden.",
@@ -3305,6 +3305,8 @@
         "explanationText": "Um eine Variable einzufügen, geben Sie '{{' ein. Achten Sie darauf, dass Sie zuvor eine Variable in einer Aktion 'Letzten Zustand abrufen' definiert haben, die vor diesem Nachrichtenblock platziert wurde."
       },
       "smsSend": {
+        "deprecatedTitle": "Aktion bald veraltet",
+        "deprecatedDescription": "Diese Aktion nutzt die integrierte Free-Mobile-Integration, die in einer künftigen Gladys-Version entfernt wird. Installiere die Community-Integration <b>Free Mobile SMS</b>, hinterlege deine Zugangsdaten in deinem Benutzerprofil und ersetze diese Aktion anschließend durch eine Aktion <b>Nachricht senden</b>, die den Kanal Free Mobile SMS anspricht.",
         "textLabel": "Nachricht",
         "explanationText": "Um eine Variable in den Text einzufügen, gib \"{{\" ein. Um einen Variablenwert festzulegen, musst du zuerst das Feld \"Eine Variable definieren\" oder \"Gerätewert abrufen\" verwenden.",
         "messagePlaceholder": "Meine Message"
@@ -3983,6 +3985,7 @@
     },
     "searchActionsPlaceholder": "Aktion suchen…",
     "searchTriggersPlaceholder": "Auslöser suchen…",
+    "deprecatedActionBadge": "Bald veraltet",
     "noResultsFound": "Keine Ergebnisse",
     "whenSectionTitle": "Wenn",
     "whenSectionSubtitle": "die Szene startet, sobald eines dieser Ereignisse eintritt",

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -1262,7 +1262,7 @@
       "description": "SMS von Gladys über Free Mobile senden.",
       "deprecatedWarning": {
         "title": "Integration bald veraltet",
-        "description": "Diese integrierte Integration wird in einer künftigen Gladys-Version entfernt. Sie wird durch die Community-Integration <b>Free Mobile SMS</b> ersetzt, die dieselben Funktionen bietet und weiterhin gepflegt wird. Installiere sie über den <a href=\"/dashboard/integration/notifications\">Integrationskatalog</a> und hinterlege anschließend deine Free-Mobile-Zugangsdaten im Bereich <b>Mein Konto</b> im Tab <b>Konfiguration</b> dieser Integration — jeder Gladys-Benutzer trägt seine eigenen ein. In deinen Szenen nutzt die Aktion <b>SMS senden</b> weiterhin diese integrierte Integration: Ersetze sie durch eine Aktion <b>Nachricht senden</b>, die den Kanal Free Mobile SMS und den Gladys-Benutzer anspricht, dessen Konto konfiguriert ist."
+        "description": "Diese native Integration wird in einer künftigen Gladys-Version entfernt. Sie wird durch die Community-Integration <b>Free Mobile SMS</b> ersetzt, die dieselben Funktionen bietet und weiterhin gepflegt wird. Installiere sie über den <a href=\"/dashboard/integration/notifications\">Integrationskatalog</a> und hinterlege anschließend deine Free-Mobile-Zugangsdaten im Bereich <b>Mein Konto</b> im Tab <b>Konfiguration</b> dieser Integration — jeder Gladys-Benutzer trägt seine eigenen ein. In deinen Szenen nutzt die Aktion <b>SMS senden</b> weiterhin diese native Integration: Ersetze sie durch eine Aktion <b>Nachricht senden</b>, die den Kanal Free Mobile SMS und den Gladys-Benutzer anspricht, dessen Konto konfiguriert ist."
       },
       "documentation": "Free Mobile Dokumentation",
       "introduction": "Dieses Plugin ermöglicht es Ihnen, SMS an Ihr Free-Handy über den Benachrichtigungsdienst von Free zu senden. Geben Sie Ihre Kundennummer und den Identifizierungsschlüssel unten ein, den Sie auf der <a href=\"https://mobile.free.fr\"> FreeMobile</a>-Website finden.",
@@ -3306,7 +3306,7 @@
       },
       "smsSend": {
         "deprecatedTitle": "Aktion bald veraltet",
-        "deprecatedDescription": "Diese Aktion nutzt die integrierte Free-Mobile-Integration, die in einer künftigen Gladys-Version entfernt wird. Installiere die Community-Integration <b>Free Mobile SMS</b>, hinterlege deine Free-Mobile-Zugangsdaten im Bereich <b>Mein Konto</b> im Tab <b>Konfiguration</b> dieser Integration und ersetze diese Aktion anschließend durch eine Aktion <b>Nachricht senden</b>, die den Kanal Free Mobile SMS und den Gladys-Benutzer anspricht, dessen Konto konfiguriert ist.",
+        "deprecatedDescription": "Diese Aktion nutzt die native Free-Mobile-Integration, die in einer künftigen Gladys-Version entfernt wird. Installiere die Community-Integration <b>Free Mobile SMS</b>, hinterlege deine Free-Mobile-Zugangsdaten im Bereich <b>Mein Konto</b> im Tab <b>Konfiguration</b> dieser Integration und ersetze diese Aktion anschließend durch eine Aktion <b>Nachricht senden</b>, die den Kanal Free Mobile SMS und den Gladys-Benutzer anspricht, dessen Konto konfiguriert ist.",
         "textLabel": "Nachricht",
         "explanationText": "Um eine Variable in den Text einzufügen, gib \"{{\" ein. Um einen Variablenwert festzulegen, musst du zuerst das Feld \"Eine Variable definieren\" oder \"Gerätewert abrufen\" verwenden.",
         "messagePlaceholder": "Meine Message"

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -1262,7 +1262,7 @@
       "description": "SMS von Gladys über Free Mobile senden.",
       "deprecatedWarning": {
         "title": "Integration bald veraltet",
-        "description": "Diese integrierte Integration wird in einer künftigen Gladys-Version entfernt. Sie wird durch die Community-Integration <b>Free Mobile SMS</b> ersetzt, die dieselben Funktionen bietet und weiterhin gepflegt wird. Installiere sie über den <a href=\"/dashboard/integration/notifications\">Integrationskatalog</a> und hinterlege anschließend deine Free-Mobile-Zugangsdaten in deinem Benutzerprofil. In deinen Szenen nutzt die Aktion <b>SMS senden</b> weiterhin diese integrierte Integration: Ersetze sie durch eine Aktion <b>Nachricht senden</b>, die den Kanal Free Mobile SMS anspricht."
+        "description": "Diese integrierte Integration wird in einer künftigen Gladys-Version entfernt. Sie wird durch die Community-Integration <b>Free Mobile SMS</b> ersetzt, die dieselben Funktionen bietet und weiterhin gepflegt wird. Installiere sie über den <a href=\"/dashboard/integration/notifications\">Integrationskatalog</a> und hinterlege anschließend deine Free-Mobile-Zugangsdaten im Bereich <b>Mein Konto</b> im Tab <b>Konfiguration</b> dieser Integration — jeder Gladys-Benutzer trägt seine eigenen ein. In deinen Szenen nutzt die Aktion <b>SMS senden</b> weiterhin diese integrierte Integration: Ersetze sie durch eine Aktion <b>Nachricht senden</b>, die den Kanal Free Mobile SMS und den Gladys-Benutzer anspricht, dessen Konto konfiguriert ist."
       },
       "documentation": "Free Mobile Dokumentation",
       "introduction": "Dieses Plugin ermöglicht es Ihnen, SMS an Ihr Free-Handy über den Benachrichtigungsdienst von Free zu senden. Geben Sie Ihre Kundennummer und den Identifizierungsschlüssel unten ein, den Sie auf der <a href=\"https://mobile.free.fr\"> FreeMobile</a>-Website finden.",
@@ -3306,7 +3306,7 @@
       },
       "smsSend": {
         "deprecatedTitle": "Aktion bald veraltet",
-        "deprecatedDescription": "Diese Aktion nutzt die integrierte Free-Mobile-Integration, die in einer künftigen Gladys-Version entfernt wird. Installiere die Community-Integration <b>Free Mobile SMS</b>, hinterlege deine Zugangsdaten in deinem Benutzerprofil und ersetze diese Aktion anschließend durch eine Aktion <b>Nachricht senden</b>, die den Kanal Free Mobile SMS anspricht.",
+        "deprecatedDescription": "Diese Aktion nutzt die integrierte Free-Mobile-Integration, die in einer künftigen Gladys-Version entfernt wird. Installiere die Community-Integration <b>Free Mobile SMS</b>, hinterlege deine Free-Mobile-Zugangsdaten im Bereich <b>Mein Konto</b> im Tab <b>Konfiguration</b> dieser Integration und ersetze diese Aktion anschließend durch eine Aktion <b>Nachricht senden</b>, die den Kanal Free Mobile SMS und den Gladys-Benutzer anspricht, dessen Konto konfiguriert ist.",
         "textLabel": "Nachricht",
         "explanationText": "Um eine Variable in den Text einzufügen, gib \"{{\" ein. Um einen Variablenwert festzulegen, musst du zuerst das Feld \"Eine Variable definieren\" oder \"Gerätewert abrufen\" verwenden.",
         "messagePlaceholder": "Meine Message"

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -1260,6 +1260,10 @@
     "free-mobile": {
       "title": "Free Mobile",
       "description": "SMS von Gladys über Free Mobile senden.",
+      "deprecatedWarning": {
+        "title": "Integration bald veraltet",
+        "description": "Diese integrierte Integration wird in einer künftigen Gladys-Version entfernt. Sie wird durch die Community-Integration <b>Free Mobile SMS</b> ersetzt, die dieselben Funktionen bietet und weiterhin gepflegt wird. Installiere sie über den <a href=\"/dashboard/integration/notifications\">Integrationskatalog</a> und stelle anschließend deine SMS-Szenen darauf um."
+      },
       "documentation": "Free Mobile Dokumentation",
       "introduction": "Dieses Plugin ermöglicht es Ihnen, SMS an Ihr Free-Handy über den Benachrichtigungsdienst von Free zu senden. Geben Sie Ihre Kundennummer und den Identifizierungsschlüssel unten ein, den Sie auf der <a href=\"https://mobile.free.fr\"> FreeMobile</a>-Website finden.",
       "username": "Free Mobile Kundennummer",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -1262,7 +1262,7 @@
       "description": "Send SMS from Gladys using Free Mobile.",
       "deprecatedWarning": {
         "title": "Integration soon deprecated",
-        "description": "This built-in integration will be removed in a future version of Gladys. It is replaced by the community integration <b>Free Mobile SMS</b>, which offers the same features and will keep being maintained. Head to the <a href=\"/dashboard/integration/notifications\">integration catalog</a> to install it, then set your Free Mobile credentials in your user profile. In your scenes, the <b>Send SMS</b> action keeps using this built-in integration: replace it with a <b>Send Message</b> action targeting the Free Mobile SMS channel."
+        "description": "This built-in integration will be removed in a future version of Gladys. It is replaced by the community integration <b>Free Mobile SMS</b>, which offers the same features and will keep being maintained. Head to the <a href=\"/dashboard/integration/notifications\">integration catalog</a> to install it, then enter your Free Mobile credentials in the <b>My account</b> section of the <b>Configuration</b> tab of that integration — each Gladys user fills in their own. In your scenes, the <b>Send SMS</b> action keeps using this built-in integration: replace it with a <b>Send Message</b> action targeting the Free Mobile SMS channel and the Gladys user whose account is configured."
       },
       "documentation": "Free Mobile Documentation",
       "introduction": "This plugin allows you to send SMS to your Free cell phone via the notification service provided by Free. Enter your customer ID and the identification key below, which you can find on the <a href=\"https://mobile.free.fr\"> FreeMobile</a> website.",
@@ -3306,7 +3306,7 @@
       },
       "smsSend": {
         "deprecatedTitle": "Action soon deprecated",
-        "deprecatedDescription": "This action uses the built-in Free Mobile integration, which will be removed in a future version of Gladys. Install the community integration <b>Free Mobile SMS</b>, set your credentials in your user profile, then replace this action with a <b>Send Message</b> action targeting the Free Mobile SMS channel.",
+        "deprecatedDescription": "This action uses the built-in Free Mobile integration, which will be removed in a future version of Gladys. Install the community integration <b>Free Mobile SMS</b>, enter your Free Mobile credentials in the <b>My account</b> section of the <b>Configuration</b> tab of that integration, then replace this action with a <b>Send Message</b> action targeting the Free Mobile SMS channel and the Gladys user whose account is configured.",
         "textLabel": "Message",
         "explanationText": "To inject a variable in the text, press '{{'. To set a variable value, you need to use a 'Set a variable' or 'Get device value' box before this one.",
         "messagePlaceholder": "My message"

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -1262,7 +1262,7 @@
       "description": "Send SMS from Gladys using Free Mobile.",
       "deprecatedWarning": {
         "title": "Integration soon deprecated",
-        "description": "This built-in integration will be removed in a future version of Gladys. It is replaced by the community integration <b>Free Mobile SMS</b>, which offers the same features and will keep being maintained. Head to the <a href=\"/dashboard/integration/notifications\">integration catalog</a> to install it, then update your SMS scenes to use it."
+        "description": "This built-in integration will be removed in a future version of Gladys. It is replaced by the community integration <b>Free Mobile SMS</b>, which offers the same features and will keep being maintained. Head to the <a href=\"/dashboard/integration/notifications\">integration catalog</a> to install it, then set your Free Mobile credentials in your user profile. In your scenes, the <b>Send SMS</b> action keeps using this built-in integration: replace it with a <b>Send Message</b> action targeting the Free Mobile SMS channel."
       },
       "documentation": "Free Mobile Documentation",
       "introduction": "This plugin allows you to send SMS to your Free cell phone via the notification service provided by Free. Enter your customer ID and the identification key below, which you can find on the <a href=\"https://mobile.free.fr\"> FreeMobile</a> website.",
@@ -3305,6 +3305,8 @@
         "explanationText": "To insert a variable, type '{{'. To set a variable value, you need to use a 'Set a variable' or 'Get device value' box before this one."
       },
       "smsSend": {
+        "deprecatedTitle": "Action soon deprecated",
+        "deprecatedDescription": "This action uses the built-in Free Mobile integration, which will be removed in a future version of Gladys. Install the community integration <b>Free Mobile SMS</b>, set your credentials in your user profile, then replace this action with a <b>Send Message</b> action targeting the Free Mobile SMS channel.",
         "textLabel": "Message",
         "explanationText": "To inject a variable in the text, press '{{'. To set a variable value, you need to use a 'Set a variable' or 'Get device value' box before this one.",
         "messagePlaceholder": "My message"
@@ -3983,6 +3985,7 @@
     },
     "searchActionsPlaceholder": "Search for an action…",
     "searchTriggersPlaceholder": "Search for a trigger…",
+    "deprecatedActionBadge": "Soon deprecated",
     "noResultsFound": "No results",
     "whenSectionTitle": "When",
     "whenSectionSubtitle": "the scene starts as soon as any one of these events occurs",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -1260,6 +1260,10 @@
     "free-mobile": {
       "title": "Free Mobile",
       "description": "Send SMS from Gladys using Free Mobile.",
+      "deprecatedWarning": {
+        "title": "Integration soon deprecated",
+        "description": "This built-in integration will be removed in a future version of Gladys. It is replaced by the community integration <b>Free Mobile SMS</b>, which offers the same features and will keep being maintained. Head to the <a href=\"/dashboard/integration/notifications\">integration catalog</a> to install it, then update your SMS scenes to use it."
+      },
       "documentation": "Free Mobile Documentation",
       "introduction": "This plugin allows you to send SMS to your Free cell phone via the notification service provided by Free. Enter your customer ID and the identification key below, which you can find on the <a href=\"https://mobile.free.fr\"> FreeMobile</a> website.",
       "username": "Free Mobile Customer ID",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -1500,7 +1500,7 @@
       "description": "Envoyer des sms depuis Gladys grâce à Free Mobile.",
       "deprecatedWarning": {
         "title": "Intégration bientôt dépréciée",
-        "description": "Cette intégration native sera supprimée dans une prochaine version de Gladys. Elle est remplacée par l'intégration communautaire <b>Free Mobile SMS</b>, qui offre les mêmes fonctionnalités et continuera d'être maintenue. Rendez-vous dans le <a href=\"/dashboard/integration/notifications\">catalogue des intégrations</a> pour l'installer, puis reconfigurez vos scènes d'envoi de SMS avec celle-ci."
+        "description": "Cette intégration native sera supprimée dans une prochaine version de Gladys. Elle est remplacée par l'intégration communautaire <b>Free Mobile SMS</b>, qui offre les mêmes fonctionnalités et continuera d'être maintenue. Rendez-vous dans le <a href=\"/dashboard/integration/notifications\">catalogue des intégrations</a> pour l'installer, puis renseignez vos identifiants Free Mobile dans votre profil utilisateur. Dans vos scènes, l'action <b>Envoyer un sms</b> continue d'utiliser cette intégration native : remplacez-la par une action <b>Envoyer un message</b> ciblant le canal Free Mobile SMS."
       },
       "documentation": "Documentation Free Mobile",
       "introduction": "Ce plugin vous permet d'envoyer des sms à votre portable Free via le service de notification proposé par Free. Entrez votre identifiant client et la clé d'identification ci-dessous que vous retrouverez sur le site <a href=\"https://mobile.free.fr\"> FreeMobile</a>.",
@@ -3305,6 +3305,8 @@
         "explanationText": "Pour injecter une variable, tapez '{{'. Attention, vous devez avoir défini une variable auparavant dans une action 'Définir une variable' ou 'Récupérer le dernier état' placée avant ce bloc message."
       },
       "smsSend": {
+        "deprecatedTitle": "Action bientôt dépréciée",
+        "deprecatedDescription": "Cette action utilise l'intégration native Free Mobile, qui sera supprimée dans une prochaine version de Gladys. Installez l'intégration communautaire <b>Free Mobile SMS</b>, renseignez vos identifiants dans votre profil utilisateur, puis remplacez cette action par une action <b>Envoyer un message</b> ciblant le canal Free Mobile SMS.",
         "textLabel": "Message",
         "explanationText": "Pour injecter une variable, tapez '{{'. Attention, vous devez avoir défini une variable auparavant dans une action 'Définir une variable' ou 'Récupérer le dernier état' placée avant ce bloc message.",
         "messagePlaceholder": "Mon message"
@@ -3983,6 +3985,7 @@
     },
     "searchActionsPlaceholder": "Rechercher une action…",
     "searchTriggersPlaceholder": "Rechercher un déclencheur…",
+    "deprecatedActionBadge": "Bientôt dépréciée",
     "noResultsFound": "Aucun résultat",
     "whenSectionTitle": "Quand",
     "whenSectionSubtitle": "la scène démarre dès qu'un seul de ces événements se produit",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -1500,7 +1500,7 @@
       "description": "Envoyer des sms depuis Gladys grâce à Free Mobile.",
       "deprecatedWarning": {
         "title": "Intégration bientôt dépréciée",
-        "description": "Cette intégration native sera supprimée dans une prochaine version de Gladys. Elle est remplacée par l'intégration communautaire <b>Free Mobile SMS</b>, qui offre les mêmes fonctionnalités et continuera d'être maintenue. Rendez-vous dans le <a href=\"/dashboard/integration/notifications\">catalogue des intégrations</a> pour l'installer, puis renseignez vos identifiants Free Mobile dans votre profil utilisateur. Dans vos scènes, l'action <b>Envoyer un sms</b> continue d'utiliser cette intégration native : remplacez-la par une action <b>Envoyer un message</b> ciblant le canal Free Mobile SMS."
+        "description": "Cette intégration native sera supprimée dans une prochaine version de Gladys. Elle est remplacée par l'intégration communautaire <b>Free Mobile SMS</b>, qui offre les mêmes fonctionnalités et continuera d'être maintenue. Rendez-vous dans le <a href=\"/dashboard/integration/notifications\">catalogue des intégrations</a> pour l'installer, puis renseignez vos identifiants Free Mobile dans le bloc <b>Mon compte</b> de l'onglet <b>Configuration</b> de cette intégration — chaque utilisateur Gladys saisit les siens. Dans vos scènes, l'action <b>Envoyer un sms</b> continue d'utiliser cette intégration native : remplacez-la par une action <b>Envoyer un message</b> ciblant le canal Free Mobile SMS et l'utilisateur Gladys dont le compte est configuré."
       },
       "documentation": "Documentation Free Mobile",
       "introduction": "Ce plugin vous permet d'envoyer des sms à votre portable Free via le service de notification proposé par Free. Entrez votre identifiant client et la clé d'identification ci-dessous que vous retrouverez sur le site <a href=\"https://mobile.free.fr\"> FreeMobile</a>.",
@@ -3306,7 +3306,7 @@
       },
       "smsSend": {
         "deprecatedTitle": "Action bientôt dépréciée",
-        "deprecatedDescription": "Cette action utilise l'intégration native Free Mobile, qui sera supprimée dans une prochaine version de Gladys. Installez l'intégration communautaire <b>Free Mobile SMS</b>, renseignez vos identifiants dans votre profil utilisateur, puis remplacez cette action par une action <b>Envoyer un message</b> ciblant le canal Free Mobile SMS.",
+        "deprecatedDescription": "Cette action utilise l'intégration native Free Mobile, qui sera supprimée dans une prochaine version de Gladys. Installez l'intégration communautaire <b>Free Mobile SMS</b>, renseignez vos identifiants Free Mobile dans le bloc <b>Mon compte</b> de l'onglet <b>Configuration</b> de cette intégration, puis remplacez cette action par une action <b>Envoyer un message</b> ciblant le canal Free Mobile SMS et l'utilisateur Gladys dont le compte est configuré.",
         "textLabel": "Message",
         "explanationText": "Pour injecter une variable, tapez '{{'. Attention, vous devez avoir défini une variable auparavant dans une action 'Définir une variable' ou 'Récupérer le dernier état' placée avant ce bloc message.",
         "messagePlaceholder": "Mon message"

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -1498,6 +1498,10 @@
     "free-mobile": {
       "title": "Free Mobile",
       "description": "Envoyer des sms depuis Gladys grâce à Free Mobile.",
+      "deprecatedWarning": {
+        "title": "Intégration bientôt dépréciée",
+        "description": "Cette intégration native sera supprimée dans une prochaine version de Gladys. Elle est remplacée par l'intégration communautaire <b>Free Mobile SMS</b>, qui offre les mêmes fonctionnalités et continuera d'être maintenue. Rendez-vous dans le <a href=\"/dashboard/integration/notifications\">catalogue des intégrations</a> pour l'installer, puis reconfigurez vos scènes d'envoi de SMS avec celle-ci."
+      },
       "documentation": "Documentation Free Mobile",
       "introduction": "Ce plugin vous permet d'envoyer des sms à votre portable Free via le service de notification proposé par Free. Entrez votre identifiant client et la clé d'identification ci-dessous que vous retrouverez sur le site <a href=\"https://mobile.free.fr\"> FreeMobile</a>.",
       "username": "Identifiant client Free Mobile",

--- a/front/src/config/integrations/communications.json
+++ b/front/src/config/integrations/communications.json
@@ -48,6 +48,7 @@
     "img": "/assets/integrations/cover/free-mobile.jpg",
     "whiteBackground": true,
     "cloud": true,
+    "deprecated": true,
     "categories": ["notifications"]
   },
   {

--- a/front/src/routes/integration/all/free-mobile/FreeMobile.jsx
+++ b/front/src/routes/integration/all/free-mobile/FreeMobile.jsx
@@ -33,6 +33,12 @@ const FreeMobilePage = ({ children, ...props }) => (
             </div>
 
             <div class="col-lg-9">
+              <div class="alert alert-warning mb-4">
+                <h4 class="alert-title">
+                  <Text id="integration.free-mobile.deprecatedWarning.title" />
+                </h4>
+                <MarkupText id="integration.free-mobile.deprecatedWarning.description" />
+              </div>
               <div class="card">
                 <div class="card-header">
                   <h1 class="card-title">

--- a/front/src/routes/scene/edit-scene/TypePicker.jsx
+++ b/front/src/routes/scene/edit-scene/TypePicker.jsx
@@ -19,7 +19,7 @@ class TypePicker extends Component {
   };
 
   getVisibleCategories = () => {
-    const { categories, filter, labelPrefix, descriptionPrefix, intl } = this.props;
+    const { categories, filter, labelPrefix, descriptionPrefix, deprecated, intl } = this.props;
     const { query } = this.state;
     const normalizedQuery = normalizeSearchText(query.trim());
 
@@ -30,7 +30,7 @@ class TypePicker extends Component {
           .map(type => {
             const label = get(intl.dictionary, `${labelPrefix}.${type}`, { default: type });
             const description = get(intl.dictionary, `${descriptionPrefix}.${type}`, { default: '' });
-            return { type, label, description };
+            return { type, label, description, deprecated: Boolean(deprecated && deprecated.includes(type)) };
           })
           .filter(
             item =>
@@ -90,7 +90,14 @@ class TypePicker extends Component {
                       <i class={icons[item.type]} />
                     </span>
                     <span class={style.typePickerOptionText}>
-                      <span class={style.typePickerOptionLabel}>{item.label}</span>
+                      <span class={style.typePickerOptionLabel}>
+                        {item.label}
+                        {item.deprecated && (
+                          <span class={cx('badge', 'badge-danger', style.typePickerOptionBadge)}>
+                            <Text id="editScene.deprecatedActionBadge" />
+                          </span>
+                        )}
+                      </span>
                       {item.description && <span class={style.typePickerOptionDescription}>{item.description}</span>}
                     </span>
                   </button>

--- a/front/src/routes/scene/edit-scene/actions/ChooseActionTypeCard.jsx
+++ b/front/src/routes/scene/edit-scene/actions/ChooseActionTypeCard.jsx
@@ -2,7 +2,7 @@ import { Component } from 'preact';
 import { Text } from 'preact-i18n';
 
 import TypePicker from '../TypePicker';
-import { ACTION_CATEGORIES, ACTION_ICON } from '../typesCatalog';
+import { ACTION_CATEGORIES, ACTION_ICON, DEPRECATED_ACTIONS } from '../typesCatalog';
 
 class ChooseActionType extends Component {
   selectActionType = actionType => {
@@ -21,6 +21,7 @@ class ChooseActionType extends Component {
           <TypePicker
             categories={ACTION_CATEGORIES}
             icons={ACTION_ICON}
+            deprecated={DEPRECATED_ACTIONS}
             filter={props.action && props.action.filter}
             labelPrefix="editScene.actions"
             descriptionPrefix="editScene.actionsDescriptions"

--- a/front/src/routes/scene/edit-scene/actions/SendSms.jsx
+++ b/front/src/routes/scene/edit-scene/actions/SendSms.jsx
@@ -1,6 +1,6 @@
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
-import { Localizer, Text } from 'preact-i18n';
+import { Localizer, MarkupText, Text } from 'preact-i18n';
 
 import TextWithVariablesInjected from '../../../../components/scene/TextWithVariablesInjected';
 
@@ -12,6 +12,12 @@ class SendSms extends Component {
   render(props, {}) {
     return (
       <div>
+        <div class="alert alert-warning">
+          <h4 class="alert-title">
+            <Text id="editScene.actionsCard.smsSend.deprecatedTitle" />
+          </h4>
+          <MarkupText id="editScene.actionsCard.smsSend.deprecatedDescription" />
+        </div>
         <div class="form-group">
           <label class="form-label">
             <Text id="editScene.actionsCard.smsSend.textLabel" />{' '}

--- a/front/src/routes/scene/edit-scene/style.css
+++ b/front/src/routes/scene/edit-scene/style.css
@@ -373,6 +373,12 @@
   line-height: 1.3;
 }
 
+.typePickerOptionBadge {
+  margin-left: 0.375rem;
+  font-size: 0.625rem;
+  vertical-align: middle;
+}
+
 .typePickerOptionDescription {
   font-size: 0.8125rem;
   color: #6e7687;

--- a/front/src/routes/scene/edit-scene/typesCatalog.js
+++ b/front/src/routes/scene/edit-scene/typesCatalog.js
@@ -40,6 +40,10 @@ export const ACTION_ICON = {
   [ACTIONS.TIME.GET_DATE]: 'fe fe-clock'
 };
 
+// Action types on their way out. They stay in the picker because existing scenes
+// still use them, but they carry a "soon deprecated" badge.
+export const DEPRECATED_ACTIONS = [ACTIONS.SMS.SEND];
+
 // Icons used for each trigger type, in the picker and in the trigger card headers
 export const TRIGGER_ICON = {
   [EVENTS.DEVICE.NEW_STATE]: 'fe fe-activity',


### PR DESCRIPTION
The external "Free Mobile SMS" integration now covers the same feature set and will keep being maintained, so the built-in service is on its way out.

Flag it with `deprecated: true` in the catalog, which is all it takes to get the red "Soon deprecated" badge on the card and list views, the same way OpenWeather does it. The badge alone doesn't say what to migrate to, so the integration page also gets a warning banner pointing at the replacement, following the Xiaomi pattern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deprecation notice to the Free Mobile integration page, with guidance for configuring per-user credentials.
  * Deprecated SMS scene actions are labeled in the action picker and show migration guidance when edited.
  * Added localized messaging in English, French, and German.
  * Expanded translations for device history exports, weather alerts, voice input, host controls, siren and battery states, trials, and two-factor authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->