### PR TITLE
fix(gateway): allow non-admin users to read the Gladys Plus status

### DIFF
--- a/front/src/components/boxs/voice-assistant/VoiceAssistantBox.jsx
+++ b/front/src/components/boxs/voice-assistant/VoiceAssistantBox.jsx
@@ -286,9 +286,9 @@ class VoiceAssistantBox extends Component {
         this.setState({ gatewayConnected: status.configured === true });
       }
     } catch (e) {
-      if (this._isMounted) {
-        this.setState({ gatewayConnected: false });
-      }
+      // The status stays unknown on a failed call: the box remains disabled,
+      // but no Gladys Plus upsell is displayed on top of it.
+      console.error(e);
     }
   };
 

--- a/front/src/components/gateway/GladysPlusUpsell.jsx
+++ b/front/src/components/gateway/GladysPlusUpsell.jsx
@@ -23,15 +23,16 @@ class GladysPlusUpsell extends Component {
     const { httpClient } = this.props;
     if (!httpClient) {
       console.error('GladysPlusUpsell: httpClient is required');
-      this.setState({ gladysPlusConnected: false });
       return;
     }
     try {
       const response = await httpClient.get('/api/v1/gateway/status');
       this.setState({ gladysPlusConnected: response.configured === true });
     } catch (e) {
+      // Only a successful answer saying the instance is not linked to Gladys
+      // Plus should trigger the upsell: on a failed call the status stays
+      // unknown and the card is not displayed.
       console.error(e);
-      this.setState({ gladysPlusConnected: false });
     }
   };
 

--- a/front/src/routes/chat/EmptyChat.jsx
+++ b/front/src/routes/chat/EmptyChat.jsx
@@ -24,10 +24,10 @@ class EmptyChat extends Component {
         gladysPlusConfigured: gatewayStatus.configured === true
       });
     } catch (e) {
+      // A failed call doesn't mean the instance has no Gladys Plus: it can
+      // simply be a network error. Staying unknown keeps the regular empty
+      // state instead of upselling a subscription the instance may already have.
       console.error(e);
-      this.setState({
-        gladysPlusConfigured: false
-      });
     }
   };
 

--- a/server/api/middlewares/authenticatedOrNotConfigured.js
+++ b/server/api/middlewares/authenticatedOrNotConfigured.js
@@ -1,7 +1,7 @@
 const AuthMiddleware = require('./authMiddleware');
 const adminMiddleware = require('./adminMiddleware');
 
