### PR TITLE
fix(front): stop the dashboard cards from opening a horizontal scrollbar

### DIFF
--- a/front/src/components/boxs/device-in-room/DeviceCard.jsx
+++ b/front/src/components/boxs/device-in-room/DeviceCard.jsx
@@ -56,8 +56,11 @@ const DeviceCard = ({ children, ...props }) => {
         <div class="loader py-3" />
         <div class="table-responsive">
           {/* device-list-table: Horizon restyle hook — the glass theme turns
-              these rows into soft pills (see routes/dashboard/style.css) */}
-          <table class="table card-table table-vcenter device-list-table">
+              these rows into soft pills (see routes/dashboard/style.css).
+              device-widget-table narrows the rules that only make sense for
+              the widget's icon/name/control triplet: the devices page shares
+              device-list-table but lays its rows out on six columns. */}
+          <table class="table card-table table-vcenter device-list-table device-widget-table">
             <tbody>
               {loading
                 ? placeholderRows.map((_, index) => (

--- a/front/src/components/boxs/weather/WeatherBox.jsx
+++ b/front/src/components/boxs/weather/WeatherBox.jsx
@@ -3,6 +3,7 @@ import { connect } from 'unistore/preact';
 import { Text, Localizer } from 'preact-i18n';
 import { Link } from 'preact-router/match';
 import get from 'get-value';
+import cx from 'classnames';
 
 import { WEATHER_UNITS } from '../../../../../server/utils/constants';
 
@@ -511,7 +512,7 @@ class WeatherBoxComponent extends Component {
               being crushed or drawing past the card edge */}
           {showHourly && (
             <div
-              class={hasContentAboveHourly ? 'border-top' : ''}
+              class={cx('weather-forecast-scroll', { 'border-top': hasContentAboveHourly })}
               style="display: flex; justify-content: space-between; align-items: flex-end; padding-top: 10px; margin-bottom: 10px; overflow-x: auto"
             >
               {hours.map((hour, index) => (
@@ -555,7 +556,7 @@ class WeatherBoxComponent extends Component {
           {/* Daily forecast */}
           {showDaily && (
             <div
-              class={hasContentAboveDaily ? 'border-top' : ''}
+              class={cx('weather-forecast-scroll', { 'border-top': hasContentAboveDaily })}
               style="display: flex; justify-content: space-between; padding-top: 10px; overflow-x: auto"
             >
               {days.map(day => (

--- a/front/src/routes/dashboard/style.css
+++ b/front/src/routes/dashboard/style.css
@@ -1204,6 +1204,64 @@
   }
 }
 
+/* The weather forecast rows scroll sideways on purpose — their slots keep a
+   readable floor rather than being crushed into a narrow card. What they must
+   not do is carry a permanent scrollbar across the card: it reads as a broken
+   layout, which is how it was reported. Same treatment as the app's other
+   sideways rows (.hz-tabs, .groupChips): the bar is hidden, and a thin one
+   comes back on hover or keyboard focus for mouse users. */
+:global(.glass-theme .weather-forecast-scroll) {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+:global(.glass-theme .weather-forecast-scroll::-webkit-scrollbar) {
+  display: none;
+}
+
+:global(.glass-theme .weather-forecast-scroll:hover),
+:global(.glass-theme .weather-forecast-scroll:focus-within) {
+  scrollbar-width: thin;
+}
+
+:global(.glass-theme .weather-forecast-scroll:hover::-webkit-scrollbar),
+:global(.glass-theme .weather-forecast-scroll:focus-within::-webkit-scrollbar) {
+  display: block;
+  height: 4px;
+}
+
+:global(.glass-theme .weather-forecast-scroll:hover::-webkit-scrollbar-thumb),
+:global(.glass-theme .weather-forecast-scroll:focus-within::-webkit-scrollbar-thumb) {
+  background: rgba(28, 35, 52, 0.2);
+  border-radius: 4px;
+}
+
+/* An auto-layout table sizes a column to its widest unbreakable word, and a
+   device name is very often one long token (`Volet_chambre_parentale`). That
+   minimum pushed the whole table past the card, and .table-responsive put the
+   row under a horizontal scrollbar — on a phone, and on desktop too as soon as
+   the dashboard column was narrow. `max-width: 0` takes the name column out of
+   that minimum so it can shrink and ellipsize instead, and `width: 50%` keeps
+   it the half of the row it used to get, leaving the controls the width they
+   ask for. It also unblocks the adaptive option controls (acAdaptiveControls):
+   they collapse to dropdowns while the card overflows, so a name that
+   overflowed whatever they did turned every button group of the card into a
+   dropdown for nothing. */
+:global(.glass-theme .device-widget-table tr td:nth-child(2)) {
+  max-width: 0;
+  width: 50%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* the light row splits its name cell in two lines (name + live summary) */
+:global(.glass-theme .device-widget-table tr td:nth-child(2) > div) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Structural rows are not feature pills: ColorDeviceFeature always renders
    a second tr with one colspan cell holding the (d-none while closed) color
    picker — without this reset it paints as an empty ghost pill. */


### PR DESCRIPTION
### Description

Two dashboard widgets were reported on the forum as showing a horizontal scrollbar, on a phone and on a narrow desktop dashboard column alike.

**Devices widget** — an auto-layout table sizes a column to its widest unbreakable word, and a device name is very often one long token (`Volet_chambre_parentale`). That minimum pushed the whole table past the card, so `.table-responsive` put the row under a horizontal scrollbar with its controls cut off at the card edge. The name column now drops out of the table's minimum-width computation (`max-width: 0`) and ellipsizes instead, keeping the half of the row it had while the controls keep the width they ask for.

This also unblocks the adaptive option controls (`acAdaptiveControls`): they collapse to dropdowns *while the card overflows*, so a name that overflowed whatever they did was quietly turning every button group of the card into a dropdown for nothing.

The new rules are scoped to a `device-widget-table` class, because the devices page shares `device-list-table` but lays its rows out on six columns.

**Weather widget** — the hourly and daily forecast rows scroll sideways on purpose (the slots keep a readable floor rather than being crushed), but they carried a permanent scrollbar drawn across the card, which is what reads as broken. They get the treatment the app's other sideways rows already use (`.hz-tabs`, `.groupChips`): the bar is hidden, and a thin one comes back on hover or keyboard focus for mouse users. The rows still scroll.

Measured in Chromium on a reproduction of the reported card (light row + shutter state + shutter position, name `Volet_chambre_parentale`), `scrollWidth - clientWidth` of `.table-responsive`:

| card width | before | after |
| --- | --- | --- |
| 1100 px | 0 | 0 |
| 950 px | 0 | 0 |
| 600 px | 0 | 0 |
| 460 px | 0 | 0 |
| 390 px | **99 px** | 0 |
| 360 px | **99 px** | 0 |
| 320 px | **139 px** | 0 |

Row height stays constant (207 px) at every width, and on wide cards the column split stays close to what it was, so the range sliders keep their length (378 px at 1100 px card width, vs 448 px before). A name containing spaces, which used to wrap to two or three lines on a phone, now stays on one line — same single-line truncation the dashboard tab names already use.

## Forum

Forum: https://community.gladysassistant.com/t/bug-ascenseur-horizontal/10725

### Checklist

- [x] Tests pass: no server code is touched, so `server && npm run coverage` is unaffected; the change is front-end CSS plus two class names, verified with `npm run build` and a Chromium reproduction across card widths rather than with Cypress
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr7kHMojMzWCkaJSEReYxX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved dashboard weather forecast scrolling with cleaner, hover- and focus-visible scrollbars.
  - Prevented long device names and summaries from overflowing widget cards.
  - Improved device widget layout to preserve space for controls.
  - Refined table styling for device widgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->