### PR TITLE
fix: show an explicit error when Zigbee2mqtt connects to an external MQTT broker with wrong credentials (#3024)

### DIFF
--- a/front/cypress/e2e/routes/integration/zigbee2mqtt/setup/Zigbee2MqttSetupRemoteGladys.cy.js
+++ b/front/cypress/e2e/routes/integration/zigbee2mqtt/setup/Zigbee2MqttSetupRemoteGladys.cy.js
@@ -135,4 +135,73 @@ describe('Zigbee2Mqtt setup wizard remote mode from scratch', () => {
       }
     });
   });
+
+  it('Display the MQTT connection error of a known error code', () => {
+    cy.get('[data-cy=z2m-mqtt-connection-error]').should('not.exist');
+
+    cy.sendWebSocket({
+      type: 'zigbee2mqtt.status-change',
+      payload: {
+        usbConfigured: false,
+        mqttExist: true,
+        mqttRunning: true,
+        zigbee2mqttExist: false,
+        zigbee2mqttRunning: false,
+        gladysConnected: false,
+        zigbee2mqttConnected: false,
+        z2mEnabled: true,
+        dockerBased: false,
+        networkModeValid: false,
+        mqttConnectionError: { code: 'BAD_CREDENTIALS', message: null }
+      }
+    });
+
+    cy.get('[data-cy=z2m-mqtt-connection-error]').i18n(
+      'integration.zigbee2mqtt.setup.mqttConnectionErrors.BAD_CREDENTIALS'
+    );
+  });
+
+  it('Display the raw message when the error code is unknown', () => {
+    cy.sendWebSocket({
+      type: 'zigbee2mqtt.status-change',
+      payload: {
+        usbConfigured: false,
+        mqttExist: true,
+        mqttRunning: true,
+        zigbee2mqttExist: false,
+        zigbee2mqttRunning: false,
+        gladysConnected: false,
+        zigbee2mqttConnected: false,
+        z2mEnabled: true,
+        dockerBased: false,
+        networkModeValid: false,
+        mqttConnectionError: { code: null, message: 'client disconnecting' }
+      }
+    });
+
+    cy.get('[data-cy=z2m-mqtt-connection-error]')
+      .i18n('integration.zigbee2mqtt.setup.mqttConnectionErrors.unknownErrorPrefix')
+      .should('contain', 'client disconnecting');
+  });
+
+  it('Hide the alert when there is no MQTT connection error', () => {
+    cy.sendWebSocket({
+      type: 'zigbee2mqtt.status-change',
+      payload: {
+        usbConfigured: false,
+        mqttExist: true,
+        mqttRunning: true,
+        zigbee2mqttExist: false,
+        zigbee2mqttRunning: false,
+        gladysConnected: true,
+        zigbee2mqttConnected: false,
+        z2mEnabled: true,
+        dockerBased: false,
+        networkModeValid: false,
+        mqttConnectionError: { code: null, message: null }
+      }
+    });
+
+    cy.get('[data-cy=z2m-mqtt-connection-error]').should('not.exist');
+  });
 });

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -1691,6 +1691,7 @@
         "toggleError": "Ein Fehler ist aufgetreten. Bitte überprüfen Sie die Konfiguration des Dienstes.",
         "mqttConnectionErrors": {
           "BAD_CREDENTIALS": "Gladys konnte keine Verbindung zum MQTT-Broker herstellen: Der Benutzername oder das Passwort ist falsch. Überprüfen Sie die Zugangsdaten Ihres MQTT-Brokers und speichern Sie die Konfiguration erneut.",
+          "NOT_AUTHORIZED": "Der MQTT-Broker hat die Verbindung abgelehnt: nicht autorisiert. Überprüfen Sie den Benutzernamen und das Passwort Ihres MQTT-Brokers sowie die Zugriffsrechte dieses Clients und speichern Sie die Konfiguration erneut.",
           "BROKER_UNREACHABLE": "Gladys konnte den MQTT-Broker nicht erreichen. Überprüfen Sie, ob die URL und der Port des Brokers korrekt sind und ob der Broker läuft und von Gladys aus erreichbar ist.",
           "unknownErrorPrefix": "MQTT-Verbindungsfehler: "
         },

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -1586,6 +1586,7 @@
         "toggleError": "An error occurred. Please check the service configuration.",
         "mqttConnectionErrors": {
           "BAD_CREDENTIALS": "Gladys could not connect to the MQTT broker: the username or the password is incorrect. Check the credentials of your MQTT broker, then save the configuration again.",
+          "NOT_AUTHORIZED": "The MQTT broker refused the connection: not authorized. Check the username and password of your MQTT broker, and that this client is allowed to connect, then save the configuration again.",
           "BROKER_UNREACHABLE": "Gladys could not reach the MQTT broker. Check that the broker URL and port are correct, and that the broker is running and reachable from Gladys.",
           "unknownErrorPrefix": "MQTT connection error: "
         },

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -1824,6 +1824,7 @@
         "toggleError": "Une erreur est survenue. Veuillez vérifier la configuration du service.",
         "mqttConnectionErrors": {
           "BAD_CREDENTIALS": "Gladys n'a pas réussi à se connecter au broker MQTT : le nom d'utilisateur ou le mot de passe est incorrect. Vérifiez les identifiants de votre broker MQTT, puis enregistrez à nouveau la configuration.",
+          "NOT_AUTHORIZED": "Le broker MQTT a refusé la connexion : non autorisé. Vérifiez le nom d'utilisateur et le mot de passe de votre broker MQTT, ainsi que les droits d'accès de ce client, puis enregistrez à nouveau la configuration.",
           "BROKER_UNREACHABLE": "Gladys n'a pas réussi à joindre le broker MQTT. Vérifiez que l'URL et le port du broker sont corrects, et que le broker est démarré et joignable depuis Gladys.",
           "unknownErrorPrefix": "Erreur de connexion MQTT : "
         },

--- a/front/src/routes/integration/all/zigbee2mqtt/setup-page/SetupTab.jsx
+++ b/front/src/routes/integration/all/zigbee2mqtt/setup-page/SetupTab.jsx
@@ -113,7 +113,7 @@ class SetupTab extends Component {
                     </div>
                   </li>
                 )}
-                {mqttConnectionError && (
+                {mqttConnectionError && (mqttConnectionError.code || mqttConnectionError.message) && (
                   <li class="list-group-item">
                     <div class="alert alert-danger my-3" data-cy="z2m-mqtt-connection-error">
                       {mqttConnectionError.code ? (

--- a/server/services/zigbee2mqtt/lib/connect.js
+++ b/server/services/zigbee2mqtt/lib/connect.js
@@ -1,5 +1,5 @@
 const logger = require('../../../utils/logger');
-const { DEFAULT } = require('./constants');
+const { DEFAULT, MQTT_CONNECTION_ERROR } = require('./constants');
 const { getMqttConnectionError } = require('../utils/getMqttConnectionError');
 
 /**
@@ -21,7 +21,9 @@ async function connect({ mqttUrl, mqttUsername, mqttPassword, mqttMode }) {
     this.mqttClient = null;
   }
 
-  if (this.mqttRunning || mqttMode === 'external') {
+  const externalBroker = mqttMode === 'external';
+
+  if (this.mqttRunning || externalBroker) {
     // Loads MQTT service
     logger.info(`Connecting Gladys to ${mqttUrl} MQTT broker...`);
 
@@ -48,7 +50,15 @@ async function connect({ mqttUrl, mqttUsername, mqttPassword, mqttMode }) {
       logger.warn(`Error while connecting to MQTT - ${err}`);
       this.gladysConnected = false;
       this.zigbee2mqttConnected = false;
-      this.mqttConnectionError = getMqttConnectionError(err);
+      const connectionError = getMqttConnectionError(err);
+      const authenticationFailed =
+        connectionError.code === MQTT_CONNECTION_ERROR.BAD_CREDENTIALS ||
+        connectionError.code === MQTT_CONNECTION_ERROR.NOT_AUTHORIZED;
+      // On a Gladys-managed broker, only authentication failures are worth showing: the client
+      // reconnects every 5 seconds, so a network error simply means the Mosquitto container is
+      // still starting or restarting, and telling the user to check the broker URL would be a
+      // wrong diagnosis. The Gladys <-> MQTT link already turns red through `gladysConnected`.
+      this.mqttConnectionError = externalBroker || authenticationFailed ? connectionError : null;
       this.emitStatusEvent();
     });
 

--- a/server/services/zigbee2mqtt/lib/constants.js
+++ b/server/services/zigbee2mqtt/lib/constants.js
@@ -28,6 +28,7 @@ const MQTT_MODE = {
 // Reasons why Gladys failed to connect to the MQTT broker, displayed as explicit messages in the UI
 const MQTT_CONNECTION_ERROR = {
   BAD_CREDENTIALS: 'BAD_CREDENTIALS',
+  NOT_AUTHORIZED: 'NOT_AUTHORIZED',
   BROKER_UNREACHABLE: 'BROKER_UNREACHABLE',
 };
 

--- a/server/services/zigbee2mqtt/utils/getMqttConnectionError.js
+++ b/server/services/zigbee2mqtt/utils/getMqttConnectionError.js
@@ -1,10 +1,17 @@
 const { MQTT_CONNECTION_ERROR } = require('../lib/constants');
 
-// CONNACK return codes rejecting the credentials: 4 & 5 in MQTT 3.1.1
-// ("Bad username or password", "Not authorized"), 134 & 135 in MQTT 5
-const AUTHENTICATION_RETURN_CODES = [4, 5, 134, 135];
-// Network level failures raised before the broker even answers
-const UNREACHABLE_ERROR_CODES = ['ECONNREFUSED', 'ENOTFOUND', 'EAI_AGAIN', 'ETIMEDOUT', 'EHOSTUNREACH'];
+// CONNACK return codes rejecting the credentials themselves: 4 in MQTT 3.1.1
+// ("Bad user name or password"), 134 in MQTT 5.
+const BAD_CREDENTIALS_RETURN_CODES = [4, 134];
+// CONNACK return codes refusing the client without blaming the credentials: 5 in MQTT 3.1.1
+// ("Not authorized"), 135 in MQTT 5. Brokers use them both for a failed login (Mosquitto) and
+// for an ACL denying an otherwise valid user, so the message must cover the two cases.
+const NOT_AUTHORIZED_RETURN_CODES = [5, 135];
+// Network level failures raised before the broker even answers.
+// mqtt@4.2 only forwards the socket errors of its own allow list (ECONNREFUSED, EADDRINUSE,
+// ECONNRESET, ENOTFOUND), while mqtt@4.3 forwards every socket error carrying a `code`, hence
+// the DNS and timeout codes below.
+const UNREACHABLE_ERROR_CODES = ['ECONNREFUSED', 'ECONNRESET', 'ENOTFOUND', 'EAI_AGAIN', 'ETIMEDOUT', 'EHOSTUNREACH'];
 
 /**
  * @description Convert an error emitted by the MQTT client into an explicit error for the UI.
@@ -16,8 +23,12 @@ const UNREACHABLE_ERROR_CODES = ['ECONNREFUSED', 'ENOTFOUND', 'EAI_AGAIN', 'ETIM
 function getMqttConnectionError(error = {}) {
   const { code, message } = error;
 
-  if (AUTHENTICATION_RETURN_CODES.includes(code)) {
+  if (BAD_CREDENTIALS_RETURN_CODES.includes(code)) {
     return { code: MQTT_CONNECTION_ERROR.BAD_CREDENTIALS, message: null };
+  }
+
+  if (NOT_AUTHORIZED_RETURN_CODES.includes(code)) {
+    return { code: MQTT_CONNECTION_ERROR.NOT_AUTHORIZED, message: null };
   }
 
   if (UNREACHABLE_ERROR_CODES.includes(code)) {

--- a/server/test/services/zigbee2mqtt/lib/connect.test.js
+++ b/server/test/services/zigbee2mqtt/lib/connect.test.js
@@ -11,6 +11,7 @@ const Zigbee2mqttManager = require('../../../../services/zigbee2mqtt/lib');
 const serviceId = 'f87b7af2-ca8e-44fc-b754-444354b42fee';
 
 const configuration = { mqttUrl: 'fakeUrl', mqttUsername: 'username', mqttPassword: 'password' };
+const externalConfiguration = { ...configuration, mqttMode: 'external' };
 
 describe('zigbee2mqtt connect', () => {
   // PREPARE
@@ -132,7 +133,7 @@ describe('zigbee2mqtt connect', () => {
     zigbee2mqttManager.mqttRunning = true;
     const error = new Error('mqtt_error');
     // EXECUTE
-    await zigbee2mqttManager.connect(configuration);
+    await zigbee2mqttManager.connect(externalConfiguration);
     zigbee2mqttManager.mqttClient.emit('error', error);
     // ASSERT
     assert.calledOnceWithExactly(gladys.event.emit, EVENTS.WEBSOCKET.SEND_ALL, {
@@ -162,18 +163,65 @@ describe('zigbee2mqtt connect', () => {
     const error = new Error('Connection refused: Bad username or password');
     error.code = 4;
     // EXECUTE
-    await zigbee2mqttManager.connect(configuration);
+    await zigbee2mqttManager.connect(externalConfiguration);
     zigbee2mqttManager.mqttClient.emit('error', error);
     // ASSERT
     expect(zigbee2mqttManager.mqttConnectionError).to.deep.equal({ code: 'BAD_CREDENTIALS', message: null });
+  });
+
+  it('it should report an unreachable external MQTT broker', async () => {
+    // PREPARE
+    zigbee2mqttManager.mqttRunning = true;
+    const error = new Error('connect ECONNREFUSED 127.0.0.1:1883');
+    error.code = 'ECONNREFUSED';
+    // EXECUTE
+    await zigbee2mqttManager.connect(externalConfiguration);
+    zigbee2mqttManager.mqttClient.emit('error', error);
+    // ASSERT
+    expect(zigbee2mqttManager.mqttConnectionError).to.deep.equal({ code: 'BROKER_UNREACHABLE', message: null });
+  });
+
+  it('it should report a not authorized client on a Gladys managed broker', async () => {
+    // PREPARE
+    zigbee2mqttManager.mqttRunning = true;
+    const error = new Error('Connection refused: Not authorized');
+    error.code = 5;
+    // EXECUTE
+    await zigbee2mqttManager.connect(configuration);
+    zigbee2mqttManager.mqttClient.emit('error', error);
+    // ASSERT
+    expect(zigbee2mqttManager.mqttConnectionError).to.deep.equal({ code: 'NOT_AUTHORIZED', message: null });
+  });
+
+  it('it should ignore a network error on a Gladys managed broker', async () => {
+    // PREPARE
+    zigbee2mqttManager.mqttRunning = true;
+    const error = new Error('connect ECONNREFUSED 127.0.0.1:1883');
+    error.code = 'ECONNREFUSED';
+    // EXECUTE
+    await zigbee2mqttManager.connect(configuration);
+    zigbee2mqttManager.mqttClient.emit('error', error);
+    // ASSERT
+    expect(zigbee2mqttManager.mqttConnectionError).to.eq(null);
+  });
+
+  it('it should ignore an unknown error on a Gladys managed broker', async () => {
+    // PREPARE
+    zigbee2mqttManager.mqttRunning = true;
+    // EXECUTE
+    await zigbee2mqttManager.connect(configuration);
+    zigbee2mqttManager.mqttClient.emit('error', new Error('mqtt_error'));
+    // ASSERT
+    expect(zigbee2mqttManager.mqttConnectionError).to.eq(null);
   });
 
   it('it should clear the MQTT connection error when connected', async () => {
     // PREPARE
     zigbee2mqttManager.mqttRunning = true;
     // EXECUTE
-    await zigbee2mqttManager.connect(configuration);
+    await zigbee2mqttManager.connect(externalConfiguration);
     zigbee2mqttManager.mqttClient.emit('error', new Error('mqtt_error'));
+    expect(zigbee2mqttManager.mqttConnectionError).to.deep.equal({ code: null, message: 'mqtt_error' });
     zigbee2mqttManager.mqttClient.emit('connect');
     // ASSERT
     expect(zigbee2mqttManager.mqttConnectionError).to.eq(null);

--- a/server/test/services/zigbee2mqtt/utils/getMqttConnectionError.test.js
+++ b/server/test/services/zigbee2mqtt/utils/getMqttConnectionError.test.js
@@ -10,14 +10,38 @@ describe('zigbee2mqtt getMqttConnectionError', () => {
   });
 
   it('should detect wrong credentials in MQTT 5', () => {
+    const error = new Error('Connection refused: Bad user name or password');
+    error.code = 134;
+    expect(getMqttConnectionError(error)).to.deep.equal({ code: 'BAD_CREDENTIALS', message: null });
+  });
+
+  it('should detect a not authorized client in MQTT 3.1.1', () => {
+    const error = new Error('Connection refused: Not authorized');
+    error.code = 5;
+    expect(getMqttConnectionError(error)).to.deep.equal({ code: 'NOT_AUTHORIZED', message: null });
+  });
+
+  it('should detect a not authorized client in MQTT 5', () => {
     const error = new Error('Connection refused: Not authorized');
     error.code = 135;
-    expect(getMqttConnectionError(error)).to.deep.equal({ code: 'BAD_CREDENTIALS', message: null });
+    expect(getMqttConnectionError(error)).to.deep.equal({ code: 'NOT_AUTHORIZED', message: null });
   });
 
   it('should detect an unreachable broker', () => {
     const error = new Error('connect ECONNREFUSED 127.0.0.1:1883');
     error.code = 'ECONNREFUSED';
+    expect(getMqttConnectionError(error)).to.deep.equal({ code: 'BROKER_UNREACHABLE', message: null });
+  });
+
+  it('should detect a broker closing the connection', () => {
+    const error = new Error('read ECONNRESET');
+    error.code = 'ECONNRESET';
+    expect(getMqttConnectionError(error)).to.deep.equal({ code: 'BROKER_UNREACHABLE', message: null });
+  });
+
+  it('should detect an unknown broker host', () => {
+    const error = new Error('getaddrinfo ENOTFOUND broker.local');
+    error.code = 'ENOTFOUND';
     expect(getMqttConnectionError(error)).to.deep.equal({ code: 'BROKER_UNREACHABLE', message: null });
   });
 


### PR DESCRIPTION
### Description

Follow-up to [#3029](https://github.com/GladysAssistant/Gladys/pull/3029), targeting its branch `claude/issue-3024` so it can be merged into it before #3029 itself is merged. It addresses the five review comments left on that PR.

**1. No network-level error when Gladys owns the broker** (`server/services/zigbee2mqtt/lib/connect.js`)

In local mode the client reconnects every 5 seconds, so a Mosquitto container that is still starting (first listen after `installMqttContainer`), restarting after `mosquitto_passwd`, or simply blipping would set `BROKER_UNREACHABLE` and show a "check the broker URL and port" alert — the wrong diagnosis, and the Gladys ↔ MQTT link already turns red through `gladysConnected`. Network-level and unknown errors are now only stored when `mqttMode === 'external'`; credential and authorization failures stay reported in both modes, since those messages are unambiguous either way.

**2. `BAD_CREDENTIALS` vs `NOT_AUTHORIZED`** (`server/services/zigbee2mqtt/utils/getMqttConnectionError.js`, `lib/constants.js`, i18n)

CONNACK `4` / `134` ("Bad user name or password") keep mapping to `BAD_CREDENTIALS`. CONNACK `5` / `135` ("Not authorized") now map to a new `NOT_AUTHORIZED` code. Its message covers both cases a broker uses those codes for — Mosquitto returns `5` on a failed login, but an ACL can also refuse an otherwise valid user — so it asks the user to check the credentials *and* the client's access rights rather than asserting the password is wrong.

**3. Alignment with what `mqtt@4` actually emits**

`ECONNRESET` is added to `UNREACHABLE_ERROR_CODES`. `mqtt@4.2` (the version pinned in `services/zigbee2mqtt/package-lock.json`) only forwards the socket errors of its own allow list — `ECONNREFUSED`, `EADDRINUSE`, `ECONNRESET`, `ENOTFOUND` — so a broker restart used to fall through to the untranslated raw Node errno. `mqtt@4.3`, which `^4.2.6` resolves to on a fresh install, forwards every socket error carrying a `code`, so the DNS and timeout codes are kept and the comment now explains why both sets are listed. `EADDRINUSE` is deliberately left out: it is a local socket conflict, not an unreachable broker.

**4. No blank red box** (`front/.../setup-page/SetupTab.jsx`)

The alert is guarded with `mqttConnectionError && (mqttConnectionError.code || mqttConnectionError.message)`, so the `{ code: null, message: null }` fallback no longer renders a danger alert containing only the prefix and an empty `<code>`.

**5. Cypress coverage** (`front/cypress/e2e/.../Zigbee2MqttSetupRemoteGladys.cy.js`)

Three cases added on `data-cy="z2m-mqtt-connection-error"`, driven through `cy.sendWebSocket`: a known code (`BAD_CREDENTIALS` → translated message), the raw-message fallback (prefix + raw message), and an empty payload (alert absent).

**What was verified locally**

- `cd server && npm_config_service=zigbee2mqtt npm run test-service` → **406 passing, 0 failing**.
- `npx c8` scoped to the two changed server files → **100% statements / branches / functions / lines**, which is what Codecov gates on.
- `cd server && npm run prettier-check` → clean; `npx eslint services/zigbee2mqtt test/services/zigbee2mqtt` → 0 errors (1 pre-existing warning in `getDiscoveredDevices.js`).
- `cd front && npm run prettier-check` → clean; `npm run compare-translations` → all locale files complete; `npx eslint` on the touched front files → clean; `npm run build` → success.

**What a human must still check**

- Cypress was not run here: the Cypress binary cannot be downloaded in this sandbox, so the three new specs have only been written, not executed. They run in CI.
- The wording of the new `NOT_AUTHORIZED` message in the three languages.
- Real-world reproduction against an external broker with wrong credentials, to confirm which CONNACK code the broker actually returns and therefore which of the two messages the user sees.

### Checklist

- [ ] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TyAxZKyB1KatoHzngR6L6

---
_Generated by [Claude Code](https://claude.ai/code/session_018TyAxZKyB1KatoHzngR6L6)_