### PR TITLE
fix(dashboard): stop truncating long MQTT device names in the devices widget

### DIFF
--- a/front/src/components/boxs/device-in-room/device-features/AdaptiveOptionControl.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/AdaptiveOptionControl.jsx
@@ -118,7 +118,9 @@ class AdaptiveOptionControl extends Component {
               </button>
             ))}
           </div>
-          <div class="form-group mb-0" ref={this.setSelect}>
+          {/* adaptive-option-select: hook for the dashboard widget's width cap, which
+              must not reach the selects that are always their row's control. */}
+          <div class="form-group mb-0 adaptive-option-select" ref={this.setSelect}>
             <select value={value} onChange={this.updateFromSelect} class="form-control form-control-sm">
               {options.map(option => (
                 <option value={option.value} key={option.value}>

--- a/front/src/components/boxs/device-in-room/device-features/sensor-value/NoRecentValueBadge.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/sensor-value/NoRecentValueBadge.jsx
@@ -1,7 +1,7 @@
 import { Text } from 'preact-i18n';
 
 const NoRecentValueBadge = () => (
-  <span class="badge bg-warning">
+  <span class="badge bg-warning no-recent-value-badge">
     <Text id="dashboard.boxes.devicesInRoom.noRecentValue" />
   </span>
 );

--- a/front/src/components/boxs/device-in-room/device-features/style.css
+++ b/front/src/components/boxs/device-in-room/device-features/style.css
@@ -116,4 +116,9 @@ input[type='range'][class~='light-temperature']::-ms-fill-lower {
 
 .rangeInput {
   flex: 1;
+  /* The slider is the widget's one elastic control: its cell may shrink for
+     a long device name (see .device-widget-table in routes/dashboard), and
+     this floor is where it stops — below ~6rem the thumb is no longer
+     usable on a phone. */
+  min-width: 6rem;
 }

--- a/front/src/routes/dashboard/style.css
+++ b/front/src/routes/dashboard/style.css
@@ -1323,30 +1323,95 @@
   border-radius: 4px;
 }
 
-/* An auto-layout table sizes a column to its widest unbreakable word, and a
-   device name is very often one long token (`Volet_chambre_parentale`). That
-   minimum pushed the whole table past the card, and .table-responsive put the
-   row under a horizontal scrollbar — on a phone, and on desktop too as soon as
-   the dashboard column was narrow. `max-width: 0` takes the name column out of
-   that minimum so it can shrink and ellipsize instead, and `width: 50%` keeps
-   it the half of the row it used to get, leaving the controls the width they
-   ask for. It also unblocks the adaptive option controls (acAdaptiveControls):
-   they collapse to dropdowns while the card overflows, so a name that
-   overflowed whatever they did turned every button group of the card into a
-   dropdown for nothing. */
+/* Each widget row becomes an independent flex row (the <tr>/<td> markup of
+   the 25+ feature components stays untouched). As a real table, the three
+   columns were SHARED by every row of the card: one wide control (a shutter
+   button group, a setpoint capsule) claimed that width for the whole control
+   column, and every name of the card was crushed against it — the truncated
+   MQTT names of the community report ("noms d'appareils MQTT tronqués sur
+   mobile"), while narrow rows showed a large dead gap. Flex frees each row
+   to split itself: the control keeps exactly its natural width, the name
+   gets every remaining pixel of ITS row, and instead of a nowrap ellipsis
+   it WRAPS on several lines like the scene rows (overflow-wrap: anywhere
+   breaks even single-token names). The adaptive option controls
+   (acAdaptiveControls) still collapse to dropdowns on real overflow: a
+   control cell never shrinks, so an oversized button group still overflows
+   the .table-responsive box, which is what the coordinator measures. */
+:global(.glass-theme .device-widget-table),
+:global(.glass-theme .device-widget-table tbody) {
+  display: block;
+}
+
+:global(.glass-theme .device-widget-table tr) {
+  display: flex;
+  /* stretch (default): the three cells paint one equal-height pill */
+}
+
+:global(.glass-theme .device-widget-table tr + tr) {
+  margin-top: 8px;
+}
+
+/* the width: 1% of the shared table sizing would crush the icon cell now
+   that width feeds flex-basis */
+:global(.glass-theme .device-widget-table tr td:first-child) {
+  flex: 0 0 auto;
+  width: auto;
+  display: flex;
+  align-items: center;
+}
+
+/* Column flex, not block: the light row stacks two divs (name + summary)
+   in this cell; plain text rows put their text in an anonymous item. */
 :global(.glass-theme .device-widget-table tr td:nth-child(2)) {
-  max-width: 0;
-  width: 50%;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  overflow-wrap: anywhere;
+}
+
+/* The control never grows past its natural width, and never wraps: nowrap
+   makes the natural width of a switch, stepper or button group its flex
+   minimum too, so those keep their designed size and hit area whatever the
+   name's length. shrink: 1 (not 0) matters for the one elastic control, the
+   slider: its track can give width back to a long name down to the
+   .rangeInput min-width floor, instead of imposing its full track on a
+   narrow card. */
+:global(.glass-theme .device-widget-table tr td:last-child) {
+  flex: 0 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
   white-space: nowrap;
 }
 
-/* the light row splits its name cell in two lines (name + live summary) */
-:global(.glass-theme .device-widget-table tr td:nth-child(2) > div) {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+/* The dropdown fallback of the adaptive controls is a select.form-control,
+   whose framework width: 100% resolves against a shrinkable flex cell: a
+   long name could crush it to its arrow. Intrinsic width, floored so the
+   current value stays readable, capped so one long option label does not
+   hand the select the row. */
+:global(.glass-theme .device-widget-table td select.form-control) {
+  width: auto;
+  min-width: 4.5rem;
+  max-width: 9rem;
+}
+
+/* The slider row (MultiLevelDeviceFeature) wraps its control in a Bootstrap
+   .col: its 15px grid gutters are 30px of dead width taken from the name. */
+:global(.glass-theme .device-widget-table td .col) {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+/* The "no recent value" badge is the exception to nowrap: folded on two
+   balanced lines (forum suggestion) it stops stealing half the row from
+   the name next to it. */
+:global(.glass-theme .device-widget-table .no-recent-value-badge) {
+  white-space: normal;
+  max-width: 7rem;
+  line-height: 1.25;
+  text-align: center;
 }
 
 /* Structural rows are not feature pills: ColorDeviceFeature always renders
@@ -1357,6 +1422,10 @@
   border: none;
   border-radius: 0;
   padding: 0;
+  /* in the flex rows of the widget (see below) this lone cell is both
+     first and last child: it must span its whole row, not shrink-to-fit */
+  flex: 1 1 auto;
+  width: 100%;
 }
 
 /* ============================================================

--- a/front/src/routes/dashboard/style.css
+++ b/front/src/routes/dashboard/style.css
@@ -1342,6 +1342,17 @@
   display: block;
 }
 
+/* A block box has no border-spacing: the `0 8px` of .device-list-table is
+   gone, and `tr + tr` below only brings back the gap BETWEEN pills. That
+   spacing also framed the rows — 8px above the first, 8px under the last,
+   on top of the table's own 8px bottom padding. This widget has no
+   .card-body and the card header stops at padding-bottom: 0, so the top one
+   was the only air under the title. Both are restored here as padding. */
+:global(.glass-theme .device-widget-table) {
+  padding-top: 8px;
+  padding-bottom: 16px;
+}
+
 :global(.glass-theme .device-widget-table tr) {
   display: flex;
   /* stretch (default): the three cells paint one equal-height pill */
@@ -1386,14 +1397,21 @@
   white-space: nowrap;
 }
 
-/* The dropdown fallback of the adaptive controls is a select.form-control,
-   whose framework width: 100% resolves against a shrinkable flex cell: a
-   long name could crush it to its arrow. Intrinsic width, floored so the
-   current value stays readable, capped so one long option label does not
-   hand the select the row. */
+/* An option select is a form-control, so the framework gives it width: 100%
+   — resolved against a shrinkable flex cell, a long name could crush it to
+   its arrow. Intrinsic width instead, floored so the current value stays
+   readable. */
 :global(.glass-theme .device-widget-table td select.form-control) {
   width: auto;
   min-width: 4.5rem;
+}
+
+/* Only the adaptive controls' fallback is also capped: it stands in for a
+   button group the coordinator judged too wide, so it must stay compact. The
+   selects that are always the control of their row (camera preset, fan,
+   vacuum and pilot-wire modes) show a real label — "Recall a preset…" — and
+   a cap would clip it, which is what this PR is fixing everywhere else. */
+:global(.glass-theme .device-widget-table td .adaptive-option-select select.form-control) {
   max-width: 9rem;
 }
 


### PR DESCRIPTION
### Description

On the dashboard devices widget, long device/feature names — typical of MQTT devices, where the feature name carries all the context — were ellipsized down to a few characters on mobile, even when the control next to them was a mere switch or value badge.

The root cause: the widget rows are a real table, so its three columns were **shared by every row of the card**. One wide control (a shutter button group, a setpoint capsule) claimed that width for the whole control column, and every name of the card was crushed against it, while narrower rows showed a large dead gap.

This change (CSS only — the `<tr>/<td>` markup of the 25+ feature components is untouched) makes each widget row an independent flex row, like the scene rows already are:

- the control keeps exactly its natural width and hit area, whatever the name's length;
- the name gets every remaining pixel of **its own row**, and wraps on several lines (`overflow-wrap: anywhere` breaks even single-token names like `Volet_roulant_chambre_parentale`) instead of being truncated;
- the slider is the one control allowed to give width back to a long name, down to a usable ~6rem floor, and the Bootstrap `.col` gutters in its cell (30px of dead width) are neutralized;
- the "no recent value" badge folds on two balanced lines instead of stealing half the row (suggested on the forum topic);
- the `select` fallback of the adaptive option controls gets a min/max width so a long name can't crush it to its arrow.

The buttons→dropdown adaptive mechanism (`acAdaptiveControls`) keeps working: `nowrap` control cells never shrink below their natural width, so an oversized button group still overflows the `.table-responsive` box, which is what the coordinator measures.

Verified with real renderings (Chromium, 390px iPhone viewport, FR locale, demo mode) on a widget mixing 8 feature families with long MQTT names — switch, sensor value, no-recent-value badge, shutter button group, slider, adaptive mode control, setpoint stepper, merged light row — plus the short-name widgets (no regression) and a narrow 3-column desktop card.

| Before (mobile) | After (mobile) |
|---|---|
| Every name cut to ~5 characters (`Prise…`, `Temp…`, `Humi…`) against the width claimed by the widest control of the card | Names readable on 2-3 lines, controls unchanged, dead gaps gone |

## Forum

Forum: https://community.gladysassistant.com/t/sur-mobile-noms-dappareils-mqtt-tronque-sur-le-dashboard/10746

### Checklist

- [x] Tests pass: server untouched (front CSS + one className only); Cypress suite not run in this environment — the change is visual, verified with real browser renderings at mobile and desktop viewports
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lkhkpg8WqqMWxyPULoBtao

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lkhkpg8WqqMWxyPULoBtao)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved device widget layouts for narrow screens and responsive displays.
  * Device names can wrap more naturally without truncation.
  * Controls and selectors maintain usable sizing and spacing.
  * “No recent value” badges can wrap cleanly.
  * Sliders now retain a practical minimum width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->