### PR TITLE
Scene editor: dropdown menus no longer paint under the next step

### DIFF
--- a/front/src/components/device/SelectDeviceFeatureValue.jsx
+++ b/front/src/components/device/SelectDeviceFeatureValue.jsx
@@ -1,5 +1,5 @@
 import { Text } from 'preact-i18n';
-import Select from 'react-select';
+import Select from '../form/Select';
 
 import { isValueInOptions } from '../../utils/deviceFeatureValueOptions';
 

--- a/front/src/components/device/SelectFanFeatureValue.jsx
+++ b/front/src/components/device/SelectFanFeatureValue.jsx
@@ -1,6 +1,6 @@
 import { Component } from 'preact';
 import { Text } from 'preact-i18n';
-import Select from 'react-select';
+import Select from '../form/Select';
 import get from 'get-value';
 
 import { getFanFeatureOptions } from '../../../../server/utils/constants';

--- a/front/src/components/device/SelectFanMode.jsx
+++ b/front/src/components/device/SelectFanMode.jsx
@@ -1,6 +1,6 @@
 import { Component } from 'preact';
 import { Text } from 'preact-i18n';
-import Select from 'react-select';
+import Select from '../form/Select';
 import get from 'get-value';
 
 import { FAN_MODE } from '../../../../server/utils/constants';

--- a/front/src/components/device/SelectPilotWireMode.jsx
+++ b/front/src/components/device/SelectPilotWireMode.jsx
@@ -1,6 +1,6 @@
 import { Component } from 'preact';
 import { Text } from 'preact-i18n';
-import Select from 'react-select';
+import Select from '../form/Select';
 import get from 'get-value';
 
 import { PILOT_WIRE_MODE } from '../../../../server/utils/constants';

--- a/front/src/components/device/SelectWaterHeaterMode.jsx
+++ b/front/src/components/device/SelectWaterHeaterMode.jsx
@@ -1,6 +1,6 @@
 import { Component } from 'preact';
 import { Text } from 'preact-i18n';
-import Select from 'react-select';
+import Select from '../form/Select';
 import get from 'get-value';
 
 import { WATER_HEATER_MODE } from '../../../../server/utils/constants';

--- a/front/src/components/form/Select.jsx
+++ b/front/src/components/form/Select.jsx
@@ -1,0 +1,32 @@
+import ReactSelect from 'react-select';
+import ReactCreatableSelect from 'react-select/creatable';
+
+import closeMenuOnScroll from '../../utils/closeMenuOnScroll';
+
+/**
+ * react-select with its menu rendered on <body> instead of inside the card.
+ *
+ * Every card of the app is glass: `.glass-theme .card` carries a
+ * backdrop-filter, and a backdrop filter makes its element a stacking context
+ * — so a menu opened inside a card is that card's prisoner whatever z-index it
+ * gets from the inside, and the cards that follow it in the document paint
+ * over it. react-select's answer is menuPortalTarget: the menu is rendered on
+ * <body>, out of every card, and positioned against its control. Its z-index
+ * lives on `.react-select__menu-portal` (style/index.css), and
+ * closeMenuOnScroll closes it when the page or a panel scrolls underneath,
+ * since a portaled menu is positioned once, when it opens.
+ *
+ * Import this instead of 'react-select' — same API, the portal props can still
+ * be overridden by the caller.
+ */
+const portalProps = () => ({
+  menuPlacement: 'auto',
+  menuPortalTarget: document.body,
+  closeMenuOnScroll
+});
+
+const Select = props => <ReactSelect {...portalProps()} {...props} />;
+
+export const CreatableSelect = props => <ReactCreatableSelect {...portalProps()} {...props} />;
+
+export default Select;

--- a/front/src/routes/scene/edit-scene/Settings.jsx
+++ b/front/src/routes/scene/edit-scene/Settings.jsx
@@ -1,6 +1,6 @@
 import cx from 'classnames';
 import { Localizer, Text } from 'preact-i18n';
-import CreatableSelect from 'react-select/creatable';
+import { CreatableSelect } from '../../../components/form/Select';
 import IconSelector from '../../../components/scene/IconSelector';
 import style from './style.css';
 

--- a/front/src/routes/scene/edit-scene/actions/AskAI.jsx
+++ b/front/src/routes/scene/edit-scene/actions/AskAI.jsx
@@ -1,4 +1,4 @@
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Localizer, Text } from 'preact-i18n';

