### PR TITLE
fix(front): stop a portaled select from closing the menu it just opened

### DIFF
--- a/front/cypress/e2e/routes/scene/Scene.cy.js
+++ b/front/cypress/e2e/routes/scene/Scene.cy.js
@@ -68,15 +68,18 @@ describe('Scene view', () => {
 
     cy.get('[data-cy="type-picker-option"][data-value="house.is-empty"]').click();
 
-    cy.get('div[class*="-control"]').then(inputs => {
-      cy.wrap(inputs[0]).as('houseControl');
-      cy.get('@houseControl').click(0, 0, { force: true });
+    cy.get('[data-cy="scene-house-empty-or-not-choose-house"] .react-select__control').click();
 
-      cy.get('@houseControl')
-        .get('[class*="-menu"]')
-        .filter(`:contains("My House")`)
-        .click(0, 0, { force: true });
-    });
+    // The menu is rendered through a portal on <body> (components/form/Select.jsx),
+    // so it is queried from the document and not from the control — only one
+    // menu is open at a time. scrollBehavior: false because a portaled menu
+    // closes on any scroll: letting Cypress scroll the option into view would
+    // close the menu it is about to click.
+    cy.get('.react-select__menu')
+      .contains('.react-select__option', 'My House')
+      .click({ scrollBehavior: false });
+
+    cy.get('[data-cy="scene-house-empty-or-not-choose-house"]').should('contain', 'My House');
   });
 
   it('Should add new condition device set value', () => {

--- a/front/src/components/form/Select.jsx
+++ b/front/src/components/form/Select.jsx
@@ -16,11 +16,21 @@ import closeMenuOnScroll from '../../utils/closeMenuOnScroll';
  * closeMenuOnScroll closes it when the page or a panel scrolls underneath,
  * since a portaled menu is positioned once, when it opens.
  *
+ * menuPosition is what keeps that pair from fighting each other: with the
+ * default 'absolute', react-select makes room for a menu that doesn't fit
+ * below the fold by scrolling the page itself (menuShouldScrollIntoView) —
+ * and that scroll is seen by closeMenuOnScroll, which closes the menu it just
+ * opened. 'fixed' positions the menu against the viewport instead, so
+ * react-select never scrolls the page ("DO NOT scroll if position is fixed"):
+ * a menu with no room below simply flips above its control, and only a real
+ * user scroll closes it.
+ *
  * Import this instead of 'react-select' — same API, the portal props can still
  * be overridden by the caller.
  */
 const portalProps = () => ({
   menuPlacement: 'auto',
+  menuPosition: 'fixed',
   menuPortalTarget: document.body,
   closeMenuOnScroll
 });

--- a/front/src/routes/scene/edit-scene/actions/HouseEmptyOrNotCondition.jsx
+++ b/front/src/routes/scene/edit-scene/actions/HouseEmptyOrNotCondition.jsx
@@ -66,7 +66,7 @@ class HouseEmptyOrNotCondition extends Component {
             )}
           </p>
         )}
-        <div class="form-group">
+        <div class="form-group" data-cy="scene-house-empty-or-not-choose-house">
           <label class="form-label">
             <Text id="editScene.actionsCard.houseEmptyOrNot.houseLabel" />
             <span class="form-required">
@@ -75,7 +75,6 @@ class HouseEmptyOrNotCondition extends Component {
           </label>
           <Select
             options={houseOptions}
-            class="scene-house-empty-or-not-choose-house"
             value={selectedHouseOption}
             onChange={this.handleHouseChange}
             className="react-select-container"


### PR DESCRIPTION
### Description

The Cypress test `Scene view > Should add new condition house empty` fails at random:

```
AssertionError: Timed out retrying after 30000ms: Expected to find element: `:contains("My House")`,
but never found it. Queried from element: [ <i.fe.fe-menu>, 1 more... ]
```

**It is not the test that is unreliable, it is the dropdown.** Since #3008 / #2994 the selects render their menu through a portal on `<body>`. A portaled menu is positioned once, when it opens, so `closeMenuOnScroll` closes it as soon as anything scrolls underneath. But with the default `menuPosition: 'absolute'`, react-select makes room for a menu that does not fit below the fold by **scrolling the page itself** (`menuShouldScrollIntoView`, on by default):

```js
// react-select 4.3.1, getMenuPlacement()
if (scrollSpaceBelow >= menuHeight && !isFixedPosition) {
  if (shouldScroll) animatedScrollTo(scrollParent, scrollDown, 160);
```

That scroll is a `scroll` event on the document, `closeMenuOnScroll` returns `true` for it, and the menu that was just opened closes a few milliseconds later. Whether it happens depends on how much room is left under the control — hence the randomness in CI, and for users a dropdown low on the page that flashes and closes.

`menuPosition: 'fixed'` positions the menu against the viewport, and react-select explicitly does not scroll the page in that mode (*"DO NOT scroll if position is fixed"*): a menu with no room below flips above its control, its height is constrained to the viewport, and only a real user scroll closes it. `closeMenuOnScroll` keeps doing its job for those.

The test itself was fragile too, and is rewritten:

- it looked up the control with `div[class*="-control"]` and then clicked a **snapshot** of that element with `force: true` — which silently does nothing whenever the element has been re-rendered in the meantime;
- `[class*="-menu"]` also matches the `fe-menu` icons of the layout, which is exactly what the failure message showed it had queried;
- it asserted nothing, so a selection that never happened still passed.

It now clicks the control through a `data-cy` hook on the form group, picks the option by text inside `.react-select__menu` (only one menu is open at a time), and asserts the house really is selected. `scrollBehavior: false` on the option click keeps Cypress from scrolling the page — which would close the menu it is about to click.

The dead `class="scene-house-empty-or-not-choose-house"` prop on the `<Select>` is dropped: react-select does not forward unknown props to the DOM, that class was never rendered.

## Forum

<!-- Not applicable, this is a bug fix. -->

### Checklist

- [x] Tests pass: no server change, the Cypress spec for the scene editor is updated by this PR
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHFAABy3ZjLWcD6yXCN32z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved house-selection menus so they remain visible and flip above the field when needed, without unexpectedly scrolling the page.
  - Added a reliable identifier for the house-selection field.
  - Updated automated coverage for selecting and confirming “My House.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->