### PR TITLE
Hide Gladys Plus user revoke/invite actions for non-admin users

### DIFF
--- a/front/src/routes/settings/settings-gateway-users/UserList.js
+++ b/front/src/routes/settings/settings-gateway-users/UserList.js
@@ -39,39 +39,41 @@ const UserList = ({ children, ...props }) => (
           </thead>
           <tbody>
             {props.users.map((user, index) => (
-              <UserRow user={user} index={index} revokeUser={props.revokeUser} />
+              <UserRow user={user} index={index} currentUser={props.currentUser} revokeUser={props.revokeUser} />
             ))}
 
-            <tr>
-              <td>
-                <Localizer>
-                  <input
-                    onChange={props.updateEmail}
-                    value={props.email}
-                    type="email"
-                    class="form-control"
-                    placeholder={<Text id="gatewayUsers.emailPlaceholder" />}
-                  />
-                </Localizer>
-              </td>
-              <td>
-                <select class="form-control custom-select selectized" onChange={props.updateRole} value={props.role}>
-                  <option value="admin">
-                    <Text id="gatewayUsers.roleAdmin" />
-                  </option>
-                  <option value="user">
-                    <Text id="gatewayUsers.roleUser" />
-                  </option>
-                </select>
-              </td>
-              <td>
-                <button onClick={props.inviteUser} class="btn btn-primary ml-auto">
-                  <Text id="gatewayUsers.inviteUserButton" />
-                </button>
-              </td>
-              <td />
-              <td />
-            </tr>
+            {props.currentUser && props.currentUser.role === 'admin' && (
+              <tr>
+                <td>
+                  <Localizer>
+                    <input
+                      onChange={props.updateEmail}
+                      value={props.email}
+                      type="email"
+                      class="form-control"
+                      placeholder={<Text id="gatewayUsers.emailPlaceholder" />}
+                    />
+                  </Localizer>
+                </td>
+                <td>
+                  <select class="form-control custom-select selectized" onChange={props.updateRole} value={props.role}>
+                    <option value="admin">
+                      <Text id="gatewayUsers.roleAdmin" />
+                    </option>
+                    <option value="user">
+                      <Text id="gatewayUsers.roleUser" />
+                    </option>
+                  </select>
+                </td>
+                <td>
+                  <button onClick={props.inviteUser} class="btn btn-primary ml-auto">
+                    <Text id="gatewayUsers.inviteUserButton" />
+                  </button>
+                </td>
+                <td />
+                <td />
+              </tr>
+            )}
           </tbody>
         </table>
       </div>

--- a/front/src/routes/settings/settings-gateway-users/UserRow.js
+++ b/front/src/routes/settings/settings-gateway-users/UserRow.js
@@ -7,6 +7,12 @@ const UserRow = ({ children, ...props }) => {
     props.revokeUser(props.user, props.index);
   };
 
+  // The gateway only allows admins to revoke users, and never lets a user revoke themselves.
+  // Hide the button in those cases so users don't get a 403 when clicking on it.
+  const isAdmin = props.currentUser && props.currentUser.role === 'admin';
+  const isCurrentUser = props.currentUser && props.currentUser.id === props.user.id;
+  const canRevoke = isAdmin && !isCurrentUser;
+
   return (
     <tr>
       <td>
@@ -24,9 +30,7 @@ const UserRow = ({ children, ...props }) => {
       <td class="text-nowrap">
         {new Date(props.user.created_at).toLocaleDateString(props.user.language, dateDisplayOptions)}
       </td>
-      <td class="w-1">
-        <i onClick={revokeUser} class="fe fe-trash-2 cursor-pointer" />
-      </td>
+      <td class="w-1">{canRevoke && <i onClick={revokeUser} class="fe fe-trash-2 cursor-pointer" />}</td>
     </tr>
   );
 };

--- a/front/src/routes/settings/settings-gateway-users/index.js
+++ b/front/src/routes/settings/settings-gateway-users/index.js
@@ -8,13 +8,23 @@ import update from 'immutability-helper';
 class DashboardUsersPage extends Component {
   state = {
     users: [],
-    role: 'user'
+    role: 'user',
+    currentUser: null
   };
 
   getUsers = () => {
     this.props.session.gatewayClient.getUsersInAccount().then(users => {
       this.setState({ users });
     });
+  };
+
+  getCurrentUser = async () => {
+    try {
+      const currentUser = await this.props.session.gatewayClient.getMyself();
+      this.setState({ currentUser });
+    } catch (e) {
+      console.error(e);
+    }
   };
 
   inviteUser = () => {
@@ -48,13 +58,15 @@ class DashboardUsersPage extends Component {
 
   componentDidMount() {
     this.getUsers();
+    this.getCurrentUser();
   }
 
-  render({}, { users, email, role, revokeUserError }) {
+  render({}, { users, email, role, revokeUserError, currentUser }) {
     return (
       <SettingsLayout>
         <UserList
           users={users}
+          currentUser={currentUser}
           getUsers={this.getUsers}
           inviteUser={this.inviteUser}
           email={email}


### PR DESCRIPTION
### Description

Sentry (Gladys Gateway) reports 403 errors "You must be admin" and "You cannot remove yourself" on user revocation. The gateway checks are correct, but the front displayed the revoke icon on the **Settings → Plus Users** page for every row, regardless of the current user's role, so non-admin users (and admins on their own row) could click it and get a 403.

Changes in `front/src/routes/settings/settings-gateway-users/`:

- `index.js`: fetch the current gateway user (`gatewayClient.getMyself()`, which returns `id` and `role`) on mount and pass it down as `currentUser`.
- `UserRow.js`: only render the revoke icon when the current user is an admin **and** the row is not their own account.
- `UserList.js`: the invite form (email / role / "Invite User") is also admin-only on the gateway side, so it is now hidden for non-admin users as well, to avoid the same class of 403.

Until `getMyself()` resolves, the actions are hidden (safe default). If it fails, the error is logged and the actions stay hidden.

## Forum

### Checklist

- [x] Tests pass: no server change; front build (`vite build`) passes. No Cypress scenario covers this page (it requires a Gladys Plus account).
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STd28KXbEVs16QL7GyPWhg

---
_Generated by [Claude Code](https://claude.ai/code/session_01STd28KXbEVs16QL7GyPWhg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted gateway user invitations to administrators.
  * Limited user revocation controls to administrators and prevented users from revoking their own access.
  * Improved permission handling to avoid unauthorized revoke attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->