--- a/front/src/routes/scene/edit-scene/actions/BlinkLightParams.jsx
+++ b/front/src/routes/scene/edit-scene/actions/BlinkLightParams.jsx
@@ -1,7 +1,7 @@
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Text, Localizer } from 'preact-i18n';
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 
 class BlinkLight extends Component {
   getOptions = async () => {

--- a/front/src/routes/scene/edit-scene/actions/CalendarGetEvents.jsx
+++ b/front/src/routes/scene/edit-scene/actions/CalendarGetEvents.jsx
@@ -1,4 +1,4 @@
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { RequestStatus } from '../../../../utils/consts';

--- a/front/src/routes/scene/edit-scene/actions/CalendarIsEventRunning.jsx
+++ b/front/src/routes/scene/edit-scene/actions/CalendarIsEventRunning.jsx
@@ -1,4 +1,4 @@
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { RequestStatus } from '../../../../utils/consts';

--- a/front/src/routes/scene/edit-scene/actions/CheckAlarmMode.jsx
+++ b/front/src/routes/scene/edit-scene/actions/CheckAlarmMode.jsx
@@ -1,4 +1,4 @@
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Text } from 'preact-i18n';

--- a/front/src/routes/scene/edit-scene/actions/CheckTime.jsx
+++ b/front/src/routes/scene/edit-scene/actions/CheckTime.jsx
@@ -1,4 +1,4 @@
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 import { Component } from 'preact';
 import DatePicker from 'react-datepicker';
 import { connect } from 'unistore/preact';

--- a/front/src/routes/scene/edit-scene/actions/CheckUserPresence.jsx
+++ b/front/src/routes/scene/edit-scene/actions/CheckUserPresence.jsx
@@ -1,4 +1,4 @@
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Text, Localizer } from 'preact-i18n';

--- a/front/src/routes/scene/edit-scene/actions/HouseEmptyOrNotCondition.jsx
+++ b/front/src/routes/scene/edit-scene/actions/HouseEmptyOrNotCondition.jsx
@@ -1,4 +1,4 @@
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Text } from 'preact-i18n';

--- a/front/src/routes/scene/edit-scene/actions/MessageServiceSelector.jsx
+++ b/front/src/routes/scene/edit-scene/actions/MessageServiceSelector.jsx
@@ -1,4 +1,4 @@
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Text } from 'preact-i18n';

--- a/front/src/routes/scene/edit-scene/actions/PlayNotification.jsx
+++ b/front/src/routes/scene/edit-scene/actions/PlayNotification.jsx
@@ -1,4 +1,4 @@
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Text } from 'preact-i18n';

--- a/front/src/routes/scene/edit-scene/actions/SendMessageCameraParams.jsx
+++ b/front/src/routes/scene/edit-scene/actions/SendMessageCameraParams.jsx
@@ -1,4 +1,4 @@
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Text } from 'preact-i18n';

--- a/front/src/routes/scene/edit-scene/actions/SendMessageParams.jsx
+++ b/front/src/routes/scene/edit-scene/actions/SendMessageParams.jsx
@@ -1,4 +1,4 @@
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Text } from 'preact-i18n';

--- a/front/src/routes/scene/edit-scene/actions/SetAlarmMode.jsx
+++ b/front/src/routes/scene/edit-scene/actions/SetAlarmMode.jsx
@@ -1,4 +1,4 @@
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Text } from 'preact-i18n';

--- a/front/src/routes/scene/edit-scene/actions/StartSceneParams.jsx
+++ b/front/src/routes/scene/edit-scene/actions/StartSceneParams.jsx
@@ -1,7 +1,7 @@
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Text } from 'preact-i18n';
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 
 import actions from '../../../../actions/scene';
 

--- a/front/src/routes/scene/edit-scene/actions/TurnOnOffLightParams.jsx
+++ b/front/src/routes/scene/edit-scene/actions/TurnOnOffLightParams.jsx
@@ -1,7 +1,7 @@
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Text } from 'preact-i18n';
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 
 import { ACTIONS } from '../../../../../../server/utils/constants';
 

--- a/front/src/routes/scene/edit-scene/actions/TurnOnOffSwitchParams.jsx
+++ b/front/src/routes/scene/edit-scene/actions/TurnOnOffSwitchParams.jsx
@@ -1,7 +1,7 @@
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Text } from 'preact-i18n';
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 
 import { ACTIONS } from '../../../../../../server/utils/constants';
 

--- a/front/src/routes/scene/edit-scene/actions/UserPresence.jsx
+++ b/front/src/routes/scene/edit-scene/actions/UserPresence.jsx
@@ -1,4 +1,4 @@
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Text } from 'preact-i18n';

--- a/front/src/routes/scene/edit-scene/actions/only-continue-if/Condition.jsx
+++ b/front/src/routes/scene/edit-scene/actions/only-continue-if/Condition.jsx
@@ -1,6 +1,6 @@
 import { Component } from 'preact';
 import { Text, Localizer } from 'preact-i18n';
