### PR TITLE
fix(front): stop a single widget error from freezing the whole app, and keep the editor's actions on screen

### DIFF
--- a/front/src/components/ErrorBoundary.jsx
+++ b/front/src/components/ErrorBoundary.jsx
@@ -1,0 +1,55 @@
+import { Component } from 'preact';
+import { Text } from 'preact-i18n';
+
+// Contains a render/lifecycle exception instead of letting it kill the whole
+// app.
+//
+// Without a boundary, Preact rethrows an uncaught render error out of its
+// `process()` loop (preact/src/component.js). That loop only resets
+// `process._rerenderCount` on its LAST line, so a throw leaves the counter
+// above zero — and `enqueueRender` then believes a flush is already
+// scheduled and never schedules another one. The app stays painted exactly
+// as it was and silently stops reacting to every later setState: buttons
+// take focus, nothing happens, and only a reload brings it back (see the
+// mobile dashboard editor report where the widget picker froze on screen).
+//
+// One misconfigured widget, one unexpected API payload, must never cost the
+// user their whole session, so this renders a small recoverable message
+// instead. `resetKey` clears the error when the surrounding context changes
+// (a route change, another widget) so the user is not stuck with it either.
+class ErrorBoundary extends Component {
+  state = { error: null, resetKey: undefined };
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  // A new resetKey means a different context (another route, another widget
+  // type): the previous failure says nothing about it, so drop it and try to
+  // render again
+  static getDerivedStateFromProps(props, state) {
+    if (props.resetKey === state.resetKey) {
+      return null;
+    }
+    return { error: null, resetKey: props.resetKey };
+  }
+
+  componentDidCatch(error) {
+    // getDerivedStateFromError already stored it; keep the trace visible for
+    // whoever debugs the report
+    console.error(error);
+  }
+
+  render({ children, compact }, { error }) {
+    if (!error) {
+      return children;
+    }
+    return (
+      <div class={compact ? 'alert alert-warning mb-0' : 'alert alert-danger'} role="alert">
+        <Text id="errorBoundary.message" />
+      </div>
+    );
+  }
+}
+
+export default ErrorBoundary;

