### PR TITLE
fix(dashboard): wrap long text values instead of overflowing the card

### DIFF
--- a/front/src/components/boxs/device-in-room/device-features/sensor-value/TextDeviceValue.jsx
+++ b/front/src/components/boxs/device-in-room/device-features/sensor-value/TextDeviceValue.jsx
@@ -9,8 +9,10 @@ const displayValue = deviceFeature => {
   return matchingOption && matchingOption.label ? matchingOption.label : deviceFeature.last_value_string;
 };
 
+// text-device-value: the one dashboard value that is free-form text of any length — the glass
+// theme lets it wrap where every other control stays on one line (routes/dashboard/style.css)
 const RawDeviceValue = ({ deviceFeature }) => (
-  <div>
+  <div class="text-device-value">
     {deviceFeature.last_value_string === null && <Text id="dashboard.boxes.devicesInRoom.noValue" />}
     {deviceFeature.last_value_string !== null && <span>{displayValue(deviceFeature)}</span>}
   </div>

--- a/front/src/routes/dashboard/style.css
+++ b/front/src/routes/dashboard/style.css
@@ -1414,6 +1414,19 @@
   text-align: center;
 }
 
+/* A text feature is the other exception: its value is free-form text of any
+   length (a sun-protection advice, a TV app name...), not a control with a
+   designed width. Kept on one line by the nowrap above, a long sentence
+   pushed the pill past the card and gave the widget a horizontal scrollbar
+   (community report "débordement horizontal"). It wraps like the name
+   next to it — overflow-wrap: anywhere so a single long token (a URL, a
+   serial number) breaks too — and stays right-aligned, as every value is. */
+:global(.glass-theme .device-widget-table .text-device-value) {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  text-align: right;
+}
+
 /* Structural rows are not feature pills: ColorDeviceFeature always renders
    a second tr with one colspan cell holding the (d-none while closed) color
    picker — without this reset it paints as an empty ghost pill. */


### PR DESCRIPTION
### Description

A community member reported that a devices-in-room widget overflowed its card horizontally: the text was truncated and a horizontal scrollbar appeared under the rows (screenshot in the forum topic: a "Conseil de protection solaire" text feature whose value is a full sentence).

**Cause.** In the glass theme, the control cell of every widget row (`td:last-child` of `.device-widget-table`) is `white-space: nowrap` on purpose: switches, steppers and button groups keep their designed width whatever the device name's length. A text feature (`TextDeviceValue`) goes through the same cell, so a long sentence became one unbreakable line that pushed the pill past the card. The `.table-responsive` wrapper then showed the horizontal scrollbar seen in the report.

**Fix.**
- `TextDeviceValue` now tags its wrapper with a `text-device-value` class.
- `routes/dashboard/style.css` makes that class the second exception to the nowrap rule (next to the existing `no-recent-value-badge` one): the value wraps on several right-aligned lines like the name next to it, with `overflow-wrap: anywhere` so a single long token (URL, serial number) breaks too. Every other control keeps its nowrap.

Reproduced and verified in demo mode with a long text feature added to the garden card, at 412px (phone) and in a narrow desktop column. Before: `scrollWidth` of the wrapper was 719px for a 386px card. After: no overflow, the sentence wraps inside the pill.

| Before | After |
| --- | --- |
| value on one line, card scrolls horizontally | value wrapped on 4 right-aligned lines, no scrollbar |

## Forum

Forum: https://community.gladysassistant.com/t/probleme-d-affichage-responsive-avec-debordement-horizontal/10772

### Checklist

- [x] Tests pass: server code untouched; UI change verified in demo mode with a headless browser (Cypress binary could not be downloaded in this environment)
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`) — run on the changed front files
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BEArtKpuA928AwjZ5ugqH

---
_Generated by [Claude Code](https://claude.ai/code/session_018BEArtKpuA928AwjZ5ugqH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Long text values in glass-themed device widgets now wrap within the card instead of extending beyond it.
  - Prevented horizontal scrolling caused by lengthy, unbroken text.
  - Text values remain right-aligned while displaying across multiple lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->