### PR TITLE
fix(dashboard): align sensor device names

### DIFF
--- a/front/src/routes/dashboard/style.css
+++ b/front/src/routes/dashboard/style.css
@@ -1347,6 +1347,13 @@
   align-items: center;
 }
 
+/* Read-only sensor icons carry Bootstrap's mr-2 utility for legacy table
+   layouts. In this flex layout that margin enlarges their icon cell by 8px,
+   shifting only sensor names (temperature, opening, etc.) to the right. */
+:global(.glass-theme .device-widget-table tr td:first-child > .fe) {
+  margin-right: 0 !important;
+}
+
 /* Column flex, not block: the light row stacks two divs (name + summary)
    in this cell; plain text rows put their text in an anonymous item. */
 :global(.glass-theme .device-widget-table tr td:nth-child(2)) {


### PR DESCRIPTION
### Description

Read-only device features such as temperature and opening sensors render their icon with the Bootstrap mr-2 utility, which adds an 8px right margin.

This spacing is not a problem in the other place where these rows are reused: the MQTT feature preview uses a regular HTML table. Table columns are shared across rows there, so the margin contributes to the common icon-column width and does not make individual labels start at different positions. The MQTT-specific SensorRowFeaturePreview also applies mr-2 explicitly, confirming that the spacing is intentional in that context.

The dashboard device widget is different. Its Horizon layout turns every table row into an independent flex container. Consequently, the sensor icon margin enlarges only the first cell of read-only sensor rows, shifting names such as temperature, door, and hatch 8px to the right. Light and writable-feature rows do not carry that margin, which makes the misalignment visible.

This change therefore neutralizes the icon margin only inside the Horizon device widget flex layout. It fixes the alignment at the point where the legacy spacing conflicts with the new layout while preserving the intended spacing in regular-table consumers such as the MQTT preview.

## Forum

Forum: https://community.gladysassistant.com/t/anomalie-affichage-ouverture-temperature/10779

### Validation

- [x] Front Prettier and Prettier check
- [x] Front ESLint (0 errors; existing warnings only)
- [x] Translation comparison
- [x] Production front build
- [x] No undocumented breaking change

Cypress was not run because this isolated CSS alignment change has no existing pixel/layout assertion in the suite.