### PR TITLE
fix(front): stop the setpoint stepper from clipping decimal values

### DIFF
--- a/front/src/components/boxs/device-in-room/device-features/SetpointDeviceFeature.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/SetpointDeviceFeature.jsx
@@ -92,7 +92,7 @@ const SetpointDeviceFeature = ({ children, ...props }) => {
               <input
                 type="number"
                 value={props.deviceFeature.last_value}
-                class={cx('form-control text-center', style.removeNumberArrow)}
+                class={cx('form-control text-center', style.removeNumberArrow, style.setpointValue)}
                 onChange={updateValueEvent}
                 step={SETPOINT_STEP}
                 min={props.deviceFeature.min}

--- a/front/src/components/boxs/device-in-room/device-features/style.css
+++ b/front/src/components/boxs/device-in-room/device-features/style.css
@@ -36,6 +36,18 @@ input[type='range'][class~='light-temperature']::-ms-fill-lower {
   min-width: 7rem;
 }
 
+/* The value input takes what is left of the capsule once the − and + buttons
+   have taken theirs, and .form-control's 0.75rem of side padding ate almost
+   all of it: on a phone a decimal setpoint (`20.5`) was cut down to two
+   glyphs, the rest hidden behind the buttons. The input keeps room for a
+   signed decimal value and drops the wide padding it does not need between
+   two buttons, so the capsule grows instead of clipping the value. */
+.setpointHorizontalControls .setpointValue {
+  min-width: 3.75rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+}
+
 .setpointVerticalControls {
   display: none;
 }


### PR DESCRIPTION
### Description

Fixes #3041 — on a phone in portrait, a setpoint row (AC / thermostat target temperature, charge current…) showed only the first two glyphs of a decimal value, the rest hidden behind the − and + buttons.

**Cause:** the horizontal capsule keeps a `min-width: 7rem` floor while the two buttons take `2.25rem` each, so the value input was left with 36px — and `.form-control`'s `0.75rem` of side padding ate 24px of those, leaving 12px of text box for a value that needs ~29px.

**Fix (CSS only):** the value input keeps room for a signed decimal value (`min-width: 3.75rem`) and drops the wide side padding it does not need between two buttons (`0.25rem`, the same trim `NumberDeviceFeature` already uses). The capsule now grows to fit the value instead of clipping it.

Measured on a reproduction of the widget row (real theme CSS, 320 / 360 / 390px viewports, coarse pointer): text box goes from 12px to 52px, which fits `20.5`, `22.75` and `-100.5` with room to spare. Wide layouts are unchanged, and a long device name still ellipsizes rather than pushing the row into a horizontal scrollbar. The stacked variant used by narrow desktop cards was already fine and is untouched.

Before / after at 390px:

| Before | After |
| --- | --- |
| `- 20( +` — value cut in half | `- 20.5 +` — value fully readable |

### Checklist

- [x] Tests pass: no server code changed; the fix is CSS + one class name on an existing input
- [x] Linter and prettier pass on the changed front files
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_011fmAMpX1i67vrUHEM7ve1F)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved horizontal setpoint controls so signed decimal values display fully without clipping.
  * Adjusted the value field sizing and padding for clearer, more consistent presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->