### PR TITLE
fix(front): keep the mobile dashboard overflow menu inside the screen

### DIFF
--- a/front/src/routes/dashboard/style.css
+++ b/front/src/routes/dashboard/style.css
@@ -891,10 +891,29 @@
     padding-bottom: calc(4.5rem + env(safe-area-inset-bottom, 0px));
   }
 
-  /* the "…" menu opens upward from the dock */
+  /* The "…" menu opens upward from the dock and spans the whole pill track.
+     Anchored to its own .dropdown wrapper (the "…" button) it could open
+     outside the screen: dropdown-menu-right hangs the panel leftward from
+     the button, which sits near the LEFT edge when only a pill or two are
+     visible, and a long dashboard name widens the nowrap panel past the
+     viewport. position: static on the wrapper hands the containing block
+     to the track (position: relative), whose box is always on-screen. */
+  .dashboardTabsOverflow {
+    position: static;
+  }
+
   .dashboardTabsMenu {
     top: auto;
     bottom: calc(100% + 8px);
+    left: 0;
+    right: 0;
+  }
+
+  /* the panel width is now the track's, not the content's: one endless
+     dashboard name must clip, not push the panel past the viewport */
+  .dashboardTabsMenu :global(.dropdown-item) {
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 


### PR DESCRIPTION
### Description

Fixes https://github.com/GladysAssistant/Gladys/issues/3031

On mobile, the dashboards "…" overflow menu could open outside of the screen. The panel is absolutely positioned against its own `.dropdown` wrapper and right-aligned on the "…" button (`dropdown-menu-right`), so:

- when only a pill or two are visible, the "…" button sits near the **left** edge of the dock, and the ≥13rem panel hangs off the left side of the viewport;
- a long dashboard name widens the panel without limit (dropdown items are `nowrap`), pushing it past the viewport the same way.

The fix anchors the panel to the pill track instead of the button, on the mobile layout only: `position: static` on the `.dropdown` wrapper hands the containing block to the track (already `position: relative`), and `left: 0; right: 0` makes the panel span the dock — whose box is always on-screen. Since the panel width is now fixed, endless dashboard names are clipped with an ellipsis instead of widening it.

CSS-only change, scoped to the existing `@media (max-width: 991.98px)` block; the desktop dropdown is untouched.

### Checklist

- [x] Tests pass: CSS-only change, no server code touched; no Cypress scenario covers the overflow menu positioning
- [x] Linter and prettier pass on both front and server (they only cover `.js`/`.jsx`/`.json`; this change is CSS-only)
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_012h4i9Tkt3p9Z4LTnNd13K2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the dashboard overflow menu layout on mobile devices.
  * The menu now spans the full tab area and opens upward when needed.
  * Long dashboard names are truncated cleanly with ellipses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->