### PR TITLE
Show room name alongside device name in the devices widget selector

### DIFF
--- a/front/src/components/boxs/device-in-room/EditDevices.jsx
+++ b/front/src/components/boxs/device-in-room/EditDevices.jsx
@@ -107,8 +107,9 @@ class EditDevices extends Component {
           feature => !selectedDeviceFeaturesOptions.some(selected => selected.value === feature.value)
         );
         if (filteredDeviceFeatures.length > 0) {
+          const roomName = device.room && device.room.name;
           deviceOptions.push({
-            label: device.name,
+            label: roomName ? `${device.name} - ${roomName}` : device.name,
             options: filteredDeviceFeatures
           });
         }


### PR DESCRIPTION
### Description

In the dashboard "Devices" widget, when adding a feature through the dropdown, devices were grouped only by their name. When several devices share the same name (e.g. multiple "Lumiere"), it became impossible to tell which one to pick.

The group label now includes the room name alongside the device name (`Lumiere - Master Bedroom`) to remove the ambiguity.

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancement**
  * Device options now display the associated room name when available, using the format “device - room.”
  * Devices without an assigned room continue to display their original names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->