### PR TITLE
fix(device): keep device features in sync with the feature store after a device is saved again

### DIFF
--- a/server/lib/device/device.add.js
+++ b/server/lib/device/device.add.js
@@ -8,6 +8,24 @@ const { DEVICE_POLL_FREQUENCIES } = require('../../utils/constants');
  * device.add(device);
  */
 function add(device) {
+  // A feature must be ONE object in RAM, whatever the store it is read from.
+  // The stores merge an update into the object they already hold (Store.setState),
+  // so a device saved a second time (edited in the UI, re-discovered by an
+  // integration) kept the "deviceFeature" store on its first object, while the
+  // "device" store pointed to the fresh objects of the new features array. From
+  // then on, device.saveState only refreshed the former: anything reading a
+  // feature through the device (the scene "toggle" actions, the switch/light
+  // voice commands...) saw a last_value frozen at the time of the save, until
+  // the next restart. Merging the new feature into the object already in RAM,
+  // and putting that object back into the device, keeps every store in sync.
+  device.features = device.features.map((feature) => {
+    const featureInRam = this.stateManager.get('deviceFeature', feature.selector);
+    if (featureInRam && featureInRam !== feature) {
+      Object.assign(featureInRam, feature);
+      return featureInRam;
+    }
+    return feature;
+  });
   this.stateManager.setState('device', device.selector, device);
   this.stateManager.setState('deviceByExternalId', device.external_id, device);
   this.stateManager.setState('deviceById', device.id, device);

--- a/server/test/lib/device/device.add.test.js
+++ b/server/test/lib/device/device.add.test.js
@@ -1,0 +1,98 @@
+const EventEmitter = require('events');
+const { expect } = require('chai');
+const Device = require('../../../lib/device');
+const StateManager = require('../../../lib/state');
+const Job = require('../../../lib/job');
+
+const event = new EventEmitter();
+const job = new Job(event);
+const service = {
+  getService: () => null,
+};
+
+const buildDevice = (lastValue) => ({
+  id: 'device-id',
+  selector: 'plug',
+  external_id: 'plug-external-id',
+  features: [
+    {
+      id: 'feature-id',
+      selector: 'plug-binary',
+      external_id: 'plug-binary-external-id',
+      category: 'switch',
+      type: 'binary',
+      last_value: lastValue,
+    },
+  ],
+  params: [],
+});
+
+describe('Device.add', () => {
+  it('should load the device and its features in RAM', () => {
+    const stateManager = new StateManager(event);
+    const deviceManager = new Device(event, {}, stateManager, service, {}, {}, job);
+    const device = buildDevice(0);
+    deviceManager.add(device);
+    expect(stateManager.get('device', 'plug')).to.equal(device);
+    expect(stateManager.get('deviceById', 'device-id')).to.equal(device);
+    expect(stateManager.get('deviceByExternalId', 'plug-external-id')).to.equal(device);
+    expect(stateManager.get('deviceFeature', 'plug-binary')).to.equal(device.features[0]);
+    expect(stateManager.get('deviceFeatureById', 'feature-id')).to.equal(device.features[0]);
+    expect(stateManager.get('deviceFeatureByExternalId', 'plug-binary-external-id')).to.equal(device.features[0]);
+  });
+  it('should keep the device features in sync with the feature store after the device is saved again', () => {
+    const stateManager = new StateManager(event);
+    const deviceManager = new Device(event, {}, stateManager, service, {}, {}, job);
+    deviceManager.add(buildDevice(0));
+    // the device is saved again (edited in the UI, re-discovered by an integration):
+    // device.create loads a fresh object from the DB and adds it again
+    const updatedDevice = buildDevice(0);
+    updatedDevice.name = 'Renamed plug';
+    updatedDevice.features[0].name = 'Renamed feature';
+    deviceManager.add(updatedDevice);
+    // then a new state arrives, as device.saveState stores it
+    stateManager.setState('deviceFeature', 'plug-binary', {
+      last_value: 1,
+      last_value_changed: new Date(),
+    });
+    const deviceInRam = stateManager.get('device', 'plug');
+    const featureInRam = stateManager.get('deviceFeature', 'plug-binary');
+    expect(deviceInRam.name).to.equal('Renamed plug');
+    expect(deviceInRam.features[0]).to.equal(featureInRam);
+    expect(deviceInRam.features[0].name).to.equal('Renamed feature');
+    expect(deviceInRam.features[0].last_value).to.equal(1);
+    expect(stateManager.get('deviceById', 'device-id').features[0].last_value).to.equal(1);
+    expect(stateManager.get('deviceFeatureById', 'feature-id')).to.equal(featureInRam);
+    expect(stateManager.get('deviceFeatureByExternalId', 'plug-binary-external-id')).to.equal(featureInRam);
+  });
+  it('should keep the same feature objects when the device already in RAM is added again', () => {
+    const stateManager = new StateManager(event);
+    const deviceManager = new Device(event, {}, stateManager, service, {}, {}, job);
+    const device = buildDevice(0);
+    deviceManager.add(device);
+    // device.addFeature adds again the very device object it read from the store
+    deviceManager.add(device);
+    expect(stateManager.get('device', 'plug')).to.equal(device);
+    expect(stateManager.get('deviceFeature', 'plug-binary')).to.equal(device.features[0]);
+  });
+  it('should add a feature which was not in RAM yet when the device is saved again', () => {
+    const stateManager = new StateManager(event);
+    const deviceManager = new Device(event, {}, stateManager, service, {}, {}, job);
+    deviceManager.add(buildDevice(0));
+    const updatedDevice = buildDevice(0);
+    updatedDevice.features.push({
+      id: 'new-feature-id',
+      selector: 'plug-power',
+      external_id: 'plug-power-external-id',
+      category: 'switch',
+      type: 'power',
+      last_value: null,
+    });
+    deviceManager.add(updatedDevice);
+    const deviceInRam = stateManager.get('device', 'plug');
+    expect(deviceInRam.features).to.have.lengthOf(2);
+    expect(deviceInRam.features[1]).to.equal(stateManager.get('deviceFeature', 'plug-power'));
+    stateManager.setState('deviceFeature', 'plug-power', { last_value: 12 });
+    expect(deviceInRam.features[1].last_value).to.equal(12);
+  });
+});


### PR DESCRIPTION
### Description

A user reported on the forum that a scene using the **"Toggle switches"** (inverser) action stopped working on a plug, while replacing it with "Turn on switches" works. Nothing in the logs.

**Root cause.** Every store of the `StateManager` merges an update into the object it already holds (`Store.setState` does an `Object.assign`). When a device already loaded in RAM is saved again (edited in the UI, re-discovered by an integration, a feature added through `device.addFeature`...), `device.add` receives a fresh object from the DB:

- the `device` store merges it, so `device.features` now points to the **new** feature objects;
- the `deviceFeature` / `deviceFeatureById` / `deviceFeatureByExternalId` stores merge each new feature into the objects they held **from the first load**, and keep those.

From that moment the two views are different objects. `device.saveState` writes the new `last_value` only into the `deviceFeature` store, so anything reading a feature *through the device* (`stateManager.get('device', selector)` + `getDeviceFeature`) sees a `last_value` frozen at the time of the save, until the next restart. That is exactly what the scene toggle actions on switches and lights do (`last_value === 0 ? 1 : 0`): with a stale `last_value`, the toggle keeps sending the same value, and the plug never turns on. The voice switch/light commands and the blink action read the feature the same way.

**Fix.** `device.add` now merges each incoming feature into the object already in RAM (when there is one) and puts that object back into the device's `features` array, so every store shares a single object per feature. Nothing else changes: `device.create`, `device.init` and `device.addFeature` all go through `device.add`.

**Tests.** New `server/test/lib/device/device.add.test.js`: loads a device, adds it again from a fresh object, then simulates a new state as `device.saveState` stores it and checks the device seen from the `device` / `deviceById` stores reflects it (the test fails on `master`). It also covers a device re-added with its own objects and a brand new feature.

## Forum

Forum: https://community.gladysassistant.com/t/soucis-inverse-les-prises-ne-semble-pas-fonctionne/10790

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx6P7ZdwruxTUCnBAuC51T

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qx6P7ZdwruxTUCnBAuC51T)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device feature synchronization so updated feature values remain consistent across the device and feature stores.
  * Preserved feature references when devices are re-added, preventing stale or mismatched state.
  * Ensured newly added device features correctly receive subsequent state updates.

* **Tests**
  * Added coverage for device and feature storage, indexing, re-adding devices, and state synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->