### PR TITLE
fix(front): address review feedback on the "Talk on a speaker" volume slider

### DIFF
--- a/front/src/routes/scene/edit-scene/actions/PlayNotification.css
+++ b/front/src/routes/scene/edit-scene/actions/PlayNotification.css
@@ -38,14 +38,22 @@
   --volume-track: linear-gradient(
     to right,
     var(--gl-accent, #3d6df0) 0%,
-    var(--gl-accent, #3d6df0) var(--volume-fill, 50%),
-    rgba(28, 35, 52, 0.09) var(--volume-fill, 50%),
+    var(--gl-accent, #3d6df0) var(--volume-fill, 0%),
+    rgba(28, 35, 52, 0.09) var(--volume-fill, 0%),
     rgba(28, 35, 52, 0.09) 100%
   );
 }
 
 .volumeRange:focus {
   outline: none;
+}
+
+/* Forced-colors mode drops box-shadow, so the focus ring below would vanish: a
+   transparent outline is repainted with a system color there and stays invisible
+   everywhere else. */
+.volumeRange:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
 }
 
 /* Chrome, Safari, Edge */
@@ -75,10 +83,21 @@
 
 /* Firefox */
 .volumeRange::-moz-range-track {
+  width: 100%;
   height: 8px;
   border-radius: 999px;
   background: var(--volume-track);
   box-shadow: inset 0 1px 3px rgba(28, 35, 52, 0.12);
+}
+
+/* Firefox paints the progress part as a sibling of the track, sized to the input
+   and not to the 8px track: the fill already lives on --volume-track, so this one
+   only has to keep out of the way. */
+.volumeRange::-moz-range-progress {
+  height: 8px;
+  border-radius: 999px;
+  background: transparent;
+  border: none;
 }
 
 .volumeRange::-moz-range-thumb {

--- a/front/src/routes/scene/edit-scene/actions/PlayNotification.jsx
+++ b/front/src/routes/scene/edit-scene/actions/PlayNotification.jsx
@@ -10,10 +10,6 @@ import TextWithVariablesInjected from '../../../../components/scene/TextWithVari
 import GladysPlusUpsell from '../../../../components/gateway/GladysPlusUpsell';
 import style from './PlayNotification.css';
 
-// The position the browser gives an untouched 0-100 range: the fill has to sit where
-// the thumb sits, even while the action carries no volume yet
-const DEFAULT_RANGE_POSITION = 50;
-
 class PlayNotification extends Component {
   getOptions = async () => {
     try {
@@ -125,13 +121,16 @@ class PlayNotification extends Component {
             </span>
             {volumeIsSet && <span class={style.volumeValue}>{`${volume}%`}</span>}
           </label>
+          {/* No accent fill until a volume is actually committed: the action still saves
+              `volume: undefined` until the slider is touched, and each speaker then applies
+              its own default, so a half-filled track would read as a 50% that is never sent. */}
           <input
             type="range"
             value={volume}
             onInput={this.updateVolumeDraft}
             onChange={this.updateVolume}
             class={style.volumeRange}
-            style={{ '--volume-fill': `${volumeIsSet ? volume : DEFAULT_RANGE_POSITION}%` }}
+            style={{ '--volume-fill': `${volumeIsSet ? volume : 0}%` }}
             step="1"
             min={0}
             max={100}


### PR DESCRIPTION
### Description

Follow-up to the review feedback on [#3030](https://github.com/GladysAssistant/Gladys/pull/3030). It targets that PR's branch (`claude/issue-3025`) so the fixes land in #3030 rather than duplicating it.

Three points were raised, all of them valid; each is addressed.

**1. The 50% fill on an unset volume was misleading** ([review comment](https://github.com/GladysAssistant/Gladys/pull/3030#discussion_r3877015021))

The accent fill sat at 50% while the pill stayed hidden and `action.volume` stayed `undefined`. `server/lib/scene/scene.actions.js:945` passes `action.volume` straight through, so an untouched slider sends `undefined` and each speaker applies its own default — never 50. A half-filled Horizon track claiming a value that is not saved is worse than the empty field it replaced.

The track now stays grey until a volume is actually committed: `--volume-fill` is `0%` while unset (and the CSS fallback moved from `50%` to `0%`), the thumb keeps the browser midpoint the reviewer suggested, and the pill still only appears once a value exists.

**2. Firefox would paint `::-moz-range-progress` over the custom track** ([review comment](https://github.com/GladysAssistant/Gladys/pull/3030#discussion_r3877015018))

The progress part is a sibling of the track sized to the input (`1.5rem`), not to the 8px track, and `appearance: none` does not hide it. It now gets an explicit rule — 8px, pill radius, transparent background, no border — so the fill stays on `--volume-track` alone. `::-moz-range-track` also got `width: 100%` to span the control.

The reviewer also asked about the WebKit thumb centering: `margin-top: -6px` is `(8px − 20px) / 2`, correct for the 8px track, so it is unchanged.

**3. Keyboard focus could disappear in forced-colors mode** ([review comment](https://github.com/GladysAssistant/Gladys/pull/3030#discussion_r3877020109))

The focus ring is a `box-shadow`, which forced-colors mode strips at paint time. `.volumeRange:focus-visible` now also sets `outline: 2px solid transparent` with an offset: invisible in normal rendering, repainted with a system color in forced-colors mode, so the existing look is untouched.

## Forum

### Checklist

- [x] Tests pass: no server code changed, so `npm run coverage` does not apply to this diff; no existing spec covers this action and Cypress cannot run in this sandbox
- [x] Linter and prettier pass on the changed file (`prettier@1.19.1`, the version pinned in `front/package.json`, reports "All matched files use Prettier code style!"; the `prettier` script does not cover `.css`)
- [x] No undocumented breaking change

**What a human must still check**

The rendering was again not verified visually — no browser in this sandbox. Worth confirming on the preview image, in light and dark mode:

- an untouched volume slider shows a fully grey track with the thumb centred, and the fill appears as soon as the slider is dragged;
- Firefox draws a single flat track with no taller native fill on top of it;
- keyboard focus stays visible when tabbing to the slider.

---
_Generated by [Claude Code](https://claude.ai/code/session_0146idk7zaUirqM8E4xCNaGz)_