### PR TITLE
fix(dashboard): make the "…" dashboard menu readable over the cards on desktop

### DIFF
--- a/front/src/routes/dashboard/style.css
+++ b/front/src/routes/dashboard/style.css
@@ -294,6 +294,8 @@
   --gl-card-bg: rgba(255, 255, 255, 0.52);
   --gl-card-nested-bg: rgba(255, 255, 255, 0.4);
   --gl-surface-strong: rgba(255, 255, 255, 0.78);
+  /* floating menus over content (the dashboard switcher's "…" list) */
+  --gl-popover-bg: rgba(255, 255, 255, 0.94);
   --gl-border: rgba(255, 255, 255, 0.85);
   --gl-shadow: 0 18px 50px rgba(44, 62, 118, 0.13), 0 2px 8px rgba(44, 62, 118, 0.05);
   --gl-shadow-soft: 0 4px 16px rgba(44, 62, 118, 0.09);
@@ -752,16 +754,40 @@
   filter: none;
 }
 
-/* Tablet dock: frosted pill, active tab inverted */
+/* Tablet dock: frosted pill, active tab inverted.
+   The frost (background + backdrop blur) is painted by the ::before layer
+   below, NOT by the bar itself, on purpose: the "…" overflow menu is a DOM
+   descendant of the bar, and an element with backdrop-filter is a backdrop
+   root — per spec (and strictly in Chromium) the backdrop-filter of a
+   descendant then only samples what is painted INSIDE that ancestor, never
+   the page behind it. With the blur on the bar, the menu's own blur was a
+   silent no-op on desktop Chrome/Edge: the cards' text showed through its
+   78% white, crisp (forum feedback). Safari does not isolate, which is why
+   the same CSS looked opaque on iOS. */
 :global(.glass-theme) .dashboardTabs {
-  background: var(--gl-card-bg);
-  backdrop-filter: blur(24px) saturate(1.5);
-  -webkit-backdrop-filter: blur(24px) saturate(1.5);
   border: 1px solid var(--gl-border);
   border-radius: 999px;
   padding: 5px;
   box-shadow: var(--gl-shadow-soft);
   gap: 4px;
+}
+
+:global(.glass-theme) .dashboardTabs::before {
+  content: '';
+  position: absolute;
+  /* longhands, not inset: — Chromium < 87 on the old wall tablets */
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  /* behind the pills, inside the bar's own stacking context (see the
+     z-index on .dashboardTabs) */
+  z-index: -1;
+  border-radius: inherit;
+  background: var(--gl-card-bg);
+  backdrop-filter: blur(24px) saturate(1.5);
+  -webkit-backdrop-filter: blur(24px) saturate(1.5);
+  pointer-events: none;
 }
 
 :global(.glass-theme) .dashboardTab {
@@ -789,9 +815,10 @@
   gap: 6px;
   min-width: 0;
   max-width: 100%;
-  /* The glass variant's backdrop-filter makes this a stacking context, which
-     would trap the overflow menu below the dashboard cards: stack the whole
-     bar above the page content so the menu opens on top */
+  /* Stacked above the page content so the overflow menu opens on top of
+     the dashboard cards. The stacking context this creates is also what
+     keeps the glass variant's ::before frost layer (z-index: -1) behind the
+     pills instead of behind the whole page. */
   position: relative;
   z-index: 10;
 }
@@ -1005,9 +1032,13 @@
 }
 
 /* Horizon glass theme: the overflow menu is a glass surface like the bar
-   it opens from, not a stock white dropdown */
+   it opens from, not a stock white dropdown. It floats over the cards'
+   text, not over the scene: a popover needs a much denser glass than a
+   card to stay readable, whatever sits under it — the blur (which now
+   works, see the bar's ::before) softens the backdrop, the near-opaque
+   white guarantees the legibility even where backdrop-filter is missing. */
 :global(.glass-theme) .dashboardTabsMenu {
-  background: var(--gl-surface-strong);
+  background: var(--gl-popover-bg);
   backdrop-filter: blur(28px) saturate(1.6);
   -webkit-backdrop-filter: blur(28px) saturate(1.6);
   border: 1px solid var(--gl-border);
@@ -1022,8 +1053,9 @@
   font-weight: 500;
 }
 
+/* an ink tint, not more white: white on the near-opaque panel is invisible */
 :global(.glass-theme) .dashboardTabsMenu :global(.dropdown-item):hover {
-  background: rgba(255, 255, 255, 0.65);
+  background: rgba(44, 62, 118, 0.08);
 }
 
 :global(.glass-theme) .dashboardTabsMenu :global(.dropdown-item.active) {
@@ -1042,7 +1074,7 @@
 /* dark-mode.css paints .dropdown-menu with a solid !important background:
    restore the glass surface with the same weight (see the card rules above) */
 :global(.dark-mode .glass-theme) .dashboardTabsMenu {
-  background-color: var(--gl-surface-strong) !important;
+  background-color: var(--gl-popover-bg) !important;
 }
 
 /* Tablet mode keeps the compact icon dock */


### PR DESCRIPTION
### Description

Forum feedback: on desktop, the "…" overflow menu of the dashboard bar lets the cards' text show through, crisp, while the very same menu looks opaque on mobile. Both use the same CSS (78% white + a 28px backdrop blur).

**Root cause: the menu's blur was a silent no-op on Chromium.** The menu is a DOM descendant of the pill bar, which carries its own `backdrop-filter`. Per the Filter Effects spec (implemented strictly by Chromium), an element with `backdrop-filter` is a *backdrop root*: the `backdrop-filter` of a descendant only samples what is painted inside that ancestor, never the page behind it. So on Chrome/Edge the menu was a plain 78% white veil over the cards. Safari does not isolate, which is why the iOS screenshot in the topic looks fine. Reproduced in headless Chromium with a minimal page (same structure, same values) before touching the app.

**Fix** (CSS only, `front/src/routes/dashboard/style.css`):

- The bar's frost (background + blur) is painted by a `::before` layer instead of the bar itself, so the menu is no longer nested under a backdrop root and its own blur works. The bar already had the `position: relative; z-index: 10` stacking context the layer needs.
- The menu gets a dedicated, near-opaque glass token (`--gl-popover-bg`, 94% white) so it stays readable over any content, with or without `backdrop-filter` support (old wall tablets).
- Hover on a menu item becomes an ink tint instead of more white, which was invisible on the denser panel.

Checked in headless Chromium against the demo dashboard, before/after: on desktop the chips' text under the menu ("Disarmed", "Dinner with Pepper…") is now blurred away instead of showing through. The mobile dock (scrollable pill track + upward menu) and dark mode render correctly with the new frost layer.

## Forum

Forum: https://community.gladysassistant.com/t/barre-des-dashboards-augmenter-lopacite-du-menu-drop-down-en-desktop/10764

### Checklist

- [x] Tests pass: no server change; Cypress not run (CSS-only change, checked visually in Chromium at desktop and mobile widths, light and dark mode)
- [x] Linter and prettier pass on both front and server (prettier checked on the changed stylesheet)
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PR53sq1y12LRaQHeQP3Aj6

---
_Generated by [Claude Code](https://claude.ai/code/session_01PR53sq1y12LRaQHeQP3Aj6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the dashboard tab bar’s glass effect for better visual layering.
  * Updated overflow menus with a denser surface, including dark mode support.
  * Refined menu hover styling for improved contrast.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->