### PR TITLE
fix: show an explicit error when Zigbee2mqtt connects to an external MQTT broker with wrong credentials (#3024)

### DIFF
--- a/front/cypress/e2e/routes/integration/zigbee2mqtt/setup/Zigbee2MqttSetupRemoteGladys.cy.js
+++ b/front/cypress/e2e/routes/integration/zigbee2mqtt/setup/Zigbee2MqttSetupRemoteGladys.cy.js
@@ -135,4 +135,73 @@ describe('Zigbee2Mqtt setup wizard remote mode from scratch', () => {
       }
     });
   });
+
+  it('Display the MQTT connection error of a known error code', () => {
+    cy.get('[data-cy=z2m-mqtt-connection-error]').should('not.exist');
+
+    cy.sendWebSocket({
+      type: 'zigbee2mqtt.status-change',
+      payload: {
+        usbConfigured: false,
+        mqttExist: true,
+        mqttRunning: true,
+        zigbee2mqttExist: false,
+        zigbee2mqttRunning: false,
+        gladysConnected: false,
+        zigbee2mqttConnected: false,
+        z2mEnabled: true,
+        dockerBased: false,
+        networkModeValid: false,
+        mqttConnectionError: { code: 'BAD_CREDENTIALS', message: null }
+      }
+    });
+
+    cy.get('[data-cy=z2m-mqtt-connection-error]').i18n(
+      'integration.zigbee2mqtt.setup.mqttConnectionErrors.BAD_CREDENTIALS'
+    );
+  });
+
+  it('Display the raw message when the error code is unknown', () => {
+    cy.sendWebSocket({
+      type: 'zigbee2mqtt.status-change',
+      payload: {
+        usbConfigured: false,
+        mqttExist: true,
+        mqttRunning: true,
+        zigbee2mqttExist: false,
+        zigbee2mqttRunning: false,
+        gladysConnected: false,
+        zigbee2mqttConnected: false,
+        z2mEnabled: true,
+        dockerBased: false,
+        networkModeValid: false,
+        mqttConnectionError: { code: null, message: 'client disconnecting' }
+      }
+    });
+
+    cy.get('[data-cy=z2m-mqtt-connection-error]')
+      .i18n('integration.zigbee2mqtt.setup.mqttConnectionErrors.unknownErrorPrefix')
+      .should('contain', 'client disconnecting');
+  });
+
+  it('Hide the alert when there is no MQTT connection error', () => {
+    cy.sendWebSocket({
+      type: 'zigbee2mqtt.status-change',
+      payload: {
+        usbConfigured: false,
+        mqttExist: true,
+        mqttRunning: true,
+        zigbee2mqttExist: false,
+        zigbee2mqttRunning: false,
+        gladysConnected: true,
+        zigbee2mqttConnected: false,
+        z2mEnabled: true,
+        dockerBased: false,
+        networkModeValid: false,
+        mqttConnectionError: { code: null, message: null }
+      }
+    });
+
+    cy.get('[data-cy=z2m-mqtt-connection-error]').should('not.exist');
+  });
 });

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -1689,6 +1689,11 @@
         "enableLabel": "Dienst aktivieren oder deaktivieren",
         "enableDescription": "Beim nächsten Neustart von Gladys wird der Dienst wieder gestartet. Abhängig von der Leistung Ihres Computers und der Geschwindigkeit Ihres Netzwerks kann das Starten dieses Dienstes im Modus \"Installation von Gladys aus\" zwischen 2 Minuten und 1 Stunde dauern. Sie können den Dienst dauerhaft von dieser Seite deaktivieren: <a href=\"/dashboard/settings/service\">Einstellungen > Dienste</a>.",
         "toggleError": "Ein Fehler ist aufgetreten. Bitte überprüfen Sie die Konfiguration des Dienstes.",
+        "mqttConnectionErrors": {
+          "BAD_CREDENTIALS": "Gladys konnte keine Verbindung zum MQTT-Broker herstellen: Der Benutzername oder das Passwort ist falsch. Überprüfen Sie die Zugangsdaten Ihres MQTT-Brokers und speichern Sie die Konfiguration erneut.",
+          "BROKER_UNREACHABLE": "Gladys konnte den MQTT-Broker nicht erreichen. Überprüfen Sie, ob die URL und der Port des Brokers korrekt sind und ob der Broker läuft und von Gladys aus erreichbar ist.",
+          "unknownErrorPrefix": "MQTT-Verbindungsfehler: "
+        },
         "serviceStatus": "Dienststatus",
         "description": "Dieser Dienst verwendet zwei Docker-Container (MQTT-Broker und Zigbee2mqtt). Aktivieren Sie Zigbee2mqtt, um diese Container bereitzustellen. Weitere Informationen finden Sie auf der Zigbee2mqtt-Dokumentationsseite.",
         "nonDockerEnv": "Gladys wird derzeit nicht in Docker ausgeführt. Es ist unmöglich, Zigbee2mqtt von Gladys aus zu aktivieren.",

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -1691,6 +1691,7 @@
         "toggleError": "Ein Fehler ist aufgetreten. Bitte überprüfen Sie die Konfiguration des Dienstes.",
         "mqttConnectionErrors": {
           "BAD_CREDENTIALS": "Gladys konnte keine Verbindung zum MQTT-Broker herstellen: Der Benutzername oder das Passwort ist falsch. Überprüfen Sie die Zugangsdaten Ihres MQTT-Brokers und speichern Sie die Konfiguration erneut.",
+          "NOT_AUTHORIZED": "Der MQTT-Broker hat die Verbindung abgelehnt: nicht autorisiert. Überprüfen Sie den Benutzernamen und das Passwort Ihres MQTT-Brokers sowie die Zugriffsrechte dieses Clients und speichern Sie die Konfiguration erneut.",
           "BROKER_UNREACHABLE": "Gladys konnte den MQTT-Broker nicht erreichen. Überprüfen Sie, ob die URL und der Port des Brokers korrekt sind und ob der Broker läuft und von Gladys aus erreichbar ist.",
           "unknownErrorPrefix": "MQTT-Verbindungsfehler: "
         },

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -1586,6 +1586,7 @@
         "toggleError": "An error occurred. Please check the service configuration.",
         "mqttConnectionErrors": {
           "BAD_CREDENTIALS": "Gladys could not connect to the MQTT broker: the username or the password is incorrect. Check the credentials of your MQTT broker, then save the configuration again.",
+          "NOT_AUTHORIZED": "The MQTT broker refused the connection: not authorized. Check the username and password of your MQTT broker, and that this client is allowed to connect, then save the configuration again.",
           "BROKER_UNREACHABLE": "Gladys could not reach the MQTT broker. Check that the broker URL and port are correct, and that the broker is running and reachable from Gladys.",
           "unknownErrorPrefix": "MQTT connection error: "
         },

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -1584,6 +1584,11 @@
         "enableLabel": "Enable or disable the service",
         "enableDescription": "At the next restart of Gladys, the service will start again. Depending on the power of your machine and the speed of your network, starting this service in \"Installation from Gladys\" mode can take between 2 minutes and 1 hour. It is possible to permanently disable the service from this page: <a href=\"/dashboard/settings/service\">Settings > Services</a>.",
         "toggleError": "An error occurred. Please check the service configuration.",
