### PR TITLE
fix(dashboard): round displayed sensor values without losing small-value meaning

### DIFF
--- a/front/src/components/boxs/device-in-room/device-features/MultiLevelDeviceFeature.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/MultiLevelDeviceFeature.jsx
@@ -3,6 +3,7 @@ import get from 'get-value';
 import cx from 'classnames';
 
 import { DeviceFeatureCategoriesIcon } from '../../../../utils/consts';
+import { smartRound } from '../../../../../../server/utils/units';
 
 import style from './style.css';
 
@@ -38,11 +39,11 @@ const MultiLevelDeviceType = ({ children, ...props }) => {
           <span class="ml-2 text-right">
             {props.deviceFeature.unit ? (
               <span>
-                {`${props.deviceFeature.last_value} `}
+                {`${smartRound(props.deviceFeature.last_value)} `}
                 <Text id={`deviceFeatureUnitShort.${props.deviceFeature.unit}`} />
               </span>
             ) : (
-              <span>{props.deviceFeature.last_value}</span>
+              <span>{smartRound(props.deviceFeature.last_value)}</span>
             )}
           </span>
         </div>

--- a/front/src/components/boxs/device-in-room/device-features/sensor-value/BadgeNumberDeviceValue.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/sensor-value/BadgeNumberDeviceValue.jsx
@@ -3,6 +3,7 @@ import get from 'get-value';
 import cx from 'classnames';
 
 import { DEVICE_FEATURE_CATEGORIES, DEVICE_FEATURE_UNITS } from '../../../../../../../server/utils/constants';
+import { smartRound } from '../../../../../../../server/utils/units';
 import RawDeviceValue from './RawDeviceValue';
 
 // Mass concentrations are declared in milligrams, micrograms or nanograms per cubic meter, while
@@ -168,7 +169,7 @@ const BadgeNumberDeviceValue = props => {
       {!valued && <Text id="dashboard.boxes.devicesInRoom.noValue" />}
       {valued && !valueIsEnum && (
         <span>
-          {`${lastValue} `}
+          {`${smartRound(lastValue)} `}
           <Text id={`deviceFeatureUnitShort.${unit}`} />
         </span>
       )}

--- a/front/src/components/boxs/device-in-room/device-features/sensor-value/DistanceSensorDeviceValue.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/sensor-value/DistanceSensorDeviceValue.jsx
@@ -1,5 +1,5 @@
 import { Text } from 'preact-i18n';
-import { checkAndConvertUnit } from '../../../../../../../server/utils/units';
+import { checkAndConvertUnit, smartRound } from '../../../../../../../server/utils/units';
 
 const DistanceSensorDeviceValue = ({ deviceFeature, user }) => {
   const { last_value: lastValue = null, unit } = deviceFeature;
@@ -13,7 +13,9 @@ const DistanceSensorDeviceValue = ({ deviceFeature, user }) => {
       {displayValue === null && <Text id="dashboard.boxes.devicesInRoom.noValue" />}
       {displayValue !== null && (
         <span>
-          {`${displayValue} `}
+          {/* checkAndConvertUnit only rounds when it converts: the no-conversion
+              path hands back the raw value, float noise included */}
+          {`${smartRound(displayValue)} `}
           <Text id={`deviceFeatureUnitShort.${displayUnit}`} />
         </span>
       )}

--- a/front/src/components/boxs/device-in-room/device-features/sensor-value/PressureSensorDeviceValue.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/sensor-value/PressureSensorDeviceValue.jsx
@@ -1,5 +1,5 @@
 import { Text } from 'preact-i18n';
-import { checkAndConvertUnit } from '../../../../../../../server/utils/units';
+import { checkAndConvertUnit, smartRound } from '../../../../../../../server/utils/units';
 
 const PressureSensorDeviceValue = ({ deviceFeature, user }) => {
   const { last_value: lastValue = null, unit } = deviceFeature;
@@ -13,7 +13,9 @@ const PressureSensorDeviceValue = ({ deviceFeature, user }) => {
       {displayValue === null && <Text id="dashboard.boxes.devicesInRoom.noValue" />}
       {displayValue !== null && (
         <span>
-          {`${displayValue} `}
+          {/* checkAndConvertUnit only rounds when it converts: the no-conversion
+              path hands back the raw value, float noise included */}
+          {`${smartRound(displayValue)} `}
           <Text id={`deviceFeatureUnitShort.${displayUnit}`} />
         </span>
       )}

--- a/front/src/components/boxs/device-in-room/device-features/sensor-value/RawDeviceValue.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/sensor-value/RawDeviceValue.jsx
@@ -1,11 +1,12 @@
 import { Text } from 'preact-i18n';
+import { smartRound } from '../../../../../../../server/utils/units';
 
 const RawDeviceValue = ({ deviceFeature }) => (
   <div>
     {deviceFeature.last_value === null && <Text id="dashboard.boxes.devicesInRoom.noValue" />}
     {deviceFeature.last_value !== null && (
       <span>
-        {`${deviceFeature.last_value} `}
+        {`${smartRound(deviceFeature.last_value)} `}
         <Text id={`deviceFeatureUnitShort.${deviceFeature.unit}`} />
       </span>
     )}

--- a/server/test/utils/units.test.js
+++ b/server/test/utils/units.test.js
@@ -183,9 +183,23 @@ describe('checkAndConvertUnit pressure', () => {
 });
 
 describe('smartRound', () => {
-  it('returns value as is for abs(value) < 1', () => {
+  it('keeps 3 significant digits for abs(value) < 1', () => {
     expect(smartRound(0.123)).to.equal(0.123);
     expect(smartRound(-0.456)).to.equal(-0.456);
+    // never collapses a small value to 0: the magnitude is the information
+    expect(smartRound(0.005)).to.equal(0.005);
+    expect(smartRound(0.00123456)).to.equal(0.00123);
+    expect(smartRound(-0.00098765)).to.equal(-0.000988);
+    // strips float32 noise instead of displaying it
+    expect(smartRound(0.10000000149011612)).to.equal(0.1);
+    expect(smartRound(0.9999)).to.equal(1);
+  });
+  it('returns zero and non-numbers untouched', () => {
+    expect(smartRound(0)).to.equal(0);
+    expect(smartRound(null)).to.equal(null);
+    expect(smartRound(undefined)).to.equal(undefined);
+    expect(smartRound('on')).to.equal('on');
+    expect(Number.isNaN(smartRound(NaN))).to.equal(true);
   });
   it('rounds to 2 decimals for 1 <= abs(value) < 10', () => {
     expect(smartRound(2.345)).to.equal(2.35);

--- a/server/utils/units.js
+++ b/server/utils/units.js
@@ -70,10 +70,15 @@ function hslToRgb(h, s, l) {
 
 /**
  * @description Smart rounding for display:
- * - No rounding if value < 1 (keep full precision)
+ * - 3 significant digits if value < 1 — NOT a fixed number of decimals: a
+ *   fixed cut would collapse a meaningful 0.005 to 0, while full precision
+ *   would keep float noise like 0.10000000149. Significant digits keep the
+ *   magnitude readable whatever it is (0.005 stays 0.005, 0.00123 stays
+ *   0.00123, 0.10000000149 becomes 0.1)
  * - 2 decimals if value < 10
  * - 1 decimal if value < 1000
  * - No decimals (integer) if value >= 1000.
+ * Anything that is not a finite number (null, strings…) is returned untouched.
  * @param {number} value - Value to round.
  * @returns {number} Rounded value.
  * @example
@@ -83,8 +88,14 @@ function hslToRgb(h, s, l) {
  * smartRound(1234.56); // returns 1235
  */
 function smartRound(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return value;
+  }
+  if (value === 0) {
+    return 0;
+  }
   if (Math.abs(value) < 1) {
-    return value; // No rounding for very small values
+    return Number(value.toPrecision(3)); // 3 significant digits
   }
   if (Math.abs(value) < 10) {
     return Math.round(value * 100) / 100; // 2 decimals


### PR DESCRIPTION
### Description

Follow-up to the mobile report on the community forum ([topic 10763](https://community.gladysassistant.com/t/5-0-2-probleme-affichage-volet-roulant-avec-long-titre-sur-mobile/10763/4)): sensor rows of the devices widget print `last_value` verbatim, so a Zigbee float32 artifact like `45.60000038146973 %` overflows the card on mobile.

Rounding to a fixed number of decimals (as suggested on the forum) would fix the noise but destroy small values — `0.0004` would become `0`, and the magnitude *is* the information. Instead, `smartRound` (which already handled values ≥ 1 with 2 decimals under 10, 1 decimal under 1000, integers above) now keeps **3 significant digits below 1** instead of full precision:

| input | displayed |
|---|---|
| `45.60000038146973` | `45.6` |
| `33.33333333333336` | `33.3` |
| `0.005` | `0.005` (not `0`) |
| `0.00123456` | `0.00123` |
| `0.10000000149011612` | `0.1` |

Non-numeric values (`null`, strings) pass through untouched, covered by tests.

`smartRound` is now applied everywhere the widget printed a raw number:

- `RawDeviceValue` — the fallback renderer of most numeric sensors (humidity, power, energy…)
- `BadgeNumberDeviceValue` — the colored badges (CO2, AQI…)
- `MultiLevelDeviceFeature` — the value label next to the slider (shutter position, dimmer…)
- `DistanceSensorDeviceValue` / `PressureSensorDeviceValue` — their no-conversion path (metric user, metric unit) skipped the rounding the converted path already had

Rendering verified in the demo front at 360px with injected noisy values (screenshots attached to the session): `Humidité 45.6 %`, `Position 33.3 %`, `Humidité 0.005 %`, badge `43` — where before the raw values overflowed the card pill.

## Forum

Forum: https://community.gladysassistant.com/t/5-0-2-probleme-affichage-volet-roulant-avec-long-titre-sur-mobile/10763

### Checklist

- [x] Tests pass: `server/test/utils/units.test.js` extended for the new `< 1` behavior and the non-number guard (38 passing locally); the changed server lines are covered
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`) — run on the changed files
- [x] No undocumented breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQBnTp4Y9wp5KBe5swY4Nf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric value formatting across device and sensor displays.
  * Small decimal values now show up to three significant digits, reducing visible floating-point noise.
  * Zero and non-numeric values continue to display correctly without unwanted rounding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->