### PR TITLE
feat(dashboard): allow forcing tablet mode via ?tabletmode=<house_selector> URL param

### DIFF
--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -326,7 +326,7 @@
       "description": "Der Tablet-Modus wird für die Alarmfunktion verwendet. Wenn du den Alarm scharf schaltest, werden alle Tablets in deinem Zuhause gesperrt und zeigen eine Bildschirmtastatur an, um den Alarm zu deaktivieren.",
       "currentBrowserOnly": "<strong>Diese Einstellung gilt nur für dieses Gerät.</strong> Mit dem Speichern legst du fest, dass der Browser, den du gerade verwendest, ein Tablet ist. Jedes Gerät wird separat konfiguriert: Aktiviere den Tablet-Modus nur auf Geräten, die bei scharf geschaltetem Alarm gesperrt werden dürfen.",
       "fullScreenForce": "Wenn du ein Tablet dazu zwingen möchtest, im Vollbildmodus zu bleiben, füge der URL <code>?fullscreen=force</code> hinzu.",
-      "tabletModeForce": "Du kannst den Tablet-Modus für ein Zuhause auch direkt aktivieren, indem du der URL <code>?tabletmode=HAUS_SELEKTOR</code> hinzufügst, wobei <code>HAUS_SELEKTOR</code> der Selektor des oben ausgewählten Zuhauses ist.",
+      "tabletModeForce": "Du kannst den Tablet-Modus für ein Zuhause auch direkt aktivieren, indem du der URL <code>?tabletmode=HAUS_NAME</code> hinzufügst, wobei <code>HAUS_NAME</code> der Name des oben ausgewählten Zuhauses ist.",
       "houseLabel": "Zuhause dieses Tablets",
       "howToDisable": "Um den Tablet-Modus auf einem Gerät zu deaktivieren, öffne dieses Menü auf dem betreffenden Gerät und wähle „Tablet-Modus deaktiviert“.",
       "tabletModeDisabled": "Tablet-Modus deaktiviert"

--- a/front/src/config/i18n/de.json
+++ b/front/src/config/i18n/de.json
@@ -326,6 +326,7 @@
       "description": "Der Tablet-Modus wird für die Alarmfunktion verwendet. Wenn du den Alarm scharf schaltest, werden alle Tablets in deinem Zuhause gesperrt und zeigen eine Bildschirmtastatur an, um den Alarm zu deaktivieren.",
       "currentBrowserOnly": "<strong>Diese Einstellung gilt nur für dieses Gerät.</strong> Mit dem Speichern legst du fest, dass der Browser, den du gerade verwendest, ein Tablet ist. Jedes Gerät wird separat konfiguriert: Aktiviere den Tablet-Modus nur auf Geräten, die bei scharf geschaltetem Alarm gesperrt werden dürfen.",
       "fullScreenForce": "Wenn du ein Tablet dazu zwingen möchtest, im Vollbildmodus zu bleiben, füge der URL <code>?fullscreen=force</code> hinzu.",
+      "tabletModeForce": "Du kannst den Tablet-Modus für ein Zuhause auch direkt aktivieren, indem du der URL <code>?tabletmode=HAUS_SELEKTOR</code> hinzufügst, wobei <code>HAUS_SELEKTOR</code> der Selektor des oben ausgewählten Zuhauses ist.",
       "houseLabel": "Zuhause dieses Tablets",
       "howToDisable": "Um den Tablet-Modus auf einem Gerät zu deaktivieren, öffne dieses Menü auf dem betreffenden Gerät und wähle „Tablet-Modus deaktiviert“.",
       "tabletModeDisabled": "Tablet-Modus deaktiviert"

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -326,7 +326,7 @@
       "description": "Tablet mode is used for the alarm functionality. If you arm the alarm, all house tablets will be locked and display a virtual keyboard to deactivate the alarm.",
       "currentBrowserOnly": "<strong>This setting only applies to this device.</strong> By saving, you declare that the browser you are currently using is a tablet. Each device is configured separately: only enable tablet mode on the devices you are happy to see locked when the alarm is armed.",
       "fullScreenForce": "If you want to force a tablet to stay in full-screen mode, you can add <code>?fullscreen=force</code> to the URL.",
-      "tabletModeForce": "You can also directly activate tablet mode for a house by adding <code>?tabletmode=HOUSE_SELECTOR</code> to the URL, where <code>HOUSE_SELECTOR</code> is the selector of the house selected above.",
+      "tabletModeForce": "You can also directly activate tablet mode for a house by adding <code>?tabletmode=HOUSE_NAME</code> to the URL, where <code>HOUSE_NAME</code> is the name of the house selected above.",
       "houseLabel": "House of this tablet",
       "howToDisable": "To turn tablet mode off on a device, open this menu from that device and select \"Tablet mode disabled\".",
       "tabletModeDisabled": "Tablet Mode Disabled"

