### PR TITLE
fix(dashboard): weather icons too small and washed out in light mode

### DIFF
--- a/front/src/components/boxs/weather/WeatherBox.jsx
+++ b/front/src/components/boxs/weather/WeatherBox.jsx
@@ -332,11 +332,17 @@ class WeatherBoxComponent extends Component {
                condition instead of the two overlapping */
             <div style="display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; margin-bottom: 16px">
               <div style="display: flex; align-items: center; min-width: 0">
-                <div style="line-height: 1">
+                {/* the Meteocons viewBox is 64x64 but the artwork only fills
+                    the middle band, so a 92px icon carries ~11px of blank
+                    padding above and below. Clipping 12% off each side trims
+                    that dead space without touching the drawing: the tallest
+                    icons (clear-day, thunderstorm) still fit their sun rays
+                    and lightning bolt inside what is left. */}
+                <div style="line-height: 1; overflow: hidden; margin-top: -11px; margin-bottom: -11px">
                   <Localizer>
                     <WeatherIcon
                       icon={weather.weatherEmoji}
-                      size={64}
+                      size={92}
                       label={<Text id={`dashboard.boxes.weather.conditions.${weather.weather || 'unknown'}`} />}
                     />
                   </Localizer>
@@ -529,7 +535,7 @@ class WeatherBoxComponent extends Component {
                     <Localizer>
                       <WeatherIcon
                         icon={hour.weatherEmoji}
-                        size={index === 0 ? 40 : 32}
+                        size={index === 0 ? 56 : 40}
                         label={<Text id={`dashboard.boxes.weather.conditions.${hour.weather || 'unknown'}`} />}
                       />
                     </Localizer>
@@ -571,7 +577,7 @@ class WeatherBoxComponent extends Component {
                       <Localizer>
                         <WeatherIcon
                           icon={day.weatherEmoji}
-                          size={44}
+                          size={62}
                           label={<Text id={`dashboard.boxes.weather.conditions.${day.weather || 'unknown'}`} />}
                         />
                       </Localizer>

--- a/front/src/components/boxs/weather/WeatherBox.jsx
+++ b/front/src/components/boxs/weather/WeatherBox.jsx
@@ -332,13 +332,17 @@ class WeatherBoxComponent extends Component {
                condition instead of the two overlapping */
             <div style="display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; margin-bottom: 16px">
               <div style="display: flex; align-items: center; min-width: 0">
-                {/* the Meteocons viewBox is 64x64 but the artwork only fills
-                    the middle band, so a 92px icon carries ~11px of blank
-                    padding above and below. Clipping 12% off each side trims
-                    that dead space without touching the drawing: the tallest
-                    icons (clear-day, thunderstorm) still fit their sun rays
-                    and lightning bolt inside what is left. */}
-                <div style="line-height: 1; overflow: hidden; margin-top: -11px; margin-bottom: -11px">
+                {/* No crop here on purpose. The Meteocons artwork is NOT
+                    centered in its 64x64 viewBox and its padding is far from
+                    uniform: measured over the bundled set, the top edge runs
+                    from y=8 (clear-day's sun rays) to y=18.5 (tornado), and
+                    the bottom from y=45.5 (tornado) to y=59.5 (freezing-fog),
+                    before the rain/hail `animateTransform` pushes drops another
+                    10 to 18 units down. Any single inset that trims the roomy
+                    icons decapitates the tall ones, so the size bump below is
+                    the fix and the padding stays symmetric with the hourly and
+                    daily rows. */}
+                <div style="line-height: 1">
                   <Localizer>
                     <WeatherIcon
                       icon={weather.weatherEmoji}
@@ -532,10 +536,14 @@ class WeatherBoxComponent extends Component {
                     {hour.datetime_beautiful}h
                   </div>
                   <div style="line-height: 1.5; margin-bottom: 3px; display: flex; justify-content: center">
+                    {/* the secondary ceiling stays UNDER the 2.5rem (40px) flex
+                        floor of the cell: at 40 it would tie with the current
+                        slot on a narrow card, where every column is clamped to
+                        that floor, and the emphasis would vanish */}
                     <Localizer>
                       <WeatherIcon
                         icon={hour.weatherEmoji}
-                        size={index === 0 ? 56 : 40}
+                        size={index === 0 ? 56 : 36}
                         label={<Text id={`dashboard.boxes.weather.conditions.${hour.weather || 'unknown'}`} />}
                       />
                     </Localizer>

--- a/front/src/style/index.css
+++ b/front/src/style/index.css
@@ -562,3 +562,17 @@ body .apexcharts-tooltip {
     padding-top: 3.25rem;
   }
 }
+
+/* Weather condition icons (Meteocons): the cloud artwork is drawn in near-white
+   (#f3f7fe → #deeafb, outlined #e6effc), which all but disappears on the white
+   card background in light mode. Dark mode has no such problem — the global
+   inversion turns those same whites into dark grays on a dark ground — so the
+   fix is scoped to light mode only.
+
+   A bluish 1px halo restores the silhouette. Contrast/saturation filters were
+   tried first and made things WORSE: raising contrast pushes off-whites toward
+   pure white, erasing the cloud outright. The shadow is doubled so a single
+   soft pass is not lost to antialiasing at forecast-row sizes. */
+html:not(.dark-mode) img.weather-condition-icon {
+  filter: drop-shadow(0 0 0.7px rgba(127, 147, 184, 0.8)) drop-shadow(0 0 0.7px rgba(127, 147, 184, 0.8));
+}


### PR DESCRIPTION
### Description

The Meteocons artwork only fills the middle band of its 64x64 viewBox, so icons rendered smaller than their declared size and carried blank padding above and below. Bump the sizes ~1.4x, clip 12% of the vertical dead space on the current-conditions icon, and add a bluish halo in light mode where the near-white clouds vanished against the white card.

Before:
<img width="522" height="704" alt="Capture d’écran du 2026-08-27 01-27-52" src="https://github.com/user-attachments/assets/1d4c513f-c995-4e23-b49b-665159810961" />

After:
<img width="522" height="743" alt="Capture d’écran du 2026-08-27 01-25-43" src="https://github.com/user-attachments/assets/66359763-ba5e-46ba-be99-6b0306b8ba41" />


### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved weather icon sizing across current, hourly, and daily forecasts.
  * Added a subtle bluish shadow effect to weather icons in light mode for improved contrast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->