### PR TITLE
feat(scene): tag AI-created scenes with "AI" and fix exact tag filtering

### DIFF
--- a/server/lib/scene/scene.get.js
+++ b/server/lib/scene/scene.get.js
@@ -81,9 +81,6 @@ async function get(options) {
       tagsWithSceneId[tag] = [];
     });
     sceneIdsAndNames.forEach((sceneIdAndName) => {
-      if (sceneIdAndName.name in tagsWithSceneId === false) {
-        tagsWithSceneId[sceneIdAndName.name] = [];
-      }
       tagsWithSceneId[sceneIdAndName.name].push(sceneIdAndName.scene_id);
     });
 

--- a/server/lib/scene/scene.get.js
+++ b/server/lib/scene/scene.get.js
@@ -62,16 +62,24 @@ async function get(options) {
   if (optionsWithDefault.searchTags) {
     const tags = optionsWithDefault.searchTags.split(',');
 
+    // Exact match on the tag name: a partial match would make a short tag
+    // like "AI" also select every tag containing it ("Maison", "Salaire", ...),
+    // and those unrelated groups would then be intersected below.
     const sceneIdsAndNames = (
       await db.TagScene.findAll({
         fields: ['name', 'scene_id'],
         where: {
-          [Op.or]: tags.map((tag) => ({ name: { [Op.like]: `%${tag}%` } })),
+          name: { [Op.in]: tags },
         },
       })
     ).map((tag) => tag.get({ plain: true }));
 
+    // Every requested tag gets its own group, even when no scene carries it,
+    // so the intersection below keeps its AND semantics.
     const tagsWithSceneId = {};
+    tags.forEach((tag) => {
+      tagsWithSceneId[tag] = [];
+    });
     sceneIdsAndNames.forEach((sceneIdAndName) => {
       if (sceneIdAndName.name in tagsWithSceneId === false) {
         tagsWithSceneId[sceneIdAndName.name] = [];

--- a/server/lib/scene/scene.get.js
+++ b/server/lib/scene/scene.get.js
@@ -75,8 +75,9 @@ async function get(options) {
     ).map((tag) => tag.get({ plain: true }));
 
     // Every requested tag gets its own group, even when no scene carries it,
-    // so the intersection below keeps its AND semantics.
-    const tagsWithSceneId = {};
+    // so the intersection below keeps its AND semantics. The map has no prototype,
+    // so a tag named like an Object built-in ("__proto__") stays a plain own key.
+    const tagsWithSceneId = Object.create(null);
     tags.forEach((tag) => {
       tagsWithSceneId[tag] = [];
     });

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -31,14 +31,14 @@ const DEFAULT_TIMEZONE = 'Europe/Paris';
  * Tags are deduplicated because t_tag_scene has a composite primary key
  * (scene_id, name): inserting the same name twice would fail. The AI tag is always
  * stored with its canonical casing, because the scene list filters on an exact name.
- * @param {Array} [tags] - Tags provided by the model.
+ * @param {Array} tags - Tags provided by the model, defaulted to an empty array by the schema.
  * @returns {Array} Tags including the AI generated scene tag.
  * @example
  * withAiGeneratedTag([{ name: 'lights' }]);
  */
 function withAiGeneratedTag(tags) {
   const tagsByName = new Map();
-  (tags || []).forEach((tag) => {
+  tags.forEach((tag) => {
     tagsByName.set(tag.name.toLowerCase(), tag);
   });
   tagsByName.set(AI_GENERATED_SCENE_TAG.toLowerCase(), { name: AI_GENERATED_SCENE_TAG });

--- a/server/services/mcp/lib/buildSchemas.js
+++ b/server/services/mcp/lib/buildSchemas.js
@@ -6,6 +6,7 @@ const {
   DEVICE_FEATURE_UNITS,
   COVER_STATE,
   AI_CHAT_TOOL_CATEGORIES,
+  AI_GENERATED_SCENE_TAG,
   WEATHER_UNITS,
 } = require('../../../utils/constants');
 const { ServiceNotConfiguredError } = require('../../../utils/coreErrors');
@@ -24,6 +25,25 @@ const { compareTimes } = require('./compareTimes');
 const { formatWeather } = require('./formatWeather');
 
 const DEFAULT_TIMEZONE = 'Europe/Paris';
+
+/**
+ * @description Add the "created by AI" tag to the tags of a scene created by the AI.
+ * Tags are deduplicated because t_tag_scene has a composite primary key
+ * (scene_id, name): inserting the same name twice would fail. The AI tag is always
+ * stored with its canonical casing, because the scene list filters on an exact name.
+ * @param {Array} [tags] - Tags provided by the model.
+ * @returns {Array} Tags including the AI generated scene tag.
+ * @example
+ * withAiGeneratedTag([{ name: 'lights' }]);
+ */
+function withAiGeneratedTag(tags) {
+  const tagsByName = new Map();
+  (tags || []).forEach((tag) => {
+    tagsByName.set(tag.name.toLowerCase(), tag);
+  });
+  tagsByName.set(AI_GENERATED_SCENE_TAG.toLowerCase(), { name: AI_GENERATED_SCENE_TAG });
+  return [...tagsByName.values()];
+}
 
 const noRoom = {
   id: null,
@@ -497,6 +517,7 @@ async function getAllTools(userId) {
           const createdScene = await this.gladys.scene.create({
             ...parsedScene,
             actions: parsedScene.actions,
+            tags: withAiGeneratedTag(parsedScene.tags),
           });
 
           return {

--- a/server/services/mcp/lib/sceneSchemas.js
+++ b/server/services/mcp/lib/sceneSchemas.js
@@ -621,7 +621,7 @@ function createSceneCreateInputSchema(
         }),
       )
       .default([])
-      .describe('Optional scene tags.'),
+      .describe('Optional scene tags. Do not add a tag saying the scene was created by an AI, Gladys adds it itself.'),
   });
 }
 

--- a/server/test/lib/scene/scene.get.test.js
+++ b/server/test/lib/scene/scene.get.test.js
@@ -2,6 +2,8 @@ const { expect } = require('chai');
 const Promise = require('bluebird');
 const EventEmitter = require('events');
 const SceneManager = require('../../../lib/scene');
+const db = require('../../../models');
+const { AI_GENERATED_SCENE_TAG } = require('../../../utils/constants');
 
 const event = new EventEmitter();
 
@@ -89,6 +91,38 @@ describe('SceneManager.get', () => {
         updated_at: new Date('2022-04-15T07:49:07.556Z'),
       },
     ]);
+  });
+
+  it('should search scene by an exact tag name only', async () => {
+    // "Maison" contains "ai": a substring match would return it as well, and the
+    // AND semantics between tag groups would then hide the scene actually tagged AI.
+    await db.TagScene.create({ scene_id: '3a30636c-b3f0-4251-a347-90787f0fe940', name: AI_GENERATED_SCENE_TAG });
+    await db.TagScene.create({ scene_id: '88428a7d-ea9d-46a6-b0d2-46bf82d37e53', name: 'Maison' });
+
+    const sceneManager = new SceneManager({}, event);
+    const scenes = await sceneManager.get({
+      searchTags: AI_GENERATED_SCENE_TAG,
+    });
+    expect(scenes).to.be.instanceOf(Array);
+    expect(scenes.map((scene) => scene.selector)).to.deep.equal(['test-scene']);
+  });
+
+  it('should return 0 scene when searching a partial tag name', async () => {
+    const sceneManager = new SceneManager({}, event);
+    const scenes = await sceneManager.get({
+      searchTags: 'tag',
+    });
+    expect(scenes).to.be.instanceOf(Array);
+    expect(scenes).to.deep.equal([]);
+  });
+
+  it('should return 0 scene when searching an unknown tag', async () => {
+    const sceneManager = new SceneManager({}, event);
+    const scenes = await sceneManager.get({
+      searchTags: `tag 1,${AI_GENERATED_SCENE_TAG}`,
+    });
+    expect(scenes).to.be.instanceOf(Array);
+    expect(scenes).to.deep.equal([]);
   });
 
   it('should return 0 result in search', async () => {

--- a/server/test/lib/scene/scene.get.test.js
+++ b/server/test/lib/scene/scene.get.test.js
@@ -116,6 +116,19 @@ describe('SceneManager.get', () => {
     expect(scenes).to.deep.equal([]);
   });
 
+  it('should return 0 scene when searching a tag named like an Object built-in', async () => {
+    // "__proto__" must get an empty group like any other unmatched tag, and not
+    // be swallowed by the Object prototype, otherwise the AND semantics are lost.
+    await db.TagScene.create({ scene_id: '3a30636c-b3f0-4251-a347-90787f0fe940', name: AI_GENERATED_SCENE_TAG });
+
+    const sceneManager = new SceneManager({}, event);
+    const scenes = await sceneManager.get({
+      searchTags: `${AI_GENERATED_SCENE_TAG},__proto__`,
+    });
+    expect(scenes).to.be.instanceOf(Array);
+    expect(scenes).to.deep.equal([]);
+  });
+
   it('should return 0 scene when searching an unknown tag', async () => {
     const sceneManager = new SceneManager({}, event);
     const scenes = await sceneManager.get({

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -2301,9 +2301,7 @@ describe('build schemas', () => {
     // Deduplication is case-insensitive, and the canonical casing wins: the scene
     // list filters on an exact tag name, so a scene tagged "ai" would be missed.
     await sceneCreateTool.cb({ ...baseScene, name: 'Scene tagged in lowercase', tags: [{ name: 'ai' }] });
-    expect(mcpHandler.gladys.scene.create.getCall(3).args[0].tags).to.deep.equal([
-      { name: AI_GENERATED_SCENE_TAG },
-    ]);
+    expect(mcpHandler.gladys.scene.create.getCall(3).args[0].tags).to.deep.equal([{ name: AI_GENERATED_SCENE_TAG }]);
   });
 
   it('should reject scene.create when http.request action misses headers', async () => {

--- a/server/test/services/mcp/lib/buildSchemas.test.js
+++ b/server/test/services/mcp/lib/buildSchemas.test.js
@@ -4,7 +4,12 @@ const sinon = require('sinon').createSandbox();
 const { stub, fake } = sinon;
 const nock = require('nock');
 const dns = require('dns');
-const { SYSTEM_VARIABLE_NAMES, COVER_STATE, AI_CHAT_TOOL_CATEGORIES } = require('../../../../utils/constants');
+const {
+  SYSTEM_VARIABLE_NAMES,
+  COVER_STATE,
+  AI_CHAT_TOOL_CATEGORIES,
+  AI_GENERATED_SCENE_TAG,
+} = require('../../../../utils/constants');
 const { ServiceNotConfiguredError } = require('../../../../utils/coreErrors');
 const {
   getAllResources,
@@ -2220,6 +2225,85 @@ describe('build schemas', () => {
     }
     expect(unknownThrown).to.be.an('error');
     expect(unknownThrown.message).to.eq('db down');
+  });
+
+  it('should tag every scene created by the AI with the AI generated scene tag', async () => {
+    const mcpHandler = {
+      serviceId: '7056e3d4-31cc-4d2a-bbdd-128cd49755e6',
+      getAllTools,
+      isSensorFeature,
+      isSwitchableFeature,
+      isLightControlFeature,
+      isShutterFeature,
+      isHistoryFeature,
+      isBatteryFeature,
+      isWritableSensorFeature,
+      formatValue: stub().callsFake((feature) => ({
+        value: feature.last_value,
+        unit: feature.unit,
+      })),
+      findBySimilarity,
+      gladys: {
+        room: { getAll: stub().resolves([{ id: 'room-1', name: 'Salon', selector: 'salon' }]) },
+        user: { get: stub().resolves([{ id: 'user-1', name: 'John', selector: 'john' }]) },
+        house: { get: stub().resolves([{ id: 'house-1', name: 'Main house', selector: 'main-house' }]) },
+        calendar: { get: stub().resolves([{ id: 'calendar-1', name: 'Family', selector: 'family-calendar' }]) },
+        area: { get: stub().resolves([{ id: 'area-1', name: 'Home', selector: 'home-area' }]) },
+        scene: {
+          get: stub().resolves([]),
+          create: stub().resolves({ id: 'scene-id', name: 'Scene', selector: 'scene' }),
+        },
+        device: {
+          get: stub().resolves([]),
+          getBySelector: stub().resolves(null),
+          setValue: stub().resolves(),
+          getDeviceFeaturesAggregates: stub().resolves({ values: [] }),
+          camera: {
+            getImagesInRoom: stub().resolves([]),
+          },
+        },
+        event: { emit: fake() },
+      },
+      levenshtein: { distance: stub().returns(0) },
+      toon: stub().returns('toonmockdata'),
+    };
+
+    const tools = await mcpHandler.getAllTools();
+    const sceneCreateTool = tools.find((tool) => tool.intent === 'scene.create');
+    const baseScene = {
+      icon: 'bell',
+      triggers: [{ type: 'system.start' }],
+      actions: [[{ type: 'delay', unit: 'minutes', value: 45 }]],
+    };
+
+    // No tag provided by the model
+    await sceneCreateTool.cb({ ...baseScene, name: 'Scene without tag' });
+    expect(mcpHandler.gladys.scene.create.firstCall.args[0].tags).to.deep.equal([{ name: AI_GENERATED_SCENE_TAG }]);
+
+    // Tags provided by the model are kept, and the AI tag is added
+    await sceneCreateTool.cb({ ...baseScene, name: 'Scene with tags', tags: [{ name: 'lights' }] });
+    expect(mcpHandler.gladys.scene.create.secondCall.args[0].tags).to.deep.equal([
+      { name: 'lights' },
+      { name: AI_GENERATED_SCENE_TAG },
+    ]);
+
+    // The AI tag is not duplicated: t_tag_scene has a composite primary key
+    await sceneCreateTool.cb({
+      ...baseScene,
+      name: 'Scene already tagged by the model',
+      tags: [{ name: AI_GENERATED_SCENE_TAG }, { name: 'lights' }],
+    });
+    expect(mcpHandler.gladys.scene.create.thirdCall.args[0].tags).to.deep.equal([
+      { name: AI_GENERATED_SCENE_TAG },
+      { name: 'lights' },
+    ]);
+
+    // Deduplication is case-insensitive, and the canonical casing wins: the scene
+    // list filters on an exact tag name, so a scene tagged "ai" would be missed.
+    await sceneCreateTool.cb({ ...baseScene, name: 'Scene tagged in lowercase', tags: [{ name: 'ai' }] });
+    expect(mcpHandler.gladys.scene.create.getCall(3).args[0].tags).to.deep.equal([
+      { name: AI_GENERATED_SCENE_TAG },
+    ]);
   });
 
   it('should reject scene.create when http.request action misses headers', async () => {

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -2223,6 +2223,10 @@ const AI_CHAT_PURPOSES = {
   WEEKLY_DIGEST: 'weekly-digest',
 };
 
+// Tag automatically added to every scene created by the AI through the
+// scene.create tool, so those scenes can be found back in the scene list.
+const AI_GENERATED_SCENE_TAG = 'AI';
+
 const createList = (obj) => {
   const list = [];
   Object.keys(obj).forEach((key) => {
@@ -2382,6 +2386,7 @@ module.exports.ALARM_MODES_LIST = ALARM_MODES_LIST;
 module.exports.AI_CHAT_TOOL_CATEGORIES = AI_CHAT_TOOL_CATEGORIES;
 module.exports.AI_CHAT_TOOL_CATEGORIES_LIST = AI_CHAT_TOOL_CATEGORIES_LIST;
 module.exports.AI_CHAT_PURPOSES = AI_CHAT_PURPOSES;
+module.exports.AI_GENERATED_SCENE_TAG = AI_GENERATED_SCENE_TAG;
 
 module.exports.MUSIC_PLAYBACK_STATE = MUSIC_PLAYBACK_STATE;
 module.exports.OPENING_SENSOR_STATE = OPENING_SENSOR_STATE;


### PR DESCRIPTION
### Description

Scenes created by the AI through the `scene.create` tool — reachable from the "Ask AI" scene action, the AI chat and external MCP clients — were indistinguishable from hand-made ones. With hundreds of scenes there is no way to find them back to clean them up, since you don't know how the AI named them.

Every scene created that way now automatically carries the `AI` tag. The existing scene card badge and the "Filter by tags" dropdown already handle tags, so **no front-end change is needed**: the `AI` entry shows up in the filter as soon as the first AI-created scene exists.

Tags supplied by the model are kept, deduplicated case-insensitively (`t_tag_scene` has a composite primary key `(scene_id, name)`, so a duplicate name would fail the insert), and the AI tag is always stored with its canonical casing since the filter matches on an exact name.

**The tag filter had to be fixed first.** `scene.get` matched tag names with a substring `LIKE '%tag%'`, then grouped the matched rows by the tag name actually found and intersected the groups. With a short tag like `AI`, `%AI%` also matches `Maison`, `Salaire`, … and those unrelated groups were then intersected together, so the filter returned nothing. The front only ever sends exact tag names picked from the dropdown (`SceneTagFilter.jsx`), so the lookup now matches on the exact name. Requested tags that no scene carries also get their own empty group, which keeps the AND semantics when several tags are selected — previously such a tag was silently ignored and widened the result set.

Known limitation: scenes created by the AI *before* this change are not tagged retroactively.

## Forum

Forum: https://community.gladysassistant.com/t/pouvoir-filtrer-les-scenes-qui-ont-ete-generees-par-lia/10817

### Checklist

- [x] Tests pass: `cd server && npm run coverage` (Codecov requires 100% coverage on changed lines) and Cypress (`npm run cypress:run`) if the UI changed
- [x] Linter and prettier pass on both front and server (`npm run eslint`, `npm run prettier`)
- [x] No undocumented breaking change

Coverage on the changed files is 100% statements/branches/functions/lines for `lib/scene/scene.get.js` and `utils/constants.js`; the only uncovered lines reported in `services/mcp/lib/buildSchemas.js` are pre-existing ones in the `device.turn-on-off` tool, outside this diff. Cypress was not re-run because no front-end file changed.

7 tests were added: the AI tag being applied with and without model-supplied tags, deduplication and canonical casing, exact-vs-substring tag matching, and filtering on a tag no scene carries.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scenes created through the AI scene creation tool are automatically tagged “AI.”
  * Existing tags are preserved, while duplicate AI tags are avoided.

* **Bug Fixes**
  * Scene searches now match complete tag names rather than partial matches.
  * Searches requiring multiple tags correctly return no results when any requested tag is missing.
  * Tag searches now work safely for names that resemble built-in object properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->