### PR TITLE
Energy monitoring: only recalculate costs for devices impacted by an Enedis sync

### DIFF
--- a/server/services/enedis/lib/enedis.sync.js
+++ b/server/services/enedis/lib/enedis.sync.js
@@ -289,8 +289,23 @@ async function sync(fromStart = false, jobId = null) {
       const energyMonitoringService = this.gladys.service && this.gladys.service.getService('energy-monitoring');
       if (energyMonitoringService && energyMonitoringService.device) {
         const earliestSyncDate = getEarliestDate(syncedDates);
-        logger.debug(`Enedis: Recalculating cost from ${earliestSyncDate} after sync`);
-        await energyMonitoringService.device.calculateCostFromDate(earliestSyncDate);
+        // Only the usage points that received new data need a cost recalculation:
+        // the consumption states of every other energy device are untouched.
+        const impactedDeviceIds = usagePoints
+          .filter((usagePoint, index) => {
+            const response = syncResponses[index];
+            return (
+              (response.dailyConsumptionSync && response.dailyConsumptionSync.firstDateSync) ||
+              (response.consumptionLoadCurveSync && response.consumptionLoadCurveSync.firstDateSync)
+            );
+          })
+          .map((usagePoint) => usagePoint.id);
+        logger.debug(
+          `Enedis: Recalculating cost from ${earliestSyncDate} after sync for ${impactedDeviceIds.length} usage points`,
+        );
+        await energyMonitoringService.device.calculateCostFromDate(earliestSyncDate, {
+          deviceIds: impactedDeviceIds,
+        });
       } else {
         logger.warn('Enedis: energy-monitoring service unavailable, skipping cost recalculation after sync');
       }

--- a/server/services/energy-monitoring/lib/energy-monitoring.calculateCostFrom.js
+++ b/server/services/energy-monitoring/lib/energy-monitoring.calculateCostFrom.js
@@ -21,21 +21,37 @@ const { buildEdfTempoDayMap } = require('../contracts/contracts.buildEdfTempoDay
 
 const isNullOrEmpty = (value) => value === null || value === undefined || value === '';
 
+const THIRTY_MINUTES_IN_MS = 30 * 60 * 1000;
+
 /**
  * @description Calculate energy monitoring cost from a specific date.
  * @param {Date} startAt - The start date.
- * @param {string} jobId - The job id.
+ * @param {string} [jobId] - The job id.
+ * @param {object} [options] - Options.
+ * @param {Array<string>} [options.deviceIds] - Only recalculate cost for these device ids.
  * @returns {Promise<null>} Return null when finished.
  * @example
  * calculateCostFrom(new Date(), '12345678-1234-1234-1234-1234567890ab');
  */
-async function calculateCostFrom(startAt, jobId) {
+async function calculateCostFrom(startAt, jobId, options = {}) {
   const systemTimezone = await this.gladys.variable.getValue(SYSTEM_VARIABLE_NAMES.TIMEZONE);
   logger.info(`Calculating cost in timezone ${systemTimezone}`);
-  const energyDevices = await this.gladys.device.get({
+  let energyDevices = await this.gladys.device.get({
     device_feature_category: DEVICE_FEATURE_CATEGORIES.ENERGY_SENSOR,
   });
-  logger.info(`Found ${energyDevices.length} energy devices`);
+  // When a sync only touched some devices (e.g. Enedis), don't rewrite the cost
+  // history of every other energy device: their consumption states are unchanged.
+  if (options.deviceIds && options.deviceIds.length > 0) {
+    const deviceIdsSet = new Set(options.deviceIds);
+    const totalDevices = energyDevices.length;
+    energyDevices = energyDevices.filter((energyDevice) => deviceIdsSet.has(energyDevice.id));
+    logger.info(`Found ${totalDevices} energy devices, recalculating cost for ${energyDevices.length} of them`);
+  } else {
+    logger.info(`Found ${energyDevices.length} energy devices`);
+  }
+  // Energy prices are per root electric meter and don't change during the run,
+  // so fetch and pre-parse them once per meter instead of once per feature.
+  const pricesByElectricMeterDeviceId = new Map();
   let edfTempoHistoricalMap = null;
   await Promise.each(energyDevices, async (energyDevice, index) => {
     try {
@@ -118,9 +134,29 @@ async function calculateCostFrom(startAt, jobId) {
         logger.debug(`Destroying states from ${ecf.consumptionCostFeature.selector} from ${startAt}`);
         await this.gladys.device.destroyStatesFrom(ecf.consumptionCostFeature.selector, startAt);
         // Get the energy prices from this electrical meter device
-        const energyPrices = await this.gladys.energyPrice.get({
-          electric_meter_device_id: electricMeterFeature.device_id,
-        });
+        let meterPrices = pricesByElectricMeterDeviceId.get(electricMeterFeature.device_id);
+        if (!meterPrices) {
+          const energyPrices = await this.gladys.energyPrice.get({
+            electric_meter_device_id: electricMeterFeature.device_id,
+          });
+          meterPrices = {
+            energyPrices,
+            // Pre-parse validity boundaries of consumption prices once: parsing
+            // start/end dates in the system timezone for every single state is
+            // what made large recalculations slow.
+            consumptionPrices: energyPrices
+              .filter((price) => price.price_type === ENERGY_PRICE_TYPES.CONSUMPTION)
+              .map((price) => ({
+                price,
+                validFromTimestamp: dayjs.tz(`${price.start_date} 00:00:00`, systemTimezone).valueOf(),
+                validUntilTimestamp: isNullOrEmpty(price.end_date)
+                  ? Infinity
+                  : dayjs.tz(`${price.end_date} 23:59:59`, systemTimezone).valueOf(),
+              })),
+          };
+          pricesByElectricMeterDeviceId.set(electricMeterFeature.device_id, meterPrices);
+        }
+        const { energyPrices, consumptionPrices } = meterPrices;
         const hasTempo = energyPrices.some((p) => p.contract === ENERGY_CONTRACT_TYPES.EDF_TEMPO);
         if (hasTempo && !edfTempoHistoricalMap) {
           logger.info(
@@ -144,21 +180,18 @@ async function calculateCostFrom(startAt, jobId) {
         logger.debug(`Found ${deviceFeatureStates.length} states for device ${ecf.consumptionFeature.selector}`);
         // For each state
         await Promise.each(deviceFeatureStates, async (deviceFeatureState) => {
-          const createdAtRemoved30Minutes = dayjs
-            .tz(deviceFeatureState.created_at, systemTimezone)
-            .subtract(30, 'minutes')
-            .toDate();
-          // Get the prices for this date
-          const energyPricesForDate = energyPrices.filter((price) => {
-            // We only keep consumption prices (no subscription)
-            return (
-              price.price_type === ENERGY_PRICE_TYPES.CONSUMPTION &&
-              // We only keep prices that are valid for this date
-              dayjs.tz(`${price.start_date} 00:00:00`, systemTimezone).toDate() <= createdAtRemoved30Minutes &&
-              (isNullOrEmpty(price.end_date) ||
-                dayjs.tz(`${price.end_date} 23:59:59`, systemTimezone).toDate() >= createdAtRemoved30Minutes)
-            );
-          });
+          // Subtracting 30 minutes is plain instant arithmetic, no timezone conversion needed
+          const createdAtRemoved30MinutesTimestamp =
+            new Date(deviceFeatureState.created_at).getTime() - THIRTY_MINUTES_IN_MS;
+          const createdAtRemoved30Minutes = new Date(createdAtRemoved30MinutesTimestamp);
+          // Get the consumption prices (no subscription) that are valid for this date
+          const energyPricesForDate = consumptionPrices
+            .filter(
+              (p) =>
+                p.validFromTimestamp <= createdAtRemoved30MinutesTimestamp &&
+                p.validUntilTimestamp >= createdAtRemoved30MinutesTimestamp,
+            )
+            .map((p) => p.price);
           if (energyPricesForDate.length === 0) {
             logger.debug(
               `No energy price found for device ${electricMeterFeature.device_id} at ${deviceFeatureState.created_at}`,

--- a/server/services/energy-monitoring/lib/energy-monitoring.calculateCostFromDate.js
+++ b/server/services/energy-monitoring/lib/energy-monitoring.calculateCostFromDate.js
@@ -13,11 +13,13 @@ const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 /**
  * @description Queue an energy cost calculation from a date.
  * @param {Date|string} startAt - Start date or ISO date string.
+ * @param {object} [options] - Options forwarded to calculateCostFrom.
+ * @param {Array<string>} [options.deviceIds] - Only recalculate cost for these device ids.
  * @returns {Promise<null>} Return when finished.
  * @example
  * calculateCostFromDate('2026-07-19');
  */
-async function calculateCostFromDate(startAt) {
+async function calculateCostFromDate(startAt, options = {}) {
   return queueWrapper(this.queue, async () => {
     let normalizedStartAt = new Date(startAt);
 
@@ -29,7 +31,7 @@ async function calculateCostFromDate(startAt) {
         .toDate();
     }
 
-    await this.calculateCostFrom(normalizedStartAt);
+    await this.calculateCostFrom(normalizedStartAt, null, options);
   });
 }
 

--- a/server/services/energy-monitoring/lib/energy-monitoring.calculateEnergyFromIndex.js
+++ b/server/services/energy-monitoring/lib/energy-monitoring.calculateEnergyFromIndex.js
@@ -63,7 +63,9 @@ async function calculateEnergyFromIndex(kind, thirtyMinutesWindowTime, jobId) {
     });
   });
 
-  logger.info(`Found ${devicesWithBothFeatures.length} devices with both INDEX and ${kind.targetFeatureType} features`);
+  // One device can carry several index features (e.g. a Linky meter exposing EASF01..EASF10),
+  // so this counts index/target feature pairs, not distinct devices
+  logger.info(`Found ${devicesWithBothFeatures.length} INDEX/${kind.targetFeatureType} feature pairs`);
 
   // Process each device
   await Promise.each(devicesWithBothFeatures, async (deviceInfo, index) => {

--- a/server/test/services/enedis/enedis.sync.dailyConsumption.test.js
+++ b/server/test/services/enedis/enedis.sync.dailyConsumption.test.js
@@ -284,7 +284,9 @@ describe('enedis.sync.dailySync', () => {
     await enedisService.sync();
 
     assert.calledOnce(calculateCostFromDate);
-    assert.calledWithExactly(calculateCostFromDate, '2022-08-02');
+    assert.calledWithExactly(calculateCostFromDate, '2022-08-02', {
+      deviceIds: ['865f0fd8-970c-4670-9e1d-f6926a0abed6'],
+    });
   });
   it('should not recalculate cost when enedis daily sync returns no new data', async () => {
     const calculateCostFromDate = fake.resolves(null);

--- a/server/test/services/enedis/enedis.sync.loadConsumptionCurve.test.js
+++ b/server/test/services/enedis/enedis.sync.loadConsumptionCurve.test.js
@@ -298,7 +298,9 @@ describe('enedis.sync.loadConsumptionCurve', () => {
     await enedisService.sync();
 
     assert.calledOnce(calculateCostFromDate);
-    assert.calledWithExactly(calculateCostFromDate, '2022-08-01T00:30:00.000Z');
+    assert.calledWithExactly(calculateCostFromDate, '2022-08-01T00:30:00.000Z', {
+      deviceIds: ['865f0fd8-970c-4670-9e1d-f6926a0abed6', '15cabd5e-4c2f-4b55-80af-228c74b11ec5'],
+    });
     assert.callCount(gladys.device.saveHistoricalState, 2);
   });
   it('should sync with 1 page = 100', async () => {

--- a/server/test/services/energy-monitoring/energy-monitoring.calculateCostFrom.test.js
+++ b/server/test/services/energy-monitoring/energy-monitoring.calculateCostFrom.test.js
@@ -162,6 +162,69 @@ describe('EnergyMonitoring.calculateCostFrom', () => {
     expect(deviceFeatureState[1]).to.have.property('value', 20 * 0.18);
     expect(gladys.job.updateProgress.called).to.equal(false);
   });
+  it('should only recalculate cost for devices in options.deviceIds', async () => {
+    await energyPrice.create({
+      electric_meter_device_id: electricalMeterDevice.id,
+      contract: ENERGY_CONTRACT_TYPES.BASE,
+      price_type: ENERGY_PRICE_TYPES.CONSUMPTION,
+      currency: 'euro',
+      start_date: '2025-01-01',
+      // 0,18€/kwh stored as integer with 4 decimals
+      price: 1800,
+    });
+    await db.duckDbBatchInsertState('17488546-e1b8-4cb9-bd75-e20526a94a99', [
+      {
+        value: 10,
+        created_at: new Date('2025-08-28T15:00:00.000Z'),
+      },
+    ]);
+    const energyMonitoring = new EnergyMonitoring(gladys, '43732e67-6669-4a95-83d6-38c50b835387');
+    const date = new Date('2025-08-28T00:00:00.000Z');
+    // The power plug device is not in the list: its cost must not be recalculated
+    await energyMonitoring.calculateCostFrom(date, null, { deviceIds: ['d1fe2ab9-8c50-4053-ac40-83421f899c59'] });
+    const stateWithoutPowerPlug = await device.getDeviceFeatureStates(
+      'power-plug-consumption-cost',
+      new Date('2025-01-01T00:00:00.000Z'),
+      new Date('2025-12-01T00:00:00.000Z'),
+    );
+    expect(stateWithoutPowerPlug).to.have.lengthOf(0);
+    // The power plug device is in the list: its cost must be recalculated
+    await energyMonitoring.calculateCostFrom(date, null, { deviceIds: ['cf43f956-2f49-4cf9-a7e2-690a014de66e'] });
+    const stateWithPowerPlug = await device.getDeviceFeatureStates(
+      'power-plug-consumption-cost',
+      new Date('2025-01-01T00:00:00.000Z'),
+      new Date('2025-12-01T00:00:00.000Z'),
+    );
+    expect(stateWithPowerPlug).to.have.lengthOf(1);
+    expect(stateWithPowerPlug[0]).to.have.property('value', 10 * 0.18);
+  });
+  it('should not calculate cost when the only price expired before the state date', async () => {
+    await energyPrice.create({
+      electric_meter_device_id: electricalMeterDevice.id,
+      contract: ENERGY_CONTRACT_TYPES.BASE,
+      price_type: ENERGY_PRICE_TYPES.CONSUMPTION,
+      currency: 'euro',
+      start_date: '2020-01-01',
+      end_date: '2020-12-31',
+      // 0,18€/kwh stored as integer with 4 decimals
+      price: 1800,
+    });
+    await db.duckDbBatchInsertState('17488546-e1b8-4cb9-bd75-e20526a94a99', [
+      {
+        value: 10,
+        created_at: new Date('2025-08-28T15:00:00.000Z'),
+      },
+    ]);
+    const energyMonitoring = new EnergyMonitoring(gladys, '43732e67-6669-4a95-83d6-38c50b835387');
+    const date = new Date('2025-08-28T00:00:00.000Z');
+    await energyMonitoring.calculateCostFrom(date);
+    const deviceFeatureState = await device.getDeviceFeatureStates(
+      'power-plug-consumption-cost',
+      new Date('2025-01-01T00:00:00.000Z'),
+      new Date('2025-12-01T00:00:00.000Z'),
+    );
+    expect(deviceFeatureState).to.have.lengthOf(0);
+  });
   it('should calculate cost from a specific date with Watt-hour unit conversion', async () => {
     // Create a device with consumption in Watt-hour (not kWh)
     await device.create({

--- a/server/test/services/energy-monitoring/energy-monitoring.calculateCostFromDate.test.js
+++ b/server/test/services/energy-monitoring/energy-monitoring.calculateCostFromDate.test.js
@@ -26,14 +26,14 @@ describe('EnergyMonitoring.calculateCostFromDate', () => {
     await energyMonitoring.calculateCostFromDate('2026-07-19');
 
     assert.calledOnce(calculateCostFrom);
-    assert.calledWithExactly(calculateCostFrom, new Date('2026-07-18T22:00:00.000Z'));
+    assert.calledWithExactly(calculateCostFrom, new Date('2026-07-18T22:00:00.000Z'), null, {});
   });
 
   it('should preserve the instant from a complete ISO date', async () => {
     await energyMonitoring.calculateCostFromDate('2026-07-19T00:30:00.000Z');
 
     assert.calledOnce(calculateCostFrom);
-    assert.calledWithExactly(calculateCostFrom, new Date('2026-07-19T00:30:00.000Z'));
+    assert.calledWithExactly(calculateCostFrom, new Date('2026-07-19T00:30:00.000Z'), null, {});
   });
 
   it('should preserve the instant from a Date object', async () => {
@@ -42,7 +42,7 @@ describe('EnergyMonitoring.calculateCostFromDate', () => {
     await energyMonitoring.calculateCostFromDate(date);
 
     assert.calledOnce(calculateCostFrom);
-    assert.calledWithExactly(calculateCostFrom, date);
+    assert.calledWithExactly(calculateCostFrom, date, null, {});
   });
 
   it('should serialize calculations', async () => {


### PR DESCRIPTION
### Description

Fixes the hourly slowdowns reported on the forum: on installations with many energy devices, the hourly Enedis sync made Gladys unresponsive (scenes and dashboard lagging by several seconds) for 10+ minutes every hour.

Root cause, confirmed by the user's logs: after downloading new Enedis data (a few seconds), the sync triggered a cost recalculation that:

- swept **all** energy devices (33 cost features in the reporter's setup), even though only the Enedis features had received new data — every other device's cost history was deleted and re-inserted identically;
- covered the whole resynced window (~8 days, because the sync re-fetches the last synced date minus 7 days), i.e. ~12,000 points rewritten every hour;
- re-parsed each price's validity dates (with timezone conversion) for every single state, making each point cost ~55 ms.

Since Node.js is single-threaded, this starved the event loop and everything else in Gladys.

Changes:

- `enedis.sync`: pass the ids of the usage points that actually received new data to the cost recalculation (`calculateCostFromDate`), so untouched devices are skipped entirely.
- `calculateCostFrom`: accept an optional `deviceIds` filter.
- `calculateCostFrom`: fetch energy prices once per electric meter (cached across features) and pre-parse price validity boundaries once, instead of per state; subtracting 30 minutes now uses plain timestamp arithmetic instead of a timezone-aware round trip.
- `calculateEnergyFromIndex`: clarify the `Found N devices` log — it counts index/target feature pairs, not distinct devices (a Linky meter exposing EASF01..EASF10 appears up to 10 times).

Behavior is unchanged for all other callers (30-minute job, daily jobs, "from beginning" recalculation): the filter only applies when a sync provides the impacted device ids.

## Forum

Forum: ``https://community.gladysassistant.com/t/probleme-faible-reactivite-de-gladys-chaque-heure-pendant-quelques-minutes-peut-etre-la-faute-de-enedis``/10593

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (159 passing; changed files at 100% line/branch coverage — `calculateCostFrom.js` goes from 97.6%/97% to 100%/100%; no UI change, so no Cypress run needed)
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier` — no front change)
- [x] No undocumented breaking change (the `calculateCostFrom`/`calculateCostFromDate` extra parameter is optional and defaults to the previous behavior)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUEasmf32TMPR3ck5XTrNU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cost recalculation after energy data synchronization now targets only affected devices, improving efficiency.
  * Prevented cost calculations when applicable energy prices have expired.
  * Improved price matching based on consumption timestamps.

* **Improvements**
  * Enhanced synchronization and energy calculation logs to provide clearer information about processed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->