--- a/front/src/components/boxs/chart/Chart.jsx
+++ b/front/src/components/boxs/chart/Chart.jsx
@@ -237,7 +237,6 @@ class Chartbox extends Component {
   getData = async () => {
     let deviceFeatures = this.props.box.device_features;
     let deviceFeatureNames = this.props.box.device_feature_names;
-    let nbFeaturesDisplayed = deviceFeatures.length;
 
     if (!deviceFeatures) {
       // migrate all box (one device feature)
@@ -247,6 +246,10 @@ class Chartbox extends Component {
         return;
       }
     }
+    // counted AFTER the guard above: a chart the user just added to a
+    // dashboard has no device_features yet, and reading .length first threw
+    // on every single render of the editor canvas
+    let nbFeaturesDisplayed = deviceFeatures.length;
     // if there is no device selected
     if (deviceFeatures.length === 0) {
       await this.setState({

--- a/front/src/components/layout/index.jsx
+++ b/front/src/components/layout/index.jsx
@@ -10,6 +10,7 @@ import dashboardStyle from '../../routes/dashboard/style.css';
 // Glass variants of the Tabler furniture the integration pages are made of —
 // loaded here (main bundle) because the code-split catalog CSS is not
 import './horizonIntegrations.css';
+import ErrorBoundary from '../ErrorBoundary';
 
 const INTEGRATION_URL_PREFIX = '/dashboard/integration';
 
@@ -151,7 +152,11 @@ class Layout extends Component {
             [`glass-theme ${dashboardStyle.dashboardBackground} ${dashboardStyle.glassScene}`]: integrationPage
           })}
         >
-          {children}
+          {/* Last-resort net around every route: an uncaught render error
+              used to freeze the whole app for good (see ErrorBoundary).
+              Keyed on the URL, so navigating away from a broken page brings
+              Gladys back without a reload. */}
+          <ErrorBoundary resetKey={currentUrl}>{children}</ErrorBoundary>
         </div>
       </div>
     );

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -35,6 +35,9 @@
     "loading": "Lädt...",
     "preview": "Vorschau"
   },
+  "errorBoundary": {
+    "message": "Beim Anzeigen ist ein Fehler aufgetreten. Lade die Seite neu und überprüfe die Konfiguration, falls es erneut auftritt."
+  },
   "color": {
     "aqua": "Aqua",
     "black": "Schwarz",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -35,6 +35,9 @@
     "loading": "Loading...",
     "preview": "Preview"
   },
+  "errorBoundary": {
+    "message": "Something went wrong while displaying this. Reload the page, and check the configuration if it happens again."
+  },
   "color": {
     "aqua": "Aqua",
     "black": "Black",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -35,6 +35,9 @@
     "loading": "Chargement...",
     "preview": "Aperçu"
   },
+  "errorBoundary": {
+    "message": "Une erreur est survenue à l'affichage. Rechargez la page, et vérifiez la configuration si cela se reproduit."
+  },
   "color": {
     "aqua": "Aqua",
     "black": "Noir",

--- a/front/src/routes/dashboard/Box.jsx
+++ b/front/src/routes/dashboard/Box.jsx
@@ -21,8 +21,9 @@ import SunBox from '../../components/boxs/sun/Sun';
 import ChipsBox from '../../components/boxs/chips/ChipsBox';
 import ActionsBox from '../../components/boxs/actions/ActionsBox';
 import HouseViewBox from '../../components/boxs/house-view/HouseViewBox';
+import ErrorBoundary from '../../components/ErrorBoundary';
 
-const Box = ({ children, ...props }) => {
+const BoxContent = ({ children, ...props }) => {
   switch (props.box.type) {
     case 'weather':
       return <WeatherBox {...props} />;
@@ -72,5 +73,16 @@ const Box = ({ children, ...props }) => {
       return <ActionsBox {...props} />;
   }
 };
+
+// Every widget renders user-supplied configuration, and a dashboard is a wall
+// of them: a single widget throwing while it renders used to take the whole
+// app down with it (see ErrorBoundary), including the editor the user needs
+// to fix that very widget. Contain it to its own card instead — the rest of
+// the dashboard keeps working, and re-picking a type clears the message.
+const Box = ({ children, ...props }) => (
+  <ErrorBoundary resetKey={props.box.type} compact>
+    <BoxContent {...props} />
+  </ErrorBoundary>
+);
 
 export default Box;

--- a/front/src/routes/dashboard/edit-dashboard/EditActions.jsx
+++ b/front/src/routes/dashboard/edit-dashboard/EditActions.jsx
@@ -1,58 +1,104 @@
+import { useLayoutEffect, useRef } from 'preact/hooks';
 import { Text } from 'preact-i18n';
 import cx from 'classnames';
 
 import style from './style.css';
 
-const EditActions = props => (
-  <div class={cx('fixed-bottom footer', style.editActionsFooter)}>
-    <div class="container">
-      <div class="row align-items-center flex-row-reverse">
-        {!props.askDeleteDashboard && (
-          <div class="col-auto">
-            {/* cancel only makes sense while there is something to discard */}
-            {props.hasUnsavedChanges && (
-              <button onClick={props.cancelDashboardEdit} className="btn btn-outline-secondary btn-sm ml-2">
+// Fixed action bar of the editor. Its height is published as a CSS variable
+// because the edit panel (a bottom sheet on mobile) must sit exactly on top
+// of it: the bar grows to two rows when the labels don't fit on one line, and
+// a hardcoded offset would then leave the sheet hidden behind it.
+const useFooterHeight = () => {
+  const ref = useRef(null);
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) {
+      return undefined;
+    }
+    const publish = () => {
+      document.documentElement.style.setProperty('--gl-editor-footer-height', `${element.offsetHeight}px`);
+    };
+    publish();
+    // ResizeObserver is not everywhere (old wall tablets): the initial
+    // measure above already covers the common case, the observer only keeps
+    // it honest across rotations and label changes
+    let observer;
+    if (typeof ResizeObserver === 'function') {
+      observer = new ResizeObserver(publish);
+      observer.observe(element);
+    }
+    window.addEventListener('resize', publish);
+    return () => {
+      if (observer) {
+        observer.disconnect();
+      }
+      window.removeEventListener('resize', publish);
+      document.documentElement.style.removeProperty('--gl-editor-footer-height');
+    };
+  }, []);
+  return ref;
+};
+
+const EditActions = props => {
+  const footerRef = useFooterHeight();
+  return (
+    <div class={cx('fixed-bottom footer', style.editActionsFooter)} ref={footerRef}>
+      <div class="container">
+        {/* the actions are one wrapping, right-aligned row: on a narrow phone
+            the three labels of a verbose language (fr: Annuler / Supprimer /
+            Sauvegarder) are wider than the screen, and a single non-wrapping
+            row overflowed off the LEFT edge — "Annuler" ended up half out of
+            the viewport, out of reach */}
+        <div class={style.editActionsRow}>
+          {!props.askDeleteDashboard && (
+            <>
+              {/* cancel only makes sense while there is something to discard */}
+              {props.hasUnsavedChanges && (
+                <button onClick={props.cancelDashboardEdit} className="btn btn-outline-secondary btn-sm">
+                  <Text id="dashboard.editDashboardCancelButton" /> <i class="fe fe-slash" />
+                </button>
+              )}
+              <button onClick={props.askDeleteCurrentDashboard} className="btn btn-outline-danger btn-sm">
+                <Text id="dashboard.editDashboardDeleteButton" /> <i class="fe fe-trash" />
+              </button>
+              {/* saving keeps the user in the editor (chain editing): the
+                  confirmation is a transient label that never blocks anything —
+                  the moment everything is saved, leaving is available */}
+              {props.justSaved && (
+                <span className="text-success" data-cy="dashboard-saved-label">
+                  <Text id="dashboard.editDashboardSavedButton" /> <i class="fe fe-check" />
+                </span>
+              )}
+              {props.hasUnsavedChanges && (
+                <button onClick={props.saveDashboard} className="btn btn-outline-primary btn-sm">
+                  <Text id="dashboard.editDashboardSaveButton" /> <i class="fe fe-check" />
+                </button>
+              )}
+              {!props.hasUnsavedChanges && (
+                <button onClick={props.cancelDashboardEdit} className="btn btn-outline-primary btn-sm">
+                  <Text id="dashboard.editDashboardDoneButton" /> <i class="fe fe-check" />
+                </button>
+              )}
+            </>
+          )}
+
+          {props.askDeleteDashboard && (
+            <>
+              <span class={style.editActionsQuestion}>
+                <Text id="dashboard.editDashboardDeleteText" />
+              </span>
+              <button onClick={props.deleteCurrentDashboard} className="btn btn-outline-danger btn-sm">
+                <Text id="dashboard.editDashboardDeleteButton" /> <i class="fe fe-trash" />
+              </button>
+              <button onClick={props.cancelDeleteCurrentDashboard} className="btn btn-outline-secondary btn-sm">
                 <Text id="dashboard.editDashboardCancelButton" /> <i class="fe fe-slash" />
               </button>
-            )}
-            <button onClick={props.askDeleteCurrentDashboard} className="btn btn-outline-danger btn-sm ml-2">
-              <Text id="dashboard.editDashboardDeleteButton" /> <i class="fe fe-trash" />
-            </button>
-            {/* saving keeps the user in the editor (chain editing): the
-                confirmation is a transient label that never blocks anything —
-                the moment everything is saved, leaving is available */}
-            {props.justSaved && (
-              <span className="text-success ml-2" data-cy="dashboard-saved-label">
-                <Text id="dashboard.editDashboardSavedButton" /> <i class="fe fe-check" />
-              </span>
-            )}
-            {props.hasUnsavedChanges && (
-              <button onClick={props.saveDashboard} className="btn btn-outline-primary btn-sm ml-2">
-                <Text id="dashboard.editDashboardSaveButton" /> <i class="fe fe-check" />
-              </button>
-            )}
-            {!props.hasUnsavedChanges && (
-              <button onClick={props.cancelDashboardEdit} className="btn btn-outline-primary btn-sm ml-2">
-                <Text id="dashboard.editDashboardDoneButton" /> <i class="fe fe-check" />
-              </button>
-            )}
-          </div>
-        )}
-
-        {props.askDeleteDashboard && (
-          <div class="col-auto">
-            <Text id="dashboard.editDashboardDeleteText" />
-            <button onClick={props.deleteCurrentDashboard} className="btn btn-outline-danger btn-sm ml-2">
-              <Text id="dashboard.editDashboardDeleteButton" /> <i class="fe fe-trash" />
-            </button>
-            <button onClick={props.cancelDeleteCurrentDashboard} className="btn btn-outline-secondary btn-sm ml-2">
-              <Text id="dashboard.editDashboardCancelButton" /> <i class="fe fe-slash" />
-            </button>
-          </div>
-        )}
+            </>
+          )}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default EditActions;

--- a/front/src/routes/dashboard/edit-dashboard/index.js
+++ b/front/src/routes/dashboard/edit-dashboard/index.js
@@ -356,16 +356,22 @@ class EditDashboard extends Component {
       this.justSavedTimeout = setTimeout(() => this.setState({ justSaved: false }), 2500);
     } catch (e) {
       console.error(e);
+      // the dimmer must come back down whatever happened: left active, it
+      // makes the whole editor transparent AND pointer-events: none, so a
+      // failed save looked like Gladys had stopped responding
       if (e.response && e.response.status === 422) {
         this.setState({
+          loading: false,
           dashboardValidationError: true
         });
       } else if (e.response && e.response.status === 409) {
         this.setState({
+          loading: false,
           dashboardAlreadyExistError: true
         });
       } else {
         this.setState({
+          loading: false,
           unknownError: true
         });
       }

--- a/front/src/routes/dashboard/edit-dashboard/style.css
+++ b/front/src/routes/dashboard/edit-dashboard/style.css
@@ -419,8 +419,10 @@
     left: 0;
     right: 0;
     /* clear the fixed save/cancel footer, like the desktop panel does —
-       at bottom: 0 the footer bar hides the form's last field or button */
-    bottom: 3.5rem;
+       at bottom: 0 the footer bar hides the form's last field or button.
+       The bar measures itself (EditActions) because it wraps to two rows
+       when the labels don't fit; the fallback is its one-row height. */
+    bottom: var(--gl-editor-footer-height, 3.5rem);
     max-height: 78vh;
     border-radius: 16px 16px 0 0;
   }
@@ -643,6 +645,33 @@
 
 :global(.glass-theme) .editorTopBar :global(.btn-outline-primary .fe) {
   color: var(--gl-accent);
+}
+
+/* The editor's action bar: one right-aligned row that wraps instead of
+   overflowing. The old markup was a Bootstrap .row / .col-auto pair, and a
+   .col-auto is sized by its content: on a 390px phone the French labels
+   ("Annuler", "Supprimer", "Sauvegarder") made it 452px wide. Right-aligned,
+   the extra 62px went off the LEFT of the screen and cut the cancel button in
+   half — an action the user could see but not fully reach. */
+.editActionsRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.editActionsQuestion {
+  flex: 0 1 auto;
+}
+
+/* A wrapped bar is two rows tall, and on a phone every pixel it takes is one
+   the widget list loses (the edit panel stops right above it) */
+@media (max-width: 991px) {
+  .editActionsFooter {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
 }
 
 /* The action footer becomes a frosted bar (same recipe as the nav rail)… */


### PR DESCRIPTION
### Description

Follow-up on the forum report: on an iPhone, opening the widget picker in the dashboard editor left Gladys unresponsive — tapping a widget name added nothing, and Cancel / Save no longer closed anything. The reporter's screenshot shows the tapped tile carrying its (sticky) hover state, so the taps *were* landing: the app had simply stopped re-rendering.

**Root cause — the freeze is structural.** Preact 10 rethrows an uncaught render error out of its `process()` loop, and that loop only resets `process._rerenderCount` on its last line. A throw leaves the counter above zero, `enqueueRender` then believes a flush is already scheduled, and the app never re-renders again. It stays painted exactly as it was — buttons still take focus, nothing else happens — until a reload. Gladys had no error boundary anywhere, so any single widget could do this.

Reproduced in WebKit at an iPhone viewport: making one widget throw during render leaves the editor stuck mid-render with every later interaction dead. With the boundary in place, the same throw shows one small card and the editor stays fully usable.

**Changes**

- **`ErrorBoundary`** (new): wraps every route (in `Layout`) and each dashboard widget (`routes/dashboard/Box`). A broken widget now degrades to a message in its own card instead of taking the page — and the editor that would fix it — down with it. It resets on the URL / widget type, so the user is never stuck with the message either.
- **`Chart.getData()`** read `device_features.length` before its own null guard, so every chart widget just added to a dashboard threw (`TypeError: undefined is not an object`). Counting moved after the guard.
- **`saveDashboard()`** never reset `loading` on failure. Left active, the Tabler dimmer makes the whole editor transparent *and* `pointer-events: none` — a second, independent way for the editor to look frozen.
- **Editor action bar**: it was a Bootstrap `.row` / `.col-auto` pair sized by its content. On a 390px phone the French labels ("Annuler", "Supprimer", "Sauvegarder") made it 452px wide and, being right-aligned, the extra 62px went off the **left** edge — cutting "Annuler" in half, which is visible in the reporter's screenshot. It is now a wrapping, right-aligned flex row that publishes its height as a CSS variable, so the mobile edit sheet keeps sitting exactly on top of it; it is also a little tighter on phones to give the widget list back some room.

Measured before → after at 390 / 375 / 320px wide, in French: previously `Annuler` spanned x −41→75 (41px off-screen); now every action sits fully inside the viewport at all three widths, with the sheet's bottom edge meeting the bar's top edge exactly. Desktop (≥992px) still renders the bar on a single row, unchanged.

## Forum

Forum: https://community.gladysassistant.com/t/sur-mobile-impossible-dajouter-un-widget-sur-un-dashboard/10726

### Checklist

- [ ] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

Notes on the checklist: no server code is touched. Cypress was not run locally (no binary in this environment); the existing `Dashboard.cy.js` editor specs select the action buttons by `.btn-outline-primary` / `.btn-outline-secondary` and their `Text` ids, both of which are preserved by the new markup. Front eslint (0 errors), prettier and `compare-translations` all pass. The flows above were verified end to end in WebKit at iPhone and desktop viewports.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXgn8CU15pgKYoyChGmvkh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized error messaging with recovery guidance when rendering failures occur.
  - Dashboard widgets now contain individual rendering errors, allowing the rest of the dashboard to remain usable.
- **Bug Fixes**
  - Prevented new chart configurations from failing when device features are missing.
  - Fixed dashboard saves leaving the editor stuck in a loading state after errors.
- **Style**
  - Improved mobile dashboard editor controls so action buttons wrap correctly and remain accessible on narrow screens.
  - Updated editor panels to account for variable footer heights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->