### PR TITLE
docs: recommend linking the forum topic or GitHub issue in pull requests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -61,7 +61,12 @@ Most labels are applied automatically, you don't need to set them yourself:
 
 Labels for contributors: look for [`good first issue`](https://github.com/gladysassistant/Gladys/labels/good%20first%20issue) and [`help wanted`](https://github.com/gladysassistant/Gladys/labels/help%20wanted) to find issues to work on.
 
-If your PR implements a forum request, add a line `Forum: https://community.gladysassistant.com/t/...` in the PR description (see the PR template): the release pipeline uses it to notify the forum topic when the feature ships.
+Every PR must link the request it answers in its description (see the PR template):
+
+- a forum request: add a line `Forum: https://community.gladysassistant.com/t/...` — the release pipeline uses it to notify the forum topic when the feature ships and to close the topic;
+- a GitHub issue: add a line `Closes #1234` — GitHub links the issue and closes it when the PR is merged.
+
+Without this link we cannot tie the PR to its topic, and those automations cannot run.
 
 ---
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Most labels are applied automatically, you don't need to set them yourself:
 
 Labels for contributors: look for [`good first issue`](https://github.com/gladysassistant/Gladys/labels/good%20first%20issue) and [`help wanted`](https://github.com/gladysassistant/Gladys/labels/help%20wanted) to find issues to work on.
 
-Every PR must link the request it answers in its description (see the PR template):
+If your PR answers a forum topic or a GitHub issue, we strongly recommend linking it in the PR description (see the PR template):
 
 - a forum request: add a line `Forum: https://community.gladysassistant.com/t/...` — the release pipeline uses it to notify the forum topic when the feature ships and to close the topic;
 - a GitHub issue: add a line `Closes #1234` — GitHub links the issue and closes it when the PR is merged.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,13 +2,14 @@
 
 <!-- A short description of the change. Screenshots are always welcome! -->
 
-### Related request (required)
+### Related request
 
 <!--
-Every pull request must link the request it answers. Keep ONE of the two lines
-below (delete the other) and fill it in. Without this link, the PR cannot be
-tied to its topic and the release automations (announcing the release on the
-forum topic and closing the topic / issue when the feature ships) cannot run.
+If this pull request answers a forum topic or a GitHub issue, please link it
+here (strongly recommended): keep the matching line below and fill it in.
+This link is what ties the PR to its topic and lets the release automations
+run (announcing the release on the forum topic and closing the topic / issue
+when the feature ships). Without it, those automations cannot happen.
 
 - Feature requested on the community forum: paste the topic URL on a single
   line using this exact format (the release pipeline parses it):
@@ -23,7 +24,7 @@ forum topic and closing the topic / issue when the feature ships) cannot run.
 
 ### Checklist
 
-- [ ] The description links the forum topic (`Forum: https://community.gladysassistant.com/t/...`) or the GitHub issue (`Closes #...`)
+- [ ] If a forum topic or GitHub issue exists, the description links it (`Forum: https://community.gladysassistant.com/t/...` or `Closes #...`)
 - [ ] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
 - [ ] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
 - [ ] No undocumented breaking change

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,20 +2,28 @@
 
 <!-- A short description of the change. Screenshots are always welcome! -->
 
-## Forum
+### Related request (required)
 
 <!--
-If this pull request implements a feature requested on the community forum,
-paste the topic URL on a single line using this exact format:
+Every pull request must link the request it answers. Keep ONE of the two lines
+below (delete the other) and fill it in. Without this link, the PR cannot be
+tied to its topic and the release automations (announcing the release on the
+forum topic and closing the topic / issue when the feature ships) cannot run.
 
-Forum: https://community.gladysassistant.com/t/...
+- Feature requested on the community forum: paste the topic URL on a single
+  line using this exact format (the release pipeline parses it):
 
-This link is what allows the release pipeline to automatically notify the
-forum topic when the feature ships.
+  Forum: https://community.gladysassistant.com/t/...
+
+- Bug or feature tracked in a GitHub issue: use a closing keyword so GitHub
+  links the issue and closes it when the PR is merged:
+
+  Closes #1234
 -->
 
 ### Checklist
 
+- [ ] The description links the forum topic (`Forum: https://community.gladysassistant.com/t/...`) or the GitHub issue (`Closes #...`)
 - [ ] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
 - [ ] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
 - [ ] No undocumented breaking change

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ All changes made by agents must follow this workflow:
 1. **Never commit directly to `master`.** Create a feature branch for every change (no matter how small) and open a pull request targeting `master`.
 2. **Write PR titles and descriptions in English**, even when the conversation with the user is in another language. This keeps the project history accessible to all contributors and matches the existing CI, templates, and documentation.
 3. **Create pull requests as ready for review (not draft).** When opening a PR, set `draft: false`. Do not create draft PRs.
+4. **Link the PR to the request it answers.** Every PR description must contain either the community forum topic (`Forum: https://community.gladysassistant.com/t/...`, on its own line, exact format) or the GitHub issue (`Closes #1234`). Without this link the release automations (forum announcement, automatic closing of the topic / issue) cannot run. If the user gave you a forum or issue link, put it in the description; if not, ask for it.
 
 ## Pull Request requirements (CI)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ All changes made by agents must follow this workflow:
 1. **Never commit directly to `master`.** Create a feature branch for every change (no matter how small) and open a pull request targeting `master`.
 2. **Write PR titles and descriptions in English**, even when the conversation with the user is in another language. This keeps the project history accessible to all contributors and matches the existing CI, templates, and documentation.
 3. **Create pull requests as ready for review (not draft).** When opening a PR, set `draft: false`. Do not create draft PRs.
-4. **Link the PR to the request it answers.** Every PR description must contain either the community forum topic (`Forum: https://community.gladysassistant.com/t/...`, on its own line, exact format) or the GitHub issue (`Closes #1234`). Without this link the release automations (forum announcement, automatic closing of the topic / issue) cannot run. If the user gave you a forum or issue link, put it in the description; if not, ask for it.
+4. **Link the PR to the request it answers when one exists.** If the change answers a community forum topic or a GitHub issue, the PR description should contain it: either `Forum: https://community.gladysassistant.com/t/...` (on its own line, exact format) or `Closes #1234`. This link is strongly recommended: without it the release automations (forum announcement, automatic closing of the topic / issue) cannot run. If the user gave you a forum or issue link, put it in the description; if you do not have one, ask whether one exists, but do not block the PR on it.
 
 ## Pull Request requirements (CI)
 


### PR DESCRIPTION
### Description

The PR template only mentioned the forum topic, and only inside an HTML comment, so contributors and AI agents opening PRs often skipped it. Without that link the PR cannot be tied to its topic and the release automations (forum announcement, automatic closing of the topic / issue when the release ships) cannot run.

This PR makes the link a clear, strongly recommended step everywhere a PR author (human or AI) looks. It is not mandatory: a PR can legitimately have no forum topic or issue behind it.

- **`.github/PULL_REQUEST_TEMPLATE.md`**: the `## Forum` section becomes `### Related request` and documents both options: the `Forum: https://community.gladysassistant.com/t/...` line (exact format kept, since the release pipeline parses it) or a `Closes #1234` line for a GitHub issue. A new first checklist item asks the author to add the link if a topic or issue exists.
- **`AGENTS.md`**: new rule 4 in the "Git workflow (agents)" section so AI agents put the forum or issue link in the description when they have one, ask whether one exists otherwise, and do not block the PR on it.
- **`.github/CONTRIBUTING.md`**: the "Labels & Forum Link" paragraph now documents both the forum line and the `Closes #` keyword.

No code change; prettier is not run on these files in CI (the pre-existing prettier warnings on `CONTRIBUTING.md` and `AGENTS.md` are unchanged).

### Related request

Maintainer request to contributors: reference the feature request on the forum or the GitHub issue in every PR when it exists, so the release automations can post on the topic and close it. No forum topic or issue exists for this documentation change itself.

### Checklist

- [x] If a forum topic or GitHub issue exists, the description links it: none exists for this change
- [x] Tests pass: not applicable, documentation only
- [x] Linter and prettier pass on both front and server: not applicable, no front or server file changed
- [x] No undocumented breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013grHfgLB92m27rY3ReJnnV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contribution guidance to recommend linking pull requests to related forum topics or GitHub issues when applicable.
  - Clarified supported link formats and how they enable release-related automation.
  - Updated the pull request template and checklist to request related links.
  - Clarified that missing links should not block pull requests when no related request exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->