### PR TITLE
Tag scenes created by AI

### DIFF
--- a/server/config/prompts/aiChatScenes.prompt.txt
+++ b/server/config/prompts/aiChatScenes.prompt.txt
@@ -2,6 +2,7 @@ Scene creation rules:
 - If the user asks to create a scene, you MUST call the `scene_create` tool and use its result as source of truth.
 - Never claim that a scene was created unless the `scene_create` tool call succeeded in this conversation.
 - Do not refuse a scene request before trying `scene_create`. Build the closest valid scene possible with available scene actions.
+- Do not add a tag to identify a scene as AI-created. Gladys automatically adds the `Gladys AI` tag.
 - For `scene_create`, always send a top-level `triggers` array for when the scene starts. Put `device.new-state`, `time.changed`, `time.sunrise` and similar types in `triggers`, never in `actions`. For `device.new-state` on binary devices, use numeric `value` (1 = ON, 0 = OFF).
 - For scene actions, strictly include all required fields for each action type. In particular, `ai.ask` requires both `user` and `text`.
 - In scene `ai.ask` text, when referencing previous `device.get-value` action outputs, use Handlebars coordinates such as `{{1.1.last_value}}` (or `{{0.0.last_value}}`) and `{{1.1.last_value_string}}`.

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -24,6 +24,7 @@ const { compareTimes } = require('./compareTimes');
 const { formatWeather } = require('./formatWeather');
 
 const DEFAULT_TIMEZONE = 'Europe/Paris';
+const AI_CREATED_SCENE_TAG = 'Gladys AI';
 
 const noRoom = {
   id: null,
@@ -494,9 +495,12 @@ async function getAllTools(userId) {
         try {
           assertTriggerTypesNotInActions(scene);
           const parsedScene = sceneCreateInputSchema.parse(scene);
+          const sceneTags = new Map(parsedScene.tags.map((tag) => [tag.name, tag]));
+          sceneTags.set(AI_CREATED_SCENE_TAG, { name: AI_CREATED_SCENE_TAG });
           const createdScene = await this.gladys.scene.create({
             ...parsedScene,
             actions: parsedScene.actions,
+            tags: Array.from(sceneTags.values()),
           });
 
           return {

--- a/server/services/mcp/lib/sceneSchemas.js
+++ b/server/services/mcp/lib/sceneSchemas.js
@@ -621,7 +621,9 @@ function createSceneCreateInputSchema(
         }),
       )
       .default([])
-      .describe('Optional scene tags.'),
+      .describe(
+        'Optional user-requested scene tags. Do not add a tag to mark AI authorship; Gladys automatically adds "Gladys AI".',
+      ),
   });
 }
 
@@ -720,7 +722,7 @@ function formatSceneCreateZodIssue(issue, rawScene) {
 }
 
 const SCENE_CREATE_TOOL_DESCRIPTION =
-  'Create a new home automation scene. The payload MUST have two separate top-level arrays: triggers (when the scene starts) and actions (what the scene does). NEVER put device.new-state, time.changed, time.sunrise or any trigger type inside actions. device.new-state belongs in triggers with numeric value (1=ON, 0=OFF). actions is nested groups only: [[group1],[group2]]. Example: {"name":"Switchbeau de ville","icon":"droplet","triggers":[{"type":"device.new-state","device_feature":"mqtt-lumiere","operator":"=","value":1,"threshold_only":true,"for_duration":2700000}],"actions":[[{"type":"delay","unit":"minutes","value":45}],[{"type":"device.get-value","device_feature":"mqtt-co2"}],[{"type":"condition.only-continue-if","conditions":[{"variable":"1.0.last_value","operator":">","value":2400}]}],[{"type":"light.turn-off","devices":["mqtt-lumiere"]}]]}';
+  'Create a new home automation scene. Gladys automatically adds the "Gladys AI" tag; do not add another tag to mark AI authorship. The payload MUST have two separate top-level arrays: triggers (when the scene starts) and actions (what the scene does). NEVER put device.new-state, time.changed, time.sunrise or any trigger type inside actions. device.new-state belongs in triggers with numeric value (1=ON, 0=OFF). actions is nested groups only: [[group1],[group2]]. Example: {"name":"Switchbeau de ville","icon":"droplet","triggers":[{"type":"device.new-state","device_feature":"mqtt-lumiere","operator":"=","value":1,"threshold_only":true,"for_duration":2700000}],"actions":[[{"type":"delay","unit":"minutes","value":45}],[{"type":"device.get-value","device_feature":"mqtt-co2"}],[{"type":"condition.only-continue-if","conditions":[{"variable":"1.0.last_value","operator":">","value":2400}]}],[{"type":"light.turn-off","devices":["mqtt-lumiere"]}]]}';
 
 module.exports = {
   createSceneCreateInputSchema,

--- a/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
+++ b/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
@@ -95,7 +95,7 @@ describe('gateway.forwardMessageToAiChat', () => {
     );
 
     expect(scenesPrompt).to.include('Do not add a tag to identify a scene as AI-created.');
-    expect(scenesPrompt).to.include('Gladys automatically adds the `Gladys AI` tag.');
+    expect(scenesPrompt).to.include('Gladys automatically adds the "Gladys AI" tag.');
   });
 
   it('should build system prompt with current date and time in the configured timezone', () => {

--- a/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
+++ b/server/test/lib/gateway/gateway.forwardMessageToAiChat.test.js
@@ -1,4 +1,6 @@
 const sinon = require('sinon').createSandbox();
+const fs = require('fs');
+const path = require('path');
 
 const { fake, stub, assert, match } = sinon;
 const { expect } = require('chai');
@@ -84,6 +86,16 @@ function buildContext({
 describe('gateway.forwardMessageToAiChat', () => {
   beforeEach(() => {
     resizeImageMock.resetHistory();
+  });
+
+  it('should tell the model that Gladys adds the AI scene tag automatically', () => {
+    const scenesPrompt = fs.readFileSync(
+      path.join(__dirname, '../../../config/prompts/aiChatScenes.prompt.txt'),
+      'utf8',
+    );
+
+    expect(scenesPrompt).to.include('Do not add a tag to identify a scene as AI-created.');
+    expect(scenesPrompt).to.include('Gladys automatically adds the `Gladys AI` tag.');
   });
 
   it('should build system prompt with current date and time in the configured timezone', () => {

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -636,9 +636,13 @@ describe('build schemas', () => {
       icon: 'bell',
       triggers: [{ type: 'system.start' }],
       actions: [[{ type: 'light.turn-on', devices: ['device-light-1'] }]],
-      tags: [{ name: 'ai-generated' }],
+      tags: [{ name: 'ai-generated' }, { name: 'Gladys AI' }],
     });
     expect(mcpHandler.gladys.scene.create.callCount).to.eq(1);
+    expect(mcpHandler.gladys.scene.create.firstCall.args[0].tags).to.deep.equal([
+      { name: 'ai-generated' },
+      { name: 'Gladys AI' },
+    ]);
     expect(sceneCreatedResult.content[0].text).to.eq('toonmockdata');
 
     let flatActionsError = null;

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -631,12 +631,14 @@ describe('build schemas', () => {
     expect(tools[1].intent).to.eq('scene.create');
     expect(tools[1].config.title).to.eq('Create scene');
     expect(tools[1].config.description).to.eq(SCENE_CREATE_TOOL_DESCRIPTION);
+    expect(tools[1].config.description).to.include('Gladys AI');
+    expect(tools[1].config.inputSchema.tags.description).to.include('Gladys AI');
     const sceneCreatedResult = await tools[1].cb({
       name: 'MCP Generated Scene',
       icon: 'bell',
       triggers: [{ type: 'system.start' }],
       actions: [[{ type: 'light.turn-on', devices: ['device-light-1'] }]],
-      tags: [{ name: 'ai-generated' }, { name: 'Gladys AI' }],
+      tags: [{ name: 'ai-generated' }],
     });
     expect(mcpHandler.gladys.scene.create.callCount).to.eq(1);
     expect(mcpHandler.gladys.scene.create.firstCall.args[0].tags).to.deep.equal([


### PR DESCRIPTION
## Summary

- automatically add the Gladys AI tag to scenes created through the AI scene.create tool
- preserve any tags selected by the model
- avoid duplicating the marker when it is already present
- reuse the existing scene tag badges and filters, with no database, API, or frontend changes

Historical scenes are intentionally not backfilled.

## Testing

- server formatting and Prettier check pass
- server ESLint passes with the existing warnings only
- targeted MCP suite: 48 passing
- full server coverage run: 6,638 passing, 1 pending, and 9 environment-specific failures unrelated to this change (local timezone, local service-install setting, and Docker unavailable)
- all changed production lines are covered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Scenes created through the MCP service are now automatically labeled with the **“Gladys AI”** tag.
  - Existing scene tags are preserved, including previously assigned AI-generated tags.
  - Scene creation guidance now explains that the **“Gladys AI”** tag is added automatically, helping prevent duplicate or conflicting AI-identifying tags.
  - The scene creation instructions and tool descriptions now provide clearer guidance about automatic AI attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

https://community.gladysassistant.com/t/pouvoir-filtrer-les-scenes-qui-ont-ete-generees-par-lia/10817