### PR TITLE
fix(front): make the sort selects read as controls, and give every select its missing arrow

### DIFF
--- a/front/src/components/layout/CardFilter.jsx
+++ b/front/src/components/layout/CardFilter.jsx
@@ -1,5 +1,7 @@
 import { Fragment } from 'preact';
-import { Text, Localizer } from 'preact-i18n';
+import { Localizer } from 'preact-i18n';
+
+import SortSelect from './SortSelect';
 
 const SearchInput = ({ searchPlaceHolder, search, searchValue }) => {
   const input = (
@@ -15,19 +17,15 @@ const SearchInput = ({ searchPlaceHolder, search, searchValue }) => {
 
 const CardFilter = ({ changeOrderDir, orderValue = 'asc', search, searchValue, searchPlaceHolder, extraOrderDirs }) => (
   <Fragment>
-    <select onChange={changeOrderDir} class="form-control custom-select w-auto">
-      <option value="asc" selected={orderValue === 'asc'}>
-        <Text id="global.orderDirAsc" />
-      </option>
-      <option value="desc" selected={orderValue === 'desc'}>
-        <Text id="global.orderDirDesc" />
-      </option>
-      {(extraOrderDirs || []).map(({ value, labelId }) => (
-        <option key={value} value={value} selected={orderValue === value}>
-          <Text id={labelId} />
-        </option>
-      ))}
-    </select>
+    <SortSelect
+      value={orderValue}
+      onChange={changeOrderDir}
+      options={[
+        { value: 'asc', labelId: 'global.orderDirAsc' },
+        { value: 'desc', labelId: 'global.orderDirDesc' },
+        ...(extraOrderDirs || [])
+      ]}
+    />
 
     <div class="input-icon ml-2">
       <span class="input-icon-addon">

--- a/front/src/components/layout/SortSelect.css
+++ b/front/src/components/layout/SortSelect.css
@@ -10,26 +10,18 @@
   height: 1rem;
 }
 
-/* Tabler's .custom-select caret never renders: its data URI embeds the arrow
-   color as a raw `#999`, and a `#` inside a data: URL starts a fragment, so
-   the browser drops the rest of the SVG. Ours is escaped (%23) — without it
-   the control has no dropdown affordance at all, which is half of why it
-   reads as a text field.
+/* The sort mode is a label, not typed-in content: it takes the ink and the
+   weight of the neighbouring page-option pills (the tag filter, the buttons)
+   rather than the page ink of a filled-in field.
 
    The stacked selector and the !important go together: the two themes that
    turn these headers into frosted pills (routes/scene/style.css and
    components/layout/horizonIntegrations.css) paint .form-control with
    four-class selectors, in dark mode with !important. The look of this
    shared control belongs here, in one place, rather than being re-stated
-   in every header that uses it. */
+   in every header that uses it. (The dropdown caret is not here: every
+   .custom-select of the app gets it back in style/index.css.) */
 select.select:global(.form-control):global(.custom-select) {
-  padding-right: 2rem;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%237c8396' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 0.7rem center;
-  background-size: 0.7rem 0.7rem;
-  /* the label ink of the neighbouring page-option pills (the tag filter, the
-     buttons): the sort mode is a label, not typed-in content */
   font-weight: 600 !important;
   color: var(--gl-muted, #7c8396) !important;
 }

--- a/front/src/components/layout/SortSelect.css
+++ b/front/src/components/layout/SortSelect.css
@@ -1,0 +1,35 @@
+/* The control keeps its natural width in the flex rows of the page headers
+   (.page-options) — it is a pill sized by its longest option, not a field
+   that should stretch or be squeezed. */
+.sortSelect {
+  flex-shrink: 0;
+}
+
+.sortIcon {
+  width: 1rem;
+  height: 1rem;
+}
+
+/* Tabler's .custom-select caret never renders: its data URI embeds the arrow
+   color as a raw `#999`, and a `#` inside a data: URL starts a fragment, so
+   the browser drops the rest of the SVG. Ours is escaped (%23) — without it
+   the control has no dropdown affordance at all, which is half of why it
+   reads as a text field.
+
+   The stacked selector and the !important go together: the two themes that
+   turn these headers into frosted pills (routes/scene/style.css and
+   components/layout/horizonIntegrations.css) paint .form-control with
+   four-class selectors, in dark mode with !important. The look of this
+   shared control belongs here, in one place, rather than being re-stated
+   in every header that uses it. */
+select.select:global(.form-control):global(.custom-select) {
+  padding-right: 2rem;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%237c8396' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.7rem center;
+  background-size: 0.7rem 0.7rem;
+  /* the label ink of the neighbouring page-option pills (the tag filter, the
+     buttons): the sort mode is a label, not typed-in content */
+  font-weight: 600 !important;
+  color: var(--gl-muted, #7c8396) !important;
+}

--- a/front/src/components/layout/SortSelect.jsx
+++ b/front/src/components/layout/SortSelect.jsx
@@ -26,15 +26,18 @@ const SortIcon = () => (
 );
 
 /**
- * The sort control of the page headers (scenes, integration catalog, device
- * lists). A bare <select> next to a search field of the same pill family read
- * as an empty search box — no icon, and no caret either, Tabler's .custom-select
- * arrow being lost to a broken data URI (see SortSelect.css). It says what it
- * is here: sort icon on the left, caret on the right, and the quiet label ink
- * of the buttons it sits next to.
+ * The sort control of the page headers (scenes, devices, integration catalog,
+ * integration device tabs). A bare <select> next to a search field of the same
+ * pill family read as an empty search box — no icon, and no caret either, the
+ * .custom-select arrow of the theme being lost to a broken data URI (fixed for
+ * every select of the app in style/index.css). It says what it is here: sort
+ * icon on the left, and the quiet label ink of the controls it sits next to.
+ *
+ * The wrapper carries an un-hashed `sort-select` class next to its module one,
+ * as a stable hook for the headers that lay their controls out themselves.
  */
 const SortSelect = ({ value, onChange, options, class: className, selectClass }) => (
-  <div class={cx('input-icon', style.sortSelect, className)}>
+  <div class={cx('input-icon', 'sort-select', style.sortSelect, className)}>
     <span class="input-icon-addon">
       <SortIcon />
     </span>

--- a/front/src/components/layout/SortSelect.jsx
+++ b/front/src/components/layout/SortSelect.jsx
@@ -1,0 +1,58 @@
+import cx from 'classnames';
+import { Text, Localizer } from 'preact-i18n';
+
+import style from './SortSelect.css';
+
+/* Feather's set has no sort glyph, so here is one drawn in its language
+   (24×24, 2px round strokes): three lines getting shorter, the icon every
+   list sorter uses. It sits in the same .input-icon-addon as the search
+   field's magnifier, so both controls carry their affordance the same way. */
+const SortIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    class={style.sortIcon}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <line x1="4" y1="6" x2="19" y2="6" />
+    <line x1="4" y1="12" x2="13" y2="12" />
+    <line x1="4" y1="18" x2="8" y2="18" />
+  </svg>
+);
+
+/**
+ * The sort control of the page headers (scenes, integration catalog, device
+ * lists). A bare <select> next to a search field of the same pill family read
+ * as an empty search box — no icon, and no caret either, Tabler's .custom-select
+ * arrow being lost to a broken data URI (see SortSelect.css). It says what it
+ * is here: sort icon on the left, caret on the right, and the quiet label ink
+ * of the buttons it sits next to.
+ */
+const SortSelect = ({ value, onChange, options, class: className, selectClass }) => (
+  <div class={cx('input-icon', style.sortSelect, className)}>
+    <span class="input-icon-addon">
+      <SortIcon />
+    </span>
+    <Localizer>
+      <select
+        onChange={onChange}
+        value={value}
+        aria-label={<Text id="global.orderDirLabel" />}
+        class={cx('form-control', 'custom-select', 'w-auto', style.select, selectClass)}
+      >
+        {options.map(({ value: optionValue, labelId }) => (
+          <option key={optionValue} value={optionValue}>
+            <Text id={labelId} />
+          </option>
+        ))}
+      </select>
+    </Localizer>
+  </div>
+);
+
+export default SortSelect;

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -5,6 +5,7 @@
     "new": "Neu",
     "orderDirAsc": "A - Z",
     "orderDirDesc": "Z - A",
+    "orderDirLabel": "Sortierreihenfolge",
     "emptySelectOption": "---------",
     "backButton": "◀️️ Zurück",
     "requiredField": "*",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -5,6 +5,7 @@
     "new": "New",
     "orderDirAsc": "A - Z",
     "orderDirDesc": "Z - A",
+    "orderDirLabel": "Sort order",
     "emptySelectOption": "---------",
     "backButton": "◀️️ Back",
     "requiredField": "*",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -5,6 +5,7 @@
     "new": "Nouveau",
     "orderDirAsc": "A - Z",
     "orderDirDesc": "Z - A",
+    "orderDirLabel": "Ordre de tri",
     "emptySelectOption": "---------",
     "backButton": "◀️️ Retour",
     "requiredField": "*",

--- a/front/src/routes/devices/style.css
+++ b/front/src/routes/devices/style.css
@@ -145,6 +145,14 @@
   color: var(--gl-muted);
 }
 
+/* The room, integration and sort selects say what the list is showing: they
+   are labels like the buttons of the other page headers, not typed-in
+   content, so they take the quieter label ink and the row reads as one
+   family (same grammar as the scene page's tag filter) */
+.devicesPage .pageOptions :global(select.form-control) {
+  color: var(--gl-muted);
+}
+
 /* dark-mode.css paints selects and inputs with solid !important backgrounds
    and double-inverts the inputs back to their light look: under glass they
    are frosted pills that must invert WITH the theme, like every other glass
@@ -154,6 +162,10 @@
   color: var(--gl-ink) !important;
   border-color: var(--gl-border) !important;
   filter: none;
+}
+
+:global(.dark-mode) .devicesPage .pageOptions :global(select.form-control) {
+  color: var(--gl-muted) !important;
 }
 
 /* dark-mode.css authors the placeholder for double-inverted inputs; with
@@ -305,10 +317,14 @@
     flex: 1 1 calc(50% - 2rem);
   }
 
-  /* the ordering select keeps its natural width so the search bar
-     fits next to it on the same row */
-  .pageOptions > select:nth-of-type(3) {
+  /* the sort control keeps its natural width so the search bar fits next to
+     it on the same row (it is a wrapper since its icon moved in, hence the
+     class rather than a child <select>) */
+  .pageOptions > :global(.sort-select) {
     flex: 0 1 auto;
+    /* the 10rem floor below is meant for the search bar, not for a pill
+       sized by its own options */
+    min-width: auto;
   }
 
   /* the search bar needs real room to be usable: below a comfortable

--- a/front/src/routes/history/style.css
+++ b/front/src/routes/history/style.css
@@ -129,6 +129,13 @@
   color: var(--gl-muted);
 }
 
+/* The room filter names what the feed is showing — a label, like the pills
+   of the other page headers, not typed-in content */
+.headerControls :global(select.form-control) {
+  font-weight: 600;
+  color: var(--gl-muted);
+}
+
 .dateInput {
   width: auto;
   min-width: 150px;

--- a/front/src/routes/integration/IntegrationPageHeader.jsx
+++ b/front/src/routes/integration/IntegrationPageHeader.jsx
@@ -1,6 +1,7 @@
 import get from 'get-value';
 import { Text } from 'preact-i18n';
 import CardFilter from '../../components/layout/CardFilter';
+import SortSelect from '../../components/layout/SortSelect';
 import InstallFromGithubCard from './all/external-integration/install-from-github/InstallFromGithubCard';
 import withIntlAsProp from '../../utils/withIntlAsProp';
 import style from './style.css';
@@ -75,17 +76,16 @@ const IntegrationPageHeader = ({
           <h1 class={style.mobileTitle}>
             <Text id="integration.root.title" />
           </h1>
-          <select onChange={changeOrderDir} class={`form-control custom-select ${style.mobileSort}`} value={orderDir}>
-            <option value="asc">
-              <Text id="global.orderDirAsc" />
-            </option>
-            <option value="desc">
-              <Text id="global.orderDirDesc" />
-            </option>
-            <option value="newest">
-              <Text id="integration.root.orderDirNewest" />
-            </option>
-          </select>
+          <SortSelect
+            value={orderDir}
+            onChange={changeOrderDir}
+            selectClass={style.mobileSort}
+            options={[
+              { value: 'asc', labelId: 'global.orderDirAsc' },
+              { value: 'desc', labelId: 'global.orderDirDesc' },
+              { value: 'newest', labelId: 'integration.root.orderDirNewest' }
+            ]}
+          />
         </div>
         <div class={style.mobileSearch}>
           <div class="input-icon">

--- a/front/src/routes/integration/all/lan-manager/device-page/LANManagerDeviceTab.jsx
+++ b/front/src/routes/integration/all/lan-manager/device-page/LANManagerDeviceTab.jsx
@@ -1,6 +1,7 @@
 import { Text, Localizer } from 'preact-i18n';
 import cx from 'classnames';
 
+import SortSelect from '../../../../../components/layout/SortSelect';
 import { RequestStatus } from '../../../../../utils/consts';
 import LANManagerDevice from './LANManagerDevice';
 import EmptyState from '../EmptyState';
@@ -13,14 +14,14 @@ const LANManagerDeviceTab = ({ children, getLANManagerDevicesStatus, lanManagerD
         <Text id="integration.lanManager.device.title" />
       </h1>
       <div class="page-options d-flex">
-        <select onChange={props.changeOrderDir} class="form-control custom-select w-auto">
-          <option value="asc">
-            <Text id="global.orderDirAsc" />
-          </option>
-          <option value="desc">
-            <Text id="global.orderDirDesc" />
-          </option>
-        </select>
+        <SortSelect
+          value={props.getLANManagerDeviceOrderDir || 'asc'}
+          onChange={props.changeOrderDir}
+          options={[
+            { value: 'asc', labelId: 'global.orderDirAsc' },
+            { value: 'desc', labelId: 'global.orderDirDesc' }
+          ]}
+        />
         <div class="input-icon ml-2">
           <span class="input-icon-addon">
             <i class="fe fe-search" />

--- a/front/src/routes/integration/all/lan-manager/device-page/index.js
+++ b/front/src/routes/integration/all/lan-manager/device-page/index.js
@@ -20,6 +20,6 @@ class LANManagerDevicePage extends Component {
 }
 
 export default connect(
-  'session,httpClient,user,lanManagerDevices,houses,getLANManagerDevicesStatus',
+  'session,httpClient,user,lanManagerDevices,houses,getLANManagerDevicesStatus,getLANManagerDeviceOrderDir',
   actions
 )(LANManagerDevicePage);

--- a/front/src/style/index.css
+++ b/front/src/style/index.css
@@ -562,3 +562,18 @@ body .apexcharts-tooltip {
     padding-top: 3.25rem;
   }
 }
+
+/* Every <select class="custom-select"> of the app is missing its dropdown
+   arrow: the one Tabler paints encodes the color as a raw `#999` inside a
+   data: URL, where a `#` starts a fragment — the browser drops the rest of
+   the SVG and renders nothing. Without an arrow a select is indistinguishable
+   from a text input, which is what the community reported on the sort control
+   of the page headers. Same chevron as the rest of the interface, escaped
+   (%23) so it actually loads; dark mode inverts it with the page. */
+.custom-select {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%237c8396' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.7rem center;
+  background-size: 0.7rem 0.7rem;
+  padding-right: 2rem;
+}


### PR DESCRIPTION
### Description

Retour forum : le select « A - Z » des en-têtes de page ne s'intègre pas au reste des contrôles, au point qu'on a envie d'écrire dedans comme dans un champ de recherche.

**Le contrôle de tri**

- **Aucune icône**, alors que son voisin (la recherche) et le filtre par tags en ont une. Il porte maintenant une icône de tri (trois traits décroissants, dessinée dans le langage de Feather qui n'en propose pas), dans le même `.input-icon-addon` que la loupe de la recherche.
- **La couleur de la police** : le select était en encre de page (`--gl-ink`, graisse 500) là où toutes les pilules voisines (filtre par tags, boutons) utilisent l'encre discrète de libellé (`--gl-muted`, graisse 600). Il prend maintenant la même.

Il devient un petit composant partagé `SortSelect`, utilisé partout où un `<select>` de tri était écrit à la main : `CardFilter` (scènes, appareils, catalogue d'intégrations, onglets « appareils » des intégrations), l'en-tête mobile du catalogue, et l'onglet appareils de LAN Manager — qui avait sa propre copie du couple tri + recherche, et dont le sens de tri est désormais connecté pour que le select affiche celui réellement appliqué. Le select reçoit au passage un `aria-label` (nouvelle clé `global.orderDirLabel`, fr/en/de) : jusqu'ici rien ne disait à un lecteur d'écran ce que ce select triait.

**La flèche manquante, dans toute l'app**

Le select n'avait pas non plus de caret — et ça vaut pour tous les `.custom-select` de Gladys : la flèche que peint le thème encode sa couleur en `#999` brut dans une URL `data:`, or un `#` y démarre un fragment, donc le navigateur jette tout le reste du SVG. Filtres pièce/intégration de la vue Appareils, filtre pièce de l'Historique, champs de date de naissance du profil, paramètres de l'éditeur de scènes : tous étaient dessinés comme de simples boîtes. La flèche est repeinte une fois pour toutes dans `style/index.css`, échappée (`%23`).

**Les filtres voisins**

Dans les deux en-têtes où un select accompagne le tri — vue Appareils (pièce, intégration) et Historique (pièce) — les selects prennent l'encre de libellé des pilules, pour que chaque rangée se lise comme une seule famille.

Vérifié dans l'app en mode démo (Chromium), en thème clair et en thème sombre : page Scènes, vue Appareils (desktop et mobile), Historique, catalogue d'intégrations (desktop et mobile), onglets appareils de Zigbee2mqtt et LAN Manager, page Profil. Le tri fonctionne toujours et la pilule de tri s'aligne visuellement avec le filtre par tags à côté.

À noter : les `<select class="form-control">` sans `custom-select` (unité de température, langue, réglages de widgets…) gardent la flèche native du navigateur, plus épaisse que la nôtre. Les uniformiser voudrait dire passer les ~130 selects de l'app en `appearance: none`, ce qui dépasse le cadre de ce retour — à faire séparément si tu le souhaites.

## Forum

Forum: https://community.gladysassistant.com/t/ui-du-select-mode-de-tri/10731

### Checklist

- [ ] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed — non lancés ici (CSS/JSX front uniquement, pas de code serveur touché) ; à confirmer par la CI
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`) — plus `npm run compare-translations`
- [x] No undocumented breaking change
