### PR TITLE
Scenes: propagate variable renumbering when an action is deleted inside a group

### DIFF
--- a/front/src/routes/scene/edit-scene/index.js
+++ b/front/src/routes/scene/edit-scene/index.js
@@ -784,29 +784,41 @@ class EditScene extends Component {
         }
       });
 
-      // Remove variables for the deleted action and update paths for subsequent actions
-      const newVariables = { ...prevState.variables };
-      delete newVariables[path];
+      // The actions which follow the deleted one in its group (or, for a condition, in the
+      // "if" list of its block) are shifted one index down, so the variables they declare must
+      // be renamed, and the references to those variables in the whole scene must be updated
+      // (the same way they are when an action group is deleted).
+      const containerSegments = pathSegments.slice(0, -1);
+      const containerPath = containerSegments.join('.');
+      const deletedActionIndex = parseInt(pathSegments[pathSegments.length - 1], 10);
+      let siblingActions = prevState.scene.actions;
+      containerSegments.forEach(segment => {
+        siblingActions =
+          siblingActions && (/^\d+$/.test(segment) ? siblingActions[parseInt(segment, 10)] : siblingActions[segment]);
+      });
+      const pathToUpdateInVariables = [];
+      if (Array.isArray(siblingActions)) {
+        // Indexes are decremented: the replacements are built from the smallest index to the
+        // biggest one so that a path is never rewritten twice
+        for (let index = deletedActionIndex + 1; index < siblingActions.length; index += 1) {
+          pathToUpdateInVariables.push({
+            prevPath: `${containerPath}.${index}`,
+            newPath: `${containerPath}.${index - 1}`
+          });
+        }
+      }
 
-      // Update paths for actions after the deleted one
-      Object.keys(newVariables).forEach(varPath => {
-        // Check if the variable path is in the same parent group as the deleted action
-        if (
-          varPath.startsWith(
-            path
-              .split('.')
-              .slice(0, -1)
-              .join('.')
-          )
-        ) {
-          const remainingVars = newVariables[varPath];
-          delete newVariables[varPath];
-          const newPath = this.updatePathAfterDeletion(varPath, path);
-          if (newPath) {
-            newVariables[newPath] = remainingVars;
-          }
+      // Drop the variables declared by the deleted action (including the ones nested in its
+      // if/then/else branches), then rename the ones declared by the shifted actions
+      const remainingVariables = {};
+      Object.entries(prevState.variables).forEach(([variablePath, value]) => {
+        if (variablePath !== path && !variablePath.startsWith(`${path}.`)) {
+          remainingVariables[variablePath] = value;
         }
       });
+      const newVariables = renameVariablesOfMovedGroups(remainingVariables, pathToUpdateInVariables);
+
+      replaceVariablePathsInActions(prevState.scene.actions, pathToUpdateInVariables);
 
       // Check if we need to remove an empty action group
       // Only if we are not in a "if" action
@@ -901,28 +913,6 @@ class EditScene extends Component {
         variables: { $set: newVariables }
       });
     }, cleanUpEmptyGroup);
-  };
-
-  updatePathAfterDeletion = (currentPath, deletedPath) => {
-    const currentSegments = currentPath.split('.');
-    const deletedSegments = deletedPath.split('.');
-    const lastDeletedIndex = parseInt(deletedSegments[deletedSegments.length - 1], 10);
-
-    // Get the parent paths to compare them
-    const currentParentPath = currentSegments.slice(0, -1).join('.');
-    const deletedParentPath = deletedSegments.slice(0, -1).join('.');
-
-    // If they are in the same parent group
-    if (currentParentPath === deletedParentPath) {
-      const currentIndex = parseInt(currentSegments[currentSegments.length - 1], 10);
-      if (currentIndex > lastDeletedIndex) {
-        currentSegments[currentSegments.length - 1] = (currentIndex - 1).toString();
-        return currentSegments.join('.');
-      }
-    }
-
-    // If not in the same group, keep the original path
-    return currentPath;
   };
 
   updateActionProperty = (path, property, value) => {


### PR DESCRIPTION
### Description

In the scene editor, the references to scene variables (e.g. `{{0.1.last_value}}`) are position-based. The renumbering was already propagated when an action **group** is inserted, deleted, moved or reordered — but not when a single action is deleted **inside** a group ("at the same time" actions), nor when a condition is deleted inside an if/while block: the following actions of the group shift one index down, and every reference to their variables in the rest of the scene became stale, forcing the user to fix each step by hand.

`deleteAction` now reuses the exact same mechanism as group deletion:

- the sibling actions which follow the deleted one produce `prevPath → newPath` replacements (`0.2 → 0.1`, …), built from the smallest index up so a path is never rewritten twice;
- the variables map is rebuilt: the variables declared by the deleted action are dropped (including the ones nested in its if/then/else branches — they were previously left behind), and the variables of the shifted actions are renamed (including nested ones, which were previously not renamed at all);
- `replaceVariablePathsInActions` rewrites every reference to a renamed variable in the whole scene (texts, evaluate values, condition variable selectors, nested branches).

The now-unused `updatePathAfterDeletion` helper is removed.

The logic was validated against the real helper functions with simulations covering: deleting the middle of 3 parallel "get last state" actions, chained index shifts (no double rewrite), a shifted sibling if/then/else block with nested variables and references, deleting a block that declares nested variables, deleting a condition inside an `if` list, and 2-digit indexes (segment-boundary matching).

## Forum

Forum: ``https://community.gladysassistant.com/t/scene-propager-la-renumerotation-des-variables-recuperees-quand-lune-delles-est-supprimee``/9343

### Checklist

- [x] Tests pass: server untouched (front-only change); Cypress scene suite has no coverage of variable renumbering (unchanged)
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier` on the changed file)
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTBWxzxbVWRGtveU28WuP8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTBWxzxbVWRGtveU28WuP8)_