### PR TITLE
CI: prepare Docker release tags for Gladys Assistant 5

### DIFF
--- a/.github/workflows/docker-release-build.yml
+++ b/.github/workflows/docker-release-build.yml
@@ -142,19 +142,22 @@ jobs:
           images: ${{ secrets.DOCKERHUB_REPO }},ghcr.io/${{ secrets.DOCKERHUB_REPO }}
           labels: |
             org.opencontainers.image.title=Gladys Assistant Production Image
-          # `latest` is pushed on every release. This was already the case
-          # through the default `latest=auto` flavor, made explicit here.
+          # `latest` is pushed on every release: the default `auto` flavor,
+          # made explicit here, adds it on semver tags — and unlike
+          # `latest=true` it skips pre-release tags (v5.0.0-rc.1), just as the
+          # semver patterns below never move `v5` or `v4` on a pre-release.
           flavor: |
-            latest=true
-          # Every v5 release also feeds the moving `v4` tag: Gladys Assistant 5
-          # is backward compatible, so v4 installations following that tag
-          # (Watchtower and the in-app upgrade both do) are upgraded to v5
-          # automatically. The raw entry is guarded on v5 tags so a future
-          # breaking major stops feeding `v4` without needing to remember this.
+            latest=auto
+          # Every stable v5 release also feeds the moving `v4` tag: Gladys
+          # Assistant 5 is backward compatible, so v4 installations following
+          # that tag (Watchtower and the in-app upgrade both do) are upgraded
+          # to v5 automatically. The raw entry is guarded on v5 tags so a
+          # future breaking major stops feeding `v4` without needing to
+          # remember this, and excludes pre-release tags, which contain a `-`.
           tags: |
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}
-            type=raw,value=v4,enable=${{ startsWith(github.ref, 'refs/tags/v5.') }}
+            type=raw,value=v4,enable=${{ startsWith(github.ref, 'refs/tags/v5.') && !contains(github.ref, '-') }}
             type=sha
       - name: 💽 Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -179,6 +182,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # The single-arch `v4-arm64v8` and `v4-amd64` tags, kept for
+      # installations predating multi-arch manifests, are abandoned with
+      # Gladys Assistant 5: they stay frozen on the last v4.x images, and the
+      # remaining installations have to be recreated on the `v4` tag.
       - name: 🐳 Build and push
         uses: docker/build-push-action@v3
         with:
@@ -190,9 +197,6 @@ jobs:
           tags: ${{ steps.docker_meta.outputs.tags }}
           cache-from: type=registry,ref=${{ env.DOCKERHUB_REPO }}:latest
           cache-to: type=inline
-          # The single-arch `v4-arm64v8` and `v4-amd64` tags, kept for
-          # installations predating multi-arch manifests, are deprecated with
-          # Gladys Assistant 5: they stay frozen on the last v4.x images.
   publish-gladys-plus:
     name: Publish Gladys Plus front
     needs: docker

--- a/.github/workflows/docker-release-build.yml
+++ b/.github/workflows/docker-release-build.yml
@@ -142,9 +142,19 @@ jobs:
           images: ${{ secrets.DOCKERHUB_REPO }},ghcr.io/${{ secrets.DOCKERHUB_REPO }}
           labels: |
             org.opencontainers.image.title=Gladys Assistant Production Image
+          # `latest` is pushed on every release. This was already the case
+          # through the default `latest=auto` flavor, made explicit here.
+          flavor: |
+            latest=true
+          # Every v5 release also feeds the moving `v4` tag: Gladys Assistant 5
+          # is backward compatible, so v4 installations following that tag
+          # (Watchtower and the in-app upgrade both do) are upgraded to v5
+          # automatically. The raw entry is guarded on v5 tags so a future
+          # breaking major stops feeding `v4` without needing to remember this.
           tags: |
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}
+            type=raw,value=v4,enable=${{ startsWith(github.ref, 'refs/tags/v5.') }}
             type=sha
       - name: 💽 Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -180,16 +190,9 @@ jobs:
           tags: ${{ steps.docker_meta.outputs.tags }}
           cache-from: type=registry,ref=${{ env.DOCKERHUB_REPO }}:latest
           cache-to: type=inline
