### PR TITLE
Zigbee2mqtt: support enum presence sensors

### DIFF
--- a/server/services/zigbee2mqtt/exposes/enumType.js
+++ b/server/services/zigbee2mqtt/exposes/enumType.js
@@ -178,6 +178,11 @@ addMapping('liquid_state', LIQUID_STATE.LOW, 'low');
 addMapping('liquid_state', LIQUID_STATE.NORMAL, 'normal');
 addMapping('liquid_state', LIQUID_STATE.HIGH, 'high');
 
+// Excellux ZG-104PLV motion sensor
+// https://www.zigbee2mqtt.io/devices/ZG-104PLV.html
+addMapping('presence', 0, 'false');
+addMapping('presence', 1, 'true');
+
 // SONOFF SWV water valve
 // https://www.zigbee2mqtt.io/devices/SWV.html
 addMapping('current_device_status', WATER_VALVE_CURRENT_DEVICE_STATUS.NORMAL_STATE, 'normal_state');
@@ -245,7 +250,7 @@ module.exports = {
       return melodyNumber === null ? undefined : parseInt(melodyNumber[1], 10);
     }
 
-    const subValue = value.replace(/^(\d+_)?/, '');
+    const subValue = `${value}`.replace(/^(\d+_)?/, '');
     return (READ_VALUE_MAPPING[expose.name] || {})[subValue];
   },
   feature: {
@@ -268,6 +273,15 @@ module.exports = {
           max: 1,
           forceOverride: true,
         },
+      },
+    },
+    presence: {
+      feature: {
+        category: DEVICE_FEATURE_CATEGORIES.MOTION_SENSOR,
+        type: DEVICE_FEATURE_TYPES.SENSOR.BINARY,
+        min: 0,
+        max: 1,
+        forceOverride: true,
       },
     },
     volume: {

--- a/server/services/zigbee2mqtt/exposes/enumType.js
+++ b/server/services/zigbee2mqtt/exposes/enumType.js
@@ -178,8 +178,9 @@ addMapping('liquid_state', LIQUID_STATE.LOW, 'low');
 addMapping('liquid_state', LIQUID_STATE.NORMAL, 'normal');
 addMapping('liquid_state', LIQUID_STATE.HIGH, 'high');
 
-// Excellux ZG-104PLV motion sensor
-// https://www.zigbee2mqtt.io/devices/ZG-104PLV.html
+// Before Zigbee2MQTT 2.12.1, the Excellux ZG-104PLV exposed presence as the
+// string enum values "true"/"false". Keep this generic mapping for older converters.
+// https://github.com/Koenkk/zigbee-herdsman-converters/issues/12505
 addMapping('presence', 0, 'false');
 addMapping('presence', 1, 'true');
 
@@ -250,6 +251,7 @@ module.exports = {
       return melodyNumber === null ? undefined : parseInt(melodyNumber[1], 10);
     }
 
+    // Some enum exposes, such as legacy presence, publish booleans instead of strings.
     const subValue = `${value}`.replace(/^(\d+_)?/, '');
     return (READ_VALUE_MAPPING[expose.name] || {})[subValue];
   },

--- a/server/test/services/zigbee2mqtt/exposes/excelluxPresenceEnumType.test.js
+++ b/server/test/services/zigbee2mqtt/exposes/excelluxPresenceEnumType.test.js
@@ -1,0 +1,49 @@
+const { assert, expect } = require('chai');
+
+const enumType = require('../../../../services/zigbee2mqtt/exposes/enumType');
+const { buildFeatures } = require('../../../../services/zigbee2mqtt/utils/features/buildFeatures');
+
+describe('zigbee2mqtt Excellux presence enumType', () => {
+  const expose = {
+    access: 1,
+    name: 'presence',
+    property: 'presence',
+    type: 'enum',
+    values: ['true', 'false'],
+  };
+
+  it('should build a read-only motion sensor feature', () => {
+    const result = buildFeatures('Excellux motion sensor', expose);
+
+    expect(result).to.deep.equal([
+      {
+        read_only: true,
+        has_feedback: false,
+        min: 0,
+        max: 1,
+        category: 'motion-sensor',
+        type: 'binary',
+        unit: null,
+        name: 'Presence',
+        external_id: 'zigbee2mqtt:Excellux motion sensor:motion-sensor:binary:presence',
+        selector: 'zigbee2mqtt-excellux-motion-sensor-motion-sensor-binary-presence',
+      },
+    ]);
+  });
+
+  [
+    { external: true, internal: 1 },
+    { external: false, internal: 0 },
+    { external: 'true', internal: 1 },
+    { external: 'false', internal: 0 },
+  ].forEach(({ external, internal }) => {
+    it(`should read ${external} as ${internal}`, () => {
+      assert.equal(enumType.readValue(expose, external), internal);
+    });
+  });
+
+  it('should map Gladys values to the exposed enum values', () => {
+    assert.equal(enumType.writeValue(expose, 1), 'true');
+    assert.equal(enumType.writeValue(expose, 0), 'false');
+  });
+});


### PR DESCRIPTION
## Summary

- recognize Zigbee2MQTT enum exposes named `presence` as Gladys motion-sensor binary features
- map boolean and string `true`/`false` states to Gladys 1/0 values
- add regression coverage for the Excellux ZG-104PLV expose shape reported in the community

## Validation

- `npm run prettier-check`
- `npm run eslint` (0 errors; 34 existing warnings)
- `npm run test-service --service=zigbee2mqtt` (397 passing)
- full server suite: 6,487 passing, 1 pending; unrelated parallel worker failures remain in scene, MCP, and MQTT tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added presence detection support for Excellux ZG-104PLV devices.
  - Supports boolean and string presence values for motion-sensor status.

- **Bug Fixes**
  - Improved handling of incoming presence values in different formats, including legacy device responses.

- **Tests**
  - Added coverage for presence detection, value conversion, and sensor feature creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->