### PR TITLE
fix(dashboard): compact the shutter buttons into icons in narrow cards

### DIFF
--- a/front/src/components/boxs/device-in-room/DeviceCard.jsx
+++ b/front/src/components/boxs/device-in-room/DeviceCard.jsx
@@ -54,7 +54,7 @@ const DeviceCard = ({ children, ...props }) => {
       )}
       <div>
         <div class="loader py-3" />
-        <div class="table-responsive">
+        <div class={`table-responsive ${style.deviceWidgetContainer}`}>
           {/* device-list-table: Horizon restyle hook — the glass theme turns
               these rows into soft pills (see routes/dashboard/style.css).
               device-widget-table narrows the rules that only make sense for

--- a/front/src/components/boxs/device-in-room/style.css
+++ b/front/src/components/boxs/device-in-room/style.css
@@ -1,3 +1,11 @@
+/* Width reference for the shutter buttons' compact mode (ShutterButtons.css):
+   the buttons react to the card's real width, not the viewport's, so a narrow
+   desktop column compacts them just like a phone does. inline-size only — a
+   size container would need a fixed height this wrapper doesn't have. */
+.deviceWidgetContainer {
+  container: device-widget / inline-size;
+}
+
 .loadingSkeleton {
   height: 1.2em;
   background: #eee;

--- a/front/src/components/device/ShutterButtons.css
+++ b/front/src/components/device/ShutterButtons.css
@@ -1,0 +1,31 @@
+/* In a narrow dashboard card, the text button group ("Ouvrir | ⏸ | Fermé" in
+   French) is wider than half a phone screen and starves the device name next
+   to it. Inside the device widget — the only place that declares the
+   `device-widget` container, on its .table-responsive wrapper — the group
+   swaps its labels for arrow icons below the width where text + a readable
+   name no longer coexist. Everywhere else (scene editor, wide cards) there is
+   no matching container, so the query never applies and the labels stay. */
+
+.shutter-btn-icon {
+  display: none;
+}
+
+@container device-widget (max-width: 24rem) {
+  .shutter-btn-icon {
+    display: inline;
+  }
+
+  /* Visually hidden, not display: none — the label keeps naming the button
+     for screen readers while the icon takes its place on screen. */
+  .shutter-btn-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+}

--- a/front/src/components/device/ShutterButtons.jsx
+++ b/front/src/components/device/ShutterButtons.jsx
@@ -3,6 +3,7 @@ import { Text } from 'preact-i18n';
 import cx from 'classnames';
 
 import { COVER_STATE } from '../../../../server/utils/constants';
+import './ShutterButtons.css';
 
 class ShutterButtons extends Component {
   open = () => {
@@ -26,11 +27,14 @@ class ShutterButtons extends Component {
           })}
           onClick={this.open}
         >
-          {value === COVER_STATE.OPEN && isLive ? (
-            <Text id={`deviceFeatureAction.category.${category}.stateLiveFinished`} plural={COVER_STATE.OPEN} />
-          ) : (
-            <Text id={`deviceFeatureAction.category.${category}.${type}`} plural={COVER_STATE.OPEN} />
-          )}
+          <i class="fe fe-arrow-up shutter-btn-icon" aria-hidden="true" />
+          <span class="shutter-btn-label">
+            {value === COVER_STATE.OPEN && isLive ? (
+              <Text id={`deviceFeatureAction.category.${category}.stateLiveFinished`} plural={COVER_STATE.OPEN} />
+            ) : (
+              <Text id={`deviceFeatureAction.category.${category}.${type}`} plural={COVER_STATE.OPEN} />
+            )}
+          </span>
         </button>
         <button
           class={cx('btn btn-sm btn-secondary', 'fe', 'fe-pause', {
@@ -44,11 +48,14 @@ class ShutterButtons extends Component {
           })}
           onClick={this.close}
         >
-          {value === COVER_STATE.CLOSE && isLive ? (
-            <Text id={`deviceFeatureAction.category.${category}.stateLiveFinished`} plural={COVER_STATE.CLOSE} />
-          ) : (
-            <Text id={`deviceFeatureAction.category.${category}.${type}`} plural={COVER_STATE.CLOSE} />
-          )}
+          <i class="fe fe-arrow-down shutter-btn-icon" aria-hidden="true" />
+          <span class="shutter-btn-label">
+            {value === COVER_STATE.CLOSE && isLive ? (
+              <Text id={`deviceFeatureAction.category.${category}.stateLiveFinished`} plural={COVER_STATE.CLOSE} />
+            ) : (
+              <Text id={`deviceFeatureAction.category.${category}.${type}`} plural={COVER_STATE.CLOSE} />
+            )}
+          </span>
         </button>
       </div>
     );

--- a/front/src/routes/dashboard/style.css
+++ b/front/src/routes/dashboard/style.css
@@ -1351,7 +1351,13 @@
    in this cell; plain text rows put their text in an anonymous item. */
 :global(.glass-theme .device-widget-table tr td:nth-child(2)) {
   flex: 1 1 auto;
-  min-width: 0;
+  /* The floor under the name: without it, a control wide enough (the shutter
+     buttons before their compact mode) squeezed this cell to a letter per
+     line — overflow-wrap: anywhere breaks ANYWHERE, including every
+     character. 6rem still wraps long names, but on readable chunks, and a
+     control that truly cannot coexist with it overflows the wrapper again,
+     which is the signal acAdaptiveControls listens for. */
+  min-width: 6rem;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
### Description

Since 5.0.2, a shutter/curtain row in the "devices in room" dashboard widget could render its device name as an unreadable vertical column of single letters on mobile: the text button group ("Ouvrir | ⏸ | Fermé" in French) is wider than half a phone screen, and the name cell — `flex: 1 1 auto` with no width floor and `overflow-wrap: anywhere` — was squeezed to about one character per line.

Two changes, CSS-first (no feature component markup touched except `ShutterButtons`):

- **Compact shutter buttons in narrow cards.** The widget's `.table-responsive` wrapper now declares a `device-widget / inline-size` container, and below 24rem of card width the shutter buttons swap their text labels for `fe-arrow-up` / `fe-arrow-down` icons. The labels stay in the DOM, visually hidden, so screen readers keep the button names; the active state stays visible through the highlighted button. The switch follows the card's real width, not the viewport's, so a narrow desktop column compacts exactly like a phone, and a wide card (tablet, single column) keeps the text labels. The scene editor renders `ShutterButtons` outside any `device-widget` container, so it is untouched.
- **A 6rem floor under the name cell.** No control can crush a name below readable word-chunks anymore, whatever its width; a control that truly cannot coexist with the floor overflows the wrapper again, which is the signal `acAdaptiveControls` measures.

Rendering verified in the demo (`npm run start-demo`) with the reporter's exact device name:

| 360px phone (after) | Narrow desktop column, before → after |
|---|---|
| Name wraps on words, icon group `↑ ⏸ ↓`, active state highlighted | "Volet" was shredded to "Vole / t" next to text buttons → icons + readable name |

Also checked: 820px single-column card still shows the full text labels, and the pre-existing vertical setpoint stepper in very narrow columns is unchanged (present on master too).

## Forum

### Checklist

- [x] Tests pass: no server change (front-only CSS/markup fix); Cypress not run in this environment
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`) — run on the changed front files
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQBnTp4Y9wp5KBe5swY4Nf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved device cards to adapt shutter controls based on available card width.
  * Shutter buttons now display clear open/close labels with directional icons.
  * On narrow cards, controls switch to a compact icon layout while retaining accessible labels.
  * Prevented device names and summaries from wrapping awkwardly on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->