-import Select from 'react-select';
+import Select from '../../../../../components/form/Select';
 import update from 'immutability-helper';
 
 import SelectDeviceFeatureValue from '../../../../../components/device/SelectDeviceFeatureValue';

--- a/front/src/routes/scene/edit-scene/style.css
+++ b/front/src/routes/scene/edit-scene/style.css
@@ -599,7 +599,10 @@
   display: block;
 }
 
-/* react-select (devices, houses, users…) joins the same family */
+/* react-select (devices, houses, users…) joins the same family. Only the
+   control is styled here: its menu is portaled onto <body> like the
+   date/time popup (components/form/Select.jsx), out of this container's
+   reach — style/index.css skins it there. */
 :global(.glass-theme) .pageContainer :global(.react-select__control) {
   border-radius: 12px;
   border: 1px solid rgba(28, 35, 52, 0.12);
@@ -609,11 +612,6 @@
 :global(.glass-theme) .pageContainer :global(.react-select__control--is-focused) {
   border-color: var(--gl-accent);
   box-shadow: 0 0 0 3px rgba(61, 109, 240, 0.15);
-}
-
-:global(.glass-theme) .pageContainer :global(.react-select__menu) {
-  border-radius: 12px;
-  overflow: hidden;
 }
 
 /* Same dark-mode counter-weight as the list controls: dark-mode.css paints
@@ -630,8 +628,7 @@
   color: var(--gl-muted) !important;
 }
 
-:global(.dark-mode .glass-theme) .pageContainer :global(.react-select__control),
-:global(.dark-mode .glass-theme) .pageContainer :global(.react-select__menu) {
+:global(.dark-mode .glass-theme) .pageContainer :global(.react-select__control) {
   background-color: rgba(255, 255, 255, 0.75) !important;
 }
 

--- a/front/src/routes/scene/edit-scene/triggers/CalendarEventIsComing.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/CalendarEventIsComing.jsx
@@ -5,7 +5,7 @@ import cx from 'classnames';
 import get from 'get-value';
 import { Text, Localizer } from 'preact-i18n';
 import { RequestStatus } from '../../../../utils/consts';
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 import withIntlAsProp from '../../../../utils/withIntlAsProp';
 
 import style from './style.css';

--- a/front/src/routes/scene/edit-scene/triggers/ScheduledTrigger.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/ScheduledTrigger.jsx
@@ -4,7 +4,7 @@ import DatePicker from 'react-datepicker';
 import get from 'get-value';
 import { Text, Localizer } from 'preact-i18n';
 import { format } from 'date-fns';
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 
 import fr from 'date-fns/locale/fr';
 

--- a/front/src/routes/scene/edit-scene/triggers/UserEnteredOrLeftArea.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/UserEnteredOrLeftArea.jsx
@@ -2,7 +2,7 @@ import { Component } from 'preact';
 import { connect } from 'unistore/preact';
 import { Text } from 'preact-i18n';
 
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 import { EVENTS } from '../../../../../../server/utils/constants';
 
 class UserPresenceTrigger extends Component {

--- a/front/src/routes/scene/edit-scene/triggers/UserPresenceTrigger.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/UserPresenceTrigger.jsx
@@ -3,7 +3,7 @@ import { connect } from 'unistore/preact';
 import { Text } from 'preact-i18n';
 
 import 'react-datepicker/dist/react-datepicker.css';
-import Select from 'react-select';
+import Select from '../../../../components/form/Select';
 import { EVENTS } from '../../../../../../server/utils/constants';
 
 class UserPresenceTrigger extends Component {

--- a/front/src/routes/scene/edit-scene/triggers/device-states/ButtonClickDeviceState.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/device-states/ButtonClickDeviceState.jsx
@@ -1,5 +1,5 @@
 import { Component, Fragment } from 'preact';
-import Select from 'react-select';
+import Select from '../../../../../components/form/Select';
 import get from 'get-value';
 
 import { BUTTON_STATUS } from '../../../../../../../server/utils/constants';

--- a/front/src/routes/scene/edit-scene/triggers/device-states/FanLabeledDeviceState.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/device-states/FanLabeledDeviceState.jsx
@@ -1,5 +1,5 @@
 import { Component, Fragment } from 'preact';
-import Select from 'react-select';
+import Select from '../../../../../components/form/Select';
 import get from 'get-value';
 
 import { getFanFeatureOptions } from '../../../../../../../server/utils/constants';

--- a/front/src/routes/scene/edit-scene/triggers/device-states/FanModeDeviceState.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/device-states/FanModeDeviceState.jsx
@@ -1,5 +1,5 @@
 import { Component, Fragment } from 'preact';
-import Select from 'react-select';
+import Select from '../../../../../components/form/Select';
 import get from 'get-value';
 
 import { FAN_MODE } from '../../../../../../../server/utils/constants';

--- a/front/src/routes/scene/edit-scene/triggers/device-states/LevelMatterSensorDeviceState.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/device-states/LevelMatterSensorDeviceState.jsx
@@ -1,5 +1,5 @@
 import { Component, Fragment } from 'preact';
-import Select from 'react-select';
+import Select from '../../../../../components/form/Select';
 import get from 'get-value';
 
 import { LEVEL_MATTER_STATE } from '../../../../../../../server/utils/constants';

--- a/front/src/routes/scene/edit-scene/triggers/device-states/LevelSensorDeviceState.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/device-states/LevelSensorDeviceState.jsx
@@ -1,5 +1,5 @@
 import { Component, Fragment } from 'preact';
-import Select from 'react-select';
+import Select from '../../../../../components/form/Select';
 import get from 'get-value';
 
 import { LIQUID_STATE } from '../../../../../../../server/utils/constants';

--- a/front/src/routes/scene/edit-scene/triggers/device-states/PilotWireModeDeviceState.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/device-states/PilotWireModeDeviceState.jsx
@@ -1,5 +1,5 @@
 import { Component, Fragment } from 'preact';
-import Select from 'react-select';
+import Select from '../../../../../components/form/Select';
 import get from 'get-value';
 
 import { PILOT_WIRE_MODE } from '../../../../../../../server/utils/constants';

--- a/front/src/routes/scene/edit-scene/triggers/device-states/WaterHeaterModeDeviceState.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/device-states/WaterHeaterModeDeviceState.jsx
@@ -1,5 +1,5 @@
 import { Component, Fragment } from 'preact';
-import Select from 'react-select';
+import Select from '../../../../../components/form/Select';
 import get from 'get-value';
 
 import { WATER_HEATER_MODE } from '../../../../../../../server/utils/constants';

--- a/front/src/routes/scene/edit-scene/triggers/device-states/WaterValveDeviceState.jsx
+++ b/front/src/routes/scene/edit-scene/triggers/device-states/WaterValveDeviceState.jsx
@@ -1,5 +1,5 @@
 import { Component, Fragment } from 'preact';
-import Select from 'react-select';
+import Select from '../../../../../components/form/Select';
 import get from 'get-value';
 
 import { WATER_VALVE_CURRENT_DEVICE_STATUS } from '../../../../../../../server/utils/constants';


### PR DESCRIPTION
### Description

Reported on the forum: in a scene, the **Weekdays** selector of the *Time condition* step opens **under** the step cards that follow it, so half of its options are unreachable.

Reproduced in the demo app — the "Time condition" step's Weekdays menu, before and after:

| Before | After |
| --- | --- |
| Thursday is hidden behind "Turn On the Lights", Saturday behind "Turn On the Switches" | the whole list is readable |

**Root cause.** Every card of the app is glass: `.glass-theme .card` carries a `backdrop-filter`, and a backdrop filter makes its element a *stacking context*. A react-select menu opened inside a step card is therefore that card's prisoner whatever z-index it gets from the inside, and the cards that follow it in the document paint over it. The date/time popups of the same editor already hit this and were fixed with a portal (`portalId`, `components/datePicker.css`) — the react-select menus never were.

**Fix.** Same remedy, written once: `front/src/components/form/Select.jsx` wraps react-select with `menuPortalTarget={document.body}`, plus `menuPlacement="auto"` and the `closeMenuOnScroll` already used by the dashboard's selects (a portaled menu is positioned only when it opens, so it must close when the page scrolls under it). Every select of the scene editor — steps, triggers, device states, scene tags — and the device value selectors it uses now import that wrapper instead of `react-select` directly.

Since the menu leaves `.pageContainer`, the two editor rules that skinned it there are dropped: `style/index.css` already skins `.react-select__menu-portal .react-select__menu`, and `dark-mode.css` paints portaled menus like every other one. Checked in light and dark mode.

## Forum

Forum: https://community.gladysassistant.com/t/bug-nouveau-theme/10706

### Checklist

- [x] Tests pass — no server code changed, so no server coverage impact. Cypress could not run in this environment (its binary download is blocked), so the change was verified by driving the demo front in a real browser: menu paints above the following steps, selection applies, menu closes on scroll, light + dark mode, and the same check on the scheduled trigger, the scene tags and the device value selects.
- [x] Linter and prettier pass on the front (`npm run eslint`, `npm run prettier-check`), and `vite build` succeeds
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wv16PHgUTnR4GbeE3TD8A3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized dropdown controls across device settings and scene editing.
  * Dropdown menus now automatically position themselves, remain visible within the page, and close when the page is scrolled.
  * Added consistent support for creating new dropdown options.
* **Style**
  * Improved dropdown appearance and dark-mode styling, including menus displayed outside the editor layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->