### PR TITLE
Upgrade Zigbee2mqtt to 2.13.0

### DIFF
--- a/server/services/zigbee2mqtt/docker/gladys-z2m-zigbee2mqtt-container.json
+++ b/server/services/zigbee2mqtt/docker/gladys-z2m-zigbee2mqtt-container.json
@@ -1,6 +1,6 @@
 {
   "name": "gladys-z2m-zigbee2mqtt",
-  "Image": "koenkk/zigbee2mqtt:2.12.0",
+  "Image": "koenkk/zigbee2mqtt:2.13.0",
   "ExposedPorts": {},
   "HostConfig": {
     "Binds": [],

--- a/server/services/zigbee2mqtt/lib/constants.js
+++ b/server/services/zigbee2mqtt/lib/constants.js
@@ -50,7 +50,7 @@ const DEFAULT = {
     'zigbee2mqtt/#', // Default zigbee2mqtt topic
   ],
   DOCKER_MQTT_VERSION: '4', // Last version of MQTT docker file
-  DOCKER_Z2M_VERSION: '10', // Last version of Z2M docker file,
+  DOCKER_Z2M_VERSION: '11', // Last version of Z2M docker file,
   CONFIGURATION_PATH: 'zigbee2mqtt/z2m/configuration.yaml',
   CONFIGURATION_CONTENT: {
     homeassistant: false,


### PR DESCRIPTION
Description of change

Upgrade Zigbee2mqtt to 2.13.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the bundled Zigbee2MQTT version to 2.13.0.
  * New installations and upgrades now use the latest default container image configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->