### PR TITLE
fix(front): center the loader on the Activity page during the first load

### DIFF
--- a/front/src/routes/history/HistoryPage.jsx
+++ b/front/src/routes/history/HistoryPage.jsx
@@ -86,6 +86,7 @@ const HistoryPage = ({ intl, user, ...props }) => {
   // (e.g. expanding/collapsing a group), since it walks the whole events list.
   const timeline = useMemo(() => buildTimeline(props.events), [props.events]);
   const language = user && user.language;
+  const initialLoading = props.loading && !props.initialized;
 
   return (
     <div class="page">
@@ -206,9 +207,15 @@ const HistoryPage = ({ intl, user, ...props }) => {
               </div>
             )}
 
+            {/* The theme centers the dimmer's loader on the dimmer itself
+                (top: 50%). On the first load the feed below is still empty,
+                so the dimmer would collapse and the loader would sit flush
+                under the filter capsule: reserve some height while it runs
+                so the spinner is centered in the empty feed area. */}
             <div
               class={cx('dimmer', {
-                active: props.loading && !props.initialized
+                active: initialLoading,
+                [style.initialLoadingDimmer]: initialLoading
               })}
             >
               <div class="loader" />

--- a/front/src/routes/history/style.css
+++ b/front/src/routes/history/style.css
@@ -720,3 +720,12 @@
     padding: 0.5rem 1rem;
   }
 }
+
+/* First load: the feed inside the dimmer is still empty, so the dimmer
+   collapses and the theme's loader — absolutely centered on the dimmer
+   (top: 50%) — ends up flush under the filter capsule. Reserve the height
+   the empty feed doesn't have so the spinner is centered in the free space
+   below the filters instead. */
+.initialLoadingDimmer {
+  min-height: 50vh;
+}


### PR DESCRIPTION
### Description

On the "Activité" page, the loader displayed while the first page of events is fetched appeared squeezed right under the filter bar instead of in the middle of the empty feed area.

Cause: the feed is wrapped in a `dimmer` whose content is still empty during the initial load, so the dimmer collapses to a near-zero height. The theme centers the spinner on the dimmer itself (`.dimmer .loader { top: 50%; transform: translateY(-50%) }`), which puts it flush under the filter capsule.

Fix: reserve a `min-height` on the dimmer while the initial load runs (`initialLoading = loading && !initialized`), so the spinner is centered in the free space below the filters. Nothing changes once the feed is initialized — the "load more" and "searching older" loaders are untouched.

### Checklist

- [x] Linter and prettier pass on the changed front files
- [x] No undocumented breaking change
- [ ] Tests pass: no test change needed, this is a CSS-only placement fix (the JSX change only adds a conditional class)

---
_Generated by [Claude Code](https://claude.ai/code/session_018J1MjjkB5PDwdWkrM4RSz6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the history page’s initial loading experience.
  * The loading indicator is now centered in the empty feed area instead of appearing misaligned.
  * Reserved space below the filters while history content is loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->