### PR TITLE
fix(gateway): send the two factor code when generating Gladys Plus recovery codes

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "gladys-front",
       "dependencies": {
-        "@gladysassistant/gladys-gateway-js": "^4.22.0",
+        "@gladysassistant/gladys-gateway-js": "^4.22.1",
         "@gladysassistant/theme-optimized": "^2.1.0",
         "@jaames/iro": "^5.5.2",
         "@maplibre/maplibre-gl-leaflet": "^0.1.4",
@@ -1219,9 +1219,9 @@
       }
     },
     "node_modules/@gladysassistant/gladys-gateway-js": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@gladysassistant/gladys-gateway-js/-/gladys-gateway-js-4.22.0.tgz",
-      "integrity": "sha512-/QnAk5AWk4M8siRaRykCVUiU1byIJslQwjmyqXqquxNb5PIDQnK5hN+IQvTLLBEHG/dMihyJxQ/0mN+cYm8P0w==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@gladysassistant/gladys-gateway-js/-/gladys-gateway-js-4.22.1.tgz",
+      "integrity": "sha512-R1kQs0lTg5D8sEQu0yd5MV8fZ/CjdwTUFyiwI956D3NKtsJ7Ji0ePO6r7GFF2tQudAfXHbOI+IRkb2DsFve7oA==",
       "license": "MIT",
       "dependencies": {
         "@ctrlpanel/pbkdf2": "^1.0.0",

--- a/front/package.json
+++ b/front/package.json
@@ -48,7 +48,7 @@
     "vite-plugin-static-copy": "^2.3.2"
   },
   "dependencies": {
-    "@gladysassistant/gladys-gateway-js": "^4.22.0",
+    "@gladysassistant/gladys-gateway-js": "^4.22.1",
     "@gladysassistant/theme-optimized": "^2.1.0",
     "@jaames/iro": "^5.5.2",
     "@maplibre/maplibre-gl-leaflet": "^0.1.4",

--- a/front/src/actions/login/loginGateway.js
+++ b/front/src/actions/login/loginGateway.js
@@ -32,7 +32,9 @@ function createActions(store) {
         gatewayLoginUseRecoveryCode: false,
         gatewayLoginRecoveryCode: null,
         gatewayLoginRecoveryCodes: null,
-        gatewayLoginRecoveryCodesStatus: null
+        gatewayLoginRecoveryCodesStatus: null,
+        gatewayLoginRecoveryCodesTwoFactorCode: null,
+        gatewayLoginRecoveryCodesWrongTwoFactorCode: false
       };
       // If there is a return URL and the URL is relative to this domain
       // (we want to avoid redirecting to another domain for security issues)
@@ -146,22 +148,37 @@ function createActions(store) {
       // The login itself already succeeded here, so a failure must not send the user
       // back to the login form: we display it on the recovery codes screen instead,
       // where they can retry, because there is no other way to get a set of codes.
+      // The Gateway requires a current code from the two-factor app: the code the user just
+      // logged in with is reused, but it expires quickly so a retry asks for a fresh one.
+      const twoFactorCode = state.gatewayLoginRecoveryCodesTwoFactorCode || state.gatewayLoginTwoFactorCode;
       store.setState({
         gatewayLoginRecoveryCodesStatus: RequestStatus.Getting,
+        gatewayLoginRecoveryCodesWrongTwoFactorCode: false,
         gatewayLoginRecoveryCodes: null
       });
       try {
-        const { recovery_codes: recoveryCodes } = await state.session.gatewayClient.generateTwoFactorRecoveryCodes();
+        const { recovery_codes: recoveryCodes } = await state.session.gatewayClient.generateTwoFactorRecoveryCodes(
+          twoFactorCode
+        );
         store.setState({
           gatewayLoginRecoveryCodes: recoveryCodes,
           gatewayLoginRecoveryCodesStatus: RequestStatus.Success
         });
       } catch (e) {
         console.error(e);
+        const status = get(e, 'response.status');
         store.setState({
-          gatewayLoginRecoveryCodesStatus: RequestStatus.Error
+          gatewayLoginRecoveryCodesStatus: RequestStatus.Error,
+          // 403: the code is wrong or expired, a new one is needed
+          gatewayLoginRecoveryCodesWrongTwoFactorCode: status === 403,
+          gatewayLoginRecoveryCodesTwoFactorCode: null
         });
       }
+    },
+    updateRecoveryCodesTwoFactorCode(state, e) {
+      store.setState({
+        gatewayLoginRecoveryCodesTwoFactorCode: e.target.value
+      });
     },
     async handleLoginError(state, e, wrongCodeStatus) {
       console.error(e);
@@ -235,7 +252,9 @@ function createActions(store) {
       store.setState({
         gatewayLoginRecoveryCodes: null,
         gatewayLoginRecoveryCodesNextUrl: null,
-        gatewayLoginRecoveryCodesStatus: null
+        gatewayLoginRecoveryCodesStatus: null,
+        gatewayLoginRecoveryCodesTwoFactorCode: null,
+        gatewayLoginRecoveryCodesWrongTwoFactorCode: false
       });
       route(nextUrl);
     },

--- a/front/src/components/gateway/GatewayRecoveryCodes.jsx
+++ b/front/src/components/gateway/GatewayRecoveryCodes.jsx
@@ -1,5 +1,5 @@
 import { Component } from 'preact';
-import { Text } from 'preact-i18n';
+import { Text, Localizer } from 'preact-i18n';
 import cx from 'classnames';
 import { RequestStatus } from '../../utils/consts';
 
@@ -21,10 +21,25 @@ class GatewayRecoveryCodes extends Component {
     }
   };
 
-  render({ recoveryCodes, status, onRetry, onContinue, continueLabelId }, { copied }) {
+  render(
+    {
+      recoveryCodes,
+      status,
+      onRetry,
+      onContinue,
+      continueLabelId,
+      twoFactorCode,
+      onTwoFactorCodeChange,
+      wrongTwoFactorCode
+    },
+    { copied }
+  ) {
     const downloadUrl = recoveryCodes
       ? `data:text/plain;charset=utf-8,${encodeURIComponent(recoveryCodes.join('\n'))}`
       : null;
+    // The Gateway requires a current code from the two-factor app to generate recovery
+    // codes: when the caller collects one, the retry needs a fresh 6 digits code.
+    const retryDisabled = onTwoFactorCodeChange && (!twoFactorCode || twoFactorCode.length < 6);
     return (
       <div class="card">
         <div class="card-body p-6">
@@ -37,11 +52,43 @@ class GatewayRecoveryCodes extends Component {
               {status === RequestStatus.Error ? (
                 <div>
                   <div class="alert alert-danger" role="alert">
-                    <Text id="gatewayRecoveryCodes.generationError" />
+                    {wrongTwoFactorCode ? (
+                      <Text id="gatewayLogin.invalidTwoFactorCode" />
+                    ) : (
+                      <Text id="gatewayRecoveryCodes.generationError" />
+                    )}
                   </div>
+                  {onTwoFactorCodeChange && (
+                    <div class="form-group">
+                      <label class="form-label">
+                        <Text id="gatewayLogin.twoFactorCodeLabel" />
+                      </label>
+                      <Localizer>
+                        <input
+                          type="text"
+                          class="form-control"
+                          placeholder={<Text id="gatewayLogin.twoFactorCodePlaceholder" />}
+                          value={twoFactorCode}
+                          onInput={onTwoFactorCodeChange}
+                          inputmode="numeric"
+                          autocomplete="one-time-code"
+                          maxlength="6"
+                          autofocus
+                        />
+                      </Localizer>
+                      <small class="form-text text-muted">
+                        <Text id="gatewayRecoveryCodes.twoFactorCodeRequired" />
+                      </small>
+                    </div>
+                  )}
                   {onRetry && (
                     <div class="form-footer">
-                      <button type="button" class="btn btn-primary btn-block" onClick={onRetry}>
+                      <button
+                        type="button"
+                        class="btn btn-primary btn-block"
+                        onClick={onRetry}
+                        disabled={retryDisabled}
+                      >
                         <Text id="gatewayRecoveryCodes.retryButton" />
                       </button>
                     </div>

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -4718,7 +4718,8 @@
     "generateButton": "Wiederherstellungscodes erzeugen",
     "confirmGenerateButton": "Neue Codes erzeugen",
     "rotationWarning": "Ein neuer Satz macht die Wiederherstellungscodes, die du eventuell schon hast, sofort ungültig. Nur die neuen funktionieren.",
-    "continueButton": "Weiter"
+    "continueButton": "Weiter",
+    "twoFactorCodeRequired": "Gib einen Code aus deiner Zwei-Faktor-App ein: Das Gateway verlangt ihn, um Wiederherstellungscodes zu erzeugen."
   },
   "gatewayConfigureTwoFactor": {
     "cardTitle": "Zwei-Faktor-Authentifizierung (2FA) konfigurieren",

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -4718,7 +4718,8 @@
     "generateButton": "Generate recovery codes",
     "confirmGenerateButton": "Generate new codes",
     "rotationWarning": "Generating a new set immediately invalidates the recovery codes you may already have. Only the new ones will work.",
-    "continueButton": "Continue"
+    "continueButton": "Continue",
+    "twoFactorCodeRequired": "Enter a code from your two-factor app: the Gateway requires it to generate recovery codes."
   },
   "gatewayConfigureTwoFactor": {
     "cardTitle": "Configure two-factor authentication (2FA)",

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -4718,7 +4718,8 @@
     "generateButton": "Générer des codes de récupération",
     "confirmGenerateButton": "Générer de nouveaux codes",
     "rotationWarning": "Générer un nouveau jeu invalide immédiatement les codes de récupération que vous possédez peut-être déjà. Seuls les nouveaux fonctionneront.",
-    "continueButton": "Continuer"
+    "continueButton": "Continuer",
+    "twoFactorCodeRequired": "Entrez un code de votre application 2FA : la Gateway l'exige pour générer les codes de récupération."
   },
   "gatewayConfigureTwoFactor": {
     "cardTitle": "Configurer l'authentification à deux facteurs (2FA)",

--- a/front/src/routes/login-gateway/LoginGatewayPage.jsx
+++ b/front/src/routes/login-gateway/LoginGatewayPage.jsx
@@ -11,6 +11,9 @@ const LoginGatewayPage = ({ children, ...props }) => (
         status={props.gatewayLoginRecoveryCodesStatus}
         onRetry={props.generateRecoveryCodes}
         onContinue={props.continueAfterRecoveryCodes}
+        twoFactorCode={props.gatewayLoginRecoveryCodesTwoFactorCode}
+        onTwoFactorCodeChange={props.updateRecoveryCodesTwoFactorCode}
+        wrongTwoFactorCode={props.gatewayLoginRecoveryCodesWrongTwoFactorCode}
       />
     ) : (
       <GatewayLoginForm {...props} />

--- a/front/src/routes/login-gateway/index.js
+++ b/front/src/routes/login-gateway/index.js
@@ -14,6 +14,6 @@ class Login extends Component {
 }
 
 export default connect(
-  'gatewayLoginStep2,gatewayLoginStatus,gatewayLoginError,gatewayTwoFactorJustEnabled,gatewayLoginUseRecoveryCode,gatewayLoginRecoveryCode,gatewayLoginRecoveryCodes,gatewayLoginRecoveryCodesStatus',
+  'gatewayLoginStep2,gatewayLoginStatus,gatewayLoginError,gatewayTwoFactorJustEnabled,gatewayLoginUseRecoveryCode,gatewayLoginRecoveryCode,gatewayLoginRecoveryCodes,gatewayLoginRecoveryCodesStatus,gatewayLoginRecoveryCodesTwoFactorCode,gatewayLoginRecoveryCodesWrongTwoFactorCode',
   actions
 )(Login);

--- a/front/src/routes/settings/settings-security/SecurityPage.jsx
+++ b/front/src/routes/settings/settings-security/SecurityPage.jsx
@@ -1,4 +1,4 @@
-import { Text } from 'preact-i18n';
+import { Text, Localizer } from 'preact-i18n';
 import cx from 'classnames';
 import SettingsLayout from '../SettingsLayout';
 import GatewayRecoveryCodes from '../../../components/gateway/GatewayRecoveryCodes';
@@ -24,7 +24,11 @@ const SecurityPage = ({ children, ...props }) => (
                   </p>
                   {props.status === RequestStatus.Error && (
                     <div class="alert alert-danger" role="alert">
-                      <Text id="gatewayRecoveryCodes.generationError" />
+                      {props.wrongTwoFactorCode ? (
+                        <Text id="gatewayLogin.invalidTwoFactorCode" />
+                      ) : (
+                        <Text id="gatewayRecoveryCodes.generationError" />
+                      )}
                     </div>
                   )}
                   {props.confirming ? (
@@ -34,8 +38,35 @@ const SecurityPage = ({ children, ...props }) => (
                       <div class="alert alert-warning" role="alert">
                         <Text id="gatewayRecoveryCodes.rotationWarning" />
                       </div>
+                      {/* the Gateway requires a current code from the two-factor app */}
+                      <div class="form-group">
+                        <label class="form-label">
+                          <Text id="gatewayLogin.twoFactorCodeLabel" />
+                        </label>
+                        <Localizer>
+                          <input
+                            type="text"
+                            class="form-control"
+                            placeholder={<Text id="gatewayLogin.twoFactorCodePlaceholder" />}
+                            value={props.twoFactorCode}
+                            onInput={props.updateTwoFactorCode}
+                            inputmode="numeric"
+                            autocomplete="one-time-code"
+                            maxlength="6"
+                            autofocus
+                          />
+                        </Localizer>
+                        <small class="form-text text-muted">
+                          <Text id="gatewayRecoveryCodes.twoFactorCodeRequired" />
+                        </small>
+                      </div>
                       <div class="btn-list">
-                        <button type="button" class="btn btn-primary" onClick={props.generateRecoveryCodes}>
+                        <button
+                          type="button"
+                          class="btn btn-primary"
+                          onClick={props.generateRecoveryCodes}
+                          disabled={!props.twoFactorCode || props.twoFactorCode.length < 6}
+                        >
                           <Text id="gatewayRecoveryCodes.confirmGenerateButton" />
                         </button>
                         <button type="button" class="btn btn-secondary" onClick={props.cancelGenerate}>

--- a/front/src/routes/settings/settings-security/index.js
+++ b/front/src/routes/settings/settings-security/index.js
@@ -22,7 +22,8 @@ class SettingsSecurity extends Component {
   };
 
   cancelGenerate = () => {
-    this.setState({ confirming: false, twoFactorCode: '' });
+    // also drops a stale "invalid code" alert left by a refused code
+    this.setState({ confirming: false, status: null, twoFactorCode: '', wrongTwoFactorCode: false });
   };
 
   updateTwoFactorCode = e => {

--- a/front/src/routes/settings/settings-security/index.js
+++ b/front/src/routes/settings/settings-security/index.js
@@ -1,5 +1,6 @@
 import { Component } from 'preact';
 import { connect } from 'unistore/preact';
+import get from 'get-value';
 import SecurityPage from './SecurityPage';
 import { RequestStatus } from '../../../utils/consts';
 
@@ -10,36 +11,56 @@ class SettingsSecurity extends Component {
   state = {
     status: null,
     confirming: false,
-    recoveryCodes: null
+    recoveryCodes: null,
+    // the Gateway requires a current code from the two-factor app to generate recovery codes
+    twoFactorCode: '',
+    wrongTwoFactorCode: false
   };
 
   askConfirmation = () => {
-    this.setState({ confirming: true, status: null });
+    this.setState({ confirming: true, status: null, twoFactorCode: '', wrongTwoFactorCode: false });
   };
 
   cancelGenerate = () => {
-    this.setState({ confirming: false });
+    this.setState({ confirming: false, twoFactorCode: '' });
+  };
+
+  updateTwoFactorCode = e => {
+    this.setState({ twoFactorCode: e.target.value });
   };
 
   generateRecoveryCodes = async () => {
-    this.setState({ status: RequestStatus.Getting });
+    this.setState({ status: RequestStatus.Getting, wrongTwoFactorCode: false });
     try {
-      const { recovery_codes: recoveryCodes } = await this.props.session.gatewayClient.generateTwoFactorRecoveryCodes();
-      this.setState({ recoveryCodes, confirming: false, status: RequestStatus.Success });
+      const { recovery_codes: recoveryCodes } = await this.props.session.gatewayClient.generateTwoFactorRecoveryCodes(
+        this.state.twoFactorCode
+      );
+      this.setState({ recoveryCodes, confirming: false, twoFactorCode: '', status: RequestStatus.Success });
     } catch (e) {
       console.error(e);
-      this.setState({ confirming: false, status: RequestStatus.Error });
+      const status = get(e, 'response.status');
+      // 403: the code is wrong or expired, the user stays on the form to enter a new one
+      const wrongTwoFactorCode = status === 403;
+      this.setState({
+        confirming: wrongTwoFactorCode,
+        wrongTwoFactorCode,
+        twoFactorCode: '',
+        status: RequestStatus.Error
+      });
     }
   };
 
-  render(props, { status, confirming, recoveryCodes }) {
+  render(props, { status, confirming, recoveryCodes, twoFactorCode, wrongTwoFactorCode }) {
     return (
       <SecurityPage
         status={status}
         confirming={confirming}
         recoveryCodes={recoveryCodes}
+        twoFactorCode={twoFactorCode}
+        wrongTwoFactorCode={wrongTwoFactorCode}
         askConfirmation={this.askConfirmation}
         cancelGenerate={this.cancelGenerate}
+        updateTwoFactorCode={this.updateTwoFactorCode}
         generateRecoveryCodes={this.generateRecoveryCodes}
       />
     );

--- a/server/lib/gateway/gateway.loginTwoFactor.js
+++ b/server/lib/gateway/gateway.loginTwoFactor.js
@@ -21,9 +21,11 @@ async function loginTwoFactor(twoFactorToken, twoFactorCode, twoFactorRecoveryCo
   // Generating recovery codes is a Gladys Plus user operation, so it has to be done here:
   // the client is still authenticated as the user, while init() below connects as the
   // instance and replaces the user access token with an instance one.
+  // The Gateway requires the current two factor code to generate recovery codes (an access
+  // token alone is not enough), so this is only possible right after a two factor login.
   let recoveryCodes = null;
   if (generateRecoveryCodes) {
-    const result = await this.gladysGatewayClient.generateTwoFactorRecoveryCodes();
+    const result = await this.gladysGatewayClient.generateTwoFactorRecoveryCodes(twoFactorCode);
     recoveryCodes = result.recovery_codes;
   }
   // we get all variables

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@duckdb/node-api": "1.4.4-r.4",
-        "@gladysassistant/gladys-gateway-js": "^4.22.0",
+        "@gladysassistant/gladys-gateway-js": "^4.22.1",
         "@hapi/joi": "^17.1.0",
         "@hapi/joi-date": "^2.0.1",
         "async-retry": "^1.3.3",
@@ -755,9 +755,9 @@
       "optional": true
     },
     "node_modules/@gladysassistant/gladys-gateway-js": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@gladysassistant/gladys-gateway-js/-/gladys-gateway-js-4.22.0.tgz",
-      "integrity": "sha512-/QnAk5AWk4M8siRaRykCVUiU1byIJslQwjmyqXqquxNb5PIDQnK5hN+IQvTLLBEHG/dMihyJxQ/0mN+cYm8P0w==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@gladysassistant/gladys-gateway-js/-/gladys-gateway-js-4.22.1.tgz",
+      "integrity": "sha512-R1kQs0lTg5D8sEQu0yd5MV8fZ/CjdwTUFyiwI956D3NKtsJ7Ji0ePO6r7GFF2tQudAfXHbOI+IRkb2DsFve7oA==",
       "license": "MIT",
       "dependencies": {
         "@ctrlpanel/pbkdf2": "^1.0.0",
@@ -12366,9 +12366,9 @@
       "optional": true
     },
     "@gladysassistant/gladys-gateway-js": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@gladysassistant/gladys-gateway-js/-/gladys-gateway-js-4.22.0.tgz",
-      "integrity": "sha512-/QnAk5AWk4M8siRaRykCVUiU1byIJslQwjmyqXqquxNb5PIDQnK5hN+IQvTLLBEHG/dMihyJxQ/0mN+cYm8P0w==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@gladysassistant/gladys-gateway-js/-/gladys-gateway-js-4.22.1.tgz",
+      "integrity": "sha512-R1kQs0lTg5D8sEQu0yd5MV8fZ/CjdwTUFyiwI956D3NKtsJ7Ji0ePO6r7GFF2tQudAfXHbOI+IRkb2DsFve7oA==",
       "requires": {
         "@ctrlpanel/pbkdf2": "^1.0.0",
         "array-buffer-to-hex": "^1.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -77,7 +77,7 @@
   },
   "dependencies": {
     "@duckdb/node-api": "1.4.4-r.4",
-    "@gladysassistant/gladys-gateway-js": "^4.22.0",
+    "@gladysassistant/gladys-gateway-js": "^4.22.1",
     "@hapi/joi": "^17.1.0",
     "@hapi/joi-date": "^2.0.1",
     "async-retry": "^1.3.3",

--- a/server/test/lib/gateway/gateway.login.test.js
+++ b/server/test/lib/gateway/gateway.login.test.js
@@ -100,6 +100,8 @@ describe('gateway.login', () => {
       gateway.gladysGatewayClient.generateTwoFactorRecoveryCodes,
       gateway.gladysGatewayClient.createInstance,
     );
+    // the Gateway requires the current two factor code to generate recovery codes
+    assert.calledWith(gateway.gladysGatewayClient.generateTwoFactorRecoveryCodes, '123456');
     expect(result).to.deep.equal({
       recovery_codes: ['1a2b-3c4d-5e6f-7a8b-9c0d-1e2f-3a4b-5c6d'],
     });


### PR DESCRIPTION
### Description

Suite au correctif de sécurité [gladys-gateway#220](https://github.com/GladysAssistant/gladys-gateway/pull/220) : le Gateway exige désormais le code 2FA courant pour générer des codes de secours (un access token volé ne doit plus suffire, un code de secours remplaçant le TOTP au login et au reset de mot de passe).

Trois appels sont impactés dans ce dépôt :

**Serveur (lien d'une instance Gladys)** : Gladys génère les codes de secours juste après le login 2FA qui active la 2FA (`gateway.loginTwoFactor`). Le code que l'utilisateur vient de saisir est transmis à `generateTwoFactorRecoveryCodes(twoFactorCode)`.

**Portail Gladys Plus (`GATEWAY_MODE`)**, qui appelle le Gateway directement :
- Première connexion après activation de la 2FA (`actions/login/loginGateway.js`) : le code du login qui vient de réussir est réutilisé. Comme il expire vite, l'écran d'erreur demande un nouveau code avant « Réessayer », et un 403 est affiché comme code invalide.
- Settings → Security : l'étape de confirmation demande un code 2FA courant avant de générer un nouveau jeu (bouton désactivé tant que 6 chiffres ne sont pas saisis), et reste sur le formulaire si le code est refusé.
- Nouvelle clé i18n `gatewayRecoveryCodes.twoFactorCodeRequired` (en/fr/de), les autres libellés réutilisent ceux du login.

Le login par code de secours ne demande jamais de nouveaux codes, il n'est pas touché. Aucun écran ne permet de changer l'email Gladys Plus ni de remplacer le secret 2FA, les deux autres routes durcies par gladys-gateway#220 ne sont pas appelées ici.

**Dépendance** : `@gladysassistant/gladys-gateway-js` bumpé en 4.22.1 (serveur et front, comme lors du bump précédent), version qui contient [gladys-gateway-js#15](https://github.com/GladysAssistant/gladys-gateway-js/pull/15). Cette version fonctionne aussi contre le Gateway actuel (le champ supplémentaire y est ignoré), donc Gladys peut être déployé avant le Gateway.

## Forum

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed — serveur : `test/lib/gateway/gateway.login.test.js` (7/7), la ligne modifiée est couverte par le test « should generate recovery codes while the user token is still valid » qui vérifie l'argument transmis. Front : pas de test Cypress existant sur le portail Plus (`GATEWAY_MODE`), build `vite build` en mode gateway OK.
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AerJRudkrAg97pRXW6sdqv