--- a/front/src/config/i18n/en.json
+++ b/front/src/config/i18n/en.json
@@ -326,6 +326,7 @@
       "description": "Tablet mode is used for the alarm functionality. If you arm the alarm, all house tablets will be locked and display a virtual keyboard to deactivate the alarm.",
       "currentBrowserOnly": "<strong>This setting only applies to this device.</strong> By saving, you declare that the browser you are currently using is a tablet. Each device is configured separately: only enable tablet mode on the devices you are happy to see locked when the alarm is armed.",
       "fullScreenForce": "If you want to force a tablet to stay in full-screen mode, you can add <code>?fullscreen=force</code> to the URL.",
+      "tabletModeForce": "You can also directly activate tablet mode for a house by adding <code>?tabletmode=HOUSE_SELECTOR</code> to the URL, where <code>HOUSE_SELECTOR</code> is the selector of the house selected above.",
       "houseLabel": "House of this tablet",
       "howToDisable": "To turn tablet mode off on a device, open this menu from that device and select \"Tablet mode disabled\".",
       "tabletModeDisabled": "Tablet Mode Disabled"

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -326,6 +326,7 @@
       "description": "Le mode tablette sert à la fonctionnalité alarme. Si vous armez l'alarme, toutes les tablettes de la maison seront verrouillées et afficheront un clavier virtuel pour désactiver l'alarme.",
       "currentBrowserOnly": "<strong>Ce réglage s'applique uniquement à cet appareil.</strong> En enregistrant, vous déclarez que le navigateur que vous utilisez en ce moment est une tablette. Chaque appareil se configure séparément : n'activez le mode tablette que sur les appareils que vous acceptez de voir verrouillés quand l'alarme est armée.",
       "fullScreenForce": "Si vous voulez forcer une tablette à rester en mode plein écran, vous pouvez ajouter <code>?fullscreen=force</code> à l'URL.",
+      "tabletModeForce": "Vous pouvez aussi activer directement le mode tablette pour une maison en ajoutant <code>?tabletmode=SELECTEUR_MAISON</code> à l'URL, où <code>SELECTEUR_MAISON</code> est le sélecteur de la maison sélectionnée ci-dessus.",
       "houseLabel": "Maison de cette tablette",
       "howToDisable": "Pour désactiver le mode tablette sur un appareil, ouvrez ce menu depuis cet appareil et sélectionnez « Mode tablette désactivé ».",
       "tabletModeDisabled": "Mode tablette désactivé"

--- a/front/src/config/i18n/fr.json
+++ b/front/src/config/i18n/fr.json
@@ -326,7 +326,7 @@
       "description": "Le mode tablette sert à la fonctionnalité alarme. Si vous armez l'alarme, toutes les tablettes de la maison seront verrouillées et afficheront un clavier virtuel pour désactiver l'alarme.",
       "currentBrowserOnly": "<strong>Ce réglage s'applique uniquement à cet appareil.</strong> En enregistrant, vous déclarez que le navigateur que vous utilisez en ce moment est une tablette. Chaque appareil se configure séparément : n'activez le mode tablette que sur les appareils que vous acceptez de voir verrouillés quand l'alarme est armée.",
       "fullScreenForce": "Si vous voulez forcer une tablette à rester en mode plein écran, vous pouvez ajouter <code>?fullscreen=force</code> à l'URL.",
-      "tabletModeForce": "Vous pouvez aussi activer directement le mode tablette pour une maison en ajoutant <code>?tabletmode=SELECTEUR_MAISON</code> à l'URL, où <code>SELECTEUR_MAISON</code> est le sélecteur de la maison sélectionnée ci-dessus.",
+      "tabletModeForce": "Vous pouvez aussi activer directement le mode tablette pour une maison en ajoutant <code>?tabletmode=NOM_MAISON</code> à l'URL, où <code>NOM_MAISON</code> est le nom de la maison sélectionnée ci-dessus.",
       "houseLabel": "Maison de cette tablette",
       "howToDisable": "Pour désactiver le mode tablette sur un appareil, ouvrez ce menu depuis cet appareil et sélectionnez « Mode tablette désactivé ».",
       "tabletModeDisabled": "Mode tablette désactivé"

--- a/front/src/routes/dashboard/SetTabletMode.jsx
+++ b/front/src/routes/dashboard/SetTabletMode.jsx
@@ -122,6 +122,9 @@ class SetTabletMode extends Component {
                   <p>
                     <MarkupText id="dashboard.tabletMode.fullScreenForce" />
                   </p>
+                  <p>
+                    <MarkupText id="dashboard.tabletMode.tabletModeForce" />
+                  </p>
                   <div className="form-group">
                     <button class="btn btn-success" onClick={this.saveTabletMode}>
                       <Text id="global.save" />

--- a/front/src/routes/dashboard/index.js
+++ b/front/src/routes/dashboard/index.js
@@ -189,9 +189,13 @@ class Dashboard extends Component {
   // Mirrors checkIfFullScreenParameterIsHere: ?tabletmode=<house_selector> in
   // the URL activates tablet mode for that house directly, the same way the
   // "Tablet Mode" menu (SetTabletMode.jsx) does, without going through its UI.
+  // Unlike ?fullscreen=force, this persists server-side on the session, so it
+  // is ignored on Gladys Plus: the "Tablet Mode" menu is hidden there
+  // (isGladysPlus in DashboardPage.jsx), which would leave a Plus browser
+  // locked by the house alarm with no UI to turn tablet mode back off.
   checkIfTabletModeParameterIsHere = async () => {
     const houseSelector = this.props.tabletmode;
-    if (!houseSelector) {
+    if (!houseSelector || this.state.isGladysPlus) {
       return;
     }
     try {

--- a/front/src/routes/dashboard/index.js
+++ b/front/src/routes/dashboard/index.js
@@ -189,13 +189,18 @@ class Dashboard extends Component {
   // Mirrors checkIfFullScreenParameterIsHere: ?tabletmode=<house_name_or_selector>
   // in the URL activates tablet mode for that house directly, the same way
   // the "Tablet Mode" menu (SetTabletMode.jsx) does, without going through
-  // its UI. Matched against the house name first - the selector is an
-  // internal slug never shown in the UI (the menu's dropdown only displays
-  // house.name) - falling back to the selector for anyone who already knows
-  // it. Unlike ?fullscreen=force, this persists server-side on the session,
-  // so it is ignored on Gladys Plus: the "Tablet Mode" menu is hidden there
-  // (isGladysPlus in DashboardPage.jsx), which would leave a Plus browser
-  // locked by the house alarm with no UI to turn tablet mode back off.
+  // its UI. The selector is an internal slug never shown in the UI (the
+  // menu's dropdown only displays house.name), so the selector and the name
+  // are each matched exactly, in their own pass - selector first, since it's
+  // the more precise identifier - rather than combined in one predicate:
+  // both columns are unique, so neither pass alone can ever be ambiguous,
+  // and a house's selector can never be mistaken for a different house's
+  // name. No case-insensitive fallback: two houses may legitimately have
+  // names that differ only by case. Unlike ?fullscreen=force, this persists
+  // server-side on the session, so it is ignored on Gladys Plus: the
+  // "Tablet Mode" menu is hidden there (isGladysPlus in DashboardPage.jsx),
+  // which would leave a Plus browser locked by the house alarm with no UI
+  // to turn tablet mode back off.
   checkIfTabletModeParameterIsHere = async () => {
     const houseNameOrSelector = this.props.tabletmode;
     if (!houseNameOrSelector || this.state.isGladysPlus) {
@@ -205,9 +210,7 @@ class Dashboard extends Component {
       const houses = await this.props.httpClient.get('/api/v1/house');
       const house =
         houses &&
-        houses.find(
-          h => h.selector === houseNameOrSelector || h.name.toLowerCase() === houseNameOrSelector.toLowerCase()
-        );
+        (houses.find(h => h.selector === houseNameOrSelector) || houses.find(h => h.name === houseNameOrSelector));
       if (!house) {
         console.error(`?tabletmode=${houseNameOrSelector} does not match any house`);
         return;

--- a/front/src/routes/dashboard/index.js
+++ b/front/src/routes/dashboard/index.js
@@ -186,25 +186,38 @@ class Dashboard extends Component {
     }
   };
 
-  // Mirrors checkIfFullScreenParameterIsHere: ?tabletmode=<house_selector> in
-  // the URL activates tablet mode for that house directly, the same way the
-  // "Tablet Mode" menu (SetTabletMode.jsx) does, without going through its UI.
-  // Unlike ?fullscreen=force, this persists server-side on the session, so it
-  // is ignored on Gladys Plus: the "Tablet Mode" menu is hidden there
+  // Mirrors checkIfFullScreenParameterIsHere: ?tabletmode=<house_name_or_selector>
+  // in the URL activates tablet mode for that house directly, the same way
+  // the "Tablet Mode" menu (SetTabletMode.jsx) does, without going through
+  // its UI. Matched against the house name first - the selector is an
+  // internal slug never shown in the UI (the menu's dropdown only displays
+  // house.name) - falling back to the selector for anyone who already knows
+  // it. Unlike ?fullscreen=force, this persists server-side on the session,
+  // so it is ignored on Gladys Plus: the "Tablet Mode" menu is hidden there
   // (isGladysPlus in DashboardPage.jsx), which would leave a Plus browser
   // locked by the house alarm with no UI to turn tablet mode back off.
   checkIfTabletModeParameterIsHere = async () => {
-    const houseSelector = this.props.tabletmode;
-    if (!houseSelector || this.state.isGladysPlus) {
+    const houseNameOrSelector = this.props.tabletmode;
+    if (!houseNameOrSelector || this.state.isGladysPlus) {
       return;
     }
     try {
+      const houses = await this.props.httpClient.get('/api/v1/house');
+      const house =
+        houses &&
+        houses.find(
+          h => h.selector === houseNameOrSelector || h.name.toLowerCase() === houseNameOrSelector.toLowerCase()
+        );
+      if (!house) {
+        console.error(`?tabletmode=${houseNameOrSelector} does not match any house`);
+        return;
+      }
       await this.props.httpClient.post('/api/v1/session/tablet_mode', {
         tablet_mode: true,
-        house: houseSelector
+        house: house.selector
       });
       await this.props.refreshTabletMode();
-      this.props.session.setTabletModeCurrentHouseSelector(houseSelector);
+      this.props.session.setTabletModeCurrentHouseSelector(house.selector);
     } catch (e) {
       console.error(e);
     }

--- a/front/src/routes/dashboard/index.js
+++ b/front/src/routes/dashboard/index.js
@@ -4,9 +4,15 @@ import { route } from 'preact-router';
 
 import DashboardPage from './DashboardPage';
 import GatewayAccountExpired from '../../components/gateway/GatewayAccountExpired';
-import actions from '../../actions/dashboard';
+import dashboardActions from '../../actions/dashboard';
+import mainActions from '../../actions/main';
 import { JOB_TYPES, WEBSOCKET_MESSAGE_TYPES } from '../../../../server/utils/constants';
 import get from 'get-value';
+
+// dashboard actions plus refreshTabletMode (main.js), needed to sync the
+// store's tabletMode after the ?tabletmode=<house_selector> URL param below
+// activates it server-side
+const actions = store => ({ ...dashboardActions(store), ...mainActions(store) });
 
 class Dashboard extends Component {
   toggleDashboardDropdown = () => {
@@ -180,6 +186,26 @@ class Dashboard extends Component {
     }
   };
 
+  // Mirrors checkIfFullScreenParameterIsHere: ?tabletmode=<house_selector> in
+  // the URL activates tablet mode for that house directly, the same way the
+  // "Tablet Mode" menu (SetTabletMode.jsx) does, without going through its UI.
+  checkIfTabletModeParameterIsHere = async () => {
+    const houseSelector = this.props.tabletmode;
+    if (!houseSelector) {
+      return;
+    }
+    try {
+      await this.props.httpClient.post('/api/v1/session/tablet_mode', {
+        tablet_mode: true,
+        house: houseSelector
+      });
+      await this.props.refreshTabletMode();
+      this.props.session.setTabletModeCurrentHouseSelector(houseSelector);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
   init = async () => {
     await this.getDashboards();
     // fire and forget, concurrent with the current dashboard's own fetch:
@@ -307,6 +333,7 @@ class Dashboard extends Component {
     this.props.session.dispatcher.addListener(WEBSOCKET_MESSAGE_TYPES.ALARM.ARMING, this.alarmArming);
     this.props.session.dispatcher.addListener(WEBSOCKET_MESSAGE_TYPES.JOB.UPDATED, this.jobUpdated);
     this.checkIfFullScreenParameterIsHere();
+    this.checkIfTabletModeParameterIsHere();
   }
 
   // Client-side dashboard switch: the dashboard list is already loaded, and


### PR DESCRIPTION
## Summary
- Adds a `?tabletmode=<house_selector>` URL parameter, mirroring the existing `?fullscreen=force` parameter, that activates tablet mode for the given house directly on dashboard load, without going through the "Tablet Mode" menu (`SetTabletMode.jsx`).
- Documents the new parameter next to the existing full-screen one in the "Tablet Mode" menu help text (English and French).

## Test plan
- [ ] Open `/dashboard?tabletmode=<a_valid_house_selector>` and confirm tablet mode activates for that house (icon-only tabs, no swiper, `GET /api/v1/session/tablet_mode` reflects `tablet_mode: true` and the correct `current_house_id`).
- [ ] Confirm an invalid/unknown selector fails silently (logged to console, no crash).
- [ ] Confirm `?fullscreen=force` still works as before.
- [ ] Confirm the "Tablet Mode" menu still opens and saves correctly through its own UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tablet mode can be activated directly for a selected house using the `?tabletmode=HOUSE_NAME` URL parameter.
  * The dashboard refreshes and switches to the matching house when the parameter is used.
  * Tablet mode settings now explain URL-based activation in English, French, and German, using the house name format.
  * House matching uses the exact house name or selector provided in the URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->