### PR TITLE
Keep the saved features of the devices box when their fetch fails

### DIFF
--- a/front/src/components/boxs/device-in-room/EditDevices.jsx
+++ b/front/src/components/boxs/device-in-room/EditDevices.jsx
@@ -110,10 +110,14 @@ class EditDevices extends Component {
   getStoredDeviceFeaturesOptions = () => {
     const deviceFeatures = this.props.box.device_features || [];
     const deviceFeatureNames = this.props.box.device_feature_names || [];
-    return deviceFeatures.map((selector, index) => ({
-      value: selector,
-      label: deviceFeatureNames[index] || selector
-    }));
+    return deviceFeatures.map((selector, index) => {
+      const option = { value: selector, label: deviceFeatureNames[index] || selector };
+      // same shape as the resolved options: the list fills its name inputs from new_label
+      if (deviceFeatureNames[index]) {
+        option.new_label = deviceFeatureNames[index];
+      }
+      return option;
+    });
   };
 
   getDeviceFeatures = async () => {

--- a/front/src/components/boxs/device-in-room/EditDevices.jsx
+++ b/front/src/components/boxs/device-in-room/EditDevices.jsx
@@ -104,6 +104,18 @@ class EditDevices extends Component {
     );
   };
 
+  // Without the devices list, fall back to what the box already stores: the
+  // picker loads on its own, and a pick must not write the list back without
+  // the features that were saved before.
+  getStoredDeviceFeaturesOptions = () => {
+    const deviceFeatures = this.props.box.device_features || [];
+    const deviceFeatureNames = this.props.box.device_feature_names || [];
+    return deviceFeatures.map((selector, index) => ({
+      value: selector,
+      label: deviceFeatureNames[index] || selector
+    }));
+  };
+
   getDeviceFeatures = async () => {
     try {
       this.setState({ loading: true });
@@ -113,7 +125,7 @@ class EditDevices extends Component {
       this.refreshDeviceFeaturesNames();
     } catch (e) {
       console.error(e);
-      this.setState({ loading: false });
+      this.setState({ selectedDeviceFeaturesOptions: this.getStoredDeviceFeaturesOptions(), loading: false });
     }
   };
 


### PR DESCRIPTION
### Description

Follow-up to #3082, addressing the residual note left by the Cursor review on its last approval.

Since #3082, the feature picker of the "Devices" widget editor is mounted right away and loads its own options. So a feature can be picked even when the editor's own `GET /api/v1/device` failed, which is the request that resolves the labels and custom names of the features already saved in the box. In that case the in-memory list was empty, and the first pick wrote it back to the box with the new feature only, dropping the selectors that were saved before.

On that failure, the editor now falls back to what the box already stores (`device_features` and `device_feature_names`, with the selector as label when no name is stored). The saved list stays visible and editable, and a later pick is appended to it instead of replacing it. The happy path is unchanged.

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed — front-only change on an error path, no server code touched
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`) — front eslint and prettier pass on the changed file
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsSpAFrNN74ZotY9e2JaM2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsSpAFrNN74ZotY9e2JaM2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved selected device-feature options when device information cannot be retrieved.
  * Device configuration now continues to display previously saved feature selections instead of appearing empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->