### PR TITLE
Fix host reboot/shutdown unavailable on AppArmor hosts: run the DBus helper container unconfined

### DIFF
--- a/server/lib/system/system.runHostPowerDbusCommand.js
+++ b/server/lib/system/system.runHostPowerDbusCommand.js
@@ -11,6 +11,14 @@ const LOGIND_PATH = '/org/freedesktop/login1';
 // The host system DBus socket, bind-mounted read-only INTO THE HELPER container
 // by the Docker daemon (Gladys itself does not need it mounted).
 const HOST_DBUS_SOCKET_BIND = '/run/dbus:/run/dbus:ro';
+// The default `docker-default` AppArmor profile carries no dbus rules, and on
+// hosts where dbus-daemon enforces AppArmor mediation (Debian 12+,
+// Ubuntu 23.10+...) that means default-deny: a confined helper is rejected by
+// the bus before it can even complete the DBus handshake. The helper only runs
+// a single dbus-send against logind, so it is started unconfined. Docker
+// daemons on hosts without AppArmor ignore the option; a daemon that rejects
+// it outright is retried without it (see runViaHelperContainer).
+const HELPER_SECURITY_OPT = ['apparmor=unconfined'];
 // Bound the DBus call so it can never hang forever.
 const COMMAND_TIMEOUT_MS = 10000;
 // Bound the helper container lifetime: a stuck container would otherwise block
@@ -78,14 +86,31 @@ async function runViaHelperContainer(method) {
     // image to run the helper with, whatever the state of the host DBus.
     throw new Error(`Unable to identify the Gladys container image to run the helper container (${e.message})`);
   }
-  const container = await this.dockerode.createContainer({
-    Image: image,
-    name: `gladys-host-power-${method.toLowerCase()}-${Date.now()}`,
-    Cmd: buildDbusArgv(method),
-    HostConfig: {
-      Binds: [HOST_DBUS_SOCKET_BIND],
-    },
-  });
+  const createHelperContainer = async (securityOpt) =>
+    this.dockerode.createContainer({
+      Image: image,
+      name: `gladys-host-power-${method.toLowerCase()}-${Date.now()}`,
+      Cmd: buildDbusArgv(method),
+      HostConfig: {
+        Binds: [HOST_DBUS_SOCKET_BIND],
+        ...(securityOpt ? { SecurityOpt: securityOpt } : {}),
+      },
+    });
+  let container;
+  try {
+    container = await createHelperContainer(HELPER_SECURITY_OPT);
+  } catch (e) {
+    // Only a daemon that rejects the AppArmor option itself is retried
+    // confined; any other creation failure (bad image, dead daemon...) would
+    // fail again identically and is surfaced as-is.
+    if (!/apparmor|security.?opt/i.test(`${e && e.message}`)) {
+      throw e;
+    }
+    logger.warn(
+      `System: Docker rejected the AppArmor security option for the host power helper container, retrying without it: ${e.message}`,
+    );
+    container = await createHelperContainer(null);
+  }
   let output = '';
   let timeout;
   try {

--- a/server/test/lib/system/system.runHostPowerDbusCommand.test.js
+++ b/server/test/lib/system/system.runHostPowerDbusCommand.test.js
@@ -65,7 +65,44 @@ describe('system.runHostPowerDbusCommand (docker-helper)', () => {
     expect(options.Image).to.equal('gladysassistant/gladys:v4');
     expect(options.Cmd).to.include('org.freedesktop.login1.Manager.Reboot');
     expect(options.HostConfig.Binds).to.deep.equal(['/run/dbus:/run/dbus:ro']);
+    // The docker-default AppArmor profile has no dbus rules, so the helper must
+    // run unconfined to reach systemd-logind on AppArmor-mediated hosts.
+    expect(options.HostConfig.SecurityOpt).to.deep.equal(['apparmor=unconfined']);
     sinon.assert.calledOnce(container.remove);
+  });
+
+  it('should retry without the AppArmor security option when the daemon rejects it', async () => {
+    const container = buildContainer(0, 'method return\n   string "yes"\n');
+    const self = buildSelf(container);
+    self.dockerode.createContainer = sinon
+      .stub()
+      .onFirstCall()
+      .rejects(new Error('invalid --security-opt: "apparmor=unconfined"'))
+      .onSecondCall()
+      .resolves(container);
+    const output = await runHostPowerDbusCommand.call(self, 'CanReboot', 'docker-helper');
+    expect(output).to.contain('yes');
+    sinon.assert.calledTwice(self.dockerode.createContainer);
+    const firstOptions = self.dockerode.createContainer.firstCall.args[0];
+    expect(firstOptions.HostConfig.SecurityOpt).to.deep.equal(['apparmor=unconfined']);
+    const secondOptions = self.dockerode.createContainer.secondCall.args[0];
+    expect(secondOptions.HostConfig).to.not.have.property('SecurityOpt');
+    sinon.assert.calledOnce(container.remove);
+  });
+
+  it('should not retry when the helper container creation fails for an unrelated reason', async () => {
+    const container = buildContainer(0, '');
+    const self = buildSelf(container);
+    self.dockerode.createContainer = sinon.stub().rejects(new Error('No such image: gladysassistant/gladys:v4'));
+    let caught;
+    try {
+      await runHostPowerDbusCommand.call(self, 'CanReboot', 'docker-helper');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).to.be.an('error');
+    expect(caught.message).to.contain('No such image');
+    sinon.assert.calledOnce(self.dockerode.createContainer);
   });
 
   it('should throw when the helper container exits with a non-zero status', async () => {


### PR DESCRIPTION
### Description

On a standard Docker install (no `/run/dbus` mounted into Gladys), the host reboot/shutdown feature goes through a short-lived helper container that gets the host's `/run/dbus` bind-mounted. That helper was created without any security options, so Docker confined it under the default `docker-default` AppArmor profile — which carries no `dbus` rules. On hosts where `dbus-daemon` enforces AppArmor mediation (Debian 12+, Ubuntu 23.10+…), that means default-deny: the helper was rejected by the system bus before it could even complete the DBus handshake, and the settings page reported reboot/shutdown as unavailable.

Reproduction on such a host:

```
$ docker run --rm -v /run/dbus:/run/dbus:ro gladysassistant/gladys:dev \
    dbus-send --system --print-reply --dest=org.freedesktop.login1 \
    /org/freedesktop/login1 org.freedesktop.login1.Manager.CanReboot
Failed to open connection to "system" message bus: An AppArmor policy prevents
this sender from sending this message to this recipient; ... member="Hello" ...
```

This PR starts the helper container with `SecurityOpt: ['apparmor=unconfined']` — it only runs a single `dbus-send` against `systemd-logind`, over a socket the user already exposed by mounting the Docker socket. Docker daemons on hosts without AppArmor accept and ignore the option; a daemon that rejects it outright is retried once without it (only when the creation error mentions AppArmor/security-opt — any other failure is surfaced as-is).

Tests added:
- the helper container is created with `apparmor=unconfined`;
- a daemon rejection of the security option triggers exactly one confined retry;
- an unrelated creation failure is not retried.

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed — new unit tests cover both branches of the fallback; no UI change
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`) — the only eslint warning on the touched file is pre-existing
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ubRWcZ5zGowkvfmzDGnVy

---
_Generated by [Claude Code](https://claude.ai/code/session_011ubRWcZ5zGowkvfmzDGnVy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host power controls on systems where AppArmor prevents DBus access.
  * Added a fallback that retries without the AppArmor setting when unsupported.
  * Preserved error reporting for unrelated container creation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->