-module.exports = function AuthenticatedOrNotConfiguredMiddleware(scope, gladys) {
+module.exports = function AuthenticatedOrNotConfiguredMiddleware(scope, gladys, adminOnly = true) {
   const authMiddleware = AuthMiddleware(scope, gladys);
   return (req, res, next) => {
     // When the instance is not configured yet (no user in database), the route is
@@ -13,10 +13,15 @@ module.exports = function AuthenticatedOrNotConfiguredMiddleware(scope, gladys) 
       next();
       return;
     }
-    // Otherwise, the route requires an authenticated admin user.
+    // Otherwise, the route requires an authenticated user, and an admin one
+    // unless the route explicitly opted out of the admin check.
     authMiddleware(req, res, (authError) => {
       if (authError) {
         next(authError);
+        return;
+      }
+      if (!adminOnly) {
+        next();
         return;
       }
       try {

--- a/server/api/routes.js
+++ b/server/api/routes.js
@@ -352,9 +352,14 @@ function getRoutes(gladys) {
     // flow can restore a Gladys Plus backup without creating a local account.
     // The "admin" flag is kept on those routes because it is also used by
     // setupGateway to protect API calls done through the Gladys Plus tunnel.
+    // The status route is the exception: it only returns two booleans (is the
+    // instance linked to Gladys Plus, is it currently connected), and every
+    // user needs it, not just admins. The front-end uses it to know whether a
+    // Gladys Plus feature (AI chat, voice assistant, camera live) is available:
+    // when it is denied, a user invited on the Plus account is wrongly invited
+    // to start a free trial for a subscription the instance already has.
     'get /api/v1/gateway/status': {
       authenticatedOrNotConfigured: true,
-      admin: true,
       controller: gatewayController.getStatus,
     },
     'post /api/v1/gateway/login': {

--- a/server/api/setupRoutes.js
+++ b/server/api/setupRoutes.js
@@ -29,6 +29,11 @@ function setupRoutes(gladys) {
   const routes = getRoutes(gladys);
   const authMiddleware = AuthMiddleware('dashboard:write', gladys);
   const authenticatedOrNotConfiguredMiddleware = AuthenticatedOrNotConfiguredMiddleware('dashboard:write', gladys);
+  const authenticatedOrNotConfiguredNonAdminMiddleware = AuthenticatedOrNotConfiguredMiddleware(
+    'dashboard:write',
+    gladys,
+    false,
+  );
   const isInstanceConfiguredMiddleware = IsInstanceConfiguredMiddleware(gladys);
   const resetPasswordAuthMiddleware = AuthMiddleware('reset-password:write', gladys);
   const alarmMiddleware = AuthMiddleware('alarm:write', gladys);
@@ -57,9 +62,14 @@ function setupRoutes(gladys) {
     if (routes[routeKey].admin && !routes[routeKey].authenticatedOrNotConfigured) {
       routerParams.push(adminMiddleware);
     }
-    // if the route requires an authenticated admin user only once the instance is configured
+    // if the route requires an authenticated user only once the instance is configured
+    // (an admin one, unless the route is not marked as admin)
     if (routes[routeKey].authenticatedOrNotConfigured) {
-      routerParams.push(authenticatedOrNotConfiguredMiddleware);
+      routerParams.push(
+        routes[routeKey].admin
+          ? authenticatedOrNotConfiguredMiddleware
+          : authenticatedOrNotConfiguredNonAdminMiddleware,
+      );
     }
     // if the route need rate limit
     if (routes[routeKey].rateLimit) {

--- a/server/test/controllers/gateway/gateway.controller.test.js
+++ b/server/test/controllers/gateway/gateway.controller.test.js
@@ -1,7 +1,9 @@
 const nock = require('nock');
 const { expect } = require('chai');
 const getConfig = require('../../../utils/getConfig');
-const { authenticatedRequest } = require('../request.test');
+const db = require('../../../models');
+const { authenticatedRequest, nonAdminRequest, NON_ADMIN_USER_ID } = require('../request.test');
+const { USER_ROLE } = require('../../../utils/constants');
 
 const config = getConfig();
 
@@ -70,6 +72,35 @@ describe('GET /api/v1/gateway/status', () => {
         expect(res.body).to.have.property('connected');
         expect(res.body).to.have.property('configured');
       });
+  });
+  it('should get gateway status as a non-admin user', async () => {
+    // Every user needs to know if the instance is linked to Gladys Plus:
+    // it's what tells the front-end that the AI chat, the voice assistant
+    // and the camera live are available, instead of offering a free trial
+    // for a subscription the instance already has.
+    await db.User.create({
+      id: NON_ADMIN_USER_ID,
+      firstname: 'Pepper',
+      lastname: 'Potts',
+      selector: 'pepper-gateway-status',
+      email: 'pepper-gateway-status@pots.com',
+      password: 'mysuperpassword',
+      role: USER_ROLE.HABITANT,
+      language: 'en',
+      birthdate: '1990-12-12',
+    });
+    try {
+      await nonAdminRequest
+        .get('/api/v1/gateway/status')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .then((res) => {
+          expect(res.body).to.have.property('connected');
+          expect(res.body).to.have.property('configured');
+        });
+    } finally {
+      await db.User.destroy({ where: { id: NON_ADMIN_USER_ID } });
+    }
   });
 });
 

--- a/server/test/controllers/gatway.test.js
+++ b/server/test/controllers/gatway.test.js
@@ -54,6 +54,35 @@ describe('Gladys Gateway call', () => {
       },
     );
   });
+  it('should get the Gladys Plus status as a non-admin user', (done) => {
+    // A user invited on the Gladys Plus account reaches Gladys through the
+    // gateway: they must be able to see that the instance is linked to Gladys
+    // Plus, otherwise the front-end offers them a free trial for a
+    // subscription the instance already has.
+    const user = {
+      id: '0cd30aef-9c4e-4a23-88e3-3547971296e5',
+      firstname: 'John',
+      lastname: 'Doe',
+      selector: 'john',
+      email: 'demo@demo.com',
+      language: 'en',
+      role: 'user',
+    };
+    // @ts-ignore
+    global.TEST_GLADYS_INSTANCE.event.emit(
+      EVENTS.GATEWAY.NEW_MESSAGE_API_CALL,
+      user,
+      'GET',
+      '/api/v1/gateway/status',
+      {},
+      {},
+      (data) => {
+        expect(data).to.have.property('configured');
+        expect(data).to.have.property('connected');
+        done();
+      },
+    );
+  });
   it('should call admin API route as admin and get response', (done) => {
     const user = {
       id: '0cd30aef-9c4e-4a23-88e3-3547971296e5',

--- a/server/test/middlewares/authenticatedOrNotConfigured.test.js
+++ b/server/test/middlewares/authenticatedOrNotConfigured.test.js
@@ -69,6 +69,52 @@ describe('authenticatedOrNotConfiguredMiddleware', () => {
       }
     });
   });
+  it('should allow access to a non-admin user when the route is not admin only', (done) => {
+    const gladys = {
+      user: {
+        getUserCount: () => 1,
+        getById: () => Promise.resolve({ id: 'user-id', role: 'habitant' }),
+      },
+      session: {
+        validateAccessToken: () => ({ user_id: 'user-id', session_id: 'session-id' }),
+      },
+    };
+    const middleware = AuthenticatedOrNotConfiguredMiddleware('dashboard:write', gladys, false);
+    const req = new MockExpressRequest({
+      headers: {
+        authorization: 'Bearer access-token',
+      },
+    });
+    middleware(req, {}, (error) => {
+      if (error) {
+        done(error);
+        return;
+      }
+      expect(req).to.have.property('user');
+      // @ts-ignore
+      expect(req.user).to.deep.equal({ id: 'user-id', role: 'habitant' });
+      done();
+    });
+  });
+  it('should refuse access without authentication when the route is not admin only', (done) => {
+    const gladys = {
+      user: {
+        getUserCount: () => 1,
+      },
+    };
+    const middleware = AuthenticatedOrNotConfiguredMiddleware('dashboard:write', gladys, false);
+    const req = new MockExpressRequest({
+      headers: {},
+    });
+    middleware(req, {}, (error) => {
+      if (!error) {
+        done('should have thrown an error');
+      } else {
+        expect(error).to.be.instanceOf(Error401);
+        done();
+      }
+    });
+  });
   it('should refuse access to a non-admin user when the instance is configured', (done) => {
     const gladys = {
       user: {


### PR DESCRIPTION
### Description

A user invited on the Gladys Plus account, with the "user" role, was asked to **start a free trial** in the AI chat, on an instance that is already connected to Gladys Plus.

Root cause: `GET /api/v1/gateway/status` was marked `admin: true`. That flag is enforced twice — by the local API middlewares, and by `setupGateway` for the API calls coming through the Gladys Plus tunnel (which is exactly how an invited user reaches the instance). A non-admin user therefore got a `403`, and the front-end, which treats a failed status call as "no Gladys Plus", displayed the upsell card instead of the chat. The same thing happened on the voice assistant dashboard box.

The route only returns two booleans (is the instance linked to Gladys Plus, is it currently connected), it exposes no secret, and every user needs it to know whether the Plus features are available. It is now accessible to any authenticated user:

- `authenticatedOrNotConfigured` middleware takes an `adminOnly` flag, so the other routes using it (backup, login, restore…) keep enforcing the admin role;
- `setupRoutes` picks the right variant depending on the route's `admin` flag;
- `admin: true` is removed from the status route, which also lifts the check in `setupGateway` for the tunnel;
- the front-end (`EmptyChat`, `GladysPlusUpsell`, `VoiceAssistantBox`) no longer treats a failed status call as "not configured": a network error should never upsell a subscription the instance may already have.

Tests added: the middleware with `adminOnly: false` (allowed for a non-admin, still `401` without authentication), the status route called by a non-admin user locally, and the same route called by a non-admin user through the Gladys Plus tunnel.

### Checklist

- [x] Tests pass: the gateway middleware, gateway controller and gateway tunnel tests were run locally (the pre-existing failures in `gateway.controller.test.js` are the `nock`-based ones, failing identically on `master` in this sandbox with no outbound network)
- [x] Linter and prettier pass on both front and server for the changed files
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jrf6znjmwnK1itvs4zhDUg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Authenticated non-admin users can now view gateway and Gladys Plus connection status.
  - Status access remains available without administrator privileges while protected for unauthenticated visitors.

- **Bug Fixes**
  - Connection failures no longer incorrectly appear as a disconnected gateway.
  - Gladys Plus promotional messages are hidden when status information is unavailable.
  - Chat retains its normal empty state when status checks fail.

- **Tests**
  - Added coverage for non-admin access, authentication requirements, and unavailable gateway status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->