-      - name: 🐳 Legacy Tags
-        run: |
-          export DIGESTARM64=$(docker manifest inspect ${{ env.DOCKERHUB_REPO }}:latest | jq -r '.manifests | to_entries[] | select(.value.platform.architecture == "arm64").value | .digest')
-          docker pull ${{ env.DOCKERHUB_REPO }}@$DIGESTARM64
-          docker tag ${{ env.DOCKERHUB_REPO }}@$DIGESTARM64 ${{ env.DOCKERHUB_REPO }}:v4-arm64v8
-          docker push ${{ env.DOCKERHUB_REPO }}:v4-arm64v8
-          export DIGESTAMD64=$(docker manifest inspect ${{ env.DOCKERHUB_REPO }}:latest | jq -r '.manifests | to_entries[] | select(.value.platform.architecture == "amd64").value | .digest')
-          docker pull ${{ env.DOCKERHUB_REPO }}@$DIGESTAMD64
-          docker tag ${{ env.DOCKERHUB_REPO }}@$DIGESTAMD64 ${{ env.DOCKERHUB_REPO }}:v4-amd64
-          docker push ${{ env.DOCKERHUB_REPO }}:v4-amd64
+          # The single-arch `v4-arm64v8` and `v4-amd64` tags, kept for
+          # installations predating multi-arch manifests, are deprecated with
+          # Gladys Assistant 5: they stay frozen on the last v4.x images.
   publish-gladys-plus:
     name: Publish Gladys Plus front
     needs: docker

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -12,6 +12,7 @@ on:
         options:
           - patch
           - minor
+          - major
 
 permissions:
   contents: write


### PR DESCRIPTION
### Description

Prepares the release CI for Gladys Assistant 5 (v5.0.0), a backward compatible major release: v4 installations must be upgraded to v5 automatically. This PR only changes the CI — the release itself (version bump) will come in a separate PR.

Docker tags pushed by a stable `v5.x.y` release after this change:

| Tag | Source | Note |
|---|---|---|
| `v5.x.y` | `type=semver,pattern=v{{version}}` | unchanged, immutable version tag |
| `v5` | `type=semver,pattern=v{{major}}` | unchanged pattern, now resolves to the new major |
| `v4` | new `type=raw,value=v4` entry | v4 installations follow this moving tag (Watchtower and the in-app upgrade), so they get v5 automatically. Guarded with `enable=startsWith(github.ref, 'refs/tags/v5.') && !contains(github.ref, '-')` so a future *breaking* major stops feeding `v4` by default, and a pre-release tag never moves it |
| `latest` | `flavor: latest=auto`, made explicit | already the default behavior; `auto` (rather than `true`) skips pre-release tags, matching how the semver patterns never move `v5`/`v4` on a pre-release |
| `sha-…` | `type=sha` | unchanged |

Also in this PR:

- **Legacy single-arch tags abandoned** (maintainer decision): the `🐳 Legacy Tags` step that re-pushed `v4-arm64v8` and `v4-amd64` (kept for installations predating multi-arch manifests) is removed. Those tags stay on Docker Hub, frozen on the last v4.x images; the remaining installations will need to be recreated on the multi-arch `v4` tag, to be covered by the release communication.
- **`major` bump option** added to the *Prepare release* workflow's `release_type` choice — it only offered `patch`/`minor`, so v5.0.0 couldn't be prepared through it.

Nothing to change server-side: `system.getGladysImage.js` derives `recommended_image` from the tag the container was created from, so a container on `:v4` keeps being recommended `:v4` — which is correct while this workflow keeps feeding that tag with v5 releases.

Worth knowing (accepted behavior): tagging a `v4.x.y` hotfix *after* v5 ships would move `:v4` back to it through `type=semver,pattern=v{{major}}` — v4 hotfixes are not expected once v5 auto-upgrades v4 users.

Left for the release PR (the `v5` tag won't exist on Docker Hub until the release ships): `docker/docker-compose.yml` and the README still document `gladysassistant/gladys:v4` as the image to install.

### Checklist

- [x] Tests pass: CI-only change, no server/front code touched (workflow YAML validated locally)
- [x] Linter and prettier pass on both front and server: not applicable, no JS changed
- [x] No undocumented breaking change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release workflows now support selecting a major version release.
  * Stable releases automatically publish the `latest` image tag.
  * Stable version 5 releases also publish a `v4` compatibility tag.

* **Changes**
  * Pre-release versions no longer update the `latest` or moving `v4` tags.
  * Legacy architecture-specific `v4` tags remain fixed to the final v4.x images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->