### PR TITLE
Demo: two languages everywhere, live integration store, tool calls in the chat, rebalanced dashboards

### DIFF
--- a/front/src/config/demo/README.md
+++ b/front/src/config/demo/README.md
@@ -65,3 +65,9 @@ devices page, in the room widgets and in the scene editor at once. Nothing else 
 Values are dated relatively (`minutesAgo(4)`) and the time series are generated from the
 current date, so the demo never shows a forecast from three years ago. When you add a page
 or a widget, open the demo, watch the console, and add the missing fixture.
+
+Texts the demo writes as **Gladys itself** — today the chat history of `scenes.js` — go
+through `localized({ en, fr })`, so they follow the language of the browser like the
+interface does (`demoLanguage()` in `helpers.js`, also what `get /api/v1/me` answers).
+The house itself (rooms, devices, scenes) stays in English: those are the names a user
+typed in, not something the product says.

--- a/front/src/config/demo/README.md
+++ b/front/src/config/demo/README.md
@@ -66,9 +66,11 @@ covers, categories, GitHub stars and documentation. A snapshot committed here
 would be out of date the week after.
 
 It is therefore the only request of the demo that leaves the browser. It is made
-only when the integrations page is opened, and a failure is not a bug: the
-catalog is then empty and the page shows the native integrations alone, exactly
-like an instance whose store is unreachable.
+only when the integrations page is opened, and a failure is not a bug: the last
+index downloaded is kept (empty if none ever was, and the page then shows the
+native integrations alone), exactly like an instance whose store is unreachable.
+The refresh button reports `refreshed: false` when the download did not happen,
+so the page warns about a stale catalog instead of claiming a fresh one.
 
 Installing from the store answers like the rest of the demo: the integration is
 turned into an installed one and its screens (Devices, Discovery, Configuration

--- a/front/src/config/demo/README.md
+++ b/front/src/config/demo/README.md
@@ -3,9 +3,10 @@
 These files feed the public demo of Gladys ([demo.gladysassistant.com](https://demo.gladysassistant.com)),
 published on every release by `.github/workflows/build-demo-website.yml`.
 
-In demo mode (`DEMO_MODE=true`), the front never talks to a server: every request goes
-through [`DemoHttpClient`](../../utils/DemoHttpClient.js), which looks the response up in
-the map exported by [`index.js`](./index.js).
+In demo mode (`DEMO_MODE=true`), the front never talks to a Gladys server: every request
+goes through [`DemoHttpClient`](../../utils/DemoHttpClient.js), which looks the response up
+in the map exported by [`index.js`](./index.js). The one exception is the community
+integration store, downloaded live from its public index (see below).
 
 ## Running it locally
 
@@ -41,6 +42,7 @@ history and device filters answer the request that was actually made.
 | `history.js`       | Chart series, energy consumption and the activity page, generated on the fly. |
 | `scenes.js`        | Scenes, calendar events and chat history.                                   |
 | `integrations.js`  | Fixtures of the integration pages (`/api/v1/service/*`).                    |
+| `store.js`         | The **live** catalog of community integrations, downloaded from the store.  |
 | `system.js`        | System, gateway, sessions and background jobs pages.                        |
 | `assets.js`        | Base64 avatars and camera snapshot.                                         |
 | `index.js`         | Assembles everything into the response map.                                 |
@@ -53,6 +55,25 @@ tablet tab bar, `background_scene` for the Horizon background, `width` for wall 
 demo uses that model to show what the theme can do — a chips bar, quick actions, the house
 view with live pins, scene buttons with a state subtitle — so keep new widgets on a real
 device of `home.js` rather than inventing a selector.
+
+## The community integration store
+
+The catalog of external integrations is the one thing the demo does not invent.
+`store.js` downloads the public store index (`index.json`, rebuilt hourly by
+`GladysAssistant/integration-store`) — the very same file every Gladys instance
+downloads, so **the demo lists the integrations published right now**, with their
+covers, categories, GitHub stars and documentation. A snapshot committed here
+would be out of date the week after.
+
+It is therefore the only request of the demo that leaves the browser. It is made
+only when the integrations page is opened, and a failure is not a bug: the
+catalog is then empty and the page shows the native integrations alone, exactly
+like an instance whose store is unreachable.
+
+Installing from the store answers like the rest of the demo: the integration is
+turned into an installed one and its screens (Devices, Discovery, Configuration
+built from the real `config_schema`, Logs) are registered on the fly, until the
+page is reloaded — nothing is persisted.
 
 ## Adding a device
 

--- a/front/src/config/demo/README.md
+++ b/front/src/config/demo/README.md
@@ -43,6 +43,7 @@ history and device filters answer the request that was actually made.
 | `scenes.js`        | Scenes, calendar events and chat history.                                   |
 | `integrations.js`  | Fixtures of the integration pages (`/api/v1/service/*`).                    |
 | `store.js`         | The **live** catalog of community integrations, downloaded from the store.  |
+| `i18n.js`          | French of everything the demo house says, and the translation pass.         |
 | `system.js`        | System, gateway, sessions and background jobs pages.                        |
 | `assets.js`        | Base64 avatars and camera snapshot.                                         |
 | `index.js`         | Assembles everything into the response map.                                 |
@@ -89,8 +90,18 @@ Values are dated relatively (`minutesAgo(4)`) and the time series are generated 
 current date, so the demo never shows a forecast from three years ago. When you add a page
 or a widget, open the demo, watch the console, and add the missing fixture.
 
-Texts the demo writes as **Gladys itself** — today the chat history of `scenes.js` — go
-through `localized({ en, fr })`, so they follow the language of the browser like the
-interface does (`demoLanguage()` in `helpers.js`, also what `get /api/v1/me` answers).
-The house itself (rooms, devices, scenes) stays in English: those are the names a user
-typed in, not something the product says.
+## Two languages
+
+The fixtures are written in English, and `i18n.js` holds the French of everything the
+house says: room and device names, features, widget labels, scenes, calendar events, the
+chat. `demoLanguage()` follows the browser (it is also what `get /api/v1/me` answers, so
+the interface is translated by the front at the same time), and a `translate()` pass
+applies the table to the values of the `name`, `title`, `label`, `description` and `text`
+keys — `home.js` translates the house at the source, so everything derived from it (the
+route map, the room pages, the generated history, the activity page) follows, and
+`index.js` translates the rest of the map.
+
+A string absent from the table is left untouched, which is the rule for everything a
+human did not write: hardware and product names (ConBee II, ZBDongle-E, Sonos Play),
+selectors, identifiers, units. **A new label added to the fixtures belongs in the table**
+— otherwise it shows up in English on the French demo.

--- a/front/src/config/demo/dashboards.js
+++ b/front/src/config/demo/dashboards.js
@@ -72,23 +72,6 @@ const HOUSE_VIEW = {
 
 const HOME_SECTIONS = [
   [[HOME_CHIPS]],
-  // The two hero visuals share a two-column section of their own: given half
-  // the dashboard each, the house illustration and the camera snapshot render
-  // near their natural proportions instead of one of them being cropped to
-  // fill the height of a column of small widgets.
-  [
-    [HOUSE_VIEW],
-    [
-      {
-        type: 'camera',
-        camera: 'garden-camera',
-        name: 'Garden'
-      }
-    ]
-  ],
-  // Three columns of comparable height: the reading side (time, weather, sun),
-  // the command side (actions, scenes, music) and the house side (alarm, who is
-  // home, the temperature curve). Columns that end together leave no hole.
   [
     [
       {
@@ -100,9 +83,9 @@ const HOME_SECTIONS = [
         type: 'weather',
         house: 'main-house',
         // Compact on purpose: today's weather and the five days ahead. The
-        // advanced block (humidity, pressure, sunrise/sunset, moon) is off —
-        // the sun widget right below already carries it, and stacking both
-        // made the column twice as tall as its neighbours.
+        // advanced block (humidity, pressure, sunrise/sunset, moon) duplicated
+        // the sun widget right below, and with the hourly strip on top of the
+        // daily one the card was 577px tall — half the dashboard.
         modes: {
           dateLocation: true,
           currentWeather: true,
@@ -115,6 +98,33 @@ const HOME_SECTIONS = [
       {
         type: 'sun',
         house: 'main-house'
+      },
+      // Down here rather than under the living-room card at the bottom of the
+      // dashboard: it takes back the height the weather widget gave up, so this
+      // column ends level with the two others.
+      {
+        type: 'music',
+        device: 'living-room-sonos'
+      }
+    ],
+    [
+      HOUSE_VIEW,
+      {
+        type: 'camera',
+        camera: 'garden-camera',
+        name: 'Garden'
+      },
+      // The camera is the one widget of this column that absorbs its leftover
+      // height, and it does it by cropping its image: with only the house view
+      // above it, it had close to 300px to swallow and the 4:3 snapshot was
+      // rendered as a portrait. The garden card below it — the room the camera
+      // watches — ends the column level with its neighbours, so the snapshot
+      // keeps its shape.
+      {
+        type: 'devices-in-room',
+        room: 'garden',
+        device_features: ['garden-lights-binary', 'garden-lights-brightness', 'garden-watering-binary', 'outdoor-aqi'],
+        device_feature_names: ['Garden lights', 'Brightness', 'Watering', 'Air quality']
       }
     ],
     [
@@ -132,26 +142,8 @@ const HOME_SECTIONS = [
         }
       },
       {
-        type: 'music',
-        device: 'living-room-sonos'
-      }
-    ],
-    [
-      {
         type: 'alarm',
         house: 'main-house'
-      },
-      {
-        type: 'user-presence'
-      },
-      {
-        type: 'chart',
-        chart_type: 'area',
-        device_features: ['living-room-temperature', 'outdoor-temperature'],
-        interval: 'last-week',
-        units: ['celsius', 'celsius'],
-        title: 'Temperature',
-        display_variation: true
       }
     ]
   ],
@@ -161,8 +153,6 @@ const HOME_SECTIONS = [
     [{ type: 'temperature-in-room', room: 'kids-room' }],
     [{ type: 'temperature-in-room', room: 'office' }]
   ],
-  // One room per column, all three of the same size: the bottom of the
-  // dashboard is a straight line.
   [
     [
       {
@@ -216,18 +206,16 @@ const HOME_SECTIONS = [
     ],
     [
       {
-        type: 'devices-in-room',
-        room: 'office',
-        device_features: [
-          'office-light-binary',
-          'office-light-brightness',
-          'office-plug-binary',
-          'office-plug-power',
-          'office-presence',
-          'office-temperature',
-          'office-co2'
-        ],
-        device_feature_names: ['Desk lamp', 'Brightness', 'Desk plug', 'Power', 'Presence', 'Temperature', 'CO2']
+        type: 'user-presence'
+      },
+      {
+        type: 'chart',
+        chart_type: 'area',
+        device_features: ['living-room-temperature', 'outdoor-temperature'],
+        interval: 'last-week',
+        units: ['celsius', 'celsius'],
+        title: 'Temperature',
+        display_variation: true
       }
     ]
   ]

--- a/front/src/config/demo/dashboards.js
+++ b/front/src/config/demo/dashboards.js
@@ -21,7 +21,9 @@ const dashboard = ({ name, selector, position, icon, backgroundScene = null, wid
   icon,
   background_scene: backgroundScene,
   width,
-  boxes: sections.map(columns => ({ columns })),
+  // a section is a plain list of columns, or `{ columns, widths }` when one
+  // of them is a wide column (weight 2 against 1, see the spec)
+  boxes: sections.map(section => (Array.isArray(section) ? { columns: section } : section)),
   created_at: '2024-01-08T09:12:00.000Z',
   updated_at: '2024-01-08T09:12:00.000Z'
 });
@@ -238,49 +240,52 @@ const ENERGY_SECTIONS = [
       }
     ]
   ],
-  [
-    [
-      {
-        type: 'energy-consumption',
-        name: 'Electricity consumption',
-        device_features: ['home-index'],
-        interval: 'last-week'
-      }
-    ],
-    [
-      {
-        type: 'chart',
-        chart_type: 'area',
-        device_features: ['solar-power'],
-        interval: 'last-day',
-        units: ['watt'],
-        title: 'Solar production',
-        display_variation: true
-      },
-      {
-        type: 'gauge',
-        device_feature: 'home-battery-level',
-        name: 'Home battery',
-        gauge_use_custom_value: true,
-        gauge_min: 0,
-        gauge_max: 100
-      }
+  // The bill and the day it comes from, on two thirds of the width — they are
+  // what one opens this dashboard for — with the two live readings of the house
+  // beside them. The only weighted section of the demo: a wide column counts
+  // double, which is exactly what a chart needs and what a gauge does not.
+  {
+    widths: [2, 1],
+    columns: [
+      [
+        {
+          type: 'energy-consumption',
+          name: 'Electricity consumption',
+          device_features: ['home-index'],
+          interval: 'last-week'
+        },
+        {
+          type: 'chart',
+          chart_type: 'area',
+          device_features: ['solar-power', 'home-power'],
+          interval: 'last-day',
+          units: ['watt', 'watt'],
+          title: 'Production and consumption',
+          display_variation: true
+        }
+      ],
+      [
+        {
+          type: 'gauge',
+          device_feature: 'home-power',
+          name: 'Home consumption',
+          gauge_use_custom_value: true,
+          gauge_min: 0,
+          gauge_max: 6000
+        },
+        {
+          type: 'gauge',
+          device_feature: 'home-battery-level',
+          name: 'Home battery',
+          gauge_use_custom_value: true,
+          gauge_min: 0,
+          gauge_max: 100
+        }
+      ]
     ]
-  ],
-  [
-    [
-      {
-        type: 'gauge',
-        device_feature: 'home-power',
-        name: 'Home consumption',
-        gauge_use_custom_value: true,
-        gauge_min: 0,
-        gauge_max: 6000
-      }
-    ],
-    [{ type: 'edf-tempo' }],
-    [{ type: 'ecowatt' }]
-  ],
+  },
+  // Three columns of the same height: what the house measures, what the grid
+  // announces (the two French signals side by side), and the car.
   [
     [
       {
@@ -294,9 +299,7 @@ const ENERGY_SECTIONS = [
           'solar-daily-production'
         ],
         device_feature_names: ['Grid power', 'Solar power', 'Battery', 'Consumed today', 'Produced today']
-      }
-    ],
-    [
+      },
       {
         type: 'actions',
         name: 'Car',
@@ -304,12 +307,27 @@ const ENERGY_SECTIONS = [
           { action_type: 'scene', scene: 'solar-car-charge' },
           { action_type: 'device-feature', device_feature: 'garage-door-lock', label: 'Garage door' }
         ]
-      },
+      }
+    ],
+    [{ type: 'edf-tempo' }, { type: 'ecowatt' }],
+    [
       {
         type: 'devices-in-room',
         room: 'garage',
         device_features: ['garage-wallbox-charge', 'garage-wallbox-power', 'garage-door-lock'],
         device_feature_names: ['Car charging', 'Charging power', 'Garage door']
+      },
+      {
+        // the battery of the house over the day, not the wallbox: the car is
+        // not charging in the demo, and a curve of a charger at rest says
+        // nothing
+        type: 'chart',
+        chart_type: 'area',
+        device_features: ['home-battery-level'],
+        interval: 'last-day',
+        units: ['percent'],
+        title: 'Home battery',
+        display_variation: true
       }
     ]
   ]

--- a/front/src/config/demo/dashboards.js
+++ b/front/src/config/demo/dashboards.js
@@ -72,6 +72,23 @@ const HOUSE_VIEW = {
 
 const HOME_SECTIONS = [
   [[HOME_CHIPS]],
+  // The two hero visuals share a two-column section of their own: given half
+  // the dashboard each, the house illustration and the camera snapshot render
+  // near their natural proportions instead of one of them being cropped to
+  // fill the height of a column of small widgets.
+  [
+    [HOUSE_VIEW],
+    [
+      {
+        type: 'camera',
+        camera: 'garden-camera',
+        name: 'Garden'
+      }
+    ]
+  ],
+  // Three columns of comparable height: the reading side (time, weather, sun),
+  // the command side (actions, scenes, music) and the house side (alarm, who is
+  // home, the temperature curve). Columns that end together leave no hole.
   [
     [
       {
@@ -82,11 +99,15 @@ const HOME_SECTIONS = [
       {
         type: 'weather',
         house: 'main-house',
+        // Compact on purpose: today's weather and the five days ahead. The
+        // advanced block (humidity, pressure, sunrise/sunset, moon) is off —
+        // the sun widget right below already carries it, and stacking both
+        // made the column twice as tall as its neighbours.
         modes: {
           dateLocation: true,
           currentWeather: true,
-          advancedWeather: true,
-          hourlyForecast: true,
+          advancedWeather: false,
+          hourlyForecast: false,
           dailyForecast: true,
           alerts: true
         }
@@ -94,14 +115,6 @@ const HOME_SECTIONS = [
       {
         type: 'sun',
         house: 'main-house'
-      }
-    ],
-    [
-      HOUSE_VIEW,
-      {
-        type: 'camera',
-        camera: 'garden-camera',
-        name: 'Garden'
       }
     ],
     [
@@ -119,8 +132,26 @@ const HOME_SECTIONS = [
         }
       },
       {
+        type: 'music',
+        device: 'living-room-sonos'
+      }
+    ],
+    [
+      {
         type: 'alarm',
         house: 'main-house'
+      },
+      {
+        type: 'user-presence'
+      },
+      {
+        type: 'chart',
+        chart_type: 'area',
+        device_features: ['living-room-temperature', 'outdoor-temperature'],
+        interval: 'last-week',
+        units: ['celsius', 'celsius'],
+        title: 'Temperature',
+        display_variation: true
       }
     ]
   ],
@@ -130,6 +161,8 @@ const HOME_SECTIONS = [
     [{ type: 'temperature-in-room', room: 'kids-room' }],
     [{ type: 'temperature-in-room', room: 'office' }]
   ],
+  // One room per column, all three of the same size: the bottom of the
+  // dashboard is a straight line.
   [
     [
       {
@@ -155,10 +188,6 @@ const HOME_SECTIONS = [
           'Air conditioning',
           'Setpoint'
         ]
-      },
-      {
-        type: 'music',
-        device: 'living-room-sonos'
       }
     ],
     [
@@ -187,16 +216,18 @@ const HOME_SECTIONS = [
     ],
     [
       {
-        type: 'user-presence'
-      },
-      {
-        type: 'chart',
-        chart_type: 'area',
-        device_features: ['living-room-temperature', 'outdoor-temperature'],
-        interval: 'last-week',
-        units: ['celsius', 'celsius'],
-        title: 'Temperature',
-        display_variation: true
+        type: 'devices-in-room',
+        room: 'office',
+        device_features: [
+          'office-light-binary',
+          'office-light-brightness',
+          'office-plug-binary',
+          'office-plug-power',
+          'office-presence',
+          'office-temperature',
+          'office-co2'
+        ],
+        device_feature_names: ['Desk lamp', 'Brightness', 'Desk plug', 'Power', 'Presence', 'Temperature', 'CO2']
       }
     ]
   ]
@@ -319,6 +350,10 @@ const COMFORT_SECTIONS = [
     [{ type: 'temperature-in-room', room: 'bathroom' }],
     [{ type: 'humidity-in-room', room: 'bathroom' }]
   ],
+  // Three columns, each a curve (or a list) over the devices it comes from,
+  // and each ending at about the same height. Two wide columns used to leave
+  // the widgets stretched across half the screen, and the documentation link
+  // sat alone in a third one with a hole under it.
   [
     [
       {
@@ -329,9 +364,7 @@ const COMFORT_SECTIONS = [
         units: ['ppm', 'ppm', 'ppm'],
         title: 'CO2',
         display_variation: true
-      }
-    ],
-    [
+      },
       {
         type: 'devices-in-room',
         room: 'bathroom',
@@ -343,10 +376,17 @@ const COMFORT_SECTIONS = [
         ],
         device_feature_names: ['Water heater', 'Hot water', 'Towel rail', 'Humidity']
       }
-    ]
-  ],
-  [
+    ],
     [
+      {
+        type: 'chart',
+        chart_type: 'line',
+        device_features: ['living-room-humidity', 'bedroom-humidity', 'bathroom-humidity'],
+        interval: 'last-day',
+        units: ['percent', 'percent', 'percent'],
+        title: 'Humidity',
+        display_variation: true
+      },
       {
         type: 'devices-in-room',
         room: 'bedroom',
@@ -373,9 +413,7 @@ const COMFORT_SECTIONS = [
           'outdoor-temperature'
         ],
         device_feature_names: ['Living room', 'Kitchen', 'Bedroom', 'Kids room', 'Office', 'Outside']
-      }
-    ],
-    [
+      },
       {
         type: 'link',
         title: 'Gladys documentation',

--- a/front/src/config/demo/helpers.js
+++ b/front/src/config/demo/helpers.js
@@ -24,16 +24,13 @@ const uuid = seed => {
 };
 
 /**
- * Language the demo writes its own texts in. The demo has no server to store a
- * user preference in: `get /api/v1/me` already answers with the language of the
- * browser, so the interface is translated — the texts the fixtures write
- * themselves (the chat history) follow the same rule, otherwise a French visitor
- * reads a French interface with an English conversation in it.
+ * Language the demo speaks. The demo has no server to store a user preference
+ * in: `get /api/v1/me` answers the language of the browser, so the interface is
+ * translated — and everything the fixtures write themselves (room and device
+ * names, scenes, the chat) follows the same rule through ./i18n.js, otherwise a
+ * French visitor reads a French interface full of English data.
  */
 const demoLanguage = () => ((navigator.language || '').toLowerCase().startsWith('fr') ? 'fr' : 'en');
-
-/** Picks, out of `{ en, fr }`, the text of the language of the browser. */
-const localized = texts => texts[demoLanguage()] || texts.en;
 
 const minutesAgo = minutes =>
   dayjs()
@@ -456,7 +453,6 @@ const productionPower = (name, selector, value, options) =>
 export {
   uuid,
   demoLanguage,
-  localized,
   minutesAgo,
   hoursAgo,
   daysAgo,

--- a/front/src/config/demo/helpers.js
+++ b/front/src/config/demo/helpers.js
@@ -23,6 +23,18 @@ const uuid = seed => {
   return `${raw.slice(0, 8)}-${raw.slice(8, 12)}-4${raw.slice(13, 16)}-a${raw.slice(17, 20)}-${raw.slice(20, 32)}`;
 };
 
+/**
+ * Language the demo writes its own texts in. The demo has no server to store a
+ * user preference in: `get /api/v1/me` already answers with the language of the
+ * browser, so the interface is translated — the texts the fixtures write
+ * themselves (the chat history) follow the same rule, otherwise a French visitor
+ * reads a French interface with an English conversation in it.
+ */
+const demoLanguage = () => ((navigator.language || '').toLowerCase().startsWith('fr') ? 'fr' : 'en');
+
+/** Picks, out of `{ en, fr }`, the text of the language of the browser. */
+const localized = texts => texts[demoLanguage()] || texts.en;
+
 const minutesAgo = minutes =>
   dayjs()
     .subtract(minutes, 'minute')
@@ -443,6 +455,8 @@ const productionPower = (name, selector, value, options) =>
 
 export {
   uuid,
+  demoLanguage,
+  localized,
   minutesAgo,
   hoursAgo,
   daysAgo,

--- a/front/src/config/demo/home.js
+++ b/front/src/config/demo/home.js
@@ -29,6 +29,7 @@ import {
   productionPower,
   feature
 } from './helpers';
+import { translate } from './i18n';
 import {
   DEVICE_FEATURE_CATEGORIES,
   DEVICE_FEATURE_TYPES,
@@ -681,6 +682,13 @@ const ROOMS = [
     ]
   }
 ];
+
+// The house speaks the language of the browser: rooms, devices and features
+// are translated here, at the source, so everything derived from them — the
+// route map, the room pages, the history and the activity page — is translated
+// with them (see ./i18n.js).
+translate(HOUSE);
+translate(ROOMS);
 
 // Rooms and devices, with the ids and back-references the API returns
 const rooms = ROOMS.map(room => ({

--- a/front/src/config/demo/i18n.js
+++ b/front/src/config/demo/i18n.js
@@ -1,0 +1,258 @@
+import { demoLanguage } from './helpers';
+
+/**
+ * French of everything the demo house says.
+ *
+ * The fixtures are written in English — they read like the house of an English
+ * speaking user — and this table is what a French visitor sees instead: room
+ * and device names on the devices, activity and settings pages, widget labels
+ * on the dashboards, scene and calendar names, the texts the scenes send. The
+ * interface itself is already translated by the front (`get /api/v1/me`
+ * answers the language of the browser); without this table the French demo was
+ * a French interface full of English data.
+ *
+ * A string absent from this table is left untouched, which is the rule for
+ * everything that is not a sentence a human wrote: hardware and product names
+ * (ConBee II, ZBDongle-E, Sonos Play), identifiers, selectors, units.
+ */
+const FRENCH = {
+  // --- House, rooms ------------------------------------------------------
+  Home: 'Maison',
+  'Living room': 'Salon',
+  'Living Room': 'Salon',
+  Kitchen: 'Cuisine',
+  Bedroom: 'Chambre',
+  'Kids room': 'Chambre des enfants',
+  Bathroom: 'Salle de bain',
+  Office: 'Bureau',
+  Garage: 'Garage',
+  Garden: 'Jardin',
+  'Technical room': 'Local technique',
+  Outside: 'Extérieur',
+
+  // --- Devices -----------------------------------------------------------
+  'Ceiling light': 'Plafonnier',
+  'TV backlight': 'Rétroéclairage TV',
+  Television: 'Télévision',
+  'Air conditioning': 'Climatisation',
+  Shutter: 'Volet',
+  'Living room sensor': 'Capteur du salon',
+  'Kitchen spots': 'Spots de la cuisine',
+  'Coffee machine': 'Machine à café',
+  Dishwasher: 'Lave-vaisselle',
+  'Kitchen sensor': 'Capteur de la cuisine',
+  'Kitchen window': 'Fenêtre de la cuisine',
+  'Under the sink': "Sous l'évier",
+  'Bedside lamps': 'Lampes de chevet',
+  Thermostat: 'Thermostat',
+  'Bedroom shutter': 'Volet de la chambre',
+  'Bedroom sensor': 'Capteur de la chambre',
+  'Kids room light': 'Lumière de la chambre des enfants',
+  'Kids room sensor': 'Capteur de la chambre des enfants',
+  'Water heater': 'Chauffe-eau',
+  'Hot water available': 'Eau chaude disponible',
+  'Towel rail': 'Sèche-serviettes',
+  'Bathroom sensor': 'Capteur de la salle de bain',
+  'Desk lamp': 'Lampe de bureau',
+  'Desk plug': 'Prise du bureau',
+  'Presence sensor': 'Capteur de présence',
+  'Office sensor': 'Capteur du bureau',
+  'Garage door': 'Porte du garage',
+  Wallbox: 'Borne de recharge',
+  'Garden camera': 'Caméra du jardin',
+  'Weather station': 'Station météo',
+  'Garden lights': 'Éclairage du jardin',
+  Watering: 'Arrosage',
+  'Electric meter': 'Compteur électrique',
+  'Solar inverter': 'Onduleur solaire',
+  'Solar Inverter': 'Onduleur solaire',
+  'Home battery': 'Batterie de la maison',
+
+  // --- Features ----------------------------------------------------------
+  Brightness: 'Luminosité',
+  Color: 'Couleur',
+  'Color temperature': 'Température de couleur',
+  Temperature: 'Température',
+  Humidity: 'Humidité',
+  Pressure: 'Pression',
+  Motion: 'Mouvement',
+  Presence: 'Présence',
+  Luminosity: 'Luminosité',
+  Battery: 'Batterie',
+  'Battery level': 'Niveau de batterie',
+  Power: 'Puissance',
+  'Current power': 'Puissance instantanée',
+  'Charging power': 'Puissance de charge',
+  Charging: 'Recharge',
+  'Meter index': 'Index du compteur',
+  'Consumption today': 'Consommation du jour',
+  'Production today': 'Production du jour',
+  'Solar production': 'Production solaire',
+  'Water leak': "Fuite d'eau",
+  'Air quality': "Qualité de l'air",
+  'Air quality index': "Indice de qualité de l'air",
+  'Outdoor temperature': 'Température extérieure',
+  'Outdoor humidity': 'Humidité extérieure',
+  Setpoint: 'Consigne',
+  Position: 'Position',
+  Mode: 'Mode',
+  Volume: 'Volume',
+  Play: 'Lecture',
+  Pause: 'Pause',
+  Previous: 'Précédent',
+  Next: 'Suivant',
+  'Playback state': 'État de lecture',
+  Window: 'Fenêtre',
+  'Hot water': 'Eau chaude',
+
+  // --- Dashboards --------------------------------------------------------
+  Energy: 'Énergie',
+  Comfort: 'Confort',
+  'My house': 'Ma maison',
+  'Quick actions': 'Actions rapides',
+  Scenes: 'Scènes',
+  Open: 'Ouvrir',
+  Close: 'Fermer',
+  Solar: 'Solaire',
+  Producing: 'Production',
+  Consuming: 'Consommation',
+  'Produced today': "Produit aujourd'hui",
+  'Consumed today': "Consommé aujourd'hui",
+  'Electricity consumption': 'Consommation électrique',
+  'Production and consumption': 'Production et consommation',
+  'Home consumption': 'Consommation de la maison',
+  'Grid power': 'Puissance réseau',
+  'Solar power': 'Puissance solaire',
+  Car: 'Voiture',
+  'Car charging': 'Recharge de la voiture',
+  Temperatures: 'Températures',
+  'Gladys documentation': 'Documentation Gladys',
+
+  // --- Scenes ------------------------------------------------------------
+  'Good morning': 'Bonjour',
+  'Opens the shutters, turns the kitchen on and starts the coffee machine.':
+    'Ouvre les volets, allume la cuisine et lance la machine à café.',
+  'Good morning! Coffee is ready ☕': 'Bonjour ! Le café est prêt ☕',
+  'Movie night': 'Soirée cinéma',
+  'Dims the living room and closes the shutters when the TV turns on.':
+    "Tamise le salon et ferme les volets quand la télévision s'allume.",
+  'Leaving home': 'Départ de la maison',
+  'Turns everything off and arms the alarm once the house is empty.':
+    "Éteint tout et arme l'alarme une fois la maison vide.",
+  'Good night': 'Bonne nuit',
+  'Closes the shutters, turns the lights off and lowers the heating.':
+    'Ferme les volets, éteint les lumières et baisse le chauffage.',
+  'Water leak alert': "Alerte fuite d'eau",
+  'Warns everyone as soon as the sensor under the sink detects water.':
+    "Prévient tout le monde dès que le capteur sous l'évier détecte de l'eau.",
+  '🚨 Water leak detected in the kitchen!': "🚨 Fuite d'eau détectée dans la cuisine !",
+  'Charge the car with the sun': 'Recharger la voiture au soleil',
+  'Starts charging the car when solar production covers it.':
+    'Lance la recharge de la voiture quand la production solaire la couvre.',
+  'The car is now charging on solar production ☀️': 'La voiture se recharge sur la production solaire ☀️',
+  Security: 'Sécurité',
+
+  // --- Chat --------------------------------------------------------------
+  'What is the temperature in the living room?': 'Quelle température fait-il dans le salon ?',
+  'It is 21.4°C in the living room.': 'Il fait 21,4°C dans le salon.',
+  'Turn on the kitchen light': 'Allume la lumière de la cuisine',
+  'The kitchen light is on.': 'La lumière de la cuisine est allumée.',
+  'How much electricity did we use today?': "Combien d'électricité avons-nous consommée aujourd'hui ?",
+  'You used 9.4 kWh today, and your solar panels produced 14.6 kWh.':
+    "Vous avez consommé 9,4 kWh aujourd'hui, et vos panneaux solaires ont produit 14,6 kWh.",
+  'What is the weather like tomorrow?': 'Quel temps fera-t-il demain ?',
+  'Tomorrow will be mostly sunny, between 14°C and 24°C.': 'Demain sera plutôt ensoleillé, entre 14°C et 24°C.',
+
+  // --- Calendar ----------------------------------------------------------
+  Family: 'Famille',
+  Work: 'Travail',
+  'Yoga class': 'Cours de yoga',
+  'Team meeting': "Réunion d'équipe",
+  Dentist: 'Dentiste',
+  'Dinner with Pepper': 'Dîner avec Pepper',
+  'Sprint review': 'Revue de sprint',
+  'Swimming pool': 'Piscine',
+
+  // --- Community integration ---------------------------------------------
+  'Reads the production of your solar inverter.': 'Lit la production de votre onduleur solaire.',
+
+  // --- Integration pages (discovered devices, remotes) --------------------
+  'Temperature sensor': 'Capteur de température',
+  'Pressure Sensor': 'Capteur de pression',
+  'Aqara Sensor': 'Capteur Aqara',
+  'Fibaro Motion Sensor': 'Capteur de mouvement Fibaro',
+  'Unsupported device': 'Appareil non pris en charge',
+  'New device': 'Nouvel appareil',
+  'Random MAC device': 'Appareil à MAC aléatoire',
+  'BLE Device 1': 'Appareil BLE 1',
+  'Media server': 'Serveur multimédia',
+  Custom: 'Personnalisé',
+  Switch: 'Interrupteur',
+  'Switch 1': 'Interrupteur 1',
+  'Switch 2': 'Interrupteur 2',
+  'Switch 1 On/Off': 'Interrupteur 1 marche/arrêt',
+  'Switch 2 On/Off': 'Interrupteur 2 marche/arrêt',
+  'On/Off': 'Marche/Arrêt',
+  'Power ON': 'Allumer',
+  'TV Remote': 'Télécommande TV',
+  'LED remote': 'Télécommande LED',
+  Source: 'Source',
+  Channel: 'Chaîne',
+  Voltage: 'Tension',
+  'New Lamp': 'Nouvelle lampe',
+  'Living room lamp': 'Lampe du salon',
+  'Plug Coffee Machine': 'Prise machine à café',
+  'Light Swimming Pool': 'Lumière de la piscine',
+  'Plug TV Dock': 'Prise du dock TV',
+  'Light Bedroom': 'Lumière de la chambre',
+  'Sonos Speaker': 'Enceinte Sonos',
+  'Xiaomi Temperature': 'Température Xiaomi',
+  'Peanut temperature': 'Température Peanut',
+  'Sonoff Basic Kitchen': 'Sonoff Basic cuisine',
+  'Sonoff Pow Kitchen': 'Sonoff Pow cuisine',
+  'Sonoff Mini Outside': 'Sonoff Mini extérieur'
+};
+
+/** The French of one text, or the text itself when it has none. */
+const t = text => (typeof text === 'string' && demoLanguage() === 'fr' ? FRENCH[text] || text : text);
+
+// Object keys whose value is a text the interface displays. Everything else is
+// left alone, so a selector, an external id or a Docker image never goes
+// through the table even if it happens to look like a sentence.
+const TRANSLATED_KEYS = ['name', 'title', 'label', 'description', 'text'];
+const TRANSLATED_LIST_KEYS = ['device_feature_names'];
+
+/**
+ * Walks a fixture and translates, in place, every text the interface displays.
+ * In place, because the demo derives its routes from a handful of shared
+ * objects (the house is read both by the route map and by the functions that
+ * generate the history): translating a copy would leave half the demo in
+ * English.
+ *
+ * @param {*} value - Fixture to translate (object, array, or anything else).
+ * @returns {*} The same value, translated.
+ * @example
+ * translate({ name: 'Living room' }); // { name: 'Salon' }
+ */
+const translate = value => {
+  if (Array.isArray(value)) {
+    value.forEach(translate);
+    return value;
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  Object.keys(value).forEach(key => {
+    const child = value[key];
+    if (TRANSLATED_KEYS.includes(key) && typeof child === 'string') {
+      value[key] = t(child);
+    } else if (TRANSLATED_LIST_KEYS.includes(key) && Array.isArray(child)) {
+      value[key] = child.map(t);
+    } else if (child && typeof child === 'object') {
+      translate(child);
+    }
+  });
+  return value;
+};
+
+export { t, translate, FRENCH };

--- a/front/src/config/demo/index.js
+++ b/front/src/config/demo/index.js
@@ -178,6 +178,11 @@ externalIntegrations.forEach(integration => {
 const simulatedInstalls = [];
 
 const installFromStore = async ({ store_slug: storeSlug }) => {
+  // Installing twice (browser-back onto the install page, for instance) gives
+  // back the integration already installed rather than a duplicate of it.
+  if (installedBySlug[storeSlug]) {
+    return installedBySlug[storeSlug];
+  }
   const { integrations: catalog } = await getStoreCatalog({}, installedBySlug);
   const entry = catalog.find(candidate => candidate.store_slug === storeSlug);
   if (!entry) {
@@ -208,6 +213,8 @@ const installFromStore = async ({ store_slug: storeSlug }) => {
   // nothing published yet: the devices screen of a fresh install is empty
   // (the ones of the house are derived from home.js, per service)
   data[`get /api/v1/service/${integration.selector}/device`] = [];
+  // the catalog and the install page read this map to flag the entry installed
+  installedBySlug[storeSlug] = integration;
   simulatedInstalls.push(integration);
   return integration;
 };

--- a/front/src/config/demo/index.js
+++ b/front/src/config/demo/index.js
@@ -8,7 +8,7 @@ import { scenes, sceneTags, calendars, calendarEvents, messages } from './scenes
 import { getAggregatedStates, getEnergyConsumption, getStatesCsv, getStatesHistory } from './history';
 import { demoLanguage, uuid, hoursAgo, minutesAgo, solarPowerNow } from './helpers';
 import integrations from './integrations';
-import { getStoreCatalog, getStoreDocs } from './store';
+import { getStoreCatalog, refreshStoreCatalog, getStoreDocs } from './store';
 import system from './system';
 
 /**
@@ -480,10 +480,10 @@ const home = {
   // catalog, and the demo lists the integrations published right now, with
   // their covers, categories, GitHub stars and documentation (see ./store.js).
   'get /api/v1/external_integration/store': query => getStoreCatalog(query, installedBySlug),
-  'post /api/v1/external_integration/store/refresh': async () => ({
-    ...(await getStoreCatalog({ refresh: true }, installedBySlug)),
-    refreshed: true
-  }),
+  // `refreshed` says whether the download really happened, like the server:
+  // a store that is down leaves the catalog as it was, and the page shows its
+  // stale-catalog warning instead of claiming a fresh one
+  'post /api/v1/external_integration/store/refresh': () => refreshStoreCatalog(installedBySlug),
   'get /api/v1/external_integration/store/docs': query => getStoreDocs(query),
   'post /api/v1/external_integration': body => installFromStore(body),
   // Hardware access classes offered by the install screen of an integration

--- a/front/src/config/demo/index.js
+++ b/front/src/config/demo/index.js
@@ -6,7 +6,7 @@ import { dashboards } from './dashboards';
 import { getWeather, getSunState } from './weather';
 import { scenes, sceneTags, calendars, calendarEvents, messages } from './scenes';
 import { getAggregatedStates, getEnergyConsumption, getStatesCsv, getStatesHistory } from './history';
-import { uuid, hoursAgo, minutesAgo, solarPowerNow } from './helpers';
+import { demoLanguage, uuid, hoursAgo, minutesAgo, solarPowerNow } from './helpers';
 import integrations from './integrations';
 import system from './system';
 
@@ -336,7 +336,7 @@ const home = {
   },
   'get /api/v1/me': {
     ...USERS[0],
-    language: (navigator.language || '').toLowerCase().startsWith('fr') ? 'fr' : 'en',
+    language: demoLanguage(),
     refresh_token: REFRESH_TOKEN,
     access_token: ACCESS_TOKEN
   },

--- a/front/src/config/demo/index.js
+++ b/front/src/config/demo/index.js
@@ -8,6 +8,7 @@ import { scenes, sceneTags, calendars, calendarEvents, messages } from './scenes
 import { getAggregatedStates, getEnergyConsumption, getStatesCsv, getStatesHistory } from './history';
 import { demoLanguage, uuid, hoursAgo, minutesAgo, solarPowerNow } from './helpers';
 import integrations from './integrations';
+import { getStoreCatalog, getStoreDocs } from './store';
 import system from './system';
 
 /**
@@ -130,23 +131,86 @@ const externalIntegrations = services
     containers: []
   }));
 
+// What the demo house has installed, so the store catalog flags it as such
+// instead of offering it for installation
+const installedBySlug = {};
+externalIntegrations.forEach(integration => {
+  if (integration.store_slug) {
+    installedBySlug[integration.store_slug] = integration;
+  }
+});
+
+// The pages of one installed community integration: its own screens
+// (Devices, Discovery, Configuration, Logs) plus the actions they trigger,
+// which — like everywhere else in the demo — answer without changing anything.
+const registerExternalIntegrationRoutes = (routes, integration, logs) => {
+  const base = `/api/v1/external_integration/${integration.selector}`;
+  routes[`get ${base}`] = integration;
+  routes[`get ${base}/config`] = { config: {}, configured_secrets: [] };
+  routes[`post ${base}/config`] = { config: {}, configured_secrets: [] };
+  routes[`get ${base}/contact`] = {};
+  routes[`get ${base}/logs`] = { logs };
+  routes[`get ${base}/discover`] = [];
+  routes[`get ${base}/discovered_device`] = [];
+  routes[`post ${base}/scan`] = { success: true };
+  routes[`delete ${base}`] = { success: true };
+};
+
 const externalIntegrationRoutes = {};
 externalIntegrations.forEach(integration => {
-  const base = `/api/v1/external_integration/${integration.selector}`;
-  externalIntegrationRoutes[`get ${base}`] = integration;
-  externalIntegrationRoutes[`get ${base}/config`] = { config: {}, configured_secrets: [] };
-  externalIntegrationRoutes[`get ${base}/contact`] = {};
-  externalIntegrationRoutes[`get ${base}/logs`] = {
-    logs: [
+  registerExternalIntegrationRoutes(
+    externalIntegrationRoutes,
+    integration,
+    [
       `${hoursAgo(52)} info: Solar Inverter integration started`,
       `${hoursAgo(52)} info: Connected to inverter at 192.168.1.42`,
       `${hoursAgo(2)} info: Published production power: 2380 W`,
       `${minutesAgo(4)} info: Published production power: ${solarPowerNow(3400)} W`
     ].join('\n')
-  };
-  externalIntegrationRoutes[`get ${base}/discover`] = [];
-  externalIntegrationRoutes[`get ${base}/discovered_device`] = [];
+  );
 });
+
+// Installing from the store: the demo has no Docker to run a container in, but
+// the button must not fail either (same rule as acting on a device). The
+// integration of the store index is turned into an installed one, its screens
+// are registered on the fly, and it joins the "Installed" list — until the page
+// is reloaded, since the demo persists nothing.
+const simulatedInstalls = [];
+
+const installFromStore = async ({ store_slug: storeSlug }) => {
+  const { integrations: catalog } = await getStoreCatalog({}, installedBySlug);
+  const entry = catalog.find(candidate => candidate.store_slug === storeSlug);
+  if (!entry) {
+    throw new Error(`${storeSlug} is not in the store index`);
+  }
+  const version = entry.manifest.version || '1.0.0';
+  const integration = {
+    id: uuid(`external-${storeSlug}`),
+    // selector derivation of the server (ext-<owner>-<repo>)
+    selector: `ext-${storeSlug.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`,
+    name: entry.manifest.name,
+    store_slug: storeSlug,
+    manifest: entry.manifest,
+    status: 'RUNNING',
+    connection_status: 'connected',
+    docker_image: entry.manifest.docker_image || null,
+    version,
+    latest_version: version,
+    update_available: false,
+    started_at: new Date().toISOString(),
+    containers: []
+  };
+  registerExternalIntegrationRoutes(
+    data,
+    integration,
+    `${new Date().toISOString()} info: ${entry.manifest.name} started`
+  );
+  // nothing published yet: the devices screen of a fresh install is empty
+  // (the ones of the house are derived from home.js, per service)
+  data[`get /api/v1/service/${integration.selector}/device`] = [];
+  simulatedInstalls.push(integration);
+  return integration;
+};
 
 // Areas of the map, and the fixture each one needs when it is opened for edit
 const AREAS = [
@@ -403,7 +467,28 @@ const home = {
   ...serviceVariables,
   'post /api/v1/service/mqtt/debug_mode': { success: true },
   ...devicesByService,
-  'get /api/v1/external_integration': externalIntegrations,
+  'get /api/v1/external_integration': () => externalIntegrations.concat(simulatedInstalls),
+  // The community store is the live one: these fixtures are functions, so the
+  // public store index is only downloaded when a page actually asks for the
+  // catalog, and the demo lists the integrations published right now, with
+  // their covers, categories, GitHub stars and documentation (see ./store.js).
+  'get /api/v1/external_integration/store': query => getStoreCatalog(query, installedBySlug),
+  'post /api/v1/external_integration/store/refresh': async () => ({
+    ...(await getStoreCatalog({ refresh: true }, installedBySlug)),
+    refreshed: true
+  }),
+  'get /api/v1/external_integration/store/docs': query => getStoreDocs(query),
+  'post /api/v1/external_integration': body => installFromStore(body),
+  // Hardware access classes offered by the install screen of an integration
+  // that asks for one: what a normal Linux host reports.
+  'get /api/v1/external_integration/hardware': {
+    classes: [
+      { class: 'coral-usb', detected: true },
+      { class: 'coral-pcie', detected: false },
+      { class: 'gpu', detected: true },
+      { class: 'video', detected: true }
+    ]
+  },
   ...externalIntegrationRoutes,
   'get /api/v1/service/ecowatt/signals': getEcowattSignals,
   // Messaging channels a "send a message" scene action can target

--- a/front/src/config/demo/index.js
+++ b/front/src/config/demo/index.js
@@ -8,6 +8,7 @@ import { scenes, sceneTags, calendars, calendarEvents, messages } from './scenes
 import { getAggregatedStates, getEnergyConsumption, getStatesCsv, getStatesHistory } from './history';
 import { demoLanguage, uuid, hoursAgo, minutesAgo, solarPowerNow } from './helpers';
 import integrations from './integrations';
+import { translate } from './i18n';
 import { getStoreCatalog, refreshStoreCatalog, getStoreDocs } from './store';
 import system from './system';
 
@@ -547,10 +548,15 @@ const home = {
   }
 };
 
-const data = {
+// Last pass over the whole map: what the house itself carries is already
+// translated (home.js does it at the source, so the generated history follows),
+// this covers everything written here and in the other fixtures — dashboards,
+// scenes, calendars, map areas, integration pages. Names the table does not
+// know (hardware models, identifiers) go through untouched.
+const data = translate({
   ...home,
   ...integrations,
   ...system
-};
+});
 
 export default data;

--- a/front/src/config/demo/integrations.js
+++ b/front/src/config/demo/integrations.js
@@ -437,9 +437,6 @@ const integrations = {
   },
   'post /api/v1/service/broadlink/learn': {},
   'post /api/v1/service/broadlink/learn/cancel': {},
-  // The installed community integration is derived from the house (see
-  // index.js); the store itself is empty, the demo cannot install anything
-  'get /api/v1/external_integration/store': { integrations: [] },
   'get /api/v1/service/mqtt': {},
   'get /api/v1/service/mqtt/status': {
     configured: true,

--- a/front/src/config/demo/scenes.js
+++ b/front/src/config/demo/scenes.js
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 
-import { uuid, minutesAgo, hoursAgo } from './helpers';
+import { uuid, localized, minutesAgo, hoursAgo } from './helpers';
 import { USERS } from './home';
 
 /**
@@ -199,24 +199,49 @@ const calendarEvents = [
 
 const TONY_ID = USERS[0].id;
 
-const message = (index, text, fromGladys) => ({
+// The conversation is the one text of the demo the assistant itself writes, so
+// it is served in the language of the browser: an interface translated into
+// French around an English conversation reads like a broken demo.
+const message = (index, texts, fromGladys) => ({
   id: uuid(`message-${index}`),
   sender_id: fromGladys ? null : TONY_ID,
   receiver_id: fromGladys ? TONY_ID : null,
-  text,
+  text: localized(texts),
   is_read: true,
   created_at: minutesAgo(60 - index)
 });
 
 const messages = [
-  message(0, 'What is the temperature in the living room?', false),
-  message(1, 'It is 21.4°C in the living room.', true),
-  message(2, 'Turn on the kitchen light', false),
-  message(3, 'The kitchen light is on.', true),
-  message(4, 'How much electricity did we use today?', false),
-  message(5, 'You used 9.4 kWh today, and your solar panels produced 14.6 kWh.', true),
-  message(6, 'What is the weather like tomorrow?', false),
-  message(7, 'Tomorrow will be mostly sunny, between 14°C and 24°C.', true)
+  message(
+    0,
+    { en: 'What is the temperature in the living room?', fr: 'Quelle température fait-il dans le salon ?' },
+    false
+  ),
+  message(1, { en: 'It is 21.4°C in the living room.', fr: 'Il fait 21,4°C dans le salon.' }, true),
+  message(2, { en: 'Turn on the kitchen light', fr: 'Allume la lumière de la cuisine' }, false),
+  message(3, { en: 'The kitchen light is on.', fr: 'La lumière de la cuisine est allumée.' }, true),
+  message(
+    4,
+    { en: 'How much electricity did we use today?', fr: "Combien d'électricité avons-nous consommé aujourd'hui ?" },
+    false
+  ),
+  message(
+    5,
+    {
+      en: 'You used 9.4 kWh today, and your solar panels produced 14.6 kWh.',
+      fr: "Vous avez consommé 9,4 kWh aujourd'hui, et vos panneaux solaires ont produit 14,6 kWh."
+    },
+    true
+  ),
+  message(6, { en: 'What is the weather like tomorrow?', fr: 'Quel temps fera-t-il demain ?' }, false),
+  message(
+    7,
+    {
+      en: 'Tomorrow will be mostly sunny, between 14°C and 24°C.',
+      fr: 'Demain sera plutôt ensoleillé, entre 14°C et 24°C.'
+    },
+    true
+  )
 ].reverse();
 
 export { scenes, sceneTags, calendars, calendarEvents, messages };

--- a/front/src/config/demo/scenes.js
+++ b/front/src/config/demo/scenes.js
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 
-import { uuid, localized, minutesAgo, hoursAgo } from './helpers';
+import { uuid, minutesAgo, hoursAgo } from './helpers';
+import { t } from './i18n';
 import { USERS } from './home';
 
 /**
@@ -199,49 +200,57 @@ const calendarEvents = [
 
 const TONY_ID = USERS[0].id;
 
-// The conversation is the one text of the demo the assistant itself writes, so
-// it is served in the language of the browser: an interface translated into
-// French around an English conversation reads like a broken demo.
-const message = (index, texts, fromGladys) => ({
+const message = (index, text, fromGladys) => ({
   id: uuid(`message-${index}`),
   sender_id: fromGladys ? null : TONY_ID,
   receiver_id: fromGladys ? TONY_ID : null,
-  text: localized(texts),
+  text,
+  message_type: 'chat',
   is_read: true,
   created_at: minutesAgo(60 - index)
 });
 
+/**
+ * Gladys does not answer a question about the house from memory: it calls its
+ * tools, and the chat shows every call between the question and the answer —
+ * the tool name, and the arguments the model sent, folded until one opens
+ * them. The demo shows the same traces, with the names and the format of the
+ * real ones (`formatToolCallTraceText` in
+ * `server/lib/gateway/gateway.forwardMessageToAiChat.js`); a chat where the
+ * answers appear out of nowhere hides half of what the assistant does.
+ */
+const toolCall = (index, toolName, args) => ({
+  id: uuid(`message-${index}`),
+  sender_id: null,
+  receiver_id: TONY_ID,
+  text: `${toolName}(${JSON.stringify(args)})`,
+  message_type: 'tool_call',
+  tool_name: toolName,
+  tool_status: 'success',
+  is_read: true,
+  created_at: minutesAgo(60 - index)
+});
+
+const today = dayjs().format('YYYY-MM-DD');
+
 const messages = [
-  message(
-    0,
-    { en: 'What is the temperature in the living room?', fr: 'Quelle température fait-il dans le salon ?' },
-    false
-  ),
-  message(1, { en: 'It is 21.4°C in the living room.', fr: 'Il fait 21,4°C dans le salon.' }, true),
-  message(2, { en: 'Turn on the kitchen light', fr: 'Allume la lumière de la cuisine' }, false),
-  message(3, { en: 'The kitchen light is on.', fr: 'La lumière de la cuisine est allumée.' }, true),
-  message(
-    4,
-    { en: 'How much electricity did we use today?', fr: "Combien d'électricité avons-nous consommée aujourd'hui ?" },
-    false
-  ),
-  message(
-    5,
-    {
-      en: 'You used 9.4 kWh today, and your solar panels produced 14.6 kWh.',
-      fr: "Vous avez consommé 9,4 kWh aujourd'hui, et vos panneaux solaires ont produit 14,6 kWh."
-    },
-    true
-  ),
-  message(6, { en: 'What is the weather like tomorrow?', fr: 'Quel temps fera-t-il demain ?' }, false),
-  message(
-    7,
-    {
-      en: 'Tomorrow will be mostly sunny, between 14°C and 24°C.',
-      fr: 'Demain sera plutôt ensoleillé, entre 14°C et 24°C.'
-    },
-    true
-  )
+  message(0, 'What is the temperature in the living room?', false),
+  toolCall(1, 'device_get_state', { room: t('Living room'), device_type: 'temperature-sensor' }),
+  message(2, 'It is 21.4°C in the living room.', true),
+  message(3, 'Turn on the kitchen light', false),
+  toolCall(4, 'device_turn_on_off', { action: 'on', device: t('Kitchen spots') }),
+  message(5, 'The kitchen light is on.', true),
+  message(6, 'How much electricity did we use today?', false),
+  toolCall(7, 'device_get_energy_consumption', {
+    device: t('Electric meter'),
+    start_date: today,
+    end_date: today
+  }),
+  toolCall(8, 'device_get_state', { device_type: 'energy-production-sensor' }),
+  message(9, 'You used 9.4 kWh today, and your solar panels produced 14.6 kWh.', true),
+  message(10, 'What is the weather like tomorrow?', false),
+  toolCall(11, 'weather_get', { house: t('Home') }),
+  message(12, 'Tomorrow will be mostly sunny, between 14°C and 24°C.', true)
 ].reverse();
 
 export { scenes, sceneTags, calendars, calendarEvents, messages };

--- a/front/src/config/demo/scenes.js
+++ b/front/src/config/demo/scenes.js
@@ -222,7 +222,7 @@ const messages = [
   message(3, { en: 'The kitchen light is on.', fr: 'La lumière de la cuisine est allumée.' }, true),
   message(
     4,
-    { en: 'How much electricity did we use today?', fr: "Combien d'électricité avons-nous consommé aujourd'hui ?" },
+    { en: 'How much electricity did we use today?', fr: "Combien d'électricité avons-nous consommée aujourd'hui ?" },
     false
   ),
   message(

--- a/front/src/config/demo/store.js
+++ b/front/src/config/demo/store.js
@@ -15,9 +15,9 @@ import { version as GLADYS_VERSION } from '../../../../package.json';
  *
  * It is therefore the only request of the demo that leaves the browser. It is
  * a public, CORS-open, CDN-cached file, it is only made when the integrations
- * page is opened, and a failure is not an error: the catalog is then empty and
- * the page shows the native integrations alone, exactly like an instance whose
- * store is unreachable.
+ * page is opened, and a failure is not an error: the last index downloaded is
+ * kept (empty if none ever was, and the page then shows the native
+ * integrations alone), exactly like an instance whose store is unreachable.
  */
 
 const STORE_INDEX_URL = 'https://integration-store-storage.gladysassistant.com/index.json';
@@ -42,6 +42,9 @@ const fetchWithTimeout = async (url, options) => {
 // the install pages — and never retried in a loop if the store is down
 let indexPromise = null;
 let fetchedAt = null;
+// The last index actually downloaded, kept like the server keeps its cache:
+// empty only until a first download succeeds
+let lastDownloadedEntries = [];
 
 const downloadIndex = async () => {
   try {
@@ -54,13 +57,16 @@ const downloadIndex = async () => {
       throw new Error(`Unsupported store index format ${index.index_format}`);
     }
     fetchedAt = new Date().toISOString();
-    return Array.isArray(index.integrations) ? index.integrations : [];
+    lastDownloadedEntries = Array.isArray(index.integrations) ? index.integrations : [];
+    return lastDownloadedEntries;
   } catch (e) {
     // An unreachable store is a supported state of a real instance, not a
-    // missing fixture: say so and show an empty catalog.
-    console.error('Demo: community integration store unreachable, catalog left empty', e);
-    fetchedAt = null;
-    return [];
+    // missing fixture: say so and serve the last index downloaded, exactly
+    // like the server falls back on its cache. A refresh that times out must
+    // not empty a catalog that had just loaded; before the first successful
+    // download there is nothing to keep, and the catalog is empty.
+    console.error('Demo: community integration store unreachable, serving the last catalog downloaded', e);
+    return lastDownloadedEntries;
   }
 };
 
@@ -136,6 +142,20 @@ const getStoreCatalog = async ({ search, refresh } = {}, installedBySlug = {}) =
 };
 
 /**
+ * Refresh on demand, like the server's store.refreshCatalog.js: an
+ * unreachable store never fails the catalog, so the catalog alone cannot tell
+ * a real download from a served-from-memory one. The fetch timestamp only
+ * moves on a successful download, so comparing it around the call is the
+ * signal — and the front warns on `refreshed: false` instead of claiming a
+ * catalog it never downloaded is up to date.
+ */
+const refreshStoreCatalog = async (installedBySlug = {}) => {
+  const fetchedAtBefore = fetchedAt;
+  const catalog = await getStoreCatalog({ refresh: true }, installedBySlug);
+  return { ...catalog, refreshed: fetchedAt !== fetchedAtBefore };
+};
+
+/**
  * Documentation of a store integration. The server re-hosts the markdown of
  * the index entry; the demo downloads it from the same URL, so the modal shows
  * the real documentation of the real integration.
@@ -155,4 +175,4 @@ const getStoreDocs = async ({ store_slug: storeSlug, lang }) => {
   return { content: await response.text(), url };
 };
 
-export { getStoreCatalog, getStoreDocs, STORE_INDEX_URL };
+export { getStoreCatalog, refreshStoreCatalog, getStoreDocs, STORE_INDEX_URL };

--- a/front/src/config/demo/store.js
+++ b/front/src/config/demo/store.js
@@ -1,0 +1,158 @@
+import { INTEGRATION_CATALOG_CATEGORIES } from '../../../../server/utils/constants';
+import { version as GLADYS_VERSION } from '../../../../package.json';
+
+/**
+ * The community integration store of the demo.
+ *
+ * This is the one thing the demo does not invent. The catalog of external
+ * integrations is a public static index (`index.json`) rebuilt hourly by the
+ * indexer (GladysAssistant/integration-store) and downloaded by every Gladys
+ * instance — see `server/lib/external-integration/store/store.constants.js`,
+ * which this file mirrors. The demo downloads the very same file, straight
+ * from the browser, so the demo catalog *is* the live catalog: a snapshot
+ * committed here would be a week out of date and would show integrations that
+ * no longer exist (or, worse, hide the ones published since).
+ *
+ * It is therefore the only request of the demo that leaves the browser. It is
+ * a public, CORS-open, CDN-cached file, it is only made when the integrations
+ * page is opened, and a failure is not an error: the catalog is then empty and
+ * the page shows the native integrations alone, exactly like an instance whose
+ * store is unreachable.
+ */
+
+const STORE_INDEX_URL = 'https://integration-store-storage.gladysassistant.com/index.json';
+// Index format this file knows how to read, like the server's
+// SUPPORTED_INDEX_FORMAT: a future breaking format must not be displayed wrong
+const SUPPORTED_INDEX_FORMAT = 1;
+const STORE_TIMEOUT_MS = 10 * 1000;
+
+const KNOWN_CATEGORIES = INTEGRATION_CATALOG_CATEGORIES;
+
+const fetchWithTimeout = async (url, options) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), STORE_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+// One download per page load, shared by the catalog, the refresh button and
+// the install pages — and never retried in a loop if the store is down
+let indexPromise = null;
+let fetchedAt = null;
+
+const downloadIndex = async () => {
+  try {
+    const response = await fetchWithTimeout(STORE_INDEX_URL);
+    if (!response.ok) {
+      throw new Error(`Store index responded ${response.status}`);
+    }
+    const index = await response.json();
+    if (index.index_format !== SUPPORTED_INDEX_FORMAT) {
+      throw new Error(`Unsupported store index format ${index.index_format}`);
+    }
+    fetchedAt = new Date().toISOString();
+    return Array.isArray(index.integrations) ? index.integrations : [];
+  } catch (e) {
+    // An unreachable store is a supported state of a real instance, not a
+    // missing fixture: say so and show an empty catalog.
+    console.error('Demo: community integration store unreachable, catalog left empty', e);
+    fetchedAt = null;
+    return [];
+  }
+};
+
+const getIndex = ({ refresh = false } = {}) => {
+  if (!indexPromise || refresh) {
+    indexPromise = downloadIndex();
+  }
+  return indexPromise;
+};
+
+/**
+ * Compatibility of an integration with the Gladys version of the demo. Every
+ * manifest of the store expresses it as a simple ">=x.y.z" range; anything
+ * else is given the benefit of the doubt rather than shown as incompatible
+ * (the server resolves the full semver grammar, which is not worth shipping
+ * in the demo bundle for a badge).
+ */
+const isCompatible = range => {
+  const match = /^>=\s*v?(\d+)\.(\d+)\.(\d+)/.exec(String(range || '').trim());
+  if (!match) {
+    return true;
+  }
+  const required = match.slice(1, 4).map(Number);
+  const current = GLADYS_VERSION.split('.').map(part => parseInt(part, 10) || 0);
+  for (let i = 0; i < 3; i += 1) {
+    if ((current[i] || 0) !== required[i]) {
+      return (current[i] || 0) > required[i];
+    }
+  }
+  return true;
+};
+
+/**
+ * The catalog as the server builds it (store.getCatalog.js): index entries
+ * plus the flags the front reads. `installedSlugs` is what the demo house has
+ * installed, so a community integration of the demo is marked as such in the
+ * catalog instead of being offered for installation.
+ */
+const getStoreCatalog = async ({ search, refresh } = {}, installedBySlug = {}) => {
+  const entries = await getIndex({ refresh });
+  let integrations = entries.map(entry => {
+    const installed = installedBySlug[entry.store_slug];
+    return {
+      store_slug: entry.store_slug,
+      repo_url: entry.repo_url,
+      manifest: entry.manifest,
+      cover_url: entry.cover_url,
+      github: entry.github,
+      docs: entry.docs || null,
+      // keys from a newer vocabulary than this front knows are dropped, never
+      // a reason to hide the integration
+      categories: Array.isArray(entry.categories)
+        ? entry.categories.filter(category => KNOWN_CATEGORIES.includes(category))
+        : [],
+      first_seen_at: typeof entry.first_seen_at === 'string' ? entry.first_seen_at : null,
+      installed: installed !== undefined,
+      installed_selector: installed ? installed.selector : null,
+      update_available: false,
+      compatible: isCompatible(entry.manifest && entry.manifest.gladys_version)
+    };
+  });
+  if (search) {
+    const keyword = search.toLowerCase();
+    integrations = integrations.filter(entry => {
+      const name = (entry.manifest.name || '').toLowerCase();
+      const descriptions = Object.values(entry.manifest.description || {})
+        .join(' ')
+        .toLowerCase();
+      return name.includes(keyword) || descriptions.includes(keyword) || entry.store_slug.includes(keyword);
+    });
+  }
+  return { refreshed_at: fetchedAt, integrations };
+};
+
+/**
+ * Documentation of a store integration. The server re-hosts the markdown of
+ * the index entry; the demo downloads it from the same URL, so the modal shows
+ * the real documentation of the real integration.
+ */
+const getStoreDocs = async ({ store_slug: storeSlug, lang }) => {
+  const entries = await getIndex();
+  const entry = entries.find(candidate => candidate.store_slug === storeSlug);
+  const urls = (entry && entry.docs) || {};
+  const url = urls[lang] || urls.en || urls.fr;
+  if (!url) {
+    throw new Error(`No documentation for ${storeSlug}`);
+  }
+  const response = await fetchWithTimeout(url);
+  if (!response.ok) {
+    throw new Error(`Documentation responded ${response.status}`);
+  }
+  return { content: await response.text(), url };
+};
+
+export { getStoreCatalog, getStoreDocs, STORE_INDEX_URL };


### PR DESCRIPTION
### Description

A pass over the public demo, all in the demo fixtures (`front/src/config/demo/`) — no change to the dashboard layout engine.

**1. Two languages, everywhere.** The interface was translated (the front follows the browser) but the data was not: a French visitor read "Solar inverter" on the activity page, English scenes, English calendar events, English rooms in the settings.

The fixtures stay written in English — they read like the house of an English speaking user — and the new `i18n.js` holds the French of everything the house says, plus the pass that applies it. `home.js` translates the house at the source, so everything derived from it follows (route map, room pages, generated history, activity page), and `index.js` translates the rest of the map (dashboards, scenes, calendars, map areas, integration pages). Only the values of the `name`, `title`, `label`, `description` and `text` keys go through the table, and a string absent from it is left untouched: hardware and product names (ConBee II, ZBDongle-E, Sonos Play), selectors, identifiers and units are never translated. The chat texts move to that table too, so `localized({ en, fr })` disappears — one place to look for the French of the demo.

**2. The chat shows the tool calls.** Gladys does not answer a question about the house from memory: it calls its tools, and the real chat shows every call between the question and the answer. The demo conversation now carries those traces, with the names and the format of the real ones (`device_get_state`, `device_turn_on_off`, `device_get_energy_consumption`, `weather_get`, arguments serialized like `formatToolCallTraceText`) — a chat where the answers appear out of nowhere hides half of what the assistant does.

**3. The community integration store was empty.** The demo answered the catalog with an empty list, so none of the 67 community integrations published today appeared, and the whole external-integration feature was invisible to anyone discovering Gladys through the demo.

The catalog is now the **live** one. `store.js` downloads the public store index (`index.json`, rebuilt hourly by the indexer — the URL mirrors `server/lib/external-integration/store/store.constants.js`), the very same file every Gladys instance downloads, and maps it exactly like `store.getCatalog.js`. A snapshot committed in the repository would be stale a week later. This is the one request of the demo that leaves the browser, made only when a page asks for the catalog, and a failure is a supported state rather than a missing fixture: the last index downloaded is kept and the refresh button reports `refreshed: false`, like an instance whose store is unreachable. Browsing is complete (covers, categories, GitHub stars, documentation modal), and installing follows the rule the rest of the demo follows — acting changes nothing but must not fail: the store entry becomes an installed integration whose screens are registered on the fly, so the Configuration screen renders the real `config_schema` of the real integration.

**4. The Energy dashboard is redesigned.** It was two sections of two wide columns (widgets stretched over half the screen) and a three-column one with 300px holes under two of them. It is now: the bill and the day it comes from on two thirds of the width, with the two live gauges of the house beside them — the demo's first weighted section, which is what makes a chart readable and a gauge not — then three columns of comparable height (what the house measures and the car scene, the two French grid signals, the garage and the battery curve). Measured: 742/647px on the weighted section, 550/583/510 on the last one. The wallbox curve is replaced by the house battery: the car is not charging in the demo, and a curve of a charger at rest says nothing.

**5. The camera looked stretched on the main dashboard.** It is the only widget of its column able to absorb leftover height, and it absorbs it by cropping: with just the house view above it, it had ~290px to swallow and rendered the 4:3 snapshot as a portrait. The Home layout is unchanged; a **garden card** now sits under the camera — the room it watches — and ends the column level with its neighbours, so the snapshot keeps its proportions (938/962/918px at 1440).

**6. The weather widget took half the page** (577px). Its advanced block duplicated the sun widget right below it, and the hourly strip stacked on top of the daily one. Current weather plus five days: 306px. The music widget moves down to the first column to take back the height the weather gave up.

**7. The Comfort tab was a showcase of what section layouts do badly** — two wide columns, and the documentation link alone in a third with a ~380px hole under it. It is now a single three-column section: the CO2 curve over the bathroom card, a new humidity curve over the bedroom card, and the temperature list with the link under it.

Everything documented in `front/src/config/demo/README.md`.

Verified by rendering the demo (`npm run start-demo`) at 390px, 1280px, 1440px, 1600px and 1920px, in English and in French, with no missing fixture in the console — including a scripted sweep of the French pages looking for any label of the table left in English, the store catalog, an install page, the documentation modal and a full install → configuration flow served from a local mirror of the store index.

## Forum

<!-- no forum topic -->

### Checklist

- [x] Tests pass: no server code changed; the demo fixtures are front-only and have no test suite of their own
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVLn6ppriSUWieSunpWEL4