### PR TITLE
fix(front): chart box header follows the series shown in the legend

### DIFF
--- a/front/src/components/boxs/chart/ApexChartComponent.jsx
+++ b/front/src/components/boxs/chart/ApexChartComponent.jsx
@@ -233,32 +233,34 @@ class ApexChartComponent extends Component {
     } else {
       options = this.getAreaChartOptions();
     }
+    this.addHiddenSeriesEvents(options);
     this.tooltipPositioning.addToOptions(options);
-    this.addLegendClickEvent(options);
     if (this.chart) {
       this.chart.updateOptions(options);
     } else {
       this.chart = new ApexCharts(this.chartRef.current, options);
 
       this.chart.render();
-      // A new chart displays all its series, whatever was hidden in a previous instance
-      if (this.props.onChartCreated) {
-        this.props.onChartCreated();
-      }
     }
   };
-  // Let the parent know when the user shows/hides a series through the legend, so the
-  // values it displays next to the chart can follow what is actually visible.
-  // ApexCharts fires this event with the index of the clicked series, before toggling it.
-  addLegendClickEvent(options) {
-    if (!this.props.onLegendClick) {
+  // Tell the parent which series are hidden (collapsed through the legend) each time the
+  // chart is drawn: after a legend click, after a data refresh (ApexCharts keeps the
+  // collapsed series) and when the chart is (re)created (all series visible again).
+  // Reading the state of the chart itself, rather than mirroring the legend clicks, keeps
+  // the parent in sync whatever ApexCharts did with the click.
+  addHiddenSeriesEvents(options) {
+    if (!this.props.onHiddenSeriesChange) {
       return;
     }
-    if (!options.chart.events) {
-      options.chart.events = {};
-    }
-    options.chart.events.legendClick = (chartContext, seriesIndex) => {
-      this.props.onLegendClick(seriesIndex);
+    const reportHiddenSeries = chartContext => {
+      const { collapsedSeriesIndices, ancillaryCollapsedSeriesIndices } = chartContext.w.globals;
+      const hiddenSeriesIndexes = [...collapsedSeriesIndices, ...ancillaryCollapsedSeriesIndices].sort((a, b) => a - b);
+      this.props.onHiddenSeriesChange(hiddenSeriesIndexes);
+    };
+    options.chart.events = {
+      ...(options.chart.events || {}),
+      mounted: reportHiddenSeries,
+      updated: reportHiddenSeries
     };
   }
   componentDidMount() {

--- a/front/src/components/boxs/chart/ApexChartComponent.jsx
+++ b/front/src/components/boxs/chart/ApexChartComponent.jsx
@@ -234,14 +234,33 @@ class ApexChartComponent extends Component {
       options = this.getAreaChartOptions();
     }
     this.tooltipPositioning.addToOptions(options);
+    this.addLegendClickEvent(options);
     if (this.chart) {
       this.chart.updateOptions(options);
     } else {
       this.chart = new ApexCharts(this.chartRef.current, options);
 
       this.chart.render();
+      // A new chart displays all its series, whatever was hidden in a previous instance
+      if (this.props.onChartCreated) {
+        this.props.onChartCreated();
+      }
     }
   };
+  // Let the parent know when the user shows/hides a series through the legend, so the
+  // values it displays next to the chart can follow what is actually visible.
+  // ApexCharts fires this event with the index of the clicked series, before toggling it.
+  addLegendClickEvent(options) {
+    if (!this.props.onLegendClick) {
+      return;
+    }
+    if (!options.chart.events) {
+      options.chart.events = {};
+    }
+    options.chart.events.legendClick = (chartContext, seriesIndex) => {
+      this.props.onLegendClick(seriesIndex);
+    };
+  }
   componentDidMount() {
     this.displayChart();
   }

--- a/front/src/components/boxs/chart/ApexChartComponent.jsx
+++ b/front/src/components/boxs/chart/ApexChartComponent.jsx
@@ -257,10 +257,23 @@ class ApexChartComponent extends Component {
       const hiddenSeriesIndexes = [...collapsedSeriesIndices, ...ancillaryCollapsedSeriesIndices].sort((a, b) => a - b);
       this.props.onHiddenSeriesChange(hiddenSeriesIndexes);
     };
+    // Chain the handlers already registered by the chart options (e.g. the y-axis
+    // styles of the timeline chart), don't replace them
+    const existingEvents = options.chart.events || {};
     options.chart.events = {
-      ...(options.chart.events || {}),
-      mounted: reportHiddenSeries,
-      updated: reportHiddenSeries
+      ...existingEvents,
+      mounted(chartContext, config) {
+        if (typeof existingEvents.mounted === 'function') {
+          existingEvents.mounted(chartContext, config);
+        }
+        reportHiddenSeries(chartContext);
+      },
+      updated(chartContext, config) {
+        if (typeof existingEvents.updated === 'function') {
+          existingEvents.updated(chartContext, config);
+        }
+        reportHiddenSeries(chartContext);
+      }
     };
   }
   componentDidMount() {

--- a/front/src/components/boxs/chart/Chart.jsx
+++ b/front/src/components/boxs/chart/Chart.jsx
@@ -100,6 +100,25 @@ const calculateVariation = (firstValue, lastValue) => {
 
 const allEqual = arr => arr.every(val => val === arr[0]);
 
+// Compute the values displayed in the header of the box (last value + variation over the period)
+// from the per-series summaries, ignoring the series hidden by the user in the chart legend.
+// The variation is the one of the averaged value, so the two numbers describe the same thing:
+// "the average of the visible series is now X, that is Y% more/less than at the start of the period".
+const getHeaderValues = (featuresSummary, hiddenSeriesIndexes) => {
+  const visibleSummaries = featuresSummary.filter(
+    (summary, index) => summary !== null && !hiddenSeriesIndexes.includes(index)
+  );
+  if (visibleSummaries.length === 0) {
+    return { variation: undefined, lastValueRounded: null };
+  }
+  const firstValue = average(visibleSummaries.map(summary => summary.firstValue));
+  const lastValue = average(visibleSummaries.map(summary => summary.lastValue));
+  return {
+    variation: calculateVariation(firstValue, lastValue),
+    lastValueRounded: roundWith2DecimalIfNeeded(lastValue)
+  };
+};
+
 const getPeriodLabel = (interval, offset, language) => {
   const endDate = dayjs().subtract(offset, 'minute');
   const startDate = endDate.subtract(interval, 'minute');
@@ -375,71 +394,38 @@ class Chartbox extends Component {
         // We check if all deviceFeatures selected are in the same unit
         const allUnitsAreSame = this.props.box.units ? allEqual(unitsByFeature) : false;
 
-        // If all deviceFeatures selected are in the same unit
-        // We do a average of all values
-        if (allUnitsAreSame) {
-          const lastValuesArray = [];
-          const variationArray = [];
-          data.forEach(oneFeature => {
-            const { values } = oneFeature;
-            if (values.length === 0) {
-              return;
-            }
-            let firstElement = values[0];
-            let lastElement = values[values.length - 1];
-            // Convert the value if it is a convertible unit
-            const { value: firstElementValue, unit: firstElementUnit } = checkAndConvertUnit(
-              firstElement.value,
-              unit,
-              userUnitPreference
-            );
-            const { value: lastElementValue } = checkAndConvertUnit(lastElement.value, unit, userUnitPreference);
-            firstElement.value = firstElementValue;
-            lastElement.value = lastElementValue;
-            displayUnit = firstElementUnit;
-
-            const variation = calculateVariation(
-              getDeviceValueByAggregateFunction(firstElement, this.props.box.aggregate_function),
-              getDeviceValueByAggregateFunction(lastElement, this.props.box.aggregate_function)
-            );
-            const lastValue = getDeviceValueByAggregateFunction(lastElement, this.props.box.aggregate_function);
-            variationArray.push(variation);
-            lastValuesArray.push(lastValue);
-          });
-          newState.variation = average(variationArray);
-          newState.variationDownIsPositive = UNITS_WHEN_DOWN_IS_POSITIVE.includes(displayUnit);
-          newState.lastValueRounded = roundWith2DecimalIfNeeded(average(lastValuesArray));
-          newState.unit = displayUnit;
-        } else {
-          // If not, we only display the first value
-          const oneFeature = data[0];
+        // First and last value of the period for each feature (one entry per series, in the same
+        // order as the chart series). If all features share the same unit, they are all summarized
+        // and averaged together, otherwise only the first feature is displayed.
+        // The header (last value + variation) is derived from these summaries, restricted to the
+        // series currently visible in the chart legend (see getHeaderValues).
+        const featuresSummary = data.map((oneFeature, index) => {
           const { values } = oneFeature;
-          if (values.length > 0) {
-            let firstElement = values[0];
-            let lastElement = values[values.length - 1];
-
-            // Convert the value if it is a convertible unit
-            const { value: firstElementValue, unit: firstElementUnit } = checkAndConvertUnit(
-              firstElement.value,
-              unit,
-              userUnitPreference
-            );
-            const { value: lastElementValue } = checkAndConvertUnit(lastElement.value, unit, userUnitPreference);
-            firstElement.value = firstElementValue;
-            lastElement.value = lastElementValue;
-            displayUnit = firstElementUnit;
-
-            newState.variation = calculateVariation(
-              getDeviceValueByAggregateFunction(firstElement, this.props.box.aggregate_function),
-              getDeviceValueByAggregateFunction(lastElement, this.props.box.aggregate_function)
-            );
-            newState.variationDownIsPositive = UNITS_WHEN_DOWN_IS_POSITIVE.includes(unit);
-            newState.lastValueRounded = roundWith2DecimalIfNeeded(
-              getDeviceValueByAggregateFunction(lastElement, this.props.box.aggregate_function)
-            );
-            newState.unit = displayUnit;
+          if (values.length === 0 || (!allUnitsAreSame && index > 0)) {
+            return null;
           }
-        }
+          const firstElement = values[0];
+          const lastElement = values[values.length - 1];
+          const rawFirstValue = getDeviceValueByAggregateFunction(firstElement, this.props.box.aggregate_function);
+          const rawLastValue = getDeviceValueByAggregateFunction(lastElement, this.props.box.aggregate_function);
+          if (!notNullNotUndefined(rawFirstValue) || !notNullNotUndefined(rawLastValue)) {
+            return null;
+          }
+          // Convert the value if it is a convertible unit
+          const { value: firstValue, unit: firstElementUnit } = checkAndConvertUnit(
+            rawFirstValue,
+            unit,
+            userUnitPreference
+          );
+          const { value: lastValue } = checkAndConvertUnit(rawLastValue, unit, userUnitPreference);
+          displayUnit = firstElementUnit;
+          return { firstValue, lastValue };
+        });
+
+        newState.featuresSummary = featuresSummary;
+        newState.variationDownIsPositive = UNITS_WHEN_DOWN_IS_POSITIVE.includes(displayUnit);
+        newState.unit = displayUnit;
+        Object.assign(newState, getHeaderValues(featuresSummary, this.state.hiddenSeriesIndexes));
       }
       await this.setState(newState);
     } catch (e) {
@@ -462,6 +448,31 @@ class Chartbox extends Component {
       this.getData();
     }
   };
+  // The user toggled a series in the chart legend (ApexCharts fires this event before
+  // hiding/showing the series): recompute the header from the series that remain visible.
+  handleLegendClick = seriesIndex => {
+    this.setState(prevState => {
+      const hiddenSeriesIndexes = prevState.hiddenSeriesIndexes.includes(seriesIndex)
+        ? prevState.hiddenSeriesIndexes.filter(index => index !== seriesIndex)
+        : [...prevState.hiddenSeriesIndexes, seriesIndex];
+      return {
+        hiddenSeriesIndexes,
+        ...getHeaderValues(prevState.featuresSummary || [], hiddenSeriesIndexes)
+      };
+    });
+  };
+  // A freshly created chart displays all its series, so the header must follow.
+  // ApexCharts keeps the hidden series when only the data is refreshed, so this is
+  // only called when the chart is (re)created, not on every data refresh.
+  resetHiddenSeries = () => {
+    if (this.state.hiddenSeriesIndexes.length === 0) {
+      return;
+    }
+    this.setState(prevState => ({
+      hiddenSeriesIndexes: [],
+      ...getHeaderValues(prevState.featuresSummary || [], [])
+    }));
+  };
   updateInterval = async () => {
     await this.setState({
       interval: intervalByName[this.props.box.interval],
@@ -477,7 +488,9 @@ class Chartbox extends Component {
       loading: true,
       initialized: false,
       height: 'small',
-      nbFeaturesDisplayed: 0
+      nbFeaturesDisplayed: 0,
+      featuresSummary: [],
+      hiddenSeriesIndexes: []
     };
   }
   componentDidMount() {
@@ -770,6 +783,8 @@ class Chartbox extends Component {
                     colors={props.box.colors}
                     additionalHeight={additionalHeight}
                     dictionary={props.intl.dictionary}
+                    onLegendClick={this.handleLegendClick}
+                    onChartCreated={this.resetHiddenSeries}
                   />
                 </div>
               )}
@@ -831,6 +846,8 @@ class Chartbox extends Component {
                     colors={props.box.colors}
                     additionalHeight={additionalHeight}
                     dictionary={props.intl.dictionary}
+                    onLegendClick={this.handleLegendClick}
+                    onChartCreated={this.resetHiddenSeries}
                   />
                 )}
               </div>

--- a/front/src/components/boxs/chart/Chart.jsx
+++ b/front/src/components/boxs/chart/Chart.jsx
@@ -537,7 +537,8 @@ class Chartbox extends Component {
     const displayVariation = box.display_variation;
     // The hidden series are positional, in ApexCharts as in the header: recreate the chart
     // (all series visible again) when the devices of the box change, e.g. in the editor.
-    const deviceFeaturesKey = (box.device_features || []).join(',');
+    // Same fallback on the legacy "device_feature" (one device) attribute as in getData.
+    const deviceFeaturesKey = (box.device_features || [box.device_feature]).join(',');
     let additionalHeight = 30 * (nbFeaturesDisplayed - 1);
     if (props.box.chart_type === 'timeline') {
       additionalHeight = 55 * nbFeaturesDisplayed;

--- a/front/src/components/boxs/chart/Chart.jsx
+++ b/front/src/components/boxs/chart/Chart.jsx
@@ -448,30 +448,21 @@ class Chartbox extends Component {
       this.getData();
     }
   };
-  // The user toggled a series in the chart legend (ApexCharts fires this event before
-  // hiding/showing the series): recompute the header from the series that remain visible.
-  handleLegendClick = seriesIndex => {
+  // Called by the chart each time it is drawn, with the indexes of the series hidden through
+  // the legend: recompute the header from the series that are actually visible.
+  handleHiddenSeriesChange = hiddenSeriesIndexes => {
     this.setState(prevState => {
-      const hiddenSeriesIndexes = prevState.hiddenSeriesIndexes.includes(seriesIndex)
-        ? prevState.hiddenSeriesIndexes.filter(index => index !== seriesIndex)
-        : [...prevState.hiddenSeriesIndexes, seriesIndex];
+      if (
+        hiddenSeriesIndexes.length === prevState.hiddenSeriesIndexes.length &&
+        hiddenSeriesIndexes.every((index, position) => index === prevState.hiddenSeriesIndexes[position])
+      ) {
+        return null;
+      }
       return {
         hiddenSeriesIndexes,
-        ...getHeaderValues(prevState.featuresSummary || [], hiddenSeriesIndexes)
+        ...getHeaderValues(prevState.featuresSummary, hiddenSeriesIndexes)
       };
     });
-  };
-  // A freshly created chart displays all its series, so the header must follow.
-  // ApexCharts keeps the hidden series when only the data is refreshed, so this is
-  // only called when the chart is (re)created, not on every data refresh.
-  resetHiddenSeries = () => {
-    if (this.state.hiddenSeriesIndexes.length === 0) {
-      return;
-    }
-    this.setState(prevState => ({
-      hiddenSeriesIndexes: [],
-      ...getHeaderValues(prevState.featuresSummary || [], [])
-    }));
   };
   updateInterval = async () => {
     await this.setState({
@@ -544,6 +535,9 @@ class Chartbox extends Component {
   ) {
     const { box } = this.props;
     const displayVariation = box.display_variation;
+    // The hidden series are positional, in ApexCharts as in the header: recreate the chart
+    // (all series visible again) when the devices of the box change, e.g. in the editor.
+    const deviceFeaturesKey = (box.device_features || []).join(',');
     let additionalHeight = 30 * (nbFeaturesDisplayed - 1);
     if (props.box.chart_type === 'timeline') {
       additionalHeight = 55 * nbFeaturesDisplayed;
@@ -774,6 +768,7 @@ class Chartbox extends Component {
               {emptySeries === false && props.box.display_axes && (
                 <div class="mt-4">
                   <ApexChartComponent
+                    key={deviceFeaturesKey}
                     series={series}
                     interval={interval}
                     user={props.user}
@@ -783,8 +778,7 @@ class Chartbox extends Component {
                     colors={props.box.colors}
                     additionalHeight={additionalHeight}
                     dictionary={props.intl.dictionary}
-                    onLegendClick={this.handleLegendClick}
-                    onChartCreated={this.resetHiddenSeries}
+                    onHiddenSeriesChange={this.handleHiddenSeriesChange}
                   />
                 </div>
               )}
@@ -837,6 +831,7 @@ class Chartbox extends Component {
                 )}
                 {emptySeries === false && !props.box.display_axes && (
                   <ApexChartComponent
+                    key={deviceFeaturesKey}
                     series={series}
                     interval={interval}
                     user={props.user}
@@ -846,8 +841,7 @@ class Chartbox extends Component {
                     colors={props.box.colors}
                     additionalHeight={additionalHeight}
                     dictionary={props.intl.dictionary}
-                    onLegendClick={this.handleLegendClick}
-                    onChartCreated={this.resetHiddenSeries}
+                    onHiddenSeriesChange={this.handleHiddenSeriesChange}
                   />
                 )}
               </div>


### PR DESCRIPTION
### Description

On a chart box with several devices and "display variation" enabled, the value and the variation shown above the chart were computed on **all** the devices of the box. Hiding a device through the chart legend changed the curves but never the numbers.

That is what the forum user saw on their "Puissance prises" box (washing machine + fridge): the header always showed `43.13 W  +47.50%`, i.e. the average of the last values `(0 + 86.25) / 2` and the average of the per-device variations `(0% + 95%) / 2`, whatever was toggled in the legend.

What changes:

- **The header follows the legend.** Each time the chart is drawn (ApexCharts `mounted` and `updated` events, which a legend toggle goes through), `ApexChartComponent` reports the series the chart has actually collapsed (`collapsedSeriesIndices` + `ancillaryCollapsedSeriesIndices`) to `Chart`, which recomputes the last value and the variation from the visible series only. Hiding the washing machine shows the fridge alone (`86.25 W  +95%`), showing it again goes back to the average of both. Reading the state of the chart rather than mirroring the clicks keeps the header right whatever ApexCharts did with a click.
- **Hidden series stay hidden while browsing periods.** ApexCharts keeps collapsed series when only the data is refreshed (`updateOptions`), and the header follows since it is fed by the chart itself. A recreated chart shows all its series, and so does the header. Hiding every series empties the header instead of showing stale numbers.
- **The chart is recreated when the devices of the box change** (`key` on `ApexChartComponent` built from `box.device_features`): the hidden series are positional, so this avoids keeping hiding an index that now points to another device, in the chart as in the header.
- **The variation is the variation of the averaged value**, not the average of the per-device variations, so the two numbers of the header describe the same quantity ("the average of the visible devices is now X, Y% more than at the start of the period"). It also avoids a device starting the period at `0` turning the whole variation into `Infinity`. In the case above the box now shows `43.13 W  +95%` with both devices visible.
- The first/last values are now converted (miles/°F preferences) on the aggregated value (`min`/`max`/`sum`…) rather than only on `value`, which was a small pre-existing inconsistency.

Verified in demo mode (`npm run start-demo`, with `display_axes` temporarily enabled on the "Production and consumption" box) using Playwright: hide series A → header shows series B only, show A again → back to the average, hide B → series A only, previous period → B stays hidden in the chart and the header shows A only, hide both → empty header.

| both visible | solar inverter hidden | previous period, electric meter hidden |
|---|---|---|
| `2199 W -23%` | `1500 W -25%` | `3996 W +48%` |

## Forum

Forum: https://community.gladysassistant.com/t/bug-d-affichage-la-variation-en-ne-se-met-pas-a-jour/10797

### Checklist

- [x] Tests pass: front-only change, no server code touched; Cypress has no chart-box spec, the behaviour was verified manually in demo mode with Playwright (see above)
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrXCc7YmGQP6o97Evz8ttc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chart event handling now preserves existing chart behaviors while tracking hidden series.
  * Chart summary values now update correctly when series are hidden or shown through the legend.
  * Hidden-series tracking now remains accurate when multiple series are collapsed.
  * Charts refresh correctly when configured device features change, including legacy single-device configurations.
  * Existing timeline chart styling and other configured chart interactions continue to work alongside hidden-series updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->