### PR TITLE
Publish each release to Gladys Plus from the release workflow

### DIFF
--- a/.github/workflows/docker-release-build.yml
+++ b/.github/workflows/docker-release-build.yml
@@ -204,3 +204,59 @@ jobs:
     steps:
       - name: Run Cloudflare Pages deploy hook
         run: curl -X POST "https://api.cloudflare.com/client/v4/pages/webhooks/deploy_hooks/${{ secrets.CLOUDFLARE_PAGES_GLADYS_PLUS_DEPLOY_HOOK }}"
+  publish-gladys-version:
+    name: Publish the version to Gladys Plus
+    # Runs once the production images are pushed: as soon as the version is
+    # published, the Gladys Plus backend tells every instance that it is the
+    # latest one, so the images it points to must already be available.
+    needs: docker
+    # Pre-release tags (v5.1.0-rc.1) are built above, but they never move
+    # `latest`, so they must not become the version every instance is
+    # invited to upgrade to.
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🚀 Create the version on Gladys Plus
+        env:
+          # Base URL of the Gladys Plus backend (Gladys Gateway), without a
+          # trailing slash, e.g. https://api.gladysgateway.com
+          GLADYS_PLUS_BACKEND_URL: ${{ secrets.GLADYS_PLUS_BACKEND_URL }}
+          # Restricted admin API key of the Gladys Gateway, only allowed on
+          # POST /admin/api/gladys/versions
+          GLADYS_VERSION_API_KEY: ${{ secrets.GLADYS_VERSION_API_KEY }}
+          VERSION: ${{ github.ref_name }}
+          RELEASE_NOTE_LINK: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GLADYS_PLUS_BACKEND_URL}" ] || [ -z "${GLADYS_VERSION_API_KEY}" ]; then
+            echo "::error::The GLADYS_PLUS_BACKEND_URL and GLADYS_VERSION_API_KEY secrets are required to publish the version to Gladys Plus."
+            exit 1
+          fi
+          # The release note links can be changed afterwards from the Gladys
+          # Plus admin (PATCH /admin/api/gladys/versions/:id), for instance to
+          # point to the forum topic of the release once it is written.
+          BODY=$(jq -n --arg name "${VERSION}" --arg link "${RELEASE_NOTE_LINK}" \
+            '{ name: $name, default_release_note_link: $link }')
+          STATUS=$(curl --silent --show-error --output response.json --write-out "%{http_code}" \
+            --retry 3 --retry-connrefused --max-time 30 \
+            -X POST "${GLADYS_PLUS_BACKEND_URL%/}/admin/api/gladys/versions" \
+            -H "Content-Type: application/json" \
+            -H "X-Admin-Api-Key: ${GLADYS_VERSION_API_KEY}" \
+            --data "${BODY}")
+          cat response.json
+          echo
+          case "${STATUS}" in
+            201)
+              echo "Version ${VERSION} published to Gladys Plus."
+              echo "- Version \`${VERSION}\` published to Gladys Plus" >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            409)
+              # Already published by a previous run of this workflow on the same tag.
+              echo "Version ${VERSION} was already published to Gladys Plus, nothing to do."
+              echo "- Version \`${VERSION}\` was already published to Gladys Plus" >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            *)
+              echo "::error::Gladys Plus answered ${STATUS} while publishing version ${VERSION}."
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
### Description

The Gladys Gateway now exposes `POST /admin/api/gladys/versions` (GladysAssistant/gladys-gateway#224), which creates the `gladys_version` that instances are told about. This PR adds a `publish-gladys-version` job to the **Release Gladys Production Images** workflow so the version is created on Gladys Plus automatically on every release, with no manual step left.

How the job works:

- Runs after the `docker` job, so the version is only published once the production images are pushed (instances are invited to upgrade as soon as the version exists).
- Skipped on pre-release tags (`v5.1.0-rc.1`): they never move the `latest` image tag, so they must not become the version every instance is invited to upgrade to.
- Sends `name` (the tag) and `default_release_note_link` (the GitHub release page). The links can be changed afterwards from the Gladys Plus admin (`PATCH /admin/api/gladys/versions/:id`), e.g. to point to the forum topic once it is written.
- `201` is a success, `409` (already published by a previous run on the same tag) is treated as a no-op so re-running the workflow is harmless, anything else fails the job.
- Fails with a clear error when a secret is missing. Secrets are read through `env`, never interpolated into the shell.

Two repository secrets have to be created before the next release:

| Secret | Value |
|---|---|
| `GLADYS_PLUS_BACKEND_URL` | Base URL of the Gladys Plus backend, e.g. `https://api.gladysgateway.com` |
| `GLADYS_VERSION_API_KEY` | Value of `GLADYS_VERSION_API_KEY` on the Gateway (restricted key, only valid on that route) |

The script was tested against a mock HTTP server for the 201, 409, 422, missing-secrets and unreachable-backend cases.

### Checklist

- [x] Tests pass: no server or front code changed (workflow only)
- [x] Linter and prettier pass on both front and server (workflow file checked with prettier)
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FTGdHiNReQPLEpnwVedTW

---
_Generated by [Claude Code](https://claude.ai/code/session_019FTGdHiNReQPLEpnwVedTW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stable releases are now automatically published to the Gladys Plus service after Docker image publication.
  * Release publication includes retry handling and recognizes already-published versions without failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->