### PR TITLE
Cypress: stop a late window.open from failing the whole OAuth run

### DIFF
--- a/front/cypress/e2e/routes/integration/external-integration/ExternalIntegrationOAuth.cy.js
+++ b/front/cypress/e2e/routes/integration/external-integration/ExternalIntegrationOAuth.cy.js
@@ -81,6 +81,13 @@ describe('External integration - OAuth2 connection', () => {
       expect(request.body.key).to.equal('spotify_account');
       expect(request.body.redirect_uri).to.equal(REDIRECT_URI);
     });
+
+    // `cy.wait` resolves as soon as the proxy answered, which is one tick
+    // before the app resumes and opens the provider. Ending the test here
+    // restores the stub first, and the real `window.open` gets the provider
+    // URL: the run then dies on `ERR_FAILED loading 'https://accounts...'`
+    // with every test green. Wait for the call before letting the test end.
+    cy.get('@windowOpen').should('have.been.called');
   });
 
   it('opens the provider with the instance address wrapped in the state', () => {

--- a/front/cypress/support/e2e.js
+++ b/front/cypress/support/e2e.js
@@ -18,3 +18,28 @@ import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+// A `cy.stub(win, 'open')` is restored the moment the test that installed it
+// ends. Application code that reaches `window.open` one tick later — an OAuth
+// "Connect" whose promise settles just after the last command — then calls the
+// real one, Electron actually loads the provider, and the whole run fails with
+// `ERR_FAILED (-2) loading 'https://…'` while every test is reported green.
+// No test has any business leaving the app, so cross-origin openings are
+// dropped: a spec that cares about them stubs `window.open` and asserts on it.
+Cypress.on('window:before:load', win => {
+  const nativeOpen = win.open;
+  win.open = function open(url, ...args) {
+    let sameOrigin = true;
+    try {
+      sameOrigin = new URL(url, win.location.href).origin === win.location.origin;
+    } catch (e) {
+      sameOrigin = false;
+    }
+    if (!sameOrigin) {
+      // eslint-disable-next-line no-console
+      console.warn(`[cypress] blocked window.open to an external URL: ${url}`);
+      return null;
+    }
+    return nativeOpen.call(this, url, ...args);
+  };
+});


### PR DESCRIPTION
### Description

Fixes the flaky CI failure on `routes/integration/external-integration/ExternalIntegrationOAuth.cy.js`, where the six tests were all reported as passing and the run still died with:

```
ERR_FAILED (-2) loading 'https://accounts.spotify.com/authorize?response_type=code&client_id=abc&…'
```

**Root cause.** In `asks the integration for an authorize URL with the redirect page as redirect_uri`, the last command is `cy.wait('@getAuthorizeUrl')`. That wait resolves as soon as the intercept has answered, which is one tick *before* the app's `await httpClient.post(...)` resumes and calls `window.open(urlToOpen, '_blank', …)`. Cypress restores the `cy.stub(win, 'open')` the moment the test ends, so when the race is lost the real `window.open` receives the provider URL, Electron actually tries to load `accounts.spotify.com`, and the run fails — after every test has been counted green, which is exactly the shape of the CI output.

The three other tests that trigger the same flow already gate on something that only becomes true after `window.open` has been called (`@windowOpen` assertions, or the `localStorage` entries written in the same synchronous block), so this one test was the only hole.

**Changes.**

- `ExternalIntegrationOAuth.cy.js`: assert `cy.get('@windowOpen').should('have.been.called')` before that test ends, so the stubbed call is guaranteed to happen while the stub is still installed.
- `cypress/support/e2e.js`: as a safety net for the whole suite, wrap `window.open` in the application window on `window:before:load` and drop cross-origin openings (warning in the console). A single escaped `window.open` takes down an entire Cypress run, not just its own test, and no e2e test has any business making the browser leave the app. Specs that care about the call keep stubbing `window.open` and asserting on it, as before.

No production code is touched.

## Forum

_Not applicable — CI test fix._

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed — no server code changed. Cypress could not be run locally in this environment (front dependencies are not installed), so the fix is validated by the CI run on this PR.
- [ ] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`) — not run locally for the same reason; the changed files follow the repo's prettier settings (single quotes, 120 columns) and are covered by the CI lint job.
- [x] No undocumented breaking change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved external integration authorization-flow test reliability by waiting for the provider authorization page to open.
  * Added safeguards in end-to-end tests to prevent unintended navigation to external or invalid URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->