+        "mqttConnectionErrors": {
+          "BAD_CREDENTIALS": "Gladys could not connect to the MQTT broker: the username or the password is incorrect. Check the credentials of your MQTT broker, then save the configuration again.",
+          "BROKER_UNREACHABLE": "Gladys could not reach the MQTT broker. Check that the broker URL and port are correct, and that the broker is running and reachable from Gladys.",
+          "unknownErrorPrefix": "MQTT connection error: "
+        },
         "serviceStatus": "Service Status",
         "description": "This service uses two Docker containers (MQTT broker and Zigbee2mqtt). Enable Zigbee2mqtt to deploy these containers. For more information, visit the Zigbee2mqtt documentation page.",
         "nonDockerEnv": "Gladys is currently not running in Docker, it is impossible to enable Zigbee2mqtt from Gladys.",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -1824,6 +1824,7 @@
         "toggleError": "Une erreur est survenue. Veuillez vérifier la configuration du service.",
         "mqttConnectionErrors": {
           "BAD_CREDENTIALS": "Gladys n'a pas réussi à se connecter au broker MQTT : le nom d'utilisateur ou le mot de passe est incorrect. Vérifiez les identifiants de votre broker MQTT, puis enregistrez à nouveau la configuration.",
+          "NOT_AUTHORIZED": "Le broker MQTT a refusé la connexion : non autorisé. Vérifiez le nom d'utilisateur et le mot de passe de votre broker MQTT, ainsi que les droits d'accès de ce client, puis enregistrez à nouveau la configuration.",
           "BROKER_UNREACHABLE": "Gladys n'a pas réussi à joindre le broker MQTT. Vérifiez que l'URL et le port du broker sont corrects, et que le broker est démarré et joignable depuis Gladys.",
           "unknownErrorPrefix": "Erreur de connexion MQTT : "
         },

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -1822,6 +1822,11 @@
         "enableLabel": "Activer ou désactiver le service",
         "enableDescription": "Au prochain redémarrage de Gladys, le service démarrera de nouveau. Suivant la puissance de votre machine et la vitesse de votre réseau, démarrer ce service en \"Installation depuis Gladys\" peut prendre entre 2 minutes et 1 heure. Il est possible de désactiver le service de manière pérenne depuis cette page : <a href=\"/dashboard/settings/service\">Paramètres > Services</a>.",
         "toggleError": "Une erreur est survenue. Veuillez vérifier la configuration du service.",
+        "mqttConnectionErrors": {
+          "BAD_CREDENTIALS": "Gladys n'a pas réussi à se connecter au broker MQTT : le nom d'utilisateur ou le mot de passe est incorrect. Vérifiez les identifiants de votre broker MQTT, puis enregistrez à nouveau la configuration.",
+          "BROKER_UNREACHABLE": "Gladys n'a pas réussi à joindre le broker MQTT. Vérifiez que l'URL et le port du broker sont corrects, et que le broker est démarré et joignable depuis Gladys.",
+          "unknownErrorPrefix": "Erreur de connexion MQTT : "
+        },
         "serviceStatus": "Etat du service",
         "description": "Ce service utilise deux containers Docker (MQTT broker et Zigbee2mqtt). Activer Zigbee2mqtt pour déployer ces containers.\nPour en savoir plus, rendez-vous sur la page de documentation Zigbee2mqtt",
         "nonDockerEnv": "Gladys ne s'exécute actuellement pas dans Docker, il est impossible d'activer Zigbee2mqtt depuis Gladys.",

--- a/front/src/routes/integration/all/zigbee2mqtt/setup-page/SetupTab.jsx
+++ b/front/src/routes/integration/all/zigbee2mqtt/setup-page/SetupTab.jsx
@@ -40,7 +40,7 @@ class SetupTab extends Component {
       resetZigbee2mqttStatus,
       configuration = {}
     } = props;
-    const { z2mContainerError } = props.zigbee2mqttStatus || {};
+    const { z2mContainerError, mqttConnectionError } = props.zigbee2mqttStatus || {};
     const loading = loadZigbee2mqttStatus === RequestStatus.Getting || loadZigbee2mqttConfig === RequestStatus.Getting;
     const error = loadZigbee2mqttStatus === RequestStatus.Error || loadZigbee2mqttConfig === RequestStatus.Error;
     const success = loadZigbee2mqttStatus === RequestStatus.Success && loadZigbee2mqttConfig === RequestStatus.Success;
@@ -108,6 +108,20 @@ class SetupTab extends Component {
                         <span>
                           <Text id="integration.zigbee2mqtt.setup.modes.local.containerErrors.unknownErrorPrefix" />
                           <code>{z2mContainerError.message}</code>
+                        </span>
+                      )}
+                    </div>
+                  </li>
+                )}
+                {mqttConnectionError && (
+                  <li class="list-group-item">
+                    <div class="alert alert-danger my-3" data-cy="z2m-mqtt-connection-error">
+                      {mqttConnectionError.code ? (
+                        <Text id={`integration.zigbee2mqtt.setup.mqttConnectionErrors.${mqttConnectionError.code}`} />
+                      ) : (
+                        <span>
+                          <Text id="integration.zigbee2mqtt.setup.mqttConnectionErrors.unknownErrorPrefix" />
+                          <code>{mqttConnectionError.message}</code>
                         </span>
                       )}
                     </div>

--- a/front/src/routes/integration/all/zigbee2mqtt/setup-page/SetupTab.jsx
+++ b/front/src/routes/integration/all/zigbee2mqtt/setup-page/SetupTab.jsx
@@ -113,7 +113,7 @@ class SetupTab extends Component {
                     </div>
                   </li>
                 )}
-                {mqttConnectionError && (
+                {mqttConnectionError && (mqttConnectionError.code || mqttConnectionError.message) && (
                   <li class="list-group-item">
                     <div class="alert alert-danger my-3" data-cy="z2m-mqtt-connection-error">
                       {mqttConnectionError.code ? (

--- a/server/services/zigbee2mqtt/lib/connect.js
+++ b/server/services/zigbee2mqtt/lib/connect.js
@@ -1,5 +1,5 @@
 const logger = require('../../../utils/logger');
-const { DEFAULT } = require('./constants');
+const { DEFAULT, MQTT_CONNECTION_ERROR } = require('./constants');
 const { getMqttConnectionError } = require('../utils/getMqttConnectionError');
 
 /**
@@ -21,7 +21,9 @@ async function connect({ mqttUrl, mqttUsername, mqttPassword, mqttMode }) {
     this.mqttClient = null;
   }
 
-  if (this.mqttRunning || mqttMode === 'external') {
+  const externalBroker = mqttMode === 'external';
+
+  if (this.mqttRunning || externalBroker) {
     // Loads MQTT service
     logger.info(`Connecting Gladys to ${mqttUrl} MQTT broker...`);
 
@@ -48,7 +50,15 @@ async function connect({ mqttUrl, mqttUsername, mqttPassword, mqttMode }) {
       logger.warn(`Error while connecting to MQTT - ${err}`);
       this.gladysConnected = false;
       this.zigbee2mqttConnected = false;
-      this.mqttConnectionError = getMqttConnectionError(err);
+      const connectionError = getMqttConnectionError(err);
+      const authenticationFailed =
+        connectionError.code === MQTT_CONNECTION_ERROR.BAD_CREDENTIALS ||
+        connectionError.code === MQTT_CONNECTION_ERROR.NOT_AUTHORIZED;
+      // On a Gladys-managed broker, only authentication failures are worth showing: the client
+      // reconnects every 5 seconds, so a network error simply means the Mosquitto container is
+      // still starting or restarting, and telling the user to check the broker URL would be a
+      // wrong diagnosis. The Gladys <-> MQTT link already turns red through `gladysConnected`.
+      this.mqttConnectionError = externalBroker || authenticationFailed ? connectionError : null;
       this.emitStatusEvent();
     });
 

--- a/server/services/zigbee2mqtt/lib/connect.js
+++ b/server/services/zigbee2mqtt/lib/connect.js
@@ -1,5 +1,6 @@
 const logger = require('../../../utils/logger');
 const { DEFAULT } = require('./constants');
+const { getMqttConnectionError } = require('../utils/getMqttConnectionError');
 
 /**
  * @description Initialize service with dependencies and connect to devices.
@@ -39,6 +40,7 @@ async function connect({ mqttUrl, mqttUsername, mqttPassword, mqttMode }) {
       this.gladysConnected = true;
       this.mqttRunning = true;
       this.mqttExist = true;
+      this.mqttConnectionError = null;
       this.emitStatusEvent();
     });
 
@@ -46,6 +48,7 @@ async function connect({ mqttUrl, mqttUsername, mqttPassword, mqttMode }) {
       logger.warn(`Error while connecting to MQTT - ${err}`);
       this.gladysConnected = false;
       this.zigbee2mqttConnected = false;
+      this.mqttConnectionError = getMqttConnectionError(err);
       this.emitStatusEvent();
     });
 

--- a/server/services/zigbee2mqtt/lib/constants.js
+++ b/server/services/zigbee2mqtt/lib/constants.js
@@ -28,6 +28,7 @@ const MQTT_MODE = {
 // Reasons why Gladys failed to connect to the MQTT broker, displayed as explicit messages in the UI
 const MQTT_CONNECTION_ERROR = {
   BAD_CREDENTIALS: 'BAD_CREDENTIALS',
+  NOT_AUTHORIZED: 'NOT_AUTHORIZED',
   BROKER_UNREACHABLE: 'BROKER_UNREACHABLE',
 };
 

--- a/server/services/zigbee2mqtt/lib/constants.js
+++ b/server/services/zigbee2mqtt/lib/constants.js
@@ -25,6 +25,12 @@ const MQTT_MODE = {
   EXTERNAL: 'external',
 };
 
+// Reasons why Gladys failed to connect to the MQTT broker, displayed as explicit messages in the UI
+const MQTT_CONNECTION_ERROR = {
+  BAD_CREDENTIALS: 'BAD_CREDENTIALS',
+  BROKER_UNREACHABLE: 'BROKER_UNREACHABLE',
+};
+
 // Zigbee coordinator connection: plugged in USB, or reachable over the network (tcp://<host>:<port>)
 const ADAPTER_MODE = {
   USB: 'usb',
@@ -93,6 +99,7 @@ const DEFAULT = {
 module.exports = {
   CONFIGURATION,
   MQTT_MODE,
+  MQTT_CONNECTION_ERROR,
   ADAPTER_MODE,
   SETUP_VARIABLES,
   DEFAULT,

--- a/server/services/zigbee2mqtt/lib/disconnect.js
+++ b/server/services/zigbee2mqtt/lib/disconnect.js
@@ -26,6 +26,7 @@ async function disconnect() {
     logger.debug('Not connected');
   }
   this.gladysConnected = false;
+  this.mqttConnectionError = null;
   this.emitStatusEvent();
 
   // Stop & remove MQTT container

--- a/server/services/zigbee2mqtt/lib/index.js
+++ b/server/services/zigbee2mqtt/lib/index.js
@@ -61,6 +61,7 @@ const Zigbee2mqttManager = function Zigbee2mqttManager(gladys, mqttLibrary, serv
   this.networkModeValid = false;
   this.coordinatorFirmware = null;
   this.z2mContainerError = null;
+  this.mqttConnectionError = null;
   this.dockerBased = false;
 
   this.containerRestartWaitTimeInMs = 5 * 1000;

--- a/server/services/zigbee2mqtt/lib/init.js
+++ b/server/services/zigbee2mqtt/lib/init.js
@@ -24,6 +24,7 @@ async function init(setupMode = false) {
   this.z2mPermitJoin = false;
   this.networkModeValid = false;
   this.z2mContainerError = null;
+  this.mqttConnectionError = null;
   this.dockerBased = false;
 
   // Load stored configuration

--- a/server/services/zigbee2mqtt/lib/reset.js
+++ b/server/services/zigbee2mqtt/lib/reset.js
@@ -57,6 +57,7 @@ async function reset() {
   this.z2mPermitJoin = false;
   this.coordinatorFirmware = null;
   this.z2mContainerError = null;
+  this.mqttConnectionError = null;
 
   // 5. Emit status event
   this.emitStatusEvent();

--- a/server/services/zigbee2mqtt/lib/status.js
+++ b/server/services/zigbee2mqtt/lib/status.js
@@ -20,6 +20,7 @@ function status() {
     networkModeValid: this.networkModeValid,
     coordinatorFirmware: this.coordinatorFirmware,
     z2mContainerError: this.z2mContainerError,
+    mqttConnectionError: this.mqttConnectionError,
   };
   return zigbee2mqttStatus;
 }

--- a/server/services/zigbee2mqtt/utils/getMqttConnectionError.js
+++ b/server/services/zigbee2mqtt/utils/getMqttConnectionError.js
@@ -1,10 +1,17 @@
 const { MQTT_CONNECTION_ERROR } = require('../lib/constants');
 
-// CONNACK return codes rejecting the credentials: 4 & 5 in MQTT 3.1.1
-// ("Bad username or password", "Not authorized"), 134 & 135 in MQTT 5
-const AUTHENTICATION_RETURN_CODES = [4, 5, 134, 135];
-// Network level failures raised before the broker even answers
-const UNREACHABLE_ERROR_CODES = ['ECONNREFUSED', 'ENOTFOUND', 'EAI_AGAIN', 'ETIMEDOUT', 'EHOSTUNREACH'];
+// CONNACK return codes rejecting the credentials themselves: 4 in MQTT 3.1.1
+// ("Bad user name or password"), 134 in MQTT 5.
+const BAD_CREDENTIALS_RETURN_CODES = [4, 134];
+// CONNACK return codes refusing the client without blaming the credentials: 5 in MQTT 3.1.1
+// ("Not authorized"), 135 in MQTT 5. Brokers use them both for a failed login (Mosquitto) and
+// for an ACL denying an otherwise valid user, so the message must cover the two cases.
+const NOT_AUTHORIZED_RETURN_CODES = [5, 135];
+// Network level failures raised before the broker even answers.
+// mqtt@4.2 only forwards the socket errors of its own allow list (ECONNREFUSED, EADDRINUSE,
+// ECONNRESET, ENOTFOUND), while mqtt@4.3 forwards every socket error carrying a `code`, hence
+// the DNS and timeout codes below.
+const UNREACHABLE_ERROR_CODES = ['ECONNREFUSED', 'ECONNRESET', 'ENOTFOUND', 'EAI_AGAIN', 'ETIMEDOUT', 'EHOSTUNREACH'];
 
 /**
  * @description Convert an error emitted by the MQTT client into an explicit error for the UI.
@@ -16,8 +23,12 @@ const UNREACHABLE_ERROR_CODES = ['ECONNREFUSED', 'ENOTFOUND', 'EAI_AGAIN', 'ETIM
 function getMqttConnectionError(error = {}) {
   const { code, message } = error;
 
-  if (AUTHENTICATION_RETURN_CODES.includes(code)) {
+  if (BAD_CREDENTIALS_RETURN_CODES.includes(code)) {
     return { code: MQTT_CONNECTION_ERROR.BAD_CREDENTIALS, message: null };
+  }
+
+  if (NOT_AUTHORIZED_RETURN_CODES.includes(code)) {
+    return { code: MQTT_CONNECTION_ERROR.NOT_AUTHORIZED, message: null };
   }
 
   if (UNREACHABLE_ERROR_CODES.includes(code)) {

--- a/server/services/zigbee2mqtt/utils/getMqttConnectionError.js
+++ b/server/services/zigbee2mqtt/utils/getMqttConnectionError.js
@@ -1,0 +1,32 @@
+const { MQTT_CONNECTION_ERROR } = require('../lib/constants');
+
+// CONNACK return codes rejecting the credentials: 4 & 5 in MQTT 3.1.1
+// ("Bad username or password", "Not authorized"), 134 & 135 in MQTT 5
+const AUTHENTICATION_RETURN_CODES = [4, 5, 134, 135];
+// Network level failures raised before the broker even answers
+const UNREACHABLE_ERROR_CODES = ['ECONNREFUSED', 'ENOTFOUND', 'EAI_AGAIN', 'ETIMEDOUT', 'EHOSTUNREACH'];
+
+/**
+ * @description Convert an error emitted by the MQTT client into an explicit error for the UI.
+ * @param {object} error - Error emitted by the MQTT client.
+ * @returns {object} Object with a known `code`, or a `null` code and the raw `message`.
+ * @example
+ * const mqttConnectionError = getMqttConnectionError(new Error('Connection refused: Not authorized'));
+ */
+function getMqttConnectionError(error = {}) {
+  const { code, message } = error;
+
+  if (AUTHENTICATION_RETURN_CODES.includes(code)) {
+    return { code: MQTT_CONNECTION_ERROR.BAD_CREDENTIALS, message: null };
+  }
+
+  if (UNREACHABLE_ERROR_CODES.includes(code)) {
+    return { code: MQTT_CONNECTION_ERROR.BROKER_UNREACHABLE, message: null };
+  }
+
+  return { code: null, message: message || null };
+}
+
+module.exports = {
+  getMqttConnectionError,
+};

--- a/server/test/services/zigbee2mqtt/lib/connect.test.js
+++ b/server/test/services/zigbee2mqtt/lib/connect.test.js
@@ -11,6 +11,7 @@ const Zigbee2mqttManager = require('../../../../services/zigbee2mqtt/lib');
 const serviceId = 'f87b7af2-ca8e-44fc-b754-444354b42fee';
 
 const configuration = { mqttUrl: 'fakeUrl', mqttUsername: 'username', mqttPassword: 'password' };
+const externalConfiguration = { ...configuration, mqttMode: 'external' };
 
 describe('zigbee2mqtt connect', () => {
   // PREPARE
@@ -132,7 +133,7 @@ describe('zigbee2mqtt connect', () => {
     zigbee2mqttManager.mqttRunning = true;
     const error = new Error('mqtt_error');
     // EXECUTE
-    await zigbee2mqttManager.connect(configuration);
+    await zigbee2mqttManager.connect(externalConfiguration);
     zigbee2mqttManager.mqttClient.emit('error', error);
     // ASSERT
     assert.calledOnceWithExactly(gladys.event.emit, EVENTS.WEBSOCKET.SEND_ALL, {
@@ -162,18 +163,65 @@ describe('zigbee2mqtt connect', () => {
     const error = new Error('Connection refused: Bad username or password');
     error.code = 4;
     // EXECUTE
-    await zigbee2mqttManager.connect(configuration);
+    await zigbee2mqttManager.connect(externalConfiguration);
     zigbee2mqttManager.mqttClient.emit('error', error);
     // ASSERT
     expect(zigbee2mqttManager.mqttConnectionError).to.deep.equal({ code: 'BAD_CREDENTIALS', message: null });
+  });
+
+  it('it should report an unreachable external MQTT broker', async () => {
+    // PREPARE
+    zigbee2mqttManager.mqttRunning = true;
+    const error = new Error('connect ECONNREFUSED 127.0.0.1:1883');
+    error.code = 'ECONNREFUSED';
+    // EXECUTE
+    await zigbee2mqttManager.connect(externalConfiguration);
+    zigbee2mqttManager.mqttClient.emit('error', error);
+    // ASSERT
+    expect(zigbee2mqttManager.mqttConnectionError).to.deep.equal({ code: 'BROKER_UNREACHABLE', message: null });
+  });
+
+  it('it should report a not authorized client on a Gladys managed broker', async () => {
+    // PREPARE
+    zigbee2mqttManager.mqttRunning = true;
+    const error = new Error('Connection refused: Not authorized');
+    error.code = 5;
+    // EXECUTE
+    await zigbee2mqttManager.connect(configuration);
+    zigbee2mqttManager.mqttClient.emit('error', error);
+    // ASSERT
+    expect(zigbee2mqttManager.mqttConnectionError).to.deep.equal({ code: 'NOT_AUTHORIZED', message: null });
+  });
+
+  it('it should ignore a network error on a Gladys managed broker', async () => {
+    // PREPARE
+    zigbee2mqttManager.mqttRunning = true;
+    const error = new Error('connect ECONNREFUSED 127.0.0.1:1883');
+    error.code = 'ECONNREFUSED';
+    // EXECUTE
+    await zigbee2mqttManager.connect(configuration);
+    zigbee2mqttManager.mqttClient.emit('error', error);
+    // ASSERT
+    expect(zigbee2mqttManager.mqttConnectionError).to.eq(null);
+  });
+
+  it('it should ignore an unknown error on a Gladys managed broker', async () => {
+    // PREPARE
+    zigbee2mqttManager.mqttRunning = true;
+    // EXECUTE
+    await zigbee2mqttManager.connect(configuration);
+    zigbee2mqttManager.mqttClient.emit('error', new Error('mqtt_error'));
+    // ASSERT
+    expect(zigbee2mqttManager.mqttConnectionError).to.eq(null);
   });
 
   it('it should clear the MQTT connection error when connected', async () => {
     // PREPARE
     zigbee2mqttManager.mqttRunning = true;
     // EXECUTE
-    await zigbee2mqttManager.connect(configuration);
+    await zigbee2mqttManager.connect(externalConfiguration);
     zigbee2mqttManager.mqttClient.emit('error', new Error('mqtt_error'));
+    expect(zigbee2mqttManager.mqttConnectionError).to.deep.equal({ code: null, message: 'mqtt_error' });
     zigbee2mqttManager.mqttClient.emit('connect');
     // ASSERT
     expect(zigbee2mqttManager.mqttConnectionError).to.eq(null);

--- a/server/test/services/zigbee2mqtt/lib/connect.test.js
+++ b/server/test/services/zigbee2mqtt/lib/connect.test.js
@@ -121,6 +121,7 @@ describe('zigbee2mqtt connect', () => {
         zigbee2mqttRunning: false,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
     assert.calledOnceWithExactly(mqttClient.subscribe, 'zigbee2mqtt/#');
@@ -150,8 +151,32 @@ describe('zigbee2mqtt connect', () => {
         zigbee2mqttRunning: false,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: { code: null, message: 'mqtt_error' },
       },
     });
+  });
+
+  it('it should report wrong MQTT credentials', async () => {
+    // PREPARE
+    zigbee2mqttManager.mqttRunning = true;
+    const error = new Error('Connection refused: Bad username or password');
+    error.code = 4;
+    // EXECUTE
+    await zigbee2mqttManager.connect(configuration);
+    zigbee2mqttManager.mqttClient.emit('error', error);
+    // ASSERT
+    expect(zigbee2mqttManager.mqttConnectionError).to.deep.equal({ code: 'BAD_CREDENTIALS', message: null });
+  });
+
+  it('it should clear the MQTT connection error when connected', async () => {
+    // PREPARE
+    zigbee2mqttManager.mqttRunning = true;
+    // EXECUTE
+    await zigbee2mqttManager.connect(configuration);
+    zigbee2mqttManager.mqttClient.emit('error', new Error('mqtt_error'));
+    zigbee2mqttManager.mqttClient.emit('connect');
+    // ASSERT
+    expect(zigbee2mqttManager.mqttConnectionError).to.eq(null);
   });
 
   it('it should receive mqtt offline message', async () => {
@@ -177,6 +202,7 @@ describe('zigbee2mqtt connect', () => {
         zigbee2mqttRunning: false,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
   });

--- a/server/test/services/zigbee2mqtt/lib/disconnect.test.js
+++ b/server/test/services/zigbee2mqtt/lib/disconnect.test.js
@@ -72,6 +72,7 @@ describe('zigbee2mqtt disconnect', () => {
         zigbee2mqttRunning: false,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
     assert.calledTwice(gladys.system.stopContainer);
@@ -101,6 +102,7 @@ describe('zigbee2mqtt disconnect', () => {
         zigbee2mqttRunning: false,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
     assert.calledTwice(gladys.system.stopContainer);
@@ -136,6 +138,7 @@ describe('zigbee2mqtt disconnect', () => {
         zigbee2mqttRunning: false,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
   });

--- a/server/test/services/zigbee2mqtt/lib/handleMqttMessage.test.js
+++ b/server/test/services/zigbee2mqtt/lib/handleMqttMessage.test.js
@@ -67,6 +67,7 @@ describe('zigbee2mqtt handleMqttMessage', () => {
         zigbee2mqttRunning: true,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
   });
@@ -322,6 +323,7 @@ describe('zigbee2mqtt handleMqttMessage', () => {
           type: 'EmberZNet',
         },
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
   });

--- a/server/test/services/zigbee2mqtt/lib/installMqttContainer.test.js
+++ b/server/test/services/zigbee2mqtt/lib/installMqttContainer.test.js
@@ -92,6 +92,7 @@ describe('zigbee2mqtt installMqttContainer', () => {
         zigbee2mqttRunning: false,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
     expect(zigbee2mqttManager.mqttRunning).to.equal(true);
@@ -122,6 +123,7 @@ describe('zigbee2mqtt installMqttContainer', () => {
         zigbee2mqttRunning: false,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
     expect(zigbee2mqttManager.mqttRunning).to.equal(true);
@@ -158,6 +160,7 @@ describe('zigbee2mqtt installMqttContainer', () => {
         zigbee2mqttRunning: false,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
     expect(zigbee2mqttManager.mqttRunning).to.equal(false);
@@ -193,6 +196,7 @@ describe('zigbee2mqtt installMqttContainer', () => {
         zigbee2mqttRunning: false,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
     expect(zigbee2mqttManager.mqttRunning).to.equal(false);
@@ -233,6 +237,7 @@ describe('zigbee2mqtt installMqttContainer', () => {
         zigbee2mqttRunning: false,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
     // 2nd call - mqtt is ready
@@ -252,6 +257,7 @@ describe('zigbee2mqtt installMqttContainer', () => {
         zigbee2mqttRunning: false,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
     assert.calledOnce(gladys.system.createContainer);
@@ -307,6 +313,7 @@ describe('zigbee2mqtt installMqttContainer', () => {
         zigbee2mqttRunning: false,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
     assert.calledOnce(gladys.system.createContainer);

--- a/server/test/services/zigbee2mqtt/lib/installZ2mContainer.test.js
+++ b/server/test/services/zigbee2mqtt/lib/installZ2mContainer.test.js
@@ -120,6 +120,7 @@ describe('zigbee2mqtt installz2mContainer', () => {
         zigbee2mqttRunning: false,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
     expect(zigbee2mqttManager.zigbee2mqttRunning).to.equal(true);
@@ -152,6 +153,7 @@ describe('zigbee2mqtt installz2mContainer', () => {
         zigbee2mqttRunning: true,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
     expect(zigbee2mqttManager.zigbee2mqttRunning).to.equal(true);
@@ -287,6 +289,7 @@ describe('zigbee2mqtt installz2mContainer', () => {
         zigbee2mqttRunning: true,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
     expect(zigbee2mqttManager.zigbee2mqttRunning).to.equal(true);
@@ -397,6 +400,7 @@ describe('zigbee2mqtt installz2mContainer', () => {
         zigbee2mqttRunning: false,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
     expect(zigbee2mqttManager.zigbee2mqttRunning).to.equal(false);
@@ -433,6 +437,7 @@ describe('zigbee2mqtt installz2mContainer', () => {
         zigbee2mqttRunning: false,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
     expect(zigbee2mqttManager.zigbee2mqttRunning).to.equal(false);
@@ -471,6 +476,7 @@ describe('zigbee2mqtt installz2mContainer', () => {
         zigbee2mqttRunning: true,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
     assert.calledWithExactly(gladys.event.emit, EVENTS.WEBSOCKET.SEND_ALL, {
@@ -489,6 +495,7 @@ describe('zigbee2mqtt installz2mContainer', () => {
         zigbee2mqttRunning: false,
         coordinatorFirmware: null,
         z2mContainerError: null,
+        mqttConnectionError: null,
       },
     });
     assert.calledOnceWithExactly(configureContainer, basePathOnContainer, config, false);

--- a/server/test/services/zigbee2mqtt/lib/reset.test.js
+++ b/server/test/services/zigbee2mqtt/lib/reset.test.js
@@ -70,6 +70,7 @@ describe('zigbee2mqtt reset', () => {
     zigbee2MqttManager.z2mPermitJoin = true;
     zigbee2MqttManager.coordinatorFirmware = '20240101';
     zigbee2MqttManager.z2mContainerError = { message: 'some error' };
+    zigbee2MqttManager.mqttConnectionError = { code: 'BAD_CREDENTIALS', message: null };
     zigbee2MqttManager.discoveredDevices = { '0x1234': { friendly_name: 'lamp' } };
     zigbee2MqttManager.topicBinds = { 'zigbee2mqtt/#': () => {} };
   });
@@ -123,6 +124,7 @@ describe('zigbee2mqtt reset', () => {
     expect(zigbee2MqttManager.z2mPermitJoin).to.equal(false);
     expect(zigbee2MqttManager.coordinatorFirmware).to.equal(null);
     expect(zigbee2MqttManager.z2mContainerError).to.equal(null);
+    expect(zigbee2MqttManager.mqttConnectionError).to.equal(null);
 
     // Host environment properties should be preserved
     expect(zigbee2MqttManager.dockerBased).to.equal(true);

--- a/server/test/services/zigbee2mqtt/lib/status.test.js
+++ b/server/test/services/zigbee2mqtt/lib/status.test.js
@@ -50,5 +50,6 @@ describe('zigbee2mqtt status', () => {
     expect(result.z2mEnabled).that.equal(true);
     expect(result.coordinatorFirmware).that.equal(null);
     expect(result.z2mContainerError).that.equal(null);
+    expect(result.mqttConnectionError).that.equal(null);
   });
 });

--- a/server/test/services/zigbee2mqtt/utils/getMqttConnectionError.test.js
+++ b/server/test/services/zigbee2mqtt/utils/getMqttConnectionError.test.js
@@ -1,0 +1,34 @@
+const { expect } = require('chai');
+
+const { getMqttConnectionError } = require('../../../../services/zigbee2mqtt/utils/getMqttConnectionError');
+
+describe('zigbee2mqtt getMqttConnectionError', () => {
+  it('should detect wrong credentials in MQTT 3.1.1', () => {
+    const error = new Error('Connection refused: Bad username or password');
+    error.code = 4;
+    expect(getMqttConnectionError(error)).to.deep.equal({ code: 'BAD_CREDENTIALS', message: null });
+  });
+
+  it('should detect wrong credentials in MQTT 5', () => {
+    const error = new Error('Connection refused: Not authorized');
+    error.code = 135;
+    expect(getMqttConnectionError(error)).to.deep.equal({ code: 'BAD_CREDENTIALS', message: null });
+  });
+
+  it('should detect an unreachable broker', () => {
+    const error = new Error('connect ECONNREFUSED 127.0.0.1:1883');
+    error.code = 'ECONNREFUSED';
+    expect(getMqttConnectionError(error)).to.deep.equal({ code: 'BROKER_UNREACHABLE', message: null });
+  });
+
+  it('should return the raw message on unknown errors', () => {
+    expect(getMqttConnectionError(new Error('something went wrong'))).to.deep.equal({
+      code: null,
+      message: 'something went wrong',
+    });
+  });
+
+  it('should return a null message when the error has no message', () => {
+    expect(getMqttConnectionError()).to.deep.equal({ code: null, message: null });
+  });
+});

--- a/server/test/services/zigbee2mqtt/utils/getMqttConnectionError.test.js
+++ b/server/test/services/zigbee2mqtt/utils/getMqttConnectionError.test.js
@@ -10,14 +10,38 @@ describe('zigbee2mqtt getMqttConnectionError', () => {
   });
 
   it('should detect wrong credentials in MQTT 5', () => {
+    const error = new Error('Connection refused: Bad user name or password');
+    error.code = 134;
+    expect(getMqttConnectionError(error)).to.deep.equal({ code: 'BAD_CREDENTIALS', message: null });
+  });
+
+  it('should detect a not authorized client in MQTT 3.1.1', () => {
+    const error = new Error('Connection refused: Not authorized');
+    error.code = 5;
+    expect(getMqttConnectionError(error)).to.deep.equal({ code: 'NOT_AUTHORIZED', message: null });
+  });
+
+  it('should detect a not authorized client in MQTT 5', () => {
     const error = new Error('Connection refused: Not authorized');
     error.code = 135;
-    expect(getMqttConnectionError(error)).to.deep.equal({ code: 'BAD_CREDENTIALS', message: null });
+    expect(getMqttConnectionError(error)).to.deep.equal({ code: 'NOT_AUTHORIZED', message: null });
   });
 
   it('should detect an unreachable broker', () => {
     const error = new Error('connect ECONNREFUSED 127.0.0.1:1883');
     error.code = 'ECONNREFUSED';
+    expect(getMqttConnectionError(error)).to.deep.equal({ code: 'BROKER_UNREACHABLE', message: null });
+  });
+
+  it('should detect a broker closing the connection', () => {
+    const error = new Error('read ECONNRESET');
+    error.code = 'ECONNRESET';
+    expect(getMqttConnectionError(error)).to.deep.equal({ code: 'BROKER_UNREACHABLE', message: null });
+  });
+
+  it('should detect an unknown broker host', () => {
+    const error = new Error('getaddrinfo ENOTFOUND broker.local');
+    error.code = 'ENOTFOUND';
     expect(getMqttConnectionError(error)).to.deep.equal({ code: 'BROKER_UNREACHABLE', message: null });
   });
 


### PR DESCRIPTION
> **Automated pull request.** This PR was produced by an automated routine and has **NOT been reviewed by a human**. Please review carefully before merging.

Fixes #3024

### Description

**What changed and why**

When a user configured the Zigbee2mqtt integration with an external MQTT broker and entered wrong credentials, the MQTT client `error` event was only written to the logs. On the setup page the user only saw the Gladys ↔ MQTT link go red, with no explanation of what went wrong.

The MQTT connection error is now surfaced in the UI:

- `server/services/zigbee2mqtt/utils/getMqttConnectionError.js` (new): maps an error emitted by the MQTT client to an explicit code — `BAD_CREDENTIALS` (CONNACK return codes 4/5 in MQTT 3.1.1, 134/135 in MQTT 5), `BROKER_UNREACHABLE` (`ECONNREFUSED`, `ENOTFOUND`, `EAI_AGAIN`, `ETIMEDOUT`, `EHOSTUNREACH`), or `null` plus the raw message for anything else.
- `lib/connect.js`: stores the mapped error in `this.mqttConnectionError` on the `error` event, and clears it on a successful `connect`.
- `lib/status.js`: exposes `mqttConnectionError` in the service status, so it reaches the front through the existing `ZIGBEE2MQTT.STATUS_CHANGE` WebSocket event (no new API).
- `lib/index.js`, `lib/init.js`, `lib/reset.js`, `lib/disconnect.js`: reset the field alongside the other in-memory status flags.
- `front/.../setup-page/SetupTab.jsx`: displays an alert with the explicit message, mirroring the existing `z2mContainerError` block.
- `front/src/config/i18n/{en,fr,de}.json`: new `mqttConnectionErrors` messages telling the user to check the broker credentials / URL.

**What was verified locally**

- `cd server && npm_config_service=zigbee2mqtt npm run test-service` → **398 passing, 0 failing** (includes the new `getMqttConnectionError` tests and the new `connect` tests).
- `cd server && npm run prettier-check` → clean; `npm run eslint` → **0 errors** (34 pre-existing warnings, none in the touched files).
- `cd front && npm run prettier-check` → clean; `npm run eslint` → **0 errors** (185 pre-existing warnings); `npm run compare-translations` → all locale files complete; `npm run build` → success.
- `cd server && npm test` (full suite) was also run: everything passes except the 4 `gateway.backup` tests, which fail in this sandbox because the `sqlite3` CLI binary is not installed (`/bin/sh: 1: sqlite3: not found`). That is environmental and unrelated to this change.

**What a human must check before merge**

- Real-world reproduction: point the Zigbee2mqtt integration at a real external MQTT broker with a wrong username/password and confirm the `BAD_CREDENTIALS` alert appears on the setup page (this could not be tested without a broker).
- Whether the `BROKER_UNREACHABLE` alert is acceptable in "Installation from Gladys" (local) mode: while the MQTT container is still starting, the client may briefly emit `ECONNREFUSED`, so the alert could flash before clearing itself on the successful connect.
- Wording and tone of the new English / French / German messages.
- Codecov patch coverage on the changed server lines (`npm run coverage` was not run here; only the Zigbee2mqtt suite and the full `npm test` were).
- Cypress was not run locally (the Cypress binary could not be downloaded in this sandbox); the change adds a conditional list item to the setup card, which should not affect the existing `z2m-*` selectors.

### Checklist

- [ ] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_01VinPPcP62ovdumA7r5n2Eu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Zigbee2MQTT setup now displays clear MQTT connection errors for invalid credentials, unauthorized access, unreachable brokers, and unknown failures.
  * Connection errors are cleared automatically after a successful reconnect or service reset.
* **Localization**
  * Added translated MQTT connection error messages in English, German, and French.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->