### PR TITLE
fix(homekit): expose air conditioners as HeaterCooler so "turn on" keeps the mode

### DIFF
--- a/server/services/homekit/lib/buildHeaterCoolerService.js
+++ b/server/services/homekit/lib/buildHeaterCoolerService.js
@@ -1,0 +1,281 @@
+const {
+  DEVICE_FEATURE_CATEGORIES,
+  DEVICE_FEATURE_TYPES,
+  ACTIONS,
+  ACTIONS_STATUS,
+  EVENTS,
+  AC_MODE,
+} = require('../../../utils/constants');
+const {
+  HOMEKIT_HEATER_COOLER_STATE,
+  HOMEKIT_CURRENT_HEATER_COOLER_STATE,
+  acModeToHeaterCoolerState,
+  heaterCoolerStateToAcMode,
+  clampToCharacteristic,
+} = require('./deviceMappings');
+const { toCelsius, fromCelsius, listSupportedModes } = require('./buildThermostatService');
+
+// Values of the HomeKit Active characteristic.
+const HOMEKIT_ACTIVE = {
+  INACTIVE: 0,
+  ACTIVE: 1,
+};
+
+// Bounds of the setpoint sliders, in Celsius. HAP defaults the heating threshold to 0..25 °C, which
+// is a thermostat's range, not an air conditioner's: one heating at 28 °C would read as 25 and could
+// not be set higher from the Home app. Both thresholds get the range the device declares, kept
+// inside the range the Thermostat service used to offer these same devices, so nothing that could be
+// set before becomes unreachable. A device declaring no range, or one that makes no sense as a
+// setpoint — Matter reports -100..200 — gets that range alone.
+const SETPOINT_BOUNDS = { minValue: 10, maxValue: 38 };
+
+/**
+ * @description Compute the bounds of the threshold characteristics backed by a setpoint feature.
+ * @param {object} setpointFeature - Gladys setpoint feature behind the thresholds.
+ * @returns {object} The minValue and maxValue props to give both thresholds, in Celsius.
+ * @example
+ * buildThresholdProps({ min: 16, max: 31 });
+ */
+function buildThresholdProps(setpointFeature) {
+  const declaredMin = Number.isFinite(setpointFeature.min)
+    ? toCelsius(setpointFeature.min, setpointFeature.unit)
+    : SETPOINT_BOUNDS.minValue;
+  const declaredMax = Number.isFinite(setpointFeature.max)
+    ? toCelsius(setpointFeature.max, setpointFeature.unit)
+    : SETPOINT_BOUNDS.maxValue;
+  const minValue = clampToCharacteristic(declaredMin, SETPOINT_BOUNDS);
+  const maxValue = clampToCharacteristic(declaredMax, SETPOINT_BOUNDS);
+
+  return minValue < maxValue ? { minValue, maxValue } : { ...SETPOINT_BOUNDS };
+}
+
+/**
+ * @description List the HomeKit heater/cooler states the device can actually be switched to, so the
+ * Home app does not offer modes the device cannot honour. Off is not one of them: a HeaterCooler is
+ * switched off through Active, which is the whole point of exposing an air conditioner as one.
+ * @param {object} heaterCoolerFeatures - Features driving the heater/cooler state.
+ * @returns {Array} HomeKit TargetHeaterCoolerState values the device supports.
+ * @example
+ * buildValidHeaterCoolerStates({ modeFeature, setpointFeature });
+ */
+function buildValidHeaterCoolerStates(heaterCoolerFeatures) {
+  const { modeFeature, setpointFeature } = heaterCoolerFeatures;
+
+  if (modeFeature) {
+    const validStates = [];
+
+    listSupportedModes(modeFeature, acModeToHeaterCoolerState).forEach((mode) => {
+      const state = acModeToHeaterCoolerState[mode];
+      if (state !== undefined && !validStates.includes(state)) {
+        validStates.push(state);
+      }
+    });
+
+    return validStates.sort((a, b) => a - b);
+  }
+
+  // Without a mode feature the device runs in the one mode its setpoint implies: an air conditioning
+  // setpoint is a cooling one. With nothing but an on/off command, it does whatever it does.
+  return [setpointFeature ? HOMEKIT_HEATER_COOLER_STATE.COOL : HOMEKIT_HEATER_COOLER_STATE.AUTO];
+}
+
+/**
+ * @description Wire the HomeKit HeaterCooler characteristics of an air conditioner.
+ * An air conditioner is exposed as a HeaterCooler rather than a Thermostat because HomeKit gives the
+ * former an Active characteristic of its own: "turn on the air conditioning" is then a power command
+ * that leaves the mode alone, where on a Thermostat being on means being in a mode, and the one Siri
+ * picks is Auto — a device told to turn on in summer would start heating.
+ * Like the Thermostat, the service is built from features of several Gladys categories at once (the
+ * on/off command, the mode, the setpoint and the temperature sensor of the same device), so the whole
+ * service is wired here instead of feature by feature.
+ * @param {object} service - HomeKit HeaterCooler service to fill.
+ * @param {object} device - Gladys device exposed as this heater/cooler.
+ * @param {object} features - Device features merged into the HeaterCooler service.
+ * @returns {object} The HomeKit service, with its characteristics bound.
+ * @example
+ * buildHeaterCoolerService.call(this, service, device, features);
+ */
+function buildHeaterCoolerService(service, device, features) {
+  const { Characteristic, CharacteristicEventTypes } = this.hap;
+
+  const findFeature = (category, type) => features.find((f) => f.category === category && f.type === type);
+
+  const currentTemperatureFeature = findFeature(
+    DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
+    DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+  );
+  const setpointFeature = findFeature(
+    DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+    DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE,
+  );
+  const modeFeature = findFeature(
+    DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+    DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
+  );
+  const powerFeature = findFeature(
+    DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+    DEVICE_FEATURE_TYPES.AIR_CONDITIONING.BINARY,
+  );
+
+  const readValue = (feature) => this.gladys.stateManager.get('deviceFeature', feature.selector).last_value;
+  const readCelsius = (feature) => toCelsius(readValue(feature), feature.unit);
+  const emitValue = (feature, value) => {
+    const action = {
+      type: ACTIONS.DEVICE.SET_VALUE,
+      status: ACTIONS_STATUS.PENDING,
+      value,
+      device: device.selector,
+      device_feature: feature.selector,
+    };
+    this.gladys.event.emit(EVENTS.ACTION.TRIGGERED, action);
+  };
+
+  // Gladys has no "off" AC mode, the binary feature carries it. A device without that feature is
+  // always considered on.
+  const isOn = () => (powerFeature ? Boolean(readValue(powerFeature)) : true);
+
+  const readTargetState = () => {
+    if (modeFeature) {
+      const state = acModeToHeaterCoolerState[readValue(modeFeature)];
+      return state === undefined ? HOMEKIT_HEATER_COOLER_STATE.AUTO : state;
+    }
+    return setpointFeature ? HOMEKIT_HEATER_COOLER_STATE.COOL : HOMEKIT_HEATER_COOLER_STATE.AUTO;
+  };
+
+  const readCurrentState = () => {
+    if (!isOn()) {
+      return HOMEKIT_CURRENT_HEATER_COOLER_STATE.INACTIVE;
+    }
+
+    // Dry and fan are reported to HomeKit as auto, but a device in one of those modes is neither
+    // heating nor cooling.
+    const mode = modeFeature ? readValue(modeFeature) : undefined;
+    if (mode === AC_MODE.DRYING || mode === AC_MODE.FAN) {
+      return HOMEKIT_CURRENT_HEATER_COOLER_STATE.IDLE;
+    }
+
+    const targetState = readTargetState();
+    if (targetState === HOMEKIT_HEATER_COOLER_STATE.HEAT) {
+      return HOMEKIT_CURRENT_HEATER_COOLER_STATE.HEATING;
+    }
+    if (targetState === HOMEKIT_HEATER_COOLER_STATE.COOL) {
+      return HOMEKIT_CURRENT_HEATER_COOLER_STATE.COOLING;
+    }
+
+    // In auto the device decides: the setpoint against the room temperature says which way it goes.
+    if (currentTemperatureFeature && setpointFeature) {
+      const currentTemperature = readCelsius(currentTemperatureFeature);
+      const setpoint = readCelsius(setpointFeature);
+      if (currentTemperature < setpoint) {
+        return HOMEKIT_CURRENT_HEATER_COOLER_STATE.HEATING;
+      }
+      if (currentTemperature > setpoint) {
+        return HOMEKIT_CURRENT_HEATER_COOLER_STATE.COOLING;
+      }
+      return HOMEKIT_CURRENT_HEATER_COOLER_STATE.IDLE;
+    }
+    // Without a room temperature to compare against, an air conditioner is assumed to be cooling.
+    return HOMEKIT_CURRENT_HEATER_COOLER_STATE.COOLING;
+  };
+
+  // A mode the device never declared must not be written to it.
+  const writeMode = (mode) => {
+    if (mode !== undefined && listSupportedModes(modeFeature, acModeToHeaterCoolerState).includes(mode)) {
+      emitValue(modeFeature, mode);
+    }
+  };
+
+  // Active is the on/off command, and the reason an air conditioner is a HeaterCooler at all.
+  const activeCharacteristic = service.getCharacteristic(Characteristic.Active);
+  if (!powerFeature) {
+    // A device with no on/off command cannot be switched off: HomeKit is told so rather than told
+    // it is off until the next read says otherwise.
+    activeCharacteristic.setProps({ validValues: [HOMEKIT_ACTIVE.ACTIVE] });
+  }
+  activeCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+    callback(undefined, isOn() ? HOMEKIT_ACTIVE.ACTIVE : HOMEKIT_ACTIVE.INACTIVE);
+  });
+  activeCharacteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
+    if (powerFeature) {
+      emitValue(powerFeature, value === HOMEKIT_ACTIVE.ACTIVE ? 1 : 0);
+    }
+    callback();
+  });
+
+  const targetStateCharacteristic = service.getCharacteristic(Characteristic.TargetHeaterCoolerState);
+  const validTargetStates = buildValidHeaterCoolerStates({ modeFeature, setpointFeature });
+  // An integration declaring only modes HomeKit has no equivalent for would leave the list empty,
+  // and HAP rejects a characteristic with no valid value at all.
+  if (validTargetStates.length > 0) {
+    targetStateCharacteristic.setProps({ validValues: validTargetStates });
+  }
+  targetStateCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+    callback(undefined, readTargetState());
+  });
+  targetStateCharacteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
+    // Only the mode is written: switching the device on is Active's job, and HomeKit writes both
+    // when it means both. Dry and fan are reported as auto, so auto has to stay selectable even on
+    // a device that has no auto mode — but writing AC_MODE.AUTO there would push a mode it never
+    // declared. The device is left in whatever mode it was running in.
+    if (modeFeature) {
+      writeMode(heaterCoolerStateToAcMode[value]);
+    }
+    callback();
+  });
+
+  service.getCharacteristic(Characteristic.CurrentHeaterCoolerState).on(CharacteristicEventTypes.GET, (callback) => {
+    callback(undefined, readCurrentState());
+  });
+
+  // HomeKit only ever exchanges Celsius, this characteristic is the unit shown in the Home app.
+  service
+    .getCharacteristic(Characteristic.TemperatureDisplayUnits)
+    .on(CharacteristicEventTypes.GET, async (callback) => {
+      callback(undefined, Characteristic.TemperatureDisplayUnits.CELSIUS);
+    });
+
+  // CurrentTemperature is required. Without a temperature sensor on the device, the setpoint is the
+  // closest thing to the room temperature we can report; a device with neither is left with the HAP
+  // default, as binding a handler there would throw on the first poll.
+  const temperatureSourceFeature = currentTemperatureFeature || setpointFeature;
+  if (temperatureSourceFeature) {
+    const currentTemperatureCharacteristic = service.getCharacteristic(Characteristic.CurrentTemperature);
+    currentTemperatureCharacteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+      callback(
+        undefined,
+        clampToCharacteristic(readCelsius(temperatureSourceFeature), currentTemperatureCharacteristic.props),
+      );
+    });
+  }
+
+  // A HeaterCooler has no TargetTemperature: the Home app shows the heating threshold in heat mode,
+  // the cooling one in cool mode and both in auto. An air conditioner has a single setpoint, so it
+  // stands behind both.
+  if (setpointFeature) {
+    const thresholdProps = buildThresholdProps(setpointFeature);
+
+    [Characteristic.CoolingThresholdTemperature, Characteristic.HeatingThresholdTemperature].forEach(
+      (characteristicType) => {
+        const characteristic = service.getCharacteristic(characteristicType);
+        characteristic.setProps(thresholdProps);
+
+        characteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+          callback(undefined, clampToCharacteristic(readCelsius(setpointFeature), characteristic.props));
+        });
+        characteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
+          emitValue(setpointFeature, fromCelsius(value, setpointFeature.unit));
+          callback();
+        });
+      },
+    );
+  }
+
+  return service;
+}
+
+module.exports = {
+  buildHeaterCoolerService,
+  buildValidHeaterCoolerStates,
+  buildThresholdProps,
+  HOMEKIT_ACTIVE,
+};

--- a/server/services/homekit/lib/buildHeaterCoolerService.js
+++ b/server/services/homekit/lib/buildHeaterCoolerService.js
@@ -134,6 +134,13 @@ function buildHeaterCoolerService(service, device, features) {
   // always considered on.
   const isOn = () => (powerFeature ? Boolean(readValue(powerFeature)) : true);
 
+  // The states the device can be switched to. They are read here and not only next to the
+  // characteristic they constrain, because what a device is able to do also bounds what it can be
+  // reported as doing, and which setpoint sliders it may be given.
+  const validTargetStates = buildValidHeaterCoolerStates({ modeFeature, setpointFeature });
+  const canHeat = validTargetStates.includes(HOMEKIT_HEATER_COOLER_STATE.HEAT);
+  const canCool = validTargetStates.includes(HOMEKIT_HEATER_COOLER_STATE.COOL);
+
   const readTargetState = () => {
     if (modeFeature) {
       const state = acModeToHeaterCoolerState[readValue(modeFeature)];
@@ -162,20 +169,23 @@ function buildHeaterCoolerService(service, device, features) {
       return HOMEKIT_CURRENT_HEATER_COOLER_STATE.COOLING;
     }
 
-    // In auto the device decides: the setpoint against the room temperature says which way it goes.
+    // In auto the device decides: the setpoint against the room temperature says which way it goes
+    // — but only a way the device declared it can go. A cooling-only air conditioner sitting below
+    // its setpoint is idle, not heating: reporting heating would announce a capability HomeKit was
+    // told the device does not have.
     if (currentTemperatureFeature && setpointFeature) {
       const currentTemperature = readCelsius(currentTemperatureFeature);
       const setpoint = readCelsius(setpointFeature);
-      if (currentTemperature < setpoint) {
+      if (canHeat && currentTemperature < setpoint) {
         return HOMEKIT_CURRENT_HEATER_COOLER_STATE.HEATING;
       }
-      if (currentTemperature > setpoint) {
+      if (canCool && currentTemperature > setpoint) {
         return HOMEKIT_CURRENT_HEATER_COOLER_STATE.COOLING;
       }
       return HOMEKIT_CURRENT_HEATER_COOLER_STATE.IDLE;
     }
     // Without a room temperature to compare against, an air conditioner is assumed to be cooling.
-    return HOMEKIT_CURRENT_HEATER_COOLER_STATE.COOLING;
+    return canCool ? HOMEKIT_CURRENT_HEATER_COOLER_STATE.COOLING : HOMEKIT_CURRENT_HEATER_COOLER_STATE.IDLE;
   };
 
   // A mode the device never declared must not be written to it.
@@ -203,7 +213,6 @@ function buildHeaterCoolerService(service, device, features) {
   });
 
   const targetStateCharacteristic = service.getCharacteristic(Characteristic.TargetHeaterCoolerState);
-  const validTargetStates = buildValidHeaterCoolerStates({ modeFeature, setpointFeature });
   // An integration declaring only modes HomeKit has no equivalent for would leave the list empty,
   // and HAP rejects a characteristic with no valid value at all.
   if (validTargetStates.length > 0) {
@@ -249,25 +258,37 @@ function buildHeaterCoolerService(service, device, features) {
   }
 
   // A HeaterCooler has no TargetTemperature: the Home app shows the heating threshold in heat mode,
-  // the cooling one in cool mode and both in auto. An air conditioner has a single setpoint, so it
-  // stands behind both.
+  // the cooling one in cool mode and, when both are there, a range in auto. An air conditioner has a
+  // single setpoint, so it only gets the thresholds of the modes it declared: a cooling-only device
+  // given both would grow a heating slider it cannot honour, and the Home app would show it a range
+  // whose two ends are the same value and fight each other on every write. A device that can both
+  // heat and cool does share its one setpoint between the two — the range stays zero-width there,
+  // and that is the device's own limitation.
   if (setpointFeature) {
     const thresholdProps = buildThresholdProps(setpointFeature);
+    const thresholdCharacteristics = [];
 
-    [Characteristic.CoolingThresholdTemperature, Characteristic.HeatingThresholdTemperature].forEach(
-      (characteristicType) => {
-        const characteristic = service.getCharacteristic(characteristicType);
-        characteristic.setProps(thresholdProps);
+    // A device that declared neither heat nor cool — auto alone, or auto with dry and fan — still
+    // has to expose its setpoint somewhere, and an air conditioning setpoint is a cooling one.
+    if (canCool || !canHeat) {
+      thresholdCharacteristics.push(Characteristic.CoolingThresholdTemperature);
+    }
+    if (canHeat) {
+      thresholdCharacteristics.push(Characteristic.HeatingThresholdTemperature);
+    }
 
-        characteristic.on(CharacteristicEventTypes.GET, async (callback) => {
-          callback(undefined, clampToCharacteristic(readCelsius(setpointFeature), characteristic.props));
-        });
-        characteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
-          emitValue(setpointFeature, fromCelsius(value, setpointFeature.unit));
-          callback();
-        });
-      },
-    );
+    thresholdCharacteristics.forEach((characteristicType) => {
+      const characteristic = service.getCharacteristic(characteristicType);
+      characteristic.setProps(thresholdProps);
+
+      characteristic.on(CharacteristicEventTypes.GET, async (callback) => {
+        callback(undefined, clampToCharacteristic(readCelsius(setpointFeature), characteristic.props));
+      });
+      characteristic.on(CharacteristicEventTypes.SET, async (value, callback) => {
+        emitValue(setpointFeature, fromCelsius(value, setpointFeature.unit));
+        callback();
+      });
+    });
   }
 
   return service;

--- a/server/services/homekit/lib/buildHeaterCoolerService.js
+++ b/server/services/homekit/lib/buildHeaterCoolerService.js
@@ -141,12 +141,29 @@ function buildHeaterCoolerService(service, device, features) {
   const canHeat = validTargetStates.includes(HOMEKIT_HEATER_COOLER_STATE.HEAT);
   const canCool = validTargetStates.includes(HOMEKIT_HEATER_COOLER_STATE.COOL);
 
-  const readTargetState = () => {
+  // The mode the device reports it is running in. Modes HomeKit has no equivalent for — dry, fan —
+  // read as auto, and so does a mode the device has not reported yet, or one the mapping does not
+  // know about.
+  const readReportedState = () => {
     if (modeFeature) {
       const state = acModeToHeaterCoolerState[readValue(modeFeature)];
       return state === undefined ? HOMEKIT_HEATER_COOLER_STATE.AUTO : state;
     }
     return setpointFeature ? HOMEKIT_HEATER_COOLER_STATE.COOL : HOMEKIT_HEATER_COOLER_STATE.AUTO;
+  };
+
+  // What HomeKit is told. The valid values set on the characteristic are a contract, and HAP only
+  // validates what a controller writes, not what a GET returns: reporting a state outside them
+  // would leave the Home app to make what it can of a mode it was told the device does not have.
+  // That is what the fallback to auto above does on a heat-only air conditioner, which has no auto.
+  // Such a state is reported as the first one the device does declare — auto when it has it, since
+  // the list is sorted, and its lowest mode otherwise.
+  const readTargetState = () => {
+    const state = readReportedState();
+    if (validTargetStates.length === 0 || validTargetStates.includes(state)) {
+      return state;
+    }
+    return validTargetStates[0];
   };
 
   const readCurrentState = () => {
@@ -161,11 +178,14 @@ function buildHeaterCoolerService(service, device, features) {
       return HOMEKIT_CURRENT_HEATER_COOLER_STATE.IDLE;
     }
 
-    const targetState = readTargetState();
-    if (targetState === HOMEKIT_HEATER_COOLER_STATE.HEAT) {
+    // What the device says it is doing, not what HomeKit was told it can do: this characteristic
+    // carries no valid values of its own, so an unknown mode is better deduced below than reported
+    // as the mode the target state falls back on.
+    const reportedState = readReportedState();
+    if (reportedState === HOMEKIT_HEATER_COOLER_STATE.HEAT) {
       return HOMEKIT_CURRENT_HEATER_COOLER_STATE.HEATING;
     }
-    if (targetState === HOMEKIT_HEATER_COOLER_STATE.COOL) {
+    if (reportedState === HOMEKIT_HEATER_COOLER_STATE.COOL) {
       return HOMEKIT_CURRENT_HEATER_COOLER_STATE.COOLING;
     }
 

--- a/server/services/homekit/lib/buildService.js
+++ b/server/services/homekit/lib/buildService.js
@@ -25,6 +25,7 @@ const {
   LOW_BATTERY_THRESHOLD,
 } = require('./deviceMappings');
 const { buildThermostatService } = require('./buildThermostatService');
+const { buildHeaterCoolerService } = require('./buildHeaterCoolerService');
 const { sanitizeName } = require('./sanitizeName');
 
 const sleep = promisify(setTimeout);
@@ -51,6 +52,9 @@ function buildService(device, features, categoryMapping, subtype) {
   // cannot be wired one feature at a time like the others.
   if (categoryMapping.service === 'Thermostat') {
     return buildThermostatService.call(this, service, device, features);
+  }
+  if (categoryMapping.service === 'HeaterCooler') {
+    return buildHeaterCoolerService.call(this, service, device, features);
   }
 
   features.forEach((feature) => {

--- a/server/services/homekit/lib/buildThermostatService.js
+++ b/server/services/homekit/lib/buildThermostatService.js
@@ -179,6 +179,10 @@ function bindThresholdCharacteristic(service, characteristicType, feature, helpe
  * Unlike the other categories, a thermostat is built from features of several Gladys categories at
  * once (the setpoints, the mode, the on/off command and the temperature sensor of the same device),
  * so the whole service is wired here instead of feature by feature.
+ * The air conditioning features are handled here only on a device carrying thermostat features next
+ * to them, such as a Matter heat pump. An air conditioner on its own is a HeaterCooler, see
+ * buildHeaterCoolerService: a Thermostat is only ever on by being in a mode, and the mode Siri picks
+ * for "turn on" is Auto, which on an air conditioner can mean heating.
  * @param {object} service - HomeKit Thermostat service to fill.
  * @param {object} device - Gladys device exposed as this thermostat.
  * @param {object} features - Device features merged into the thermostat service.
@@ -440,6 +444,7 @@ function buildThermostatService(service, device, features) {
 module.exports = {
   buildThermostatService,
   buildValidTargetStates,
+  listSupportedModes,
   toCelsius,
   fromCelsius,
 };

--- a/server/services/homekit/lib/deviceMappings.js
+++ b/server/services/homekit/lib/deviceMappings.js
@@ -305,17 +305,24 @@ const mappings = {
       },
     },
   },
+  // An air conditioner is a HeaterCooler, not a Thermostat: HomeKit gives the former an Active
+  // characteristic of its own, so "turn on the air conditioning" is a power command that leaves the
+  // mode alone. On a Thermostat the only way to be on is to be in a mode, and Siri picks Auto — an
+  // air conditioner told to turn on in summer would start heating. A device carrying thermostat
+  // features next to these ones is still a Thermostat, see mergedServiceCategories.
   [DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]: {
-    service: 'Thermostat',
+    service: 'HeaterCooler',
     capabilities: {
+      // A single setpoint stands behind both thresholds: the Home app shows the heating one in heat
+      // mode and the cooling one in cool mode.
       [DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE]: {
-        characteristics: ['TargetTemperature'],
+        characteristics: ['CoolingThresholdTemperature', 'HeatingThresholdTemperature'],
       },
       [DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE]: {
-        characteristics: ['TargetHeatingCoolingState', 'CurrentHeatingCoolingState'],
+        characteristics: ['TargetHeaterCoolerState', 'CurrentHeaterCoolerState'],
       },
       [DEVICE_FEATURE_TYPES.AIR_CONDITIONING.BINARY]: {
-        characteristics: ['TargetHeatingCoolingState', 'CurrentHeatingCoolingState'],
+        characteristics: ['Active', 'CurrentHeaterCoolerState'],
       },
     },
   },
@@ -462,8 +469,12 @@ const mergedServiceCategories = [
     hosts: [DEVICE_FEATURE_CATEGORIES.BATTERY, DEVICE_FEATURE_CATEGORIES.BATTERY_LOW],
     merged: [],
   },
-  // A heating or cooling device is one Thermostat service, while Gladys splits it across the
-  // setpoints, the mode, the on/off command and the temperature sensor reading the room.
+  // A heating or cooling device is one HomeKit service, while Gladys splits it across the
+  // setpoints, the mode, the on/off command and the temperature sensor reading the room. The first
+  // host present decides the service: a device with thermostat features is a Thermostat, and its
+  // air conditioning features join it (a Matter heat pump declares its heating setpoint as a
+  // thermostat and its cooling setpoint and mode as air conditioning); a device with air
+  // conditioning features alone is a HeaterCooler.
   {
     hosts: [DEVICE_FEATURE_CATEGORIES.THERMOSTAT, DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING],
     merged: [DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR],
@@ -492,6 +503,38 @@ const heatingCoolingStateToAcMode = {
   [HOMEKIT_HEATING_COOLING_STATE.HEAT]: AC_MODE.HEATING,
   [HOMEKIT_HEATING_COOLING_STATE.COOL]: AC_MODE.COOLING,
   [HOMEKIT_HEATING_COOLING_STATE.AUTO]: AC_MODE.AUTO,
+};
+
+// Values of the HomeKit TargetHeaterCoolerState characteristic. They are not the Thermostat ones:
+// there is no off, the device is switched off through Active, and auto is 0 rather than 3.
+const HOMEKIT_HEATER_COOLER_STATE = {
+  AUTO: 0,
+  HEAT: 1,
+  COOL: 2,
+};
+
+// Values of the HomeKit CurrentHeaterCoolerState characteristic. Unlike CurrentHeatingCoolingState
+// it tells a device that is off from one that is on and doing nothing.
+const HOMEKIT_CURRENT_HEATER_COOLER_STATE = {
+  INACTIVE: 0,
+  IDLE: 1,
+  HEATING: 2,
+  COOLING: 3,
+};
+
+// AC_MODE.DRYING and AC_MODE.FAN have no HomeKit equivalent here either, they are reported as AUTO.
+const acModeToHeaterCoolerState = {
+  [AC_MODE.AUTO]: HOMEKIT_HEATER_COOLER_STATE.AUTO,
+  [AC_MODE.COOLING]: HOMEKIT_HEATER_COOLER_STATE.COOL,
+  [AC_MODE.HEATING]: HOMEKIT_HEATER_COOLER_STATE.HEAT,
+  [AC_MODE.DRYING]: HOMEKIT_HEATER_COOLER_STATE.AUTO,
+  [AC_MODE.FAN]: HOMEKIT_HEATER_COOLER_STATE.AUTO,
+};
+
+const heaterCoolerStateToAcMode = {
+  [HOMEKIT_HEATER_COOLER_STATE.AUTO]: AC_MODE.AUTO,
+  [HOMEKIT_HEATER_COOLER_STATE.HEAT]: AC_MODE.HEATING,
+  [HOMEKIT_HEATER_COOLER_STATE.COOL]: AC_MODE.COOLING,
 };
 
 // Unlike the air conditioning mode, the thermostat mode carries its own off value, so a device
@@ -568,6 +611,10 @@ module.exports = {
   HOMEKIT_HEATING_COOLING_STATE,
   acModeToHeatingCoolingState,
   heatingCoolingStateToAcMode,
+  HOMEKIT_HEATER_COOLER_STATE,
+  HOMEKIT_CURRENT_HEATER_COOLER_STATE,
+  acModeToHeaterCoolerState,
+  heaterCoolerStateToAcMode,
   thermostatModeToHeatingCoolingState,
   heatingCoolingStateToThermostatMode,
   thermostatOperatingStateToHeatingCoolingState,

--- a/server/services/homekit/lib/sendState.js
+++ b/server/services/homekit/lib/sendState.js
@@ -59,7 +59,7 @@ function refreshCharacteristic(hap, service, characteristicType) {
  * isHeaterCooler(hap, service);
  */
 function isHeaterCooler(hap, service) {
-  return service.UUID !== undefined && service.UUID === hap.Service.HeaterCooler.UUID;
+  return Boolean(service) && service.UUID !== undefined && service.UUID === hap.Service.HeaterCooler.UUID;
 }
 
 /**
@@ -100,7 +100,16 @@ function sendState(hkAccessory, feature, event) {
       );
     }
 
-    return hkAccessory.getService(serviceType);
+    // An air conditioning feature is built into a HeaterCooler on its own, but joins the Thermostat
+    // of a device that also carries thermostat features (a Matter heat pump). The type it maps to
+    // only names the first of the two, so the other is tried as well, like the merged temperature
+    // sensor does below.
+    const typedService = hkAccessory.getService(serviceType);
+    if (!typedService && feature.category === DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING) {
+      return hkAccessory.getService(Service.Thermostat);
+    }
+
+    return typedService;
   };
 
   switch (`${feature.category}:${feature.type}`) {

--- a/server/services/homekit/lib/sendState.js
+++ b/server/services/homekit/lib/sendState.js
@@ -49,6 +49,20 @@ function refreshCharacteristic(hap, service, characteristicType) {
 }
 
 /**
+ * @description Tell a HeaterCooler service from a Thermostat one. An air conditioning feature can
+ * land on either: on its own the device is a HeaterCooler, next to thermostat features it joins a
+ * Thermostat, and the two services do not carry the same characteristics.
+ * @param {object} hap - HAP library.
+ * @param {object} service - HomeKit service a feature was built into.
+ * @returns {boolean} True when the service is a HeaterCooler.
+ * @example
+ * isHeaterCooler(hap, service);
+ */
+function isHeaterCooler(hap, service) {
+  return service.UUID !== undefined && service.UUID === hap.Service.HeaterCooler.UUID;
+}
+
+/**
  * @description Forward new state value to HomeKit.
  * @param {object} hkAccessory - HomeKit accessories.
  * @param {object} feature - Updated Gladys feature.
@@ -171,8 +185,10 @@ function sendState(hkAccessory, feature, event) {
       } else if (feature.unit === DEVICE_FEATURE_UNITS.FAHRENHEIT) {
         currentTemp = fahrenheitToCelsius(currentTemp);
       }
-      // On a heating or cooling device the temperature sensor is merged into the Thermostat service.
-      const service = serviceFor() || hkAccessory.getService(Service.Thermostat);
+      // On a heating or cooling device the temperature sensor is merged into the Thermostat or the
+      // HeaterCooler service.
+      const service =
+        serviceFor() || hkAccessory.getService(Service.Thermostat) || hkAccessory.getService(Service.HeaterCooler);
       // Clamped like the GET path: HAP throws on a value outside the characteristic bounds, and a
       // sensor reporting an out-of-range reading must not take the bridge down.
       service.updateCharacteristic(
@@ -180,12 +196,38 @@ function sendState(hkAccessory, feature, event) {
         clampToCharacteristic(currentTemp, service.getCharacteristic(Characteristic.CurrentTemperature).props),
       );
       // In AUTO, whether the device is heating or cooling depends on the room temperature.
-      refreshCharacteristic(this.hap, service, Characteristic.CurrentHeatingCoolingState);
+      refreshCharacteristic(
+        this.hap,
+        service,
+        isHeaterCooler(this.hap, service)
+          ? Characteristic.CurrentHeaterCoolerState
+          : Characteristic.CurrentHeatingCoolingState,
+      );
       break;
     }
     case `${DEVICE_FEATURE_CATEGORIES.THERMOSTAT}:${DEVICE_FEATURE_TYPES.THERMOSTAT.TARGET_TEMPERATURE}`:
     case `${DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING}:${DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE}`: {
       const service = serviceFor();
+
+      if (isHeaterCooler(this.hap, service)) {
+        // The single setpoint of an air conditioner stands behind both thresholds.
+        const setpoint = toCelsius(event.last_value, feature.unit);
+
+        [Characteristic.CoolingThresholdTemperature, Characteristic.HeatingThresholdTemperature].forEach(
+          (thresholdCharacteristic) => {
+            if (service.testCharacteristic(thresholdCharacteristic)) {
+              service.updateCharacteristic(
+                thresholdCharacteristic,
+                clampToCharacteristic(setpoint, service.getCharacteristic(thresholdCharacteristic).props),
+              );
+            }
+          },
+        );
+        // In auto, heating or cooling is deduced from the setpoint.
+        refreshCharacteristic(this.hap, service, Characteristic.CurrentHeaterCoolerState);
+        break;
+      }
+
       const thresholdCharacteristic =
         feature.category === DEVICE_FEATURE_CATEGORIES.THERMOSTAT
           ? Characteristic.HeatingThresholdTemperature
@@ -209,6 +251,14 @@ function sendState(hkAccessory, feature, event) {
     case `${DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING}:${DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE}`:
     case `${DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING}:${DEVICE_FEATURE_TYPES.AIR_CONDITIONING.BINARY}`: {
       const service = serviceFor();
+
+      if (isHeaterCooler(this.hap, service)) {
+        refreshCharacteristic(this.hap, service, Characteristic.Active);
+        refreshCharacteristic(this.hap, service, Characteristic.TargetHeaterCoolerState);
+        refreshCharacteristic(this.hap, service, Characteristic.CurrentHeaterCoolerState);
+        break;
+      }
+
       refreshCharacteristic(this.hap, service, Characteristic.TargetHeatingCoolingState);
       refreshCharacteristic(this.hap, service, Characteristic.CurrentHeatingCoolingState);
       refreshCharacteristic(this.hap, service, Characteristic.TargetTemperature);

--- a/server/test/services/homekit/lib/buildAccessory.test.js
+++ b/server/test/services/homekit/lib/buildAccessory.test.js
@@ -309,6 +309,50 @@ describe('Build accessory', () => {
     expect(addService.callCount).to.equal(1);
   });
 
+  it('should build an air conditioner on its own as a heater cooler, with its temperature sensor', async () => {
+    homekitHandler.buildService = sinon.stub().returns('builded-service');
+    const addService = sinon.stub();
+    homekitHandler.hap = {
+      Accessory: sinon.stub().returns({ addService, services: ['service1', 'service2'] }),
+    };
+
+    const device = {
+      id: 'c22a4d4b-e261-4b22-a2be-309baf12c3ca',
+      name: 'Clim',
+      features: [
+        {
+          name: 'Température',
+          category: 'temperature-sensor',
+          type: 'decimal',
+        },
+        {
+          name: 'Marche',
+          category: 'air-conditioning',
+          type: 'binary',
+        },
+        {
+          name: 'Mode',
+          category: 'air-conditioning',
+          type: 'mode',
+        },
+        {
+          name: 'Consigne',
+          category: 'air-conditioning',
+          type: 'target-temperature',
+        },
+      ],
+    };
+
+    await homekitHandler.buildAccessory(device);
+
+    // without thermostat features the device is a HeaterCooler, so that switching it on from
+    // HomeKit is a power command and not a mode
+    expect(homekitHandler.buildService.callCount).to.equal(1);
+    expect(homekitHandler.buildService.args[0][1]).to.have.deep.members(device.features);
+    expect(homekitHandler.buildService.args[0][2].service).to.equal('HeaterCooler');
+    expect(addService.callCount).to.equal(1);
+  });
+
   it('should keep extra temperature sensors out of the thermostat service', async () => {
     homekitHandler.buildService = sinon.stub().returns('builded-service');
     const addService = sinon.stub();

--- a/server/test/services/homekit/lib/buildHeaterCoolerService.test.js
+++ b/server/test/services/homekit/lib/buildHeaterCoolerService.test.js
@@ -471,8 +471,109 @@ describe('Build heater cooler service', () => {
     expect(homekitHandler.gladys.event.emit.args[0][1].device_feature).to.equal(SETPOINT.selector);
   });
 
+  it('should not report a cooling-only air conditioner as heating, nor give it a heating slider', async () => {
+    // A device that cannot heat sitting below its setpoint is idle. Reporting it as heating would
+    // announce a capability HomeKit was told, through the valid target states, that it does not
+    // have — and the heating threshold behind it would be a slider the device cannot honour.
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-power').returns({ last_value: 1 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-mode').returns({ last_value: AC_MODE.AUTO });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-setpoint').returns({ last_value: 24 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-temp').returns({ last_value: 21 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildHeaterCoolerHapStub();
+    homekitHandler.hap = hap;
+
+    // a MELCloud air conditioner offering auto and cool, but no heat
+    const mode = { ...MODE, supported_options: [{ value: AC_MODE.AUTO }, { value: AC_MODE.COOLING }] };
+
+    await homekitHandler.buildService(
+      device,
+      [POWER, mode, SETPOINT, TEMPERATURE],
+      mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING],
+    );
+
+    expect(characteristics.TargetHeaterCoolerState.setProps.args[0][0]).to.eql({ validValues: [0, 2] });
+    expect(await readCharacteristic(characteristics.TargetHeaterCoolerState)).to.equal(0);
+    // colder than the setpoint, and unable to heat: idle, not heating
+    expect(await readCharacteristic(characteristics.CurrentHeaterCoolerState)).to.equal(1);
+    // warmer than the setpoint, and able to cool: cooling
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-temp').returns({ last_value: 27 });
+    expect(await readCharacteristic(characteristics.CurrentHeaterCoolerState)).to.equal(3);
+
+    // the one setpoint stands behind the cooling threshold alone
+    expect(characteristics.CoolingThresholdTemperature.setProps.args[0][0]).to.eql({ minValue: 16, maxValue: 31 });
+    expect(await readCharacteristic(characteristics.CoolingThresholdTemperature)).to.equal(24);
+    expect(characteristics.HeatingThresholdTemperature.handlers.get).to.equal(undefined);
+    expect(characteristics.HeatingThresholdTemperature.setProps.callCount).to.equal(0);
+  });
+
+  it('should not report a heating-only air conditioner as cooling, nor give it a cooling slider', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-power').returns({ last_value: 1 });
+    // a mode value the AC_MODE mapping does not know about, which reads as auto
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-mode').returns({ last_value: 99 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-setpoint').returns({ last_value: 20 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-temp').returns({ last_value: 24 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildHeaterCoolerHapStub();
+    homekitHandler.hap = hap;
+
+    const mode = { ...MODE, supported_options: [{ value: AC_MODE.HEATING }] };
+
+    await homekitHandler.buildService(
+      device,
+      [POWER, mode, SETPOINT, TEMPERATURE],
+      mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING],
+    );
+
+    expect(characteristics.TargetHeaterCoolerState.setProps.args[0][0]).to.eql({ validValues: [1] });
+    // warmer than the setpoint, and unable to cool: idle, not cooling
+    expect(await readCharacteristic(characteristics.CurrentHeaterCoolerState)).to.equal(1);
+
+    expect(await readCharacteristic(characteristics.HeatingThresholdTemperature)).to.equal(20);
+    expect(characteristics.CoolingThresholdTemperature.handlers.get).to.equal(undefined);
+    expect(characteristics.CoolingThresholdTemperature.setProps.callCount).to.equal(0);
+  });
+
+  it('should still expose the setpoint of a device declaring neither heat nor cool', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-power').returns({ last_value: 1 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-mode').returns({ last_value: AC_MODE.AUTO });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-setpoint').returns({ last_value: 22 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildHeaterCoolerHapStub();
+    homekitHandler.hap = hap;
+
+    // auto, dry and fan only: nothing maps to heat or cool, and the setpoint must stay reachable
+    const mode = {
+      ...MODE,
+      supported_options: [{ value: AC_MODE.AUTO }, { value: AC_MODE.DRYING }, { value: AC_MODE.FAN }],
+    };
+
+    await homekitHandler.buildService(
+      device,
+      [POWER, mode, SETPOINT],
+      mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING],
+    );
+
+    expect(characteristics.TargetHeaterCoolerState.setProps.args[0][0]).to.eql({ validValues: [0] });
+    // an air conditioning setpoint is a cooling one
+    expect(await readCharacteristic(characteristics.CoolingThresholdTemperature)).to.equal(22);
+    expect(characteristics.HeatingThresholdTemperature.handlers.get).to.equal(undefined);
+
+    const cb = stub();
+    await characteristics.CoolingThresholdTemperature.handlers.set(23, cb);
+    expect(homekitHandler.gladys.event.emit.args[0][1].device_feature).to.equal(SETPOINT.selector);
+    expect(homekitHandler.gladys.event.emit.args[0][1].value).to.equal(23);
+  });
+
   it('should clamp the readings to the bounds the thresholds were given', async () => {
     homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-mode').returns({ last_value: AC_MODE.AUTO });
     homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-setpoint').returns({ last_value: 28 });
     homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-temp').returns({ last_value: 150 });
     homekitHandler.gladys.event.emit = stub();
@@ -480,10 +581,11 @@ describe('Build heater cooler service', () => {
     const { hap, characteristics } = buildHeaterCoolerHapStub();
     homekitHandler.hap = hap;
 
-    // Matter declares -100..200 on its setpoint
+    // Matter declares -100..200 on its setpoint. The device declares heat, so it gets the heating
+    // threshold, whose HAP default range is the one that has to be widened.
     await homekitHandler.buildService(
       device,
-      [{ ...SETPOINT, min: -100, max: 200 }, TEMPERATURE],
+      [MODE, { ...SETPOINT, min: -100, max: 200 }, TEMPERATURE],
       mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING],
     );
 
@@ -507,6 +609,10 @@ describe('Build heater cooler service', () => {
     expect(characteristics.TargetHeaterCoolerState.setProps.args[0][0]).to.eql({ validValues: [2] });
     expect(await readCharacteristic(characteristics.TargetHeaterCoolerState)).to.equal(2);
     expect(await readCharacteristic(characteristics.CurrentHeaterCoolerState)).to.equal(3);
+    // the setpoint is a cooling one, and the device never declared it could heat: no heating slider
+    expect(await readCharacteristic(characteristics.CoolingThresholdTemperature)).to.equal(24);
+    expect(characteristics.HeatingThresholdTemperature.handlers.get).to.equal(undefined);
+    expect(characteristics.HeatingThresholdTemperature.setProps.callCount).to.equal(0);
     // no on/off command: the device is always on, and HomeKit is told it cannot be switched off
     expect(characteristics.Active.setProps.args[0][0]).to.eql({ validValues: [1] });
     expect(await readCharacteristic(characteristics.Active)).to.equal(1);
@@ -553,6 +659,10 @@ describe('Build heater cooler service', () => {
     expect(await readCharacteristic(characteristics.TargetHeaterCoolerState)).to.equal(0);
     expect(await readCharacteristic(characteristics.Active)).to.equal(0);
     expect(await readCharacteristic(characteristics.CurrentHeaterCoolerState)).to.equal(0);
+
+    // switched on, it declared neither heat nor cool: it runs, and it says nothing more than that
+    homekitHandler.gladys.stateManager.get = stub().returns({ last_value: 1 });
+    expect(await readCharacteristic(characteristics.CurrentHeaterCoolerState)).to.equal(1);
 
     const cb = stub();
     await characteristics.Active.handlers.set(1, cb);

--- a/server/test/services/homekit/lib/buildHeaterCoolerService.test.js
+++ b/server/test/services/homekit/lib/buildHeaterCoolerService.test.js
@@ -400,6 +400,8 @@ describe('Build heater cooler service', () => {
     await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
 
     expect(characteristics.TargetHeaterCoolerState.setProps.callCount).to.equal(0);
+    // with no contract set on the characteristic, the unknown mode is reported as auto as it is
+    expect(await readCharacteristic(characteristics.TargetHeaterCoolerState)).to.equal(0);
   });
 
   it('should report idle in the dry and fan modes, and auto as their target', async () => {
@@ -530,7 +532,11 @@ describe('Build heater cooler service', () => {
     );
 
     expect(characteristics.TargetHeaterCoolerState.setProps.args[0][0]).to.eql({ validValues: [1] });
-    // warmer than the setpoint, and unable to cool: idle, not cooling
+    // the unknown mode reads as auto, which this device does not have: HomeKit is told the only
+    // state it was given, not one outside the valid values it was just handed
+    expect(await readCharacteristic(characteristics.TargetHeaterCoolerState)).to.equal(1);
+    // warmer than the setpoint, and unable to cool: idle, not cooling — the current state follows
+    // the mode the device reports, not the state the target one falls back on
     expect(await readCharacteristic(characteristics.CurrentHeaterCoolerState)).to.equal(1);
 
     expect(await readCharacteristic(characteristics.HeatingThresholdTemperature)).to.equal(20);

--- a/server/test/services/homekit/lib/buildHeaterCoolerService.test.js
+++ b/server/test/services/homekit/lib/buildHeaterCoolerService.test.js
@@ -1,0 +1,563 @@
+const { expect } = require('chai');
+const sinon = require('sinon').createSandbox();
+
+const { stub } = sinon;
+const { buildService } = require('../../../../services/homekit/lib/buildService');
+const { mappings } = require('../../../../services/homekit/lib/deviceMappings');
+const {
+  buildValidHeaterCoolerStates,
+  buildThresholdProps,
+} = require('../../../../services/homekit/lib/buildHeaterCoolerService');
+const {
+  DEVICE_FEATURE_CATEGORIES,
+  DEVICE_FEATURE_TYPES,
+  ACTIONS,
+  ACTIONS_STATUS,
+  DEVICE_FEATURE_UNITS,
+  AC_MODE,
+  EVENTS,
+} = require('../../../../utils/constants');
+
+// What HAP gives the characteristics before the service sets its own props.
+const HEATER_COOLER_CHARACTERISTIC_PROPS = {
+  Active: { validValues: [0, 1] },
+  TargetHeaterCoolerState: { validValues: [0, 1, 2] },
+  CurrentTemperature: { minValue: -270, maxValue: 100 },
+  HeatingThresholdTemperature: { minValue: 0, maxValue: 25 },
+  CoolingThresholdTemperature: { minValue: 10, maxValue: 35 },
+};
+
+/**
+ * @description Build a HomeKit stub exposing a HeaterCooler service. Each characteristic records
+ * its GET/SET handlers so tests can trigger them directly, and setProps changes its props the way
+ * HAP does, since the reads are clamped to them.
+ * @returns {object} An object holding the fake hap library and the stubbed characteristics.
+ * @example
+ * const { hap, characteristics } = buildHeaterCoolerHapStub();
+ */
+function buildHeaterCoolerHapStub() {
+  const names = [
+    'Active',
+    'CurrentHeaterCoolerState',
+    'TargetHeaterCoolerState',
+    'CurrentTemperature',
+    'HeatingThresholdTemperature',
+    'CoolingThresholdTemperature',
+  ];
+
+  const Characteristic = { TemperatureDisplayUnits: { name: 'TemperatureDisplayUnits', CELSIUS: 0 } };
+  const characteristics = {
+    TemperatureDisplayUnits: { handlers: {}, props: {}, setProps: stub() },
+  };
+
+  names.forEach((name) => {
+    Characteristic[name] = { name };
+    const characteristic = {
+      handlers: {},
+      props: { ...(HEATER_COOLER_CHARACTERISTIC_PROPS[name] || {}) },
+    };
+    characteristic.setProps = stub().callsFake((props) => Object.assign(characteristic.props, props));
+    characteristics[name] = characteristic;
+  });
+
+  Object.values(characteristics).forEach((characteristic) => {
+    characteristic.on = (event, handler) => {
+      characteristic.handlers[event] = handler;
+      return characteristic;
+    };
+  });
+
+  const HeaterCooler = stub().returns({
+    getCharacteristic: (type) => characteristics[type.name],
+    updateCharacteristic: stub(),
+  });
+
+  return {
+    characteristics,
+    hap: {
+      Characteristic,
+      CharacteristicEventTypes: { GET: 'get', SET: 'set' },
+      Perms: { PAIRED_READ: 'PAIRED_READ', PAIRED_WRITE: 'PAIRED_WRITE' },
+      Service: { HeaterCooler },
+    },
+  };
+}
+
+/**
+ * @description Call the GET handler of a stubbed characteristic and return the value it reports.
+ * @param {object} characteristic - Stubbed characteristic holding the handlers.
+ * @returns {Promise} The value passed to the HomeKit callback.
+ * @example
+ * const value = await readCharacteristic(characteristics.Active);
+ */
+async function readCharacteristic(characteristic) {
+  let read;
+  await characteristic.handlers.get((error, value) => {
+    read = value;
+  });
+  return read;
+}
+
+const POWER = {
+  name: 'Marche',
+  selector: 'clim-power',
+  category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+  type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.BINARY,
+  min: 0,
+  max: 1,
+};
+const MODE = {
+  name: 'Mode',
+  selector: 'clim-mode',
+  category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+  type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
+  min: AC_MODE.AUTO,
+  max: AC_MODE.FAN,
+};
+const SETPOINT = {
+  name: 'Consigne',
+  selector: 'clim-setpoint',
+  category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+  type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE,
+  unit: DEVICE_FEATURE_UNITS.CELSIUS,
+  min: 16,
+  max: 31,
+};
+const TEMPERATURE = {
+  name: 'Température',
+  selector: 'clim-temp',
+  category: DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
+  type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+  unit: DEVICE_FEATURE_UNITS.CELSIUS,
+};
+
+describe('Heater cooler valid target states', () => {
+  it('should derive the states from the AC modes the device declares, without any off', () => {
+    // a heat pump declaring auto, cooling and heating: off is not a state, Active carries it
+    expect(buildValidHeaterCoolerStates({ modeFeature: { min: AC_MODE.AUTO, max: AC_MODE.HEATING } })).to.eql([
+      0,
+      1,
+      2,
+    ]);
+    // a cooling only air conditioner: auto and cooling
+    expect(buildValidHeaterCoolerStates({ modeFeature: { min: AC_MODE.AUTO, max: AC_MODE.COOLING } })).to.eql([0, 2]);
+  });
+
+  it('should follow supported_options rather than the min/max range', () => {
+    // a Matter cooling-only air conditioner: cool, dry and fan, so auto stays for dry and fan but
+    // heat, which sits inside the 1..4 range, is not offered
+    const coolingOnly = {
+      min: 1,
+      max: 4,
+      supported_options: [{ value: AC_MODE.COOLING }, { value: AC_MODE.DRYING }, { value: AC_MODE.FAN }],
+    };
+    expect(buildValidHeaterCoolerStates({ modeFeature: coolingOnly })).to.eql([0, 2]);
+  });
+
+  it('should fall back on the min/max range when the options list is empty', () => {
+    expect(
+      buildValidHeaterCoolerStates({
+        modeFeature: { min: AC_MODE.AUTO, max: AC_MODE.COOLING, supported_options: [] },
+      }),
+    ).to.eql([0, 2]);
+  });
+
+  it('should return no state at all when the device declares only unknown modes', () => {
+    expect(buildValidHeaterCoolerStates({ modeFeature: { supported_options: [{ value: 99 }] } })).to.eql([]);
+  });
+
+  it('should only offer cool on a device with a setpoint and no mode', () => {
+    expect(buildValidHeaterCoolerStates({ setpointFeature: SETPOINT })).to.eql([2]);
+  });
+
+  it('should only offer auto on a device with nothing but an on/off command', () => {
+    expect(buildValidHeaterCoolerStates({})).to.eql([0]);
+  });
+});
+
+describe('Heater cooler threshold bounds', () => {
+  it('should give both thresholds the range the setpoint declares', () => {
+    expect(buildThresholdProps({ min: 16, max: 31 })).to.eql({ minValue: 16, maxValue: 31 });
+    // 60.8 °F to 87.8 °F
+    expect(buildThresholdProps({ min: 60.8, max: 87.8, unit: DEVICE_FEATURE_UNITS.FAHRENHEIT })).to.eql({
+      minValue: 16,
+      maxValue: 31,
+    });
+  });
+
+  it('should keep the range inside what a setpoint can be', () => {
+    // Matter declares -100..200 on its setpoints
+    expect(buildThresholdProps({ min: -100, max: 200 })).to.eql({ minValue: 10, maxValue: 38 });
+    expect(buildThresholdProps({ min: 5, max: 30 })).to.eql({ minValue: 10, maxValue: 30 });
+  });
+
+  it('should fall back on the default range when the setpoint declares none, or an empty one', () => {
+    expect(buildThresholdProps({})).to.eql({ minValue: 10, maxValue: 38 });
+    expect(buildThresholdProps({ min: 20 })).to.eql({ minValue: 20, maxValue: 38 });
+    expect(buildThresholdProps({ min: 25, max: 25 })).to.eql({ minValue: 10, maxValue: 38 });
+    expect(buildThresholdProps({ min: 200, max: 300 })).to.eql({ minValue: 10, maxValue: 38 });
+  });
+});
+
+describe('Build heater cooler service', () => {
+  const homekitHandler = {
+    serviceId: '7056e3d4-31cc-4d2a-bbdd-128cd49755e6',
+    buildService,
+    gladys: {
+      event: {},
+      stateManager: {},
+    },
+  };
+  const device = { name: 'Clim', selector: 'clim' };
+
+  afterEach(() => {
+    sinon.reset();
+  });
+
+  it('should build a heater cooler for an air conditioner', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-power').returns({ last_value: 1 });
+    homekitHandler.gladys.stateManager.get
+      .withArgs('deviceFeature', 'clim-mode')
+      .returns({ last_value: AC_MODE.COOLING });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-setpoint').returns({ last_value: 24 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildHeaterCoolerHapStub();
+    homekitHandler.hap = hap;
+
+    const features = [POWER, MODE, SETPOINT];
+
+    const service = await homekitHandler.buildService(
+      device,
+      features,
+      mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING],
+    );
+
+    expect(hap.Service.HeaterCooler.args[0][0]).to.equal('Clim');
+    expect(service).to.equal(hap.Service.HeaterCooler.returnValues[0]);
+
+    // every mode, and no off: the device is switched off through Active
+    expect(characteristics.TargetHeaterCoolerState.setProps.args[0][0]).to.eql({ validValues: [0, 1, 2] });
+    expect(characteristics.Active.setProps.callCount).to.equal(0);
+    expect(await readCharacteristic(characteristics.Active)).to.equal(1);
+    expect(await readCharacteristic(characteristics.TargetHeaterCoolerState)).to.equal(2);
+    expect(await readCharacteristic(characteristics.CurrentHeaterCoolerState)).to.equal(3);
+    expect(await readCharacteristic(characteristics.TemperatureDisplayUnits)).to.equal(0);
+    // no temperature sensor on the device, the setpoint is the closest reading available
+    expect(await readCharacteristic(characteristics.CurrentTemperature)).to.equal(24);
+    // the single setpoint stands behind both thresholds, with the range the device declares
+    expect(characteristics.CoolingThresholdTemperature.setProps.args[0][0]).to.eql({ minValue: 16, maxValue: 31 });
+    expect(characteristics.HeatingThresholdTemperature.setProps.args[0][0]).to.eql({ minValue: 16, maxValue: 31 });
+    expect(await readCharacteristic(characteristics.CoolingThresholdTemperature)).to.equal(24);
+    expect(await readCharacteristic(characteristics.HeatingThresholdTemperature)).to.equal(24);
+
+    const cb = stub();
+    await characteristics.HeatingThresholdTemperature.handlers.set(22.5, cb);
+    expect(homekitHandler.gladys.event.emit.args[0][1]).to.eql({
+      type: ACTIONS.DEVICE.SET_VALUE,
+      status: ACTIONS_STATUS.PENDING,
+      value: 22.5,
+      device: device.selector,
+      device_feature: SETPOINT.selector,
+    });
+    await characteristics.CoolingThresholdTemperature.handlers.set(26, cb);
+    expect(homekitHandler.gladys.event.emit.args[1][1].value).to.equal(26);
+    expect(homekitHandler.gladys.event.emit.args[1][1].device_feature).to.equal(SETPOINT.selector);
+
+    // a mode change writes the mode alone, HomeKit writes Active itself when it means both
+    homekitHandler.gladys.event.emit = stub();
+    await characteristics.TargetHeaterCoolerState.handlers.set(1, cb);
+    expect(homekitHandler.gladys.event.emit.args).to.eql([
+      [
+        EVENTS.ACTION.TRIGGERED,
+        {
+          type: ACTIONS.DEVICE.SET_VALUE,
+          status: ACTIONS_STATUS.PENDING,
+          value: AC_MODE.HEATING,
+          device: device.selector,
+          device_feature: MODE.selector,
+        },
+      ],
+    ]);
+
+    homekitHandler.gladys.stateManager.get
+      .withArgs('deviceFeature', 'clim-mode')
+      .returns({ last_value: AC_MODE.HEATING });
+    expect(await readCharacteristic(characteristics.TargetHeaterCoolerState)).to.equal(1);
+    expect(await readCharacteristic(characteristics.CurrentHeaterCoolerState)).to.equal(2);
+
+    // switching off only writes the binary feature, Gladys has no "off" AC mode
+    homekitHandler.gladys.event.emit = stub();
+    await characteristics.Active.handlers.set(0, cb);
+    expect(homekitHandler.gladys.event.emit.args.map(([, action]) => [action.device_feature, action.value])).to.eql([
+      ['clim-power', 0],
+    ]);
+
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-power').returns({ last_value: 0 });
+    expect(await readCharacteristic(characteristics.Active)).to.equal(0);
+    expect(await readCharacteristic(characteristics.CurrentHeaterCoolerState)).to.equal(0);
+    // the mode is still reported while off, so the Home app shows which one it will run in
+    expect(await readCharacteristic(characteristics.TargetHeaterCoolerState)).to.equal(1);
+  });
+
+  it('should turn the device on in the mode it was in, not in auto', async () => {
+    // "Hey Siri, turn on the air conditioning" on a Thermostat used to pick the auto mode, and an
+    // air conditioner in auto decides for itself — it heated a home in summer. On a HeaterCooler
+    // the same request is a write on Active, and nothing else.
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-power').returns({ last_value: 0 });
+    homekitHandler.gladys.stateManager.get
+      .withArgs('deviceFeature', 'clim-mode')
+      .returns({ last_value: AC_MODE.COOLING });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-setpoint').returns({ last_value: 24 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildHeaterCoolerHapStub();
+    homekitHandler.hap = hap;
+
+    await homekitHandler.buildService(
+      device,
+      [POWER, MODE, SETPOINT],
+      mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING],
+    );
+
+    const cb = stub();
+    await characteristics.Active.handlers.set(1, cb);
+
+    expect(homekitHandler.gladys.event.emit.args.map(([, action]) => [action.device_feature, action.value])).to.eql([
+      ['clim-power', 1],
+    ]);
+  });
+
+  it('should not write an auto mode the air conditioner never declared', async () => {
+    homekitHandler.gladys.stateManager.get = stub().returns({ last_value: AC_MODE.COOLING });
+    homekitHandler.gladys.event.emit = stub();
+    const { hap, characteristics } = buildHeaterCoolerHapStub();
+    homekitHandler.hap = hap;
+
+    // a Matter cooling-only air conditioner: cool, dry and fan, no auto
+    const features = [
+      POWER,
+      {
+        ...MODE,
+        supported_options: [{ value: AC_MODE.COOLING }, { value: AC_MODE.DRYING }, { value: AC_MODE.FAN }],
+      },
+    ];
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
+
+    // dry and fan are reported to HomeKit as auto, so auto stays selectable
+    expect(characteristics.TargetHeaterCoolerState.setProps.args[0][0]).to.eql({ validValues: [0, 2] });
+
+    const cb = stub();
+    await characteristics.TargetHeaterCoolerState.handlers.set(0, cb);
+
+    // the mode is left alone rather than written to an auto it never declared and could not honour
+    expect(homekitHandler.gladys.event.emit.callCount).to.equal(0);
+
+    // a mode it does declare is written
+    await characteristics.TargetHeaterCoolerState.handlers.set(2, cb);
+
+    expect(homekitHandler.gladys.event.emit.args[0][1].device_feature).to.equal('clim-mode');
+    expect(homekitHandler.gladys.event.emit.args[0][1].value).to.equal(AC_MODE.COOLING);
+  });
+
+  it('should still offer the modes when the device declares an empty options list', async () => {
+    homekitHandler.gladys.stateManager.get = stub().returns({ last_value: 1 });
+    homekitHandler.gladys.event.emit = stub();
+    const { hap, characteristics } = buildHeaterCoolerHapStub();
+    homekitHandler.hap = hap;
+
+    // loaded from the database, a feature with no declared option carries an empty list, not a
+    // missing one: the modes must still be deduced from the min/max range
+    const features = [
+      { ...POWER, supported_options: [] },
+      { ...MODE, max: AC_MODE.COOLING, supported_options: [] },
+      { ...SETPOINT, supported_options: [] },
+    ];
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
+
+    expect(characteristics.TargetHeaterCoolerState.setProps.args[0][0]).to.eql({ validValues: [0, 2] });
+
+    const cb = stub();
+    await characteristics.TargetHeaterCoolerState.handlers.set(2, cb);
+    expect(homekitHandler.gladys.event.emit.args[0][1].device_feature).to.equal('clim-mode');
+    expect(homekitHandler.gladys.event.emit.args[0][1].value).to.equal(AC_MODE.COOLING);
+  });
+
+  it('should leave the target state unconstrained when no mode maps to HomeKit', async () => {
+    homekitHandler.gladys.stateManager.get = stub().returns({ last_value: 0 });
+    homekitHandler.gladys.event.emit = stub();
+    const { hap, characteristics } = buildHeaterCoolerHapStub();
+    homekitHandler.hap = hap;
+
+    // an integration declaring only modes HomeKit has no equivalent for would produce an empty
+    // validValues list, which HAP rejects: setProps must be skipped rather than called with []
+    const features = [{ ...MODE, supported_options: [{ value: 99 }] }];
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
+
+    expect(characteristics.TargetHeaterCoolerState.setProps.callCount).to.equal(0);
+  });
+
+  it('should report idle in the dry and fan modes, and auto as their target', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-power').returns({ last_value: 1 });
+    homekitHandler.gladys.stateManager.get
+      .withArgs('deviceFeature', 'clim-mode')
+      .returns({ last_value: AC_MODE.DRYING });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-setpoint').returns({ last_value: 24 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-temp').returns({ last_value: 28 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildHeaterCoolerHapStub();
+    homekitHandler.hap = hap;
+
+    await homekitHandler.buildService(
+      device,
+      [POWER, MODE, SETPOINT, TEMPERATURE],
+      mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING],
+    );
+
+    expect(await readCharacteristic(characteristics.TargetHeaterCoolerState)).to.equal(0);
+    // the room is warmer than the setpoint, but a device drying is not cooling
+    expect(await readCharacteristic(characteristics.CurrentHeaterCoolerState)).to.equal(1);
+
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-mode').returns({ last_value: AC_MODE.FAN });
+    expect(await readCharacteristic(characteristics.TargetHeaterCoolerState)).to.equal(0);
+    expect(await readCharacteristic(characteristics.CurrentHeaterCoolerState)).to.equal(1);
+  });
+
+  it('should deduce heating or cooling from the room temperature in auto', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-mode').returns({ last_value: AC_MODE.AUTO });
+    // 75.2 °F is 24 °C
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-setpoint').returns({ last_value: 75.2 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-temp').returns({ last_value: 21 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildHeaterCoolerHapStub();
+    homekitHandler.hap = hap;
+
+    const setpoint = { ...SETPOINT, unit: DEVICE_FEATURE_UNITS.FAHRENHEIT, min: 60.8, max: 87.8 };
+
+    await homekitHandler.buildService(
+      device,
+      [MODE, setpoint, TEMPERATURE],
+      mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING],
+    );
+
+    // the room temperature comes from the sensor, in Celsius, not from the setpoint
+    expect(await readCharacteristic(characteristics.CurrentTemperature)).to.equal(21);
+    expect(await readCharacteristic(characteristics.CoolingThresholdTemperature)).to.be.closeTo(24, 0.001);
+    expect(characteristics.CoolingThresholdTemperature.setProps.args[0][0].minValue).to.be.closeTo(16, 0.001);
+    expect(characteristics.CoolingThresholdTemperature.setProps.args[0][0].maxValue).to.be.closeTo(31, 0.001);
+    expect(await readCharacteristic(characteristics.TargetHeaterCoolerState)).to.equal(0);
+    // colder than the setpoint: heating
+    expect(await readCharacteristic(characteristics.CurrentHeaterCoolerState)).to.equal(2);
+
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-temp').returns({ last_value: 27 });
+    expect(await readCharacteristic(characteristics.CurrentHeaterCoolerState)).to.equal(3);
+
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-temp').returns({ last_value: 24 });
+    expect(await readCharacteristic(characteristics.CurrentHeaterCoolerState)).to.equal(1);
+
+    // a write goes back to the feature in its own unit
+    const cb = stub();
+    await characteristics.CoolingThresholdTemperature.handlers.set(25, cb);
+    expect(homekitHandler.gladys.event.emit.args[0][1].value).to.equal(77);
+    expect(homekitHandler.gladys.event.emit.args[0][1].device_feature).to.equal(SETPOINT.selector);
+  });
+
+  it('should clamp the readings to the bounds the thresholds were given', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-setpoint').returns({ last_value: 28 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-temp').returns({ last_value: 150 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildHeaterCoolerHapStub();
+    homekitHandler.hap = hap;
+
+    // Matter declares -100..200 on its setpoint
+    await homekitHandler.buildService(
+      device,
+      [{ ...SETPOINT, min: -100, max: 200 }, TEMPERATURE],
+      mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING],
+    );
+
+    expect(characteristics.HeatingThresholdTemperature.setProps.args[0][0]).to.eql({ minValue: 10, maxValue: 38 });
+    // 28 °C sits above the 25 °C HAP gives a heating threshold by default, and is reported as is
+    expect(await readCharacteristic(characteristics.HeatingThresholdTemperature)).to.equal(28);
+    // a sensor reporting out of range must not take the bridge down
+    expect(await readCharacteristic(characteristics.CurrentTemperature)).to.equal(100);
+  });
+
+  it('should only offer cool on a device with a setpoint and no mode', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-setpoint').returns({ last_value: 24 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildHeaterCoolerHapStub();
+    homekitHandler.hap = hap;
+
+    await homekitHandler.buildService(device, [SETPOINT], mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
+
+    expect(characteristics.TargetHeaterCoolerState.setProps.args[0][0]).to.eql({ validValues: [2] });
+    expect(await readCharacteristic(characteristics.TargetHeaterCoolerState)).to.equal(2);
+    expect(await readCharacteristic(characteristics.CurrentHeaterCoolerState)).to.equal(3);
+    // no on/off command: the device is always on, and HomeKit is told it cannot be switched off
+    expect(characteristics.Active.setProps.args[0][0]).to.eql({ validValues: [1] });
+    expect(await readCharacteristic(characteristics.Active)).to.equal(1);
+
+    const cb = stub();
+    await characteristics.Active.handlers.set(0, cb);
+    await characteristics.TargetHeaterCoolerState.handlers.set(2, cb);
+    // nothing to write either way
+    expect(homekitHandler.gladys.event.emit.callCount).to.equal(0);
+  });
+
+  it('should build a heater cooler without any temperature feature', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-power').returns({ last_value: 1 });
+    // a mode value the AC_MODE mapping does not know about
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-mode').returns({ last_value: 99 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildHeaterCoolerHapStub();
+    homekitHandler.hap = hap;
+
+    await homekitHandler.buildService(device, [POWER, MODE], mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
+
+    // nothing carries a temperature: CurrentTemperature and the thresholds are left unbound
+    expect(characteristics.CurrentTemperature.handlers.get).to.equal(undefined);
+    expect(characteristics.CoolingThresholdTemperature.handlers.get).to.equal(undefined);
+    expect(characteristics.HeatingThresholdTemperature.handlers.get).to.equal(undefined);
+    // an unknown AC mode falls back to auto
+    expect(await readCharacteristic(characteristics.TargetHeaterCoolerState)).to.equal(0);
+    // in auto without any temperature to compare, an air conditioner is assumed to be cooling
+    expect(await readCharacteristic(characteristics.CurrentHeaterCoolerState)).to.equal(3);
+  });
+
+  it('should only offer auto on a device with nothing but an on/off command', async () => {
+    homekitHandler.gladys.stateManager.get = stub().returns({ last_value: 0 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildHeaterCoolerHapStub();
+    homekitHandler.hap = hap;
+
+    await homekitHandler.buildService(device, [POWER], mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
+
+    expect(characteristics.TargetHeaterCoolerState.setProps.args[0][0]).to.eql({ validValues: [0] });
+    expect(await readCharacteristic(characteristics.TargetHeaterCoolerState)).to.equal(0);
+    expect(await readCharacteristic(characteristics.Active)).to.equal(0);
+    expect(await readCharacteristic(characteristics.CurrentHeaterCoolerState)).to.equal(0);
+
+    const cb = stub();
+    await characteristics.Active.handlers.set(1, cb);
+    expect(homekitHandler.gladys.event.emit.args.map(([, action]) => [action.device_feature, action.value])).to.eql([
+      ['clim-power', 1],
+    ]);
+  });
+});

--- a/server/test/services/homekit/lib/buildService.test.js
+++ b/server/test/services/homekit/lib/buildService.test.js
@@ -2137,21 +2137,24 @@ describe('Build service', () => {
     const { hap, characteristics } = buildThermostatHapStub();
     homekitHandler.hap = hap;
 
-    // an air conditioner exposing only an on/off command has nothing to back TargetTemperature,
-    // and binding a handler there would throw on the first HomeKit poll
+    // a thermostat exposing only a mode has nothing to back TargetTemperature, and binding a
+    // handler there would throw on the first HomeKit poll
     const features = [
       {
-        name: 'Marche',
-        selector: 'clim-power',
-        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
-        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.BINARY,
+        name: 'Mode',
+        selector: 'chauffage-mode',
+        category: DEVICE_FEATURE_CATEGORIES.THERMOSTAT,
+        type: DEVICE_FEATURE_TYPES.THERMOSTAT.MODE,
+        supported_options: [{ value: THERMOSTAT_MODE.OFF }, { value: THERMOSTAT_MODE.HEATING }],
       },
     ];
 
-    await homekitHandler.buildService({ name: 'Clim' }, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
+    await homekitHandler.buildService({ name: 'Chauffage' }, features, mappings[DEVICE_FEATURE_CATEGORIES.THERMOSTAT]);
 
     expect(characteristics.TargetTemperature.handlers.get).to.equal(undefined);
     expect(characteristics.TargetTemperature.handlers.set).to.equal(undefined);
+    // nothing carries a temperature either, CurrentTemperature is left unbound
+    expect(characteristics.CurrentTemperature.handlers.get).to.equal(undefined);
     // the states it can honour are still offered
     expect(characteristics.TargetHeatingCoolingState.handlers.get).to.be.a('function');
   });
@@ -2167,14 +2170,14 @@ describe('Build service', () => {
     const features = [
       {
         name: 'Mode',
-        selector: 'clim-mode-inconnu',
-        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
-        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
+        selector: 'chauffage-mode-inconnu',
+        category: DEVICE_FEATURE_CATEGORIES.THERMOSTAT,
+        type: DEVICE_FEATURE_TYPES.THERMOSTAT.MODE,
         supported_options: [{ value: 99 }],
       },
     ];
 
-    await homekitHandler.buildService({ name: 'Clim' }, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
+    await homekitHandler.buildService({ name: 'Chauffage' }, features, mappings[DEVICE_FEATURE_CATEGORIES.THERMOSTAT]);
 
     expect(characteristics.TargetHeatingCoolingState.setProps.callCount).to.equal(0);
   });
@@ -2223,13 +2226,14 @@ describe('Build service', () => {
     expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(2);
   });
 
-  it('should not write an auto mode the air conditioner never declared', async () => {
+  it('should not write an auto mode the air conditioning mode of a thermostat never declared', async () => {
     homekitHandler.gladys.stateManager.get = stub().returns({ last_value: AC_MODE.COOLING });
     homekitHandler.gladys.event.emit = stub();
     const { hap, characteristics } = buildThermostatHapStub();
     homekitHandler.hap = hap;
 
-    // a Matter cooling-only air conditioner: cool, dry and fan, no auto
+    // an air conditioning mode declaring cool, dry and fan, no auto, next to a thermostat setpoint
+    // that keeps the device a Thermostat rather than a HeaterCooler
     const features = [
       {
         name: 'Marche',
@@ -2244,9 +2248,16 @@ describe('Build service', () => {
         type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
         supported_options: [{ value: AC_MODE.COOLING }, { value: AC_MODE.DRYING }, { value: AC_MODE.FAN }],
       },
+      {
+        name: 'Consigne',
+        selector: 'clim-heat',
+        category: DEVICE_FEATURE_CATEGORIES.THERMOSTAT,
+        type: DEVICE_FEATURE_TYPES.THERMOSTAT.TARGET_TEMPERATURE,
+        unit: DEVICE_FEATURE_UNITS.CELSIUS,
+      },
     ];
 
-    await homekitHandler.buildService({ name: 'Clim' }, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
+    await homekitHandler.buildService({ name: 'Clim' }, features, mappings[DEVICE_FEATURE_CATEGORIES.THERMOSTAT]);
 
     // dry and fan are reported to HomeKit as auto, so auto stays selectable
     expect(characteristics.TargetHeatingCoolingState.setProps.args[0][0]).to.eql({ validValues: [0, 2, 3] });
@@ -2266,69 +2277,147 @@ describe('Build service', () => {
     expect(homekitHandler.gladys.event.emit.args[2][1].value).to.equal(AC_MODE.COOLING);
   });
 
-  it('should still offer the on states when the device declares an empty options list', async () => {
+  it('should report auto on an air conditioning mode value Gladys does not know', async () => {
     homekitHandler.gladys.stateManager.get = stub();
-    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-power').returns({ last_value: 0 });
-    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-mode').returns({ last_value: AC_MODE.AUTO });
-    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-temp').returns({ last_value: 21 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pac-power').returns({ last_value: 1 });
+    // a mode value the AC_MODE mapping does not know about
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pac-mode').returns({ last_value: 99 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pac-heat').returns({ last_value: 20 });
     homekitHandler.gladys.event.emit = stub();
 
     const { hap, characteristics } = buildThermostatHapStub();
     homekitHandler.hap = hap;
 
-    // an air conditioner whose integration declares no supported option: loaded from the database
-    // the feature carries an empty list, not a missing one, and the modes must still be deduced
-    // from the min/max range — otherwise off is the only state HomeKit is given and the Home app
-    // cannot turn the device back on
-    const device = { name: 'Clim', selector: 'clim' };
+    // a heat pump: the thermostat setpoint keeps it a Thermostat, the air conditioning mode drives it
+    const device = { name: 'PAC', selector: 'pac' };
     const features = [
       {
         name: 'Marche',
-        selector: 'clim-power',
+        selector: 'pac-power',
         category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
         type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.BINARY,
-        min: 0,
-        max: 1,
-        supported_options: [],
       },
       {
         name: 'Mode',
-        selector: 'clim-mode',
+        selector: 'pac-mode',
         category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
         type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
         min: AC_MODE.AUTO,
-        max: AC_MODE.COOLING,
-        supported_options: [],
+        max: AC_MODE.FAN,
       },
       {
         name: 'Consigne',
-        selector: 'clim-temp',
-        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
-        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE,
+        selector: 'pac-heat',
+        category: DEVICE_FEATURE_CATEGORIES.THERMOSTAT,
+        type: DEVICE_FEATURE_TYPES.THERMOSTAT.TARGET_TEMPERATURE,
         unit: DEVICE_FEATURE_UNITS.CELSIUS,
-        min: 16,
-        max: 31,
-        supported_options: [],
       },
     ];
 
-    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.THERMOSTAT]);
 
-    // off, cool and auto, instead of off alone
+    expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(3);
+    // in auto without any room temperature, the single setpoint is the one to compare against,
+    // and it is also the temperature reported: heating is the assumed state
+    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(1);
+
+    // switched off through its on/off command, whatever the mode says
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pac-power').returns({ last_value: 0 });
+    expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(0);
+    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(0);
+  });
+
+  it('should drive TargetTemperature from a cooling setpoint next to a thermostat mode', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-mode').returns({
+      last_value: THERMOSTAT_MODE.COOLING,
+    });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-cool').returns({ last_value: 24 });
+    homekitHandler.gladys.event.emit = stub();
+
+    const { hap, characteristics } = buildThermostatHapStub();
+    homekitHandler.hap = hap;
+
+    // a cooling only thermostat declaring its setpoint as an air conditioning one
+    const device = { name: 'Clim', selector: 'clim' };
+    const features = [
+      {
+        name: 'Mode',
+        selector: 'clim-mode',
+        category: DEVICE_FEATURE_CATEGORIES.THERMOSTAT,
+        type: DEVICE_FEATURE_TYPES.THERMOSTAT.MODE,
+        supported_options: [
+          { value: THERMOSTAT_MODE.OFF },
+          { value: THERMOSTAT_MODE.COOLING },
+          { value: THERMOSTAT_MODE.AUTO },
+        ],
+      },
+      {
+        name: 'Consigne froid',
+        selector: 'clim-cool',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE,
+        unit: DEVICE_FEATURE_UNITS.CELSIUS,
+      },
+    ];
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.THERMOSTAT]);
+
     expect(characteristics.TargetHeatingCoolingState.setProps.args[0][0]).to.eql({ validValues: [0, 2, 3] });
+    expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(2);
+    // the cooling setpoint is the only setpoint, so it drives TargetTemperature
+    expect(await readCharacteristic(characteristics.TargetTemperature)).to.equal(24);
+    // and it stands in for the missing room temperature
+    expect(await readCharacteristic(characteristics.CurrentTemperature)).to.equal(24);
 
     const cb = stub();
-    await characteristics.TargetHeatingCoolingState.handlers.set(2, cb);
+    await characteristics.TargetTemperature.handlers.set(25, cb);
+    expect(homekitHandler.gladys.event.emit.args[0][1].value).to.equal(25);
+    expect(homekitHandler.gladys.event.emit.args[0][1].device_feature).to.equal('clim-cool');
 
-    expect(homekitHandler.gladys.event.emit.args[0][1].device_feature).to.equal('clim-power');
-    expect(homekitHandler.gladys.event.emit.args[0][1].value).to.equal(1);
-    expect(homekitHandler.gladys.event.emit.args[1][1].device_feature).to.equal('clim-mode');
-    expect(homekitHandler.gladys.event.emit.args[1][1].value).to.equal(AC_MODE.COOLING);
+    // in auto with no room temperature to compare against, the device can only cool
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-mode').returns({
+      last_value: THERMOSTAT_MODE.AUTO,
+    });
+    expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(3);
+    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(2);
+  });
 
-    await characteristics.TargetHeatingCoolingState.handlers.set(0, cb);
+  it('should report cooling on a cooling setpoint next to an operating state', async () => {
+    homekitHandler.gladys.stateManager.get = stub();
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-cool').returns({ last_value: 24 });
+    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-state').returns({
+      last_value: THERMOSTAT_OPERATING_STATE.IDLE,
+    });
+    homekitHandler.gladys.event.emit = stub();
 
-    expect(homekitHandler.gladys.event.emit.args[2][1].device_feature).to.equal('clim-power');
-    expect(homekitHandler.gladys.event.emit.args[2][1].value).to.equal(0);
+    const { hap, characteristics } = buildThermostatHapStub();
+    homekitHandler.hap = hap;
+
+    // no mode of either kind: the states are deduced from the one setpoint the device exposes
+    const device = { name: 'Clim', selector: 'clim' };
+    const features = [
+      {
+        name: 'Consigne froid',
+        selector: 'clim-cool',
+        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE,
+        unit: DEVICE_FEATURE_UNITS.CELSIUS,
+      },
+      {
+        name: 'État',
+        selector: 'clim-state',
+        category: DEVICE_FEATURE_CATEGORIES.THERMOSTAT,
+        type: DEVICE_FEATURE_TYPES.THERMOSTAT.OPERATING_STATE,
+      },
+    ];
+
+    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.THERMOSTAT]);
+
+    expect(characteristics.TargetHeatingCoolingState.setProps.args[0][0]).to.eql({ validValues: [2] });
+    expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(2);
+    // the device says what it is doing: idle, whatever the setpoint
+    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(0);
   });
 
   it('should build thermostat service from a setpoint and a temperature sensor', async () => {
@@ -2381,84 +2470,6 @@ describe('Build service', () => {
       device: device.selector,
       device_feature: features[0].selector,
     });
-  });
-
-  it('should build thermostat service for an air conditioner', async () => {
-    homekitHandler.gladys.stateManager.get = stub();
-    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-power').returns({ last_value: 1 });
-    homekitHandler.gladys.stateManager.get
-      .withArgs('deviceFeature', 'clim-mode')
-      .returns({ last_value: AC_MODE.COOLING });
-    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-setpoint').returns({ last_value: 24 });
-    homekitHandler.gladys.event.emit = stub();
-
-    const { hap, characteristics } = buildThermostatHapStub();
-    homekitHandler.hap = hap;
-
-    const device = { name: 'Clim', selector: 'clim' };
-    const features = [
-      {
-        name: 'Marche',
-        selector: 'clim-power',
-        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
-        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.BINARY,
-        min: 0,
-        max: 1,
-      },
-      {
-        name: 'Mode',
-        selector: 'clim-mode',
-        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
-        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
-        min: AC_MODE.AUTO,
-        max: AC_MODE.FAN,
-      },
-      {
-        name: 'Consigne',
-        selector: 'clim-setpoint',
-        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
-        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE,
-        unit: DEVICE_FEATURE_UNITS.CELSIUS,
-        min: 16,
-        max: 31,
-      },
-    ];
-
-    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
-
-    expect(characteristics.TargetHeatingCoolingState.setProps.args[0][0]).to.eql({ validValues: [0, 1, 2, 3] });
-    expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(2);
-    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(2);
-    // no temperature sensor on the device, the setpoint is the closest reading available
-    expect(await readCharacteristic(characteristics.CurrentTemperature)).to.equal(24);
-
-    const cb = stub();
-    await characteristics.TargetHeatingCoolingState.handlers.set(1, cb);
-    expect(homekitHandler.gladys.event.emit.args[0][1]).to.eql({
-      type: ACTIONS.DEVICE.SET_VALUE,
-      status: ACTIONS_STATUS.PENDING,
-      value: 1,
-      device: device.selector,
-      device_feature: features[0].selector,
-    });
-    expect(homekitHandler.gladys.event.emit.args[1][1]).to.eql({
-      type: ACTIONS.DEVICE.SET_VALUE,
-      status: ACTIONS_STATUS.PENDING,
-      value: AC_MODE.HEATING,
-      device: device.selector,
-      device_feature: features[1].selector,
-    });
-
-    // switching off only writes the binary feature, Gladys has no "off" AC mode
-    homekitHandler.gladys.event.emit = stub();
-    await characteristics.TargetHeatingCoolingState.handlers.set(0, cb);
-    expect(homekitHandler.gladys.event.emit.callCount).to.equal(1);
-    expect(homekitHandler.gladys.event.emit.args[0][1].value).to.equal(0);
-    expect(homekitHandler.gladys.event.emit.args[0][1].device_feature).to.equal(features[0].selector);
-
-    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-power').returns({ last_value: 0 });
-    expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(0);
-    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(0);
   });
 
   it('should build thermostat service with both setpoints in Fahrenheit', async () => {
@@ -2540,41 +2551,6 @@ describe('Build service', () => {
     expect(await readCharacteristic(characteristics.TargetTemperature)).to.equal(25);
   });
 
-  it('should report cooling in auto when only a cooling setpoint is known', async () => {
-    homekitHandler.gladys.stateManager.get = stub();
-    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-mode').returns({ last_value: AC_MODE.AUTO });
-    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-cool').returns({ last_value: 24 });
-    homekitHandler.gladys.event.emit = stub();
-
-    const { hap, characteristics } = buildThermostatHapStub();
-    homekitHandler.hap = hap;
-
-    const device = { name: 'Clim', selector: 'clim' };
-    const features = [
-      {
-        name: 'Mode',
-        selector: 'clim-mode',
-        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
-        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
-        min: AC_MODE.AUTO,
-        max: AC_MODE.COOLING,
-      },
-      {
-        name: 'Consigne froid',
-        selector: 'clim-cool',
-        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
-        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE,
-        unit: DEVICE_FEATURE_UNITS.CELSIUS,
-      },
-    ];
-
-    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
-
-    expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(3);
-    // no room temperature to compare against, but the device can only cool
-    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(2);
-  });
-
   it('should build thermostat service with both setpoints and no mode feature', async () => {
     homekitHandler.gladys.stateManager.get = stub();
     homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pac-heat').returns({ last_value: 22 });
@@ -2632,80 +2608,6 @@ describe('Build service', () => {
     // above the cooling setpoint it is cooling
     homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'pac-temp').returns({ last_value: 28 });
     expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(2);
-  });
-
-  it('should build thermostat service for a cooling only device', async () => {
-    homekitHandler.gladys.stateManager.get = stub();
-    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-cool').returns({ last_value: 24 });
-    homekitHandler.gladys.event.emit = stub();
-
-    const { hap, characteristics } = buildThermostatHapStub();
-    homekitHandler.hap = hap;
-
-    const device = { name: 'Clim', selector: 'clim' };
-    const features = [
-      {
-        name: 'Consigne froid',
-        selector: 'clim-cool',
-        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
-        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE,
-        unit: DEVICE_FEATURE_UNITS.CELSIUS,
-      },
-    ];
-
-    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
-
-    // no mode and no heating setpoint: the device can only cool
-    expect(characteristics.TargetHeatingCoolingState.setProps.args[0][0]).to.eql({ validValues: [2] });
-    expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(2);
-    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(2);
-    // the cooling setpoint is the only setpoint, so it drives TargetTemperature
-    expect(await readCharacteristic(characteristics.TargetTemperature)).to.equal(24);
-    // and it stands in for the missing room temperature
-    expect(await readCharacteristic(characteristics.CurrentTemperature)).to.equal(24);
-
-    const cb = stub();
-    await characteristics.TargetTemperature.handlers.set(25, cb);
-    expect(homekitHandler.gladys.event.emit.args[0][1].value).to.equal(25);
-    expect(homekitHandler.gladys.event.emit.args[0][1].device_feature).to.equal(features[0].selector);
-  });
-
-  it('should build thermostat service without any temperature feature', async () => {
-    homekitHandler.gladys.stateManager.get = stub();
-    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-power').returns({ last_value: 1 });
-    // a mode value the AC_MODE mapping does not know about
-    homekitHandler.gladys.stateManager.get.withArgs('deviceFeature', 'clim-mode').returns({ last_value: 99 });
-    homekitHandler.gladys.event.emit = stub();
-
-    const { hap, characteristics } = buildThermostatHapStub();
-    homekitHandler.hap = hap;
-
-    const device = { name: 'Clim', selector: 'clim' };
-    const features = [
-      {
-        name: 'Marche',
-        selector: 'clim-power',
-        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
-        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.BINARY,
-      },
-      {
-        name: 'Mode',
-        selector: 'clim-mode',
-        category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
-        type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
-        min: AC_MODE.AUTO,
-        max: AC_MODE.FAN,
-      },
-    ];
-
-    await homekitHandler.buildService(device, features, mappings[DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING]);
-
-    // nothing carries a temperature, CurrentTemperature is left unbound
-    expect(characteristics.CurrentTemperature.handlers.get).to.equal(undefined);
-    // an unknown AC mode falls back to auto
-    expect(await readCharacteristic(characteristics.TargetHeatingCoolingState)).to.equal(3);
-    // in auto without any temperature to compare, heating is the assumed state
-    expect(await readCharacteristic(characteristics.CurrentHeatingCoolingState)).to.equal(1);
   });
 
   it('should build thermostat service without an on/off command', async () => {

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -38,6 +38,8 @@ describe('Send state to HomeKit', () => {
         HeatingThresholdTemperature: 'HEATINGTHRESHOLDTEMPERATURE',
         TargetHeatingCoolingState: 'TARGETHEATINGCOOLINGSTATE',
         CurrentHeatingCoolingState: 'CURRENTHEATINGCOOLINGSTATE',
+        TargetHeaterCoolerState: 'TARGETHEATERCOOLERSTATE',
+        CurrentHeaterCoolerState: 'CURRENTHEATERCOOLERSTATE',
         TargetTemperature: 'TARGETTEMPERATURE',
         MotionDetected: 'MOTIONDETECTED',
         OccupancyDetected: 'OCCUPANCYDETECTED',
@@ -75,6 +77,8 @@ describe('Send state to HomeKit', () => {
         OccupancySensor: 'OCCUPANCYSENSOR',
         WindowCovering: 'WINDOWCOVERING',
         Thermostat: 'THERMOSTAT',
+        // sendState tells a HeaterCooler from a Thermostat by its UUID
+        HeaterCooler: { UUID: 'HEATERCOOLER' },
         TemperatureSensor: 'TEMPERATURESENSOR',
         LockMechanism: 'LOCKMECHANISM',
         LightSensor: 'LIGHTSENSOR',
@@ -1572,6 +1576,160 @@ describe('Send state to HomeKit', () => {
     expect(updateCharacteristic.args[0]).eql(['TARGETHEATINGCOOLINGSTATE', 0]);
     expect(updateCharacteristic.args[1]).eql(['CURRENTHEATINGCOOLINGSTATE', 0]);
     expect(updateCharacteristic.args[2]).eql(['TARGETTEMPERATURE', 0]);
+  });
+
+  it('should notify an air conditioning setpoint on a heater cooler', async () => {
+    const updateCharacteristic = stub().returns();
+    const characteristic = { emit: stub().callsArgWith(1, undefined, 3), props: { minValue: 16, maxValue: 31 } };
+    const heaterCoolerService = {
+      UUID: 'HEATERCOOLER',
+      updateCharacteristic,
+      testCharacteristic: stub().returns(true),
+      getCharacteristic: stub().returns(characteristic),
+    };
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns(heaterCoolerService),
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Setpoint',
+      category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+      type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.TARGET_TEMPERATURE,
+      unit: DEVICE_FEATURE_UNITS.FAHRENHEIT,
+    };
+
+    // 82.4 °F is 28 °C
+    await homekitHandler.sendState(accessory, feature, { type: EVENTS.DEVICE.NEW_STATE, last_value: 82.4 });
+
+    // the single setpoint stands behind both thresholds
+    expect(updateCharacteristic.args[0][0]).eql('COOLINGTHRESHOLDTEMPERATURE');
+    expect(updateCharacteristic.args[0][1]).to.be.closeTo(28, 0.001);
+    expect(updateCharacteristic.args[1][0]).eql('HEATINGTHRESHOLDTEMPERATURE');
+    expect(updateCharacteristic.args[1][1]).to.be.closeTo(28, 0.001);
+    // heating or cooling in auto depends on the setpoint, so it is recomputed
+    expect(updateCharacteristic.args[2]).eql(['CURRENTHEATERCOOLERSTATE', 3]);
+    expect(updateCharacteristic.callCount).eql(3);
+
+    // a setpoint outside the bounds the thresholds were given is clamped, HAP would throw
+    updateCharacteristic.resetHistory();
+    await homekitHandler.sendState(
+      accessory,
+      { ...feature, unit: DEVICE_FEATURE_UNITS.CELSIUS },
+      {
+        type: EVENTS.DEVICE.NEW_STATE,
+        last_value: 40,
+      },
+    );
+
+    expect(updateCharacteristic.args[0]).eql(['COOLINGTHRESHOLDTEMPERATURE', 31]);
+    expect(updateCharacteristic.args[1]).eql(['HEATINGTHRESHOLDTEMPERATURE', 31]);
+  });
+
+  it('should notify an air conditioning mode change on a heater cooler', async () => {
+    const updateCharacteristic = stub().returns();
+    const characteristic = { emit: stub().callsArgWith(1, undefined, 1) };
+    const heaterCoolerService = {
+      UUID: 'HEATERCOOLER',
+      updateCharacteristic,
+      testCharacteristic: stub().returns(true),
+      getCharacteristic: stub().returns(characteristic),
+    };
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns(heaterCoolerService),
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Mode',
+      category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+      type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
+    };
+
+    await homekitHandler.sendState(accessory, feature, { type: EVENTS.DEVICE.NEW_STATE, last_value: 2 });
+
+    // the HeaterCooler characteristics, not the Thermostat ones
+    expect(updateCharacteristic.args).eql([
+      ['ACTIVE', 1],
+      ['TARGETHEATERCOOLERSTATE', 1],
+      ['CURRENTHEATERCOOLERSTATE', 1],
+    ]);
+  });
+
+  it('should notify an air conditioning power change on a heater cooler', async () => {
+    const updateCharacteristic = stub().returns();
+    const characteristic = { emit: stub().callsArgWith(1, undefined, 0) };
+    const heaterCoolerService = {
+      UUID: 'HEATERCOOLER',
+      updateCharacteristic,
+      testCharacteristic: stub().returns(true),
+      getCharacteristic: stub().returns(characteristic),
+    };
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService: stub().returns(heaterCoolerService),
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Power',
+      category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+      type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.BINARY,
+    };
+
+    await homekitHandler.sendState(accessory, feature, { type: EVENTS.DEVICE.NEW_STATE, last_value: 0 });
+
+    expect(updateCharacteristic.args).eql([
+      ['ACTIVE', 0],
+      ['TARGETHEATERCOOLERSTATE', 0],
+      ['CURRENTHEATERCOOLERSTATE', 0],
+    ]);
+  });
+
+  it('should notify current temperature on a merged heater cooler', async () => {
+    const updateCharacteristic = stub().returns();
+    const currentStateCharacteristic = {
+      emit: stub().callsArgWith(1, undefined, 3),
+      props: { minValue: -270, maxValue: 100 },
+    };
+    const heaterCoolerService = {
+      UUID: 'HEATERCOOLER',
+      updateCharacteristic,
+      testCharacteristic: stub().returns(true),
+      getCharacteristic: stub().returns(currentStateCharacteristic),
+    };
+    // the device has no standalone TemperatureSensor service and is no Thermostat either, its
+    // sensor was merged into the HeaterCooler
+    const getService = stub();
+    getService.withArgs('TEMPERATURESENSOR').returns(undefined);
+    getService.withArgs('THERMOSTAT').returns(undefined);
+    getService.withArgs(homekitHandler.hap.Service.HeaterCooler).returns(heaterCoolerService);
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService,
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Room temperature',
+      category: DEVICE_FEATURE_CATEGORIES.TEMPERATURE_SENSOR,
+      type: DEVICE_FEATURE_TYPES.SENSOR.DECIMAL,
+      unit: DEVICE_FEATURE_UNITS.CELSIUS,
+    };
+
+    await homekitHandler.sendState(accessory, feature, { type: EVENTS.DEVICE.NEW_STATE, last_value: 26.5 });
+
+    expect(updateCharacteristic.args).eql([
+      ['CURRENTTEMPERATURE', 26.5],
+      // heating or cooling in auto depends on the room temperature, so it is recomputed
+      ['CURRENTHEATERCOOLERSTATE', 3],
+    ]);
   });
 
   it('should notify a thermostat mode change', async () => {

--- a/server/test/services/homekit/lib/sendState.test.js
+++ b/server/test/services/homekit/lib/sendState.test.js
@@ -1691,6 +1691,44 @@ describe('Send state to HomeKit', () => {
     ]);
   });
 
+  it('should fall back on the thermostat of a heat pump for an unindexed air conditioning feature', async () => {
+    // An air conditioning feature maps to a HeaterCooler, but on a device that also carries
+    // thermostat features it was built into the Thermostat. Without the index — a service that
+    // buildAccessory did not build — the type lookup finds no HeaterCooler, and the Thermostat has
+    // to be tried rather than leaving the update to throw on an undefined service.
+    const updateCharacteristic = stub().returns();
+    const characteristic = { emit: stub().callsArgWith(1, undefined, 2) };
+    const thermostatService = {
+      updateCharacteristic,
+      testCharacteristic: stub().returns(true),
+      getCharacteristic: stub().returns(characteristic),
+    };
+    const getService = stub();
+    getService.withArgs(homekitHandler.hap.Service.HeaterCooler).returns(undefined);
+    getService.withArgs('THERMOSTAT').returns(thermostatService);
+    const accessory = {
+      UUID: '4756151c-369e-4772-8bf7-943a6ac70583',
+      getService,
+    };
+
+    const feature = {
+      id: '4f7060d7-7960-4c68-b435-8952bf3f40bf',
+      device_id: '4756151c-369e-4772-8bf7-943a6ac70583',
+      name: 'Mode',
+      category: DEVICE_FEATURE_CATEGORIES.AIR_CONDITIONING,
+      type: DEVICE_FEATURE_TYPES.AIR_CONDITIONING.MODE,
+    };
+
+    await homekitHandler.sendState(accessory, feature, { type: EVENTS.DEVICE.NEW_STATE, last_value: 1 });
+
+    // the Thermostat characteristics, since that is the service the feature lives on
+    expect(updateCharacteristic.args).eql([
+      ['TARGETHEATINGCOOLINGSTATE', 2],
+      ['CURRENTHEATINGCOOLINGSTATE', 2],
+      ['TARGETTEMPERATURE', 2],
+    ]);
+  });
+
   it('should notify current temperature on a merged heater cooler', async () => {
     const updateCharacteristic = stub().returns();
     const currentStateCharacteristic = {


### PR DESCRIPTION
### Description

**Bug:** "Hey Siri, allume la climatisation" put the air conditioner in **auto** mode, and the air conditioner started **heating**.

**Cause:** an air conditioner was exposed to HomeKit as a `Thermostat`. On a Thermostat the only way to be on is to be in a mode (`TargetHeatingCoolingState`), and the mode Siri picks for "turn on" is Auto. Gladys wrote `AC_MODE.AUTO` to the device, which then decided for itself.

**Fix:** a device carrying only air conditioning features (MELCloud, a cooling-only Matter air conditioner) is now exposed as a HomeKit **`HeaterCooler`**, which is Apple's own model for an air conditioner:

- `Active` is the on/off command. "Turn on / turn off the air conditioning" writes the binary feature only and leaves the mode alone.
- `TargetHeaterCoolerState` (auto / heat / cool) writes the mode only. HomeKit writes `Active` alongside when it means both.
- `CurrentHeaterCoolerState` reports off / idle / heating / cooling. Dry and fan are still reported as auto, and as idle while running.
- The single air conditioning setpoint stands behind both `CoolingThresholdTemperature` and `HeatingThresholdTemperature`, with the range the device declares, kept inside 10..38 °C (HAP would otherwise cap a heating setpoint at 25 °C, and Matter declares -100..200).
- The same rules as before apply: modes the device never declared are not written, an auto the device does not have is not written, unknown modes read as auto.

A device carrying thermostat features next to air conditioning ones (a Matter heat pump: thermostat heating setpoint + air conditioning cooling setpoint and mode) stays a `Thermostat`, exactly as before. The Thermostat builder is unchanged apart from a comment.

`sendState` tells a `HeaterCooler` from a `Thermostat` by the service UUID and refreshes the right characteristics; the merged temperature sensor falls back on either service.

**Behaviour change to be aware of:** for users who already exposed an air conditioner, the accessory changes from a Thermostat tile to an Air Conditioner tile in the Home app (HAP bumps the configuration number, no re-pairing needed). Scenes or automations that referenced the old Thermostat characteristics of that accessory will have to be recreated.

Verified against the real `@homebridge/hap-nodejs` library (service built through `buildAccessory`, writes through the characteristic handlers, updates through `sendState`) in addition to the unit tests.

Side note, not changed here: the MELCloud air-to-air mode feature declares `min: 0, max: 1`, so without `supported_options` only auto and cool are offered to HomeKit, not heat. That looks like a separate fix in the MELCloud integration.

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
  - HomeKit suite: 230 passing. `buildHeaterCoolerService.js`, `buildThermostatService.js`, `deviceMappings.js` and `sendState.js` at 100% lines.
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change (the accessory type change is documented above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Mp8jzVBtaxiVziNhGZ1ye

---
_Generated by [Claude Code](https://claude.ai/code/session_016Mp8jzVBtaxiVziNhGZ1ye)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HomeKit HeaterCooler support for standalone air conditioners.
  * Air conditioners now expose power, heating/cooling modes, current temperature, and heating/cooling threshold controls.
  * Supports devices with limited or missing power, mode, or temperature features.
* **Bug Fixes**
  * Improved synchronization of temperature, mode, power, and setpoint changes with HomeKit.
  * Ensured reported modes remain valid for each device’s capabilities.
  * Thermostat-backed devices continue using Thermostat, while standalone air conditioners use HeaterCooler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->