### PR TITLE
Gladys Plus: warn when the local instance is behind the hosted front

### DIFF
--- a/front/src/actions/main.js
+++ b/front/src/actions/main.js
@@ -218,8 +218,15 @@ function createActions(store) {
         return;
       }
       lastInstanceVersionRefresh = Date.now();
+      // logout swaps the session object out of the store: that identity is
+      // what tells a response landing after logout that it must not write
+      // the previous session's version into the next one
+      const requestSession = state.session;
       try {
         const systemInfos = await state.httpClient.get('/api/v1/system/info');
+        if (store.getState().session !== requestSession) {
+          return;
+        }
         const instanceGladysVersion = systemInfos.gladys_version || null;
         // a response with no mismatch settles the check — an unreadable
         // version too, since it could never display the notice anyway
@@ -245,6 +252,9 @@ function createActions(store) {
       // a pending "integrations to update" request must not write the count of
       // the session being closed into the fresh state
       actionsExternalIntegrationUpdates.invalidateExternalIntegrationsToUpdate();
+      // and the instance version throttle must not carry over: logging back
+      // in right away gets a fresh check, not a 60s silence
+      lastInstanceVersionRefresh = 0;
       route('/login', true);
       const defaultState = getDefaultState();
       store.setState(defaultState, true);

--- a/front/src/actions/main.js
+++ b/front/src/actions/main.js
@@ -4,6 +4,7 @@ import createActionsExternalIntegrationUpdates from './externalIntegrationUpdate
 import { getDefaultState } from '../utils/getDefaultState';
 import { route } from 'preact-router';
 import get from 'get-value';
+import config from '../config';
 import { isUrlInArray } from '../utils/url';
 
 const ONE_DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
@@ -13,8 +14,12 @@ const MAX_TRIAL_DAYS_DISPLAYED = 92;
 // Every focus-triggered refresh costs the gateway two Stripe calls: a user
 // hopping between tabs must not pay for them over and over.
 const GATEWAY_TRIAL_REFRESH_INTERVAL_MS = 30 * 1000;
+// The instance version changes at most a few times a day (Watchtower): one
+// call a minute on tab focus is enough to notice an update happened.
+const INSTANCE_VERSION_REFRESH_INTERVAL_MS = 60 * 1000;
 
 let lastGatewayTrialRefresh = 0;
+let lastInstanceVersionRefresh = 0;
 
 const OPEN_PAGES = [
   '/signup',
@@ -93,6 +98,8 @@ function createActions(store) {
         // every page: it is loaded once the user (and their role) is known,
         // without blocking the rest of the session check
         actionsExternalIntegrationUpdates.refreshExternalIntegrationsToUpdate(state, user);
+        // same fire-and-forget for the instance version behind Gladys Plus
+        actions.refreshInstanceVersionState(state);
         if (state.session.getGatewayUser) {
           const gatewayUser = await state.session.getGatewayUser();
           const now = new Date();
@@ -183,6 +190,32 @@ function createActions(store) {
         gatewayTrialHasPaymentMethod: hasPaymentMethod,
         gatewayTrialStripePortalKey: stripePortalKey
       });
+    },
+    // On Gladys Plus the front redeploys at release time while the local
+    // instance waits for Watchtower (up to ~24h): the instance version is
+    // loaded so the header can announce the mismatch (InstanceUpdateNotice)
+    // instead of letting it surface as random bugs. Called at session check,
+    // and again when the tab regains focus while the notice is displayed —
+    // the moment Watchtower may just have resolved it.
+    async refreshInstanceVersionState(state) {
+      // served locally, the front comes from the instance itself: the
+      // versions cannot diverge. The demo has no real instance at all.
+      if (!config.gatewayMode || config.demoMode) {
+        return;
+      }
+      if (Date.now() - lastInstanceVersionRefresh < INSTANCE_VERSION_REFRESH_INTERVAL_MS) {
+        return;
+      }
+      lastInstanceVersionRefresh = Date.now();
+      try {
+        const systemInfos = await state.httpClient.get('/api/v1/system/info');
+        store.setState({
+          instanceGladysVersion: systemInfos.gladys_version || null
+        });
+      } catch (e) {
+        // instance unreachable: better no notice than a wrong one
+        console.error(e);
+      }
     },
     async logout(state, e) {
       e.preventDefault();

--- a/front/src/actions/main.js
+++ b/front/src/actions/main.js
@@ -6,6 +6,11 @@ import { route } from 'preact-router';
 import get from 'get-value';
 import config from '../config';
 import { isUrlInArray } from '../utils/url';
+import {
+  isInstanceBehindFront,
+  isInstanceVersionCheckSettled,
+  markInstanceVersionCheckSettled
+} from '../utils/instanceVersion';
 
 const ONE_DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
 // Self-hosted gateways without Stripe get a ~100-year "trial": past this
@@ -203,17 +208,30 @@ function createActions(store) {
       if (!config.gatewayMode || config.demoMode) {
         return;
       }
+      // the system/info payload is a lot more than a version string: once the
+      // instance has caught up with this front build, stop asking for it
+      // until the next front deploy (see instanceVersion.js)
+      if (isInstanceVersionCheckSettled()) {
+        return;
+      }
       if (Date.now() - lastInstanceVersionRefresh < INSTANCE_VERSION_REFRESH_INTERVAL_MS) {
         return;
       }
       lastInstanceVersionRefresh = Date.now();
       try {
         const systemInfos = await state.httpClient.get('/api/v1/system/info');
+        const instanceGladysVersion = systemInfos.gladys_version || null;
+        // a response with no mismatch settles the check — an unreadable
+        // version too, since it could never display the notice anyway
+        if (!isInstanceBehindFront(instanceGladysVersion)) {
+          markInstanceVersionCheckSettled();
+        }
         store.setState({
-          instanceGladysVersion: systemInfos.gladys_version || null
+          instanceGladysVersion
         });
       } catch (e) {
-        // instance unreachable: better no notice than a wrong one
+        // instance unreachable: better no notice than a wrong one, and the
+        // check stays unsettled so the next session retries
         console.error(e);
       }
     },

--- a/front/src/components/app.jsx
+++ b/front/src/components/app.jsx
@@ -216,7 +216,7 @@ const SafeAsyncRoute = props => (
 );
 
 const AppRouter = connect(
-  'currentUrl,user,profilePicture,showDropDown,showCollapsedMenu,fullScreen,externalIntegrationsToUpdate,session,gatewayTrialDaysLeft,gatewayTrialHasPaymentMethod,gatewayTrialStripePortalKey',
+  'currentUrl,user,profilePicture,showDropDown,showCollapsedMenu,fullScreen,externalIntegrationsToUpdate,session,gatewayTrialDaysLeft,gatewayTrialHasPaymentMethod,gatewayTrialStripePortalKey,instanceGladysVersion',
   actions
 )(props => (
   <div id="app">
@@ -243,6 +243,8 @@ const AppRouter = connect(
       gatewayTrialHasPaymentMethod={props.gatewayTrialHasPaymentMethod}
       gatewayTrialStripePortalKey={props.gatewayTrialStripePortalKey}
       refreshGatewayTrialState={props.refreshGatewayTrialState}
+      instanceGladysVersion={props.instanceGladysVersion}
+      refreshInstanceVersionState={props.refreshInstanceVersionState}
     />
     <Layout currentUrl={props.currentUrl}>
       <Router onChange={props.handleRoute}>

--- a/front/src/components/header/InstanceUpdateNotice.jsx
+++ b/front/src/components/header/InstanceUpdateNotice.jsx
@@ -2,7 +2,7 @@ import { Component } from 'preact';
 import { Text, Localizer } from 'preact-i18n';
 import cx from 'classnames';
 import { USER_ROLE } from '../../../../server/utils/constants';
-import { getFrontVersion, isUpdateNoticeDismissed, dismissUpdateNotice } from '../../utils/instanceVersion';
+import { getFrontVersion, dismissUpdateNotice } from '../../utils/instanceVersion';
 import style from './style.css';
 
 // Displayed on Gladys Plus when the hosted front is on a newer release than
@@ -31,15 +31,12 @@ class InstanceUpdateNotice extends Component {
 
   dismiss = () => {
     dismissUpdateNotice(this.props.instanceVersion);
-    // the dismissal lives in localStorage: this empty setState only forces
-    // the re-render that reads it back and hides the notice
-    this.setState({});
+    // the dismissal lives in localStorage: the header owns both this notice
+    // and the mobile dot echoing it, so it is the one told to re-read it
+    this.props.onDismiss();
   };
 
   render({ instanceVersion, user }) {
-    if (isUpdateNoticeDismissed(instanceVersion)) {
-      return null;
-    }
     return (
       <div class={style.updateNoticeCard} data-cy="instance-update-notice">
         <Localizer>

--- a/front/src/components/header/InstanceUpdateNotice.jsx
+++ b/front/src/components/header/InstanceUpdateNotice.jsx
@@ -1,0 +1,77 @@
+import { Component } from 'preact';
+import { Text, Localizer } from 'preact-i18n';
+import cx from 'classnames';
+import { USER_ROLE } from '../../../../server/utils/constants';
+import { getFrontVersion, isUpdateNoticeDismissed, dismissUpdateNotice } from '../../utils/instanceVersion';
+import style from './style.css';
+
+// Displayed on Gladys Plus when the hosted front is on a newer release than
+// the local instance (Watchtower can take up to ~24h to pull it): explains
+// why things may misbehave, and offers the one-click fix to the admin.
+// Only mounted while the mismatch exists (see the header): the visibility
+// listener below then lives exactly as long as this notice does.
+class InstanceUpdateNotice extends Component {
+  // Watchtower resolves the mismatch on its own, and the update button opens
+  // another page: coming back to the tab is the moment the instance may just
+  // have been updated, and the moment this notice must re-check itself
+  // instead of keep warning.
+  handleVisibilityChange = () => {
+    if (!document.hidden) {
+      this.props.refreshInstanceVersionState();
+    }
+  };
+
+  componentDidMount() {
+    document.addEventListener('visibilitychange', this.handleVisibilityChange);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('visibilitychange', this.handleVisibilityChange);
+  }
+
+  dismiss = () => {
+    dismissUpdateNotice(this.props.instanceVersion);
+    // the dismissal lives in localStorage: this empty setState only forces
+    // the re-render that reads it back and hides the notice
+    this.setState({});
+  };
+
+  render({ instanceVersion, user }) {
+    if (isUpdateNoticeDismissed(instanceVersion)) {
+      return null;
+    }
+    return (
+      <div class={style.updateNoticeCard} data-cy="instance-update-notice">
+        <Localizer>
+          <button
+            type="button"
+            class={style.updateNoticeDismiss}
+            onClick={this.dismiss}
+            aria-label={<Text id="header.instanceUpdateNoticeDismiss" />}
+          >
+            <i class="fe fe-x" />
+          </button>
+        </Localizer>
+        <div class={style.updateNoticeTitle}>
+          <i class={cx('fe fe-arrow-up-circle', style.updateNoticeIcon)} />
+          <span>
+            <Text id="header.instanceUpdateNoticeTitle" />
+          </span>
+        </div>
+        <div class={style.updateNoticeText}>
+          <Text
+            id="header.instanceUpdateNoticeText"
+            fields={{ latestVersion: `v${getFrontVersion()}`, instanceVersion }}
+          />
+        </div>
+        {user.role === USER_ROLE.ADMIN && (
+          <a href="/dashboard/settings/system" class={style.updateNoticeCta}>
+            <Text id="header.instanceUpdateNoticeButton" />
+          </a>
+        )}
+      </div>
+    );
+  }
+}
+
+export default InstanceUpdateNotice;

--- a/front/src/components/header/index.jsx
+++ b/front/src/components/header/index.jsx
@@ -7,6 +7,8 @@ import { isUrlInArray } from '../../utils/url';
 import { USER_ROLE } from '../../../../server/utils/constants';
 import DarkModeToggle from '../darkmode/DarkModeToggle';
 import GatewayTrialIndicator from './GatewayTrialIndicator';
+import InstanceUpdateNotice from './InstanceUpdateNotice';
+import { isInstanceBehindFront } from '../../utils/instanceVersion';
 import style from './style.css';
 
 const PAGES_WITHOUT_HEADER = [
@@ -231,6 +233,13 @@ class Header extends Component {
               </li>
             ))}
           </ul>
+          {isInstanceBehindFront(props.instanceGladysVersion) && (
+            <InstanceUpdateNotice
+              instanceVersion={props.instanceGladysVersion}
+              user={props.user}
+              refreshInstanceVersionState={props.refreshInstanceVersionState}
+            />
+          )}
           {Number.isInteger(props.gatewayTrialDaysLeft) && (
             <GatewayTrialIndicator
               daysLeft={props.gatewayTrialDaysLeft}

--- a/front/src/components/header/index.jsx
+++ b/front/src/components/header/index.jsx
@@ -8,7 +8,7 @@ import { USER_ROLE } from '../../../../server/utils/constants';
 import DarkModeToggle from '../darkmode/DarkModeToggle';
 import GatewayTrialIndicator from './GatewayTrialIndicator';
 import InstanceUpdateNotice from './InstanceUpdateNotice';
-import { isInstanceBehindFront } from '../../utils/instanceVersion';
+import { isInstanceBehindFront, isUpdateNoticeDismissed } from '../../utils/instanceVersion';
 import style from './style.css';
 
 const PAGES_WITHOUT_HEADER = [
@@ -119,6 +119,13 @@ class Header extends Component {
 
   isHidden = () => isUrlInArray(this.props.currentUrl, PAGES_WITHOUT_HEADER) || this.props.fullScreen;
 
+  // the dismissal is written to localStorage by the notice itself: this only
+  // forces the re-render that reads it back, hiding the notice and the
+  // mobile dot echoing it in the same pass
+  handleInstanceNoticeDismiss = () => {
+    this.setState({});
+  };
+
   // Content offsets (style/index.css) key off this body class so they vanish
   // together with the sidebar on auth pages and in fullscreen mode
   syncBodyClass = () => {
@@ -155,6 +162,8 @@ class Header extends Component {
     const userLanguage = get(props, 'user.language');
     const forumUrl =
       userLanguage === 'fr' ? 'https://community.gladysassistant.com/' : 'https://community.gladysassistant.com/';
+    const showInstanceUpdateNotice =
+      isInstanceBehindFront(props.instanceGladysVersion) && !isUpdateNoticeDismissed(props.instanceGladysVersion);
 
     return (
       <div>
@@ -168,6 +177,10 @@ class Header extends Component {
             aria-controls="sidebar-navigation"
           >
             <i class="fe fe-menu" />
+            {/* on mobile the notice lives in the closed menu: this dot is
+                what tells the user there is something to open it for. Screen
+                readers get the notice content itself, in the menu. */}
+            {showInstanceUpdateNotice && <span class={style.mobileTogglerDot} aria-hidden="true" />}
           </button>
           <a class={style.mobileBrand} href="/dashboard">
             <Localizer>
@@ -233,11 +246,12 @@ class Header extends Component {
               </li>
             ))}
           </ul>
-          {isInstanceBehindFront(props.instanceGladysVersion) && (
+          {showInstanceUpdateNotice && (
             <InstanceUpdateNotice
               instanceVersion={props.instanceGladysVersion}
               user={props.user}
               refreshInstanceVersionState={props.refreshInstanceVersionState}
+              onDismiss={this.handleInstanceNoticeDismiss}
             />
           )}
           {Number.isInteger(props.gatewayTrialDaysLeft) && (

--- a/front/src/components/header/index.jsx
+++ b/front/src/components/header/index.jsx
@@ -126,6 +126,20 @@ class Header extends Component {
     this.setState({});
   };
 
+  // The instance version is normally loaded at session check, but a
+  // client-side login never gets there: /login is an open page checkSession
+  // returns early from, and finishing the login routes here without
+  // remounting the app. The header is the consumer of the version, so it
+  // asks for it whenever it renders for a signed-in user — the action guards
+  // itself (gateway mode only, settled marker, one call a minute), so these
+  // calls are almost always a no-op, and double as the retry path when the
+  // instance was unreachable on the first attempt.
+  maybeRefreshInstanceVersion = () => {
+    if (!this.isHidden() && this.props.user && this.props.user.id) {
+      this.props.refreshInstanceVersionState();
+    }
+  };
+
   // Content offsets (style/index.css) key off this body class so they vanish
   // together with the sidebar on auth pages and in fullscreen mode
   syncBodyClass = () => {
@@ -143,10 +157,12 @@ class Header extends Component {
   componentDidMount() {
     document.addEventListener('mousedown', this.handleClickOutside);
     this.syncBodyClass();
+    this.maybeRefreshInstanceVersion();
   }
 
   componentDidUpdate() {
     this.syncBodyClass();
+    this.maybeRefreshInstanceVersion();
   }
 
   componentWillUnmount() {

--- a/front/src/components/header/style.css
+++ b/front/src/components/header/style.css
@@ -144,6 +144,69 @@
   color: #3d6df0;
 }
 
+/* Version mismatch notice: the hosted Gladys Plus front updates at release
+   time while the local instance waits for Watchtower (up to ~24h) — during
+   that window the mismatch is announced here instead of surfacing as random
+   bugs. Same visual family as the trial card above. */
+.updateNoticeCard {
+  position: relative;
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.65rem;
+  border-radius: 10px;
+  background-color: rgba(245, 166, 35, 0.16);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.78rem;
+  line-height: 1.35;
+  color: #1c2334;
+}
+
+.updateNoticeTitle {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.45rem;
+  font-weight: 600;
+  /* keep clear of the dismiss cross */
+  padding-right: 1.1rem;
+}
+
+.updateNoticeIcon {
+  color: #c4762a;
+  margin-top: 1px;
+}
+
+.updateNoticeText {
+  margin-left: 1.35rem;
+}
+
+.updateNoticeCta {
+  margin-left: 1.35rem;
+  font-weight: 600;
+  color: #3d6df0;
+}
+
+.updateNoticeCta:hover {
+  color: #3d6df0;
+}
+
+.updateNoticeDismiss {
+  position: absolute;
+  top: 0.3rem;
+  right: 0.35rem;
+  border: 0;
+  background: none;
+  padding: 0.1rem;
+  line-height: 1;
+  color: #1c2334;
+  opacity: 0.55;
+  cursor: pointer;
+}
+
+.updateNoticeDismiss:hover {
+  opacity: 1;
+}
+
 /* Footer: profile row opening a dropup menu, dark-mode toggle beside it */
 .sidebarFooter {
   position: relative;

--- a/front/src/components/header/style.css
+++ b/front/src/components/header/style.css
@@ -317,6 +317,7 @@
 }
 
 .mobileToggler {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -334,6 +335,19 @@
 .mobileToggler:hover {
   color: #1c2334;
   text-decoration: none;
+}
+
+/* Echo of the instance update notice (see .updateNoticeCard): on mobile the
+   notice sits in the closed menu, so the burger carries a dot in the same
+   amber to signal there is something worth opening it for */
+.mobileTogglerDot {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: #c4762a;
 }
 
 .mobileBrand {

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -6309,6 +6309,10 @@
       "other": "Gladys-Plus-Testphase: noch {{count}} Tage"
     },
     "trialAddPaymentMethod": "Zahlungsmethode hinzufügen",
+    "instanceUpdateNoticeTitle": "Update verfügbar",
+    "instanceUpdateNoticeText": "Gladys Plus wurde auf {{latestVersion}} aktualisiert, deine Instanz ist aber noch auf {{instanceVersion}}. Einige Funktionen können fehlerhaft sein, bis deine Instanz aktualisiert ist.",
+    "instanceUpdateNoticeButton": "Meine Instanz aktualisieren",
+    "instanceUpdateNoticeDismiss": "Diese Meldung ausblenden",
     "needHelp": "Hilfe benötigt",
     "signOut": "Abmelden"
   },

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -6309,6 +6309,10 @@
       "other": "Gladys Plus trial: {{count}} days left"
     },
     "trialAddPaymentMethod": "Add a payment method",
+    "instanceUpdateNoticeTitle": "Update available",
+    "instanceUpdateNoticeText": "Gladys Plus has been updated to {{latestVersion}}, but your instance is still on {{instanceVersion}}. Some features may not work properly until your instance is updated.",
+    "instanceUpdateNoticeButton": "Update my instance",
+    "instanceUpdateNoticeDismiss": "Hide this message",
     "needHelp": "Need help",
     "signOut": "Sign Out"
   },

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -6309,6 +6309,10 @@
       "other": "Essai Gladys Plus : {{count}} jours restants"
     },
     "trialAddPaymentMethod": "Ajouter un moyen de paiement",
+    "instanceUpdateNoticeTitle": "Mise à jour disponible",
+    "instanceUpdateNoticeText": "Gladys Plus a été mis à jour en {{latestVersion}}, mais votre instance est encore en {{instanceVersion}}. Certaines fonctionnalités peuvent mal fonctionner tant que votre instance n'est pas à jour.",
+    "instanceUpdateNoticeButton": "Mettre à jour mon instance",
+    "instanceUpdateNoticeDismiss": "Masquer ce message",
     "needHelp": "Besoin d'aide",
     "signOut": "Déconnexion"
   },

--- a/front/src/utils/instanceVersion.js
+++ b/front/src/utils/instanceVersion.js
@@ -13,6 +13,7 @@ import keyValStore from './keyValueStore';
 const FRONT_VERSION = process.env.GLADYS_FRONT_VERSION;
 
 const DISMISSED_NOTICE_KEY = 'dismissed_instance_update_notice';
+const SETTLED_CHECK_KEY = 'instance_version_check_settled_for';
 
 // Both versions come from the release process ("x.y.z", the instance with a
 // leading "v"): a plain major.minor.patch comparison is enough, the full
@@ -57,4 +58,24 @@ const isUpdateNoticeDismissed = instanceVersion =>
 const dismissUpdateNotice = instanceVersion =>
   keyValStore.set(DISMISSED_NOTICE_KEY, dismissedNoticeValue(instanceVersion));
 
-export { getFrontVersion, isInstanceBehindFront, isUpdateNoticeDismissed, dismissUpdateNotice };
+// /api/v1/system/info returns much more than a version (network interfaces,
+// docker image, CPU...) and can trigger background probes: not something to
+// pull on every session of every household member forever. Once the instance
+// has been seen at (or past) the front version, the answer cannot change
+// until the next front deploy — the front version baked in the bundle then
+// changes and the marker goes stale on its own. Steady state is thus one
+// call per browser per release, exactly in the window the check exists for.
+// The trade-off, accepted: an instance rolled back after settling is not
+// re-detected until the next release.
+const isInstanceVersionCheckSettled = () => keyValStore.get(SETTLED_CHECK_KEY) === FRONT_VERSION;
+
+const markInstanceVersionCheckSettled = () => keyValStore.set(SETTLED_CHECK_KEY, FRONT_VERSION);
+
+export {
+  getFrontVersion,
+  isInstanceBehindFront,
+  isUpdateNoticeDismissed,
+  dismissUpdateNotice,
+  isInstanceVersionCheckSettled,
+  markInstanceVersionCheckSettled
+};

--- a/front/src/utils/instanceVersion.js
+++ b/front/src/utils/instanceVersion.js
@@ -1,0 +1,60 @@
+import keyValStore from './keyValueStore';
+
+// The hosted Gladys Plus front redeploys the moment a release is published,
+// while the local instance waits for Watchtower to pull the new image (up to
+// ~24 hours). During that window the front can be ahead of the backend and
+// call APIs the instance does not have yet: the header announces the mismatch
+// (see components/header/InstanceUpdateNotice) instead of letting it surface
+// as random bugs.
+
+// Injected at build time from the root package.json (vite.config.mjs), the
+// same field the server reads at startup — so front and instance versions
+// come from one source and are directly comparable.
+const FRONT_VERSION = process.env.GLADYS_FRONT_VERSION;
+
+const DISMISSED_NOTICE_KEY = 'dismissed_instance_update_notice';
+
+// Both versions come from the release process ("x.y.z", the instance with a
+// leading "v"): a plain major.minor.patch comparison is enough, the full
+// semver grammar is not worth shipping in the bundle (same trade-off as the
+// demo store compatibility badge).
+const parseVersion = version => {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(String(version || '').trim());
+  if (!match) {
+    return null;
+  }
+  return match.slice(1, 4).map(Number);
+};
+
+const getFrontVersion = () => FRONT_VERSION;
+
+// Strictly greater only: an instance AHEAD of the front (stale front cached
+// by the browser) is not something the update button could fix, so it must
+// not raise the notice. An unparseable version on either side means "don't
+// know", which renders as no notice rather than a wrong one.
+const isInstanceBehindFront = instanceVersion => {
+  const front = parseVersion(FRONT_VERSION);
+  const instance = parseVersion(instanceVersion);
+  if (!front || !instance) {
+    return false;
+  }
+  for (let i = 0; i < 3; i += 1) {
+    if (front[i] !== instance[i]) {
+      return front[i] > instance[i];
+    }
+  }
+  return false;
+};
+
+// The dismissal is scoped to the exact (front, instance) pair: waiting for
+// Watchtower is a legitimate choice and must not be nagged, but the next
+// release is a new situation and shows the notice again.
+const dismissedNoticeValue = instanceVersion => `${FRONT_VERSION}|${instanceVersion}`;
+
+const isUpdateNoticeDismissed = instanceVersion =>
+  keyValStore.get(DISMISSED_NOTICE_KEY) === dismissedNoticeValue(instanceVersion);
+
+const dismissUpdateNotice = instanceVersion =>
+  keyValStore.set(DISMISSED_NOTICE_KEY, dismissedNoticeValue(instanceVersion));
+
+export { getFrontVersion, isInstanceBehindFront, isUpdateNoticeDismissed, dismissUpdateNotice };

--- a/front/vite.config.mjs
+++ b/front/vite.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig, loadEnv, transformWithEsbuild } from 'vite';
 import preact from '@preact/preset-vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 import { patchCssModules } from 'vite-css-modules';
+import { readFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { preactCliCssModules } from './vite-plugins/preact-cli-css-modules.js';
@@ -10,6 +11,12 @@ import { serverCommonjsInterop } from './vite-plugins/server-commonjs-interop.js
 
 const FRONT_ROOT = dirname(fileURLToPath(import.meta.url));
 const SRC_ROOT = resolve(FRONT_ROOT, 'src');
+
+// The released Gladys version, from the same root package.json field the
+// server reads at startup (server/lib/system/system.init.js). The hosted
+// Gladys Plus front is built from the release tag, so baking it in lets the
+// front detect an instance lagging behind (see utils/instanceVersion.js).
+const GLADYS_VERSION = JSON.parse(readFileSync(resolve(FRONT_ROOT, '../package.json'), 'utf8')).version;
 
 function treatJsFilesAsJsx() {
   return {
@@ -78,6 +85,7 @@ export default defineConfig(({ mode }) => {
     },
     define: {
       'process.env.NODE_ENV': JSON.stringify(mode === 'production' ? 'production' : 'development'),
+      'process.env.GLADYS_FRONT_VERSION': JSON.stringify(GLADYS_VERSION),
       ...processEnvDefine
     },
     server: {


### PR DESCRIPTION
### Description

The hosted Gladys Plus front redeploys the moment a release is published, while local instances wait for Watchtower to pull the new image (up to ~24h). During that window users run the new front against the old backend, and missing APIs surface as random bugs.

This PR makes the front aware of the mismatch and announces it instead:

- **Version baked into the front bundle at build time** (`front/vite.config.mjs`): `process.env.GLADYS_FRONT_VERSION` is injected from the root `package.json` — the same field the server reads at startup (`server/lib/system/system.init.js`), so both sides compare the same release number. The hosted front is built from the release tag, so the baked version is exactly the published one.
- **Instance version fetched in gateway mode** (`front/src/actions/main.js`): at session check (and again when the tab regains focus while the notice is displayed, throttled to one call per minute), the front reads `gladys_version` from `GET /api/v1/system/info` — an authenticated, non-admin route that already goes through the gateway. Skipped entirely in local and demo modes, where the versions cannot diverge.
- **Sidebar notice** (`front/src/components/header/InstanceUpdateNotice.jsx`): shown only when the front is strictly ahead of the instance (plain major.minor.patch comparison, no semver dependency shipped). It explains that some features may misbehave until the instance updates, and gives admins a direct link to `/dashboard/settings/system` where the one-click upgrade button lives. Non-admin users see the explanation without the link.
- **Mobile**: the sidebar (and the notice in it) sits behind the burger menu, so while the notice is active the burger carries a small amber dot in the same color family, signaling there is something worth opening the menu for. Dismissing the notice hides the dot in the same render pass.
- **Dismissible without nagging**: the dismissal is stored in `localStorage`, scoped to the exact (front, instance) version pair — waiting for Watchtower stays a legitimate choice, but the next release shows the notice again. Since the notice re-checks the instance on tab focus, it also disappears on its own once the update lands.
- Translations added for EN/FR/DE.

An instance *ahead* of the front (stale cached front) deliberately does not trigger the notice, since the update button could not fix it. No server change was needed.

### Checklist

- [x] Tests pass: no server change (`npm run coverage` not impacted); front validated via `eslint`, `compare-translations` and `npm run build`. The notice only renders in gateway mode, which Cypress does not run, so no E2E spec is affected.
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sidebar notice when the local Gladys instance is behind the current Gladys Plus version.
  * Provides a direct link to update the instance.
  * Notices can be dismissed and remain hidden for the current version pair.
  * Version checks refresh automatically for signed-in users.
  * Added a mobile notification indicator when an update notice is available.
  * Added English, French, and German translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->