### PR TITLE
fix(mqtt): subscribe to the custom topics of devices when connecting to the broker

### DIFF
--- a/server/services/mqtt/lib/connect.js
+++ b/server/services/mqtt/lib/connect.js
@@ -45,6 +45,21 @@ async function connect({ mqttUrl, mqttUsername, mqttPassword }) {
       Object.keys(this.topicBinds).forEach((topic) => {
         this.subscribe(topic, this.topicBinds[topic]);
       });
+      // The custom MQTT topics of the devices are not part of topicBinds: they are
+      // registered when the devices are loaded in RAM (device.init), which happens
+      // before the services are started, so the MQTT client did not exist yet and
+      // no SUBSCRIBE was ever sent to the broker. Without this, a device with a
+      // custom topic stopped receiving anything after a restart, until the user
+      // opened it and clicked "save" again.
+      const customTopicsAlreadyListened = new Set();
+      this.deviceFeatureCustomMqttTopics.forEach(({ topic }) => {
+        if (!topic || customTopicsAlreadyListened.has(topic)) {
+          return;
+        }
+        customTopicsAlreadyListened.add(topic);
+        logger.info(`Subscribing to MQTT custom topic ${topic}`);
+        this.mqttClient.subscribe(topic);
+      });
       this.defaultTopicsAlreadySubscribed = true;
     } else {
       logger.info('Already subscribed to default topics');

--- a/server/test/services/mqtt/lib/connect.test.js
+++ b/server/test/services/mqtt/lib/connect.test.js
@@ -4,7 +4,7 @@ const { expect } = require('chai');
 const { assert, fake } = sinon;
 const { EVENTS, WEBSOCKET_MESSAGE_TYPES } = require('../../../../utils/constants');
 const { ServiceNotConfiguredError } = require('../../../../utils/coreErrors');
-const { MockedMqttClient } = require('../mocks.test');
+const { MockedMqttClient, mqttApi } = require('../mocks.test');
 
 const MqttHandler = require('../../../../services/mqtt/lib');
 
@@ -146,5 +146,43 @@ describe('mqttHandler.connect', () => {
       Buffer.from('19.8'),
     );
     assert.calledOnce(mqttHandler.handleNewMessage);
+  });
+
+  it('should subscribe to the custom topics of the devices loaded before the connection', async () => {
+    const gladys = {
+      event: {
+        emit: fake.returns(null),
+      },
+    };
+
+    const mqttHandler = new MqttHandler(gladys, MockedMqttClient, 'faea9c35-759a-44d5-bcc9-2af1de37b8b4');
+
+    // Devices are loaded in RAM before the services are started, so the custom
+    // topics are registered while there is no MQTT client yet
+    await mqttHandler.listenToCustomMqttTopicIfNeeded({
+      selector: 'my-device',
+      features: [{ id: 'b42d3688-4403-479a-9376-9f5227ab543a' }, { id: '8bd23b1b-b8f5-4b31-9c0e-2b23b1a06c26' }],
+      params: [
+        {
+          name: 'mqtt_custom_topic_feature:b42d3688-4403-479a-9376-9f5227ab543a',
+          value: 'custom_mqtt_topic/temperature',
+        },
+        {
+          name: 'mqtt_custom_topic_feature:8bd23b1b-b8f5-4b31-9c0e-2b23b1a06c26',
+          value: 'custom_mqtt_topic/temperature',
+        },
+      ],
+    });
+    assert.notCalled(mqttApi.subscribe);
+
+    await mqttHandler.connect({ mqttUrl: 'url' });
+    mqttHandler.mqttClient.emit('connect');
+
+    assert.calledWith(mqttApi.subscribe, 'custom_mqtt_topic/temperature');
+    // The two features share the same topic: only one subscription is sent
+    const subscriptionsToCustomTopic = mqttApi.subscribe
+      .getCalls()
+      .filter((call) => call.args[0] === 'custom_mqtt_topic/temperature');
+    expect(subscriptionsToCustomTopic).to.have.lengthOf(1);
   });
 });


### PR DESCRIPTION
### Description

A user reported on the forum that, since 5.0.1, MQTT data sent back to Gladys was no longer received: the scene published its message fine, the external system answered on the expected topic, but nothing arrived in Gladys. The workaround found on the forum was to open each virtual device and click "save" again.

This is a real regression, not a UX issue, and it affects every device with a custom MQTT topic (not only those used in scenes).

Root cause:

- Custom topics of device features are registered by `listenToCustomMqttTopicIfNeeded`, called from `device.add` when devices are loaded in RAM. That function only sends a `SUBSCRIBE` if `this.mqttClient` already exists.
- In the new boot sequence, `device.init()` runs **before** `service.startAll()`, so at that point the MQTT service is loaded but not started: `mqttClient` is `null`. The topics are pushed into `deviceFeatureCustomMqttTopics`, but no `SUBSCRIBE` is ever sent.
- Unlike topics registered through `subscribe()` (default topics, Home Assistant state topics), the device custom topics are not part of `topicBinds`, so the `connect` handler did not replay them either.

Result: after a restart, the broker never forwards those topics to Gladys, until the user saves the device again (`device.add` runs a second time, this time with a connected client). The same happened after saving the MQTT configuration, since that builds a brand new client.

Fix: the `connect` handler now also subscribes to the custom topics registered so far, deduplicated by topic. A regression test covers the exact sequence (topics registered while `mqttClient` is `null`, then connection) and fails on `master`.

## Forum

Forum: https://community.gladysassistant.com/t/question-about-the-mqtt-in-scenes/10739

### Checklist

- [x] Tests pass: `npm_config_service=mqtt npm run test-service` → 253 passing, including the new regression test (which fails without the fix)
- [x] Linter and prettier pass on the changed files (`npx eslint`, `npx prettier --check`)
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_0118ndMFrKoZ3XWYdgPpk7RF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom device MQTT topics are now automatically subscribed to when the MQTT connection is established.
  * Duplicate and empty topics are ignored to prevent unnecessary subscriptions.

* **Bug Fixes**
  * Ensures custom topics registered before connection become active after connecting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->