### PR TITLE
fix(front): wrap long scene names in the dashboard scene widget

### DIFF
--- a/front/src/components/boxs/scene/SceneRow.jsx
+++ b/front/src/components/boxs/scene/SceneRow.jsx
@@ -43,21 +43,23 @@ class SceneRow extends Component {
             </div>
           )}
         </div>
-        {props.runningInfo ? (
-          <RunningStopButton runningInfo={props.runningInfo} onStop={this.stopScene} small />
-        ) : (
-          <button
-            onClick={this.startScene}
-            type="button"
-            class={cx('btn', 'btn-outline-success', 'btn-sm', style.btnLoading, {
-              'btn-loading': loading
-            })}
-            disabled={loading}
-          >
-            <i class="fe fe-play" />
-            <Text id="scene.startButton" />
-          </button>
-        )}
+        <div class={style.sceneAction}>
+          {props.runningInfo ? (
+            <RunningStopButton runningInfo={props.runningInfo} onStop={this.stopScene} small />
+          ) : (
+            <button
+              onClick={this.startScene}
+              type="button"
+              class={cx('btn', 'btn-outline-success', 'btn-sm', style.btnLoading, {
+                'btn-loading': loading
+              })}
+              disabled={loading}
+            >
+              <i class="fe fe-play" />
+              <Text id="scene.startButton" />
+            </button>
+          )}
+        </div>
       </div>
     );
   }

--- a/front/src/components/boxs/scene/style.css
+++ b/front/src/components/boxs/scene/style.css
@@ -41,9 +41,14 @@
 
 .sceneName {
   font-weight: 600;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  /* Long scene names wrap on several lines instead of being truncated */
+  overflow-wrap: anywhere;
+}
+
+.sceneAction {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
 }
 
 /* Horizon glass theme */


### PR DESCRIPTION
### Description

On mobile, scene names in the dashboard scene widget were cut with an ellipsis: `.sceneName` forced the text on a single line (`white-space: nowrap` + `text-overflow: ellipsis`), so on a narrow screen only the first few words of a scene name were readable.

Changes in `front/src/components/boxs/scene/`:

- `style.css`: `.sceneName` no longer forces a single line — long names wrap on several lines, and `overflow-wrap: anywhere` handles very long names without spaces.
- `style.css` / `SceneRow.jsx`: the start / running-stop button is wrapped in a `.sceneAction` container with `flex: 0 0 auto`, so it keeps its natural size and is never squashed when a name takes several lines.

Checked on a 375px-wide viewport: a name like "Extinction de toutes les lumières du salon" now renders on two lines instead of "Extinction de toutes l…", the status line under the name is unchanged, and the "Démarrer" button stays the same size.

## Forum

Forum: https://community.gladysassistant.com/t/sur-mobile-noms-de-scenes-tronquees-dans-le-dashboard/10727

### Checklist

- [x] Tests pass: no server code changed; the change is CSS/markup only in the front
- [x] Linter and prettier pass on the changed files
- [x] No undocumented breaking change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Long scene names now wrap across multiple lines instead of being truncated.
  * Improved layout consistency for scene action controls, including